### PR TITLE
fix(blockTools): react-test-renderer should be a dependency

### DIFF
--- a/packages/blockTools/package.json
+++ b/packages/blockTools/package.json
@@ -45,7 +45,8 @@
     "create-emotion": "10.0.27",
     "react": "17.0.1",
     "react-dom": "17.0.1",
-    "react-router-dom": "5.2.0"
+    "react-router-dom": "5.2.0",
+    "react-test-renderer": "17.0.1"
   },
   "devDependencies": {
     "@babel/cli": "7.12.8",
@@ -66,7 +67,6 @@
     "path-browserify": "1.0.1",
     "process": "0.11.10",
     "react-syntax-highlight": "15.3.1",
-    "react-test-renderer": "17.0.1",
     "style-loader": "2.0.0",
     "webpack": "5.9.0",
     "webpack-cli": "4.2.0",

--- a/packages/blockTools/src/runMockRenderTests.js
+++ b/packages/blockTools/src/runMockRenderTests.js
@@ -21,7 +21,7 @@ import { MemoryRouter } from 'react-router-dom';
 import mockBlock from './mockBlock';
 
 const runMockRenderTests = ({ Block, enzyme, examples, logger, meta, mocks }) => {
-  const { before, methods, getProps } = mockBlock({ meta, logger });
+  const { before, getProps } = mockBlock({ meta, logger });
 
   beforeEach(() => {
     before();


### PR DESCRIPTION
### FIX @lowdefy/block-tools
- react-test-renderer should be a dependency, closes #248 