### PR TITLE
chore: add `Apache`

### DIFF
--- a/packages/blocks/blocksECharts/README.md
+++ b/packages/blocks/blocksECharts/README.md
@@ -1,11 +1,11 @@
 # Lowdefy ECharts Blocks
 
-Lowdefy blocks for [ECharts](https://echarts.apache.org/), is a feature rich javascript charting library.
+Lowdefy blocks for [Apache ECharts](https://echarts.apache.org/), is a feature rich javascript charting library.
 
 The implementation of these blocks is a minimal wrapper for the [echarts-for-react
 ](https://www.npmjs.com/package/echarts-for-react) package. This means you write normal EChart config to create charts.
 
-See the [ECharts docs](https://echarts.apache.org/en/api.html#echarts) for the chart settings API.
+See the [Apache ECharts docs](https://echarts.apache.org/en/api.html#echarts) for the chart settings API.
 
 ### EChart Example
 

--- a/packages/docs/blocks/display/EChart.yaml
+++ b/packages/docs/blocks/display/EChart.yaml
@@ -44,10 +44,10 @@ _ref:
               - 147
               - 260
     description_content: |
-      [ECharts](https://echarts.apache.org/) is a feature rich javascript charting library.
+      [Apache ECharts](https://echarts.apache.org/) is a feature rich javascript charting library.
 
       This implementation is a minimal wrapper for the [echarts-for-react](https://www.npmjs.com/package/echarts-for-react) package. This means you write normal EChart config to create charts.
 
-      See the [ECharts docs](https://echarts.apache.org/en/api.html#echarts) for the chart settings API. See the [ECharts theme builder](https://echarts.apache.org/en/theme-builder.html) to create beautiful custom themes.
+      See the [Apache ECharts docs](https://echarts.apache.org/en/api.html#echarts) for the chart settings API. See the [ECharts theme builder](https://echarts.apache.org/en/theme-builder.html) to create beautiful custom themes.
 
-      > View more [EChart examples](https://echarts.apache.org/examples/en/index.html).
+      > View more [Apache EChart examples](https://echarts.apache.org/examples/en/index.html).


### PR DESCRIPTION
Hi, my name is Sven and I'm a member of Apache ECharts PMC. Very glad to see `lowdefy` has chosen Apache ECharts. I came across and notice some issue in doc. It should be `Apache ECharts` rather than `ECharts` because right now it is TLP of Apache Foundation.   Could you merge this PR, so there would be no brand issue. Thanks, and excellent job you guys have done here,