### PR TITLE
Fix @lowdefy/block-tools

### DIFF
--- a/packages/blockTools/src/mediaToCssObject.js
+++ b/packages/blockTools/src/mediaToCssObject.js
@@ -56,11 +56,11 @@ export const mq = [
   },
 ];
 
-const mediaToCssObject = (obj = {}, options = {}) => {
+const mediaToCssObject = (obj, options) => {
   // ES2015 key order matters.
   const result = [];
-  const media = options.react ? 'mediaReact' : 'media';
-  Object.keys(obj).forEach((key) => {
+  const media = (options || {}).react ? 'mediaReact' : 'media';
+  Object.keys(obj || {}).forEach((key) => {
     switch (key) {
       case 'xs':
         result.push({ key: mq[0][media], value: obj.xs });

--- a/packages/blockTools/src/mediaToCssObject.test.js
+++ b/packages/blockTools/src/mediaToCssObject.test.js
@@ -20,6 +20,11 @@ test('no object', () => {
   expect(mediaToCssObject()).toEqual({});
 });
 
+test('object with null obj to pass', () => {
+  const obj = null;
+  expect(mediaToCssObject(obj)).toEqual({});
+});
+
 test('object with no media unchanged', () => {
   const obj = {
     a: 'a',


### PR DESCRIPTION
### block-tools
##### Fix
- mediaToCssObject with `null` should not throw.
