### PR TITLE
fix(operators): _request getter default value should be null.

### DIFF
--- a/packages/operators/src/web/request.js
+++ b/packages/operators/src/web/request.js
@@ -33,6 +33,7 @@ function _request({ arrayIndices, params, requests, location }) {
     const key = keyParts.reduce((acc, value) => (acc === '' ? value : acc.concat('.', value)), '');
     return get(requests[requestId].response, applyArrayIndices(arrayIndices, key), {
       copy: true,
+      default: null,
     });
   }
   return null;

--- a/packages/operators/test/testContext.js
+++ b/packages/operators/test/testContext.js
@@ -65,6 +65,7 @@ const context = {
     string: { loading: false, response: 'request String' },
     number: { loading: false, response: 500 },
     arr: { loading: false, response: [{ a: 'request a1' }, { a: 'request a2' }] },
+    returnsNull: { loading: false, response: null },
   },
   lowdefy,
   state: {

--- a/packages/operators/test/web/request.test.js
+++ b/packages/operators/test/web/request.test.js
@@ -102,3 +102,12 @@ test('_request dot notation with arrayindices', async () => {
   expect(res.output).toEqual('request a2');
   expect(res.errors).toMatchInlineSnapshot(`Array []`);
 });
+
+test('_request dot notation returns null if ', async () => {
+  const input = { _request: 'returnsNull.key' };
+  const parser = new WebParser({ context, contexts });
+  await parser.init();
+  const res = parser.parse({ input, location: 'locationId', arrayIndices });
+  expect(res.output).toEqual(null);
+  expect(res.errors).toMatchInlineSnapshot(`Array []`);
+});

--- a/packages/operators/test/web/request_details.test.js
+++ b/packages/operators/test/web/request_details.test.js
@@ -41,6 +41,7 @@ test('_request_details all requests', async () => {
     string: { loading: false, response: 'request String' },
     number: { loading: false, response: 500 },
     arr: { loading: false, response: [{ a: 'request a1' }, { a: 'request a2' }] },
+    returnsNull: { loading: false, response: null },
   });
   expect(res.errors).toMatchInlineSnapshot(`Array []`);
 });
@@ -94,6 +95,7 @@ test('_request_details param object all', async () => {
     string: { loading: false, response: 'request String' },
     number: { loading: false, response: 500 },
     arr: { loading: false, response: [{ a: 'request a1' }, { a: 'request a2' }] },
+    returnsNull: { loading: false, response: null },
   });
   expect(res.errors).toMatchInlineSnapshot(`Array []`);
 });
@@ -113,6 +115,7 @@ test('_request_details param object all and key', async () => {
     string: { loading: false, response: 'request String' },
     number: { loading: false, response: 500 },
     arr: { loading: false, response: [{ a: 'request a1' }, { a: 'request a2' }] },
+    returnsNull: { loading: false, response: null },
   });
   expect(res.errors).toMatchInlineSnapshot(`Array []`);
 });


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Follow the checklist and complete everything that is applicable
-->

Closes: No issue

### What are the changes and their implications?

All getters return `null` as their default value. When using the `_request` operator with dot notation, the default value returned was `undefined`, instead of `null`. This PR makes `_request` work like other getters.

## Checklist

- [x] Pull request is made to the "develop" branch
- [x] Tests added
- [ ] Documentation added/updated
