### PR TITLE
feat(graphql): Mongodb driver and MongoDBAggregation docs update.

### DIFF
--- a/packages/docs/connections/MongoDB.yaml
+++ b/packages/docs/connections/MongoDB.yaml
@@ -64,6 +64,7 @@ _ref:
             - `collection: string`: __Required__ -  The name of the MongoDB collection.
             - `read: boolean`: Default: `true` - Allow read operations like find on the collection.
             - `write: boolean`: Default: `false` - Allow write operations like update on the collection.
+            - `options: object`: See the [driver docs](https://mongodb.github.io/node-mongodb-native/4.0/interfaces/mongoclientoptions.html) for more information.
 
             #### Examples
 
@@ -158,14 +159,27 @@ _ref:
 
             #### Properties
             - `filter: object`: __Required__ - The filter used to select the document to update.
-            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/3.3/api/Collection.html#updateOne) for more information. Supported settings are:
+            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/4.0/classes/collection.html#deletemany) for more information. Supported settings are:
+              - `authdb: string`: Specifies the authentication information to be used.
+              - `bsonRegExp: boolean`: Return the BSON regular expressions as BSONRegExp instances.
               - `checkKeys: boolean`: Default: `false` - If true, will throw if bson documents start with $ or include a . in any key value.
               - `collation: object`: Specify collation (MongoDB 3.4 or higher) settings for update operation.
-              - `hint: object`: An optional hint for query optimization.
+              - `comment: string`: A user-provided comment to attach to this command.
+              - `dbName: string`: The database name.
+              - `explain: boolean`: Specifies the verbosity mode for the explain output.
+              - `fullResponse: boolean`: Return the full server response for the command.
+              - `hint: string | object`: An optional hint for query optimization.
               - `ignoreUndefined: boolean`: Default: `false` - Specify if the BSON serializer should ignore undefined fields.
-              - `j: boolean`: Specify a journal write concern.
-              - `w: number | string`: The write concern
-              - `wtimeout: number`: The write concern timeout.
+              - `let: object`: Map of parameter names and values that can be accessed using `$$var` (requires MongoDB 5.0).
+              - `maxTimeMS: number`: Specifies a cumulative time limit in milliseconds for processing operations on the cursor.
+              - `noResponse: boolean`: Admin command option.
+              - `ordered: boolean`: If true, when an insert fails, don't execute the remaining writes. If false, continue with remaining inserts when one fails.
+              - `readConcern: object`: Specify a read concern and level for the collection. (only MongoDB 3.2 or higher supported).
+              - `readPreference: string | object`: The read preference.
+              - `retryWrites: boolean`: Should retry failed writes.
+              - `serializeFunctions: boolean`: Default: `false` - Serialize the javascript functions.
+              - `willRetryWrites: boolean`: Option whether to retry writes.
+              - `writeConcern: object`: An object that expresses the write concern.
 
             #### Examples
 
@@ -187,14 +201,27 @@ _ref:
 
             #### Properties
             - `filter: object`: __Required__ - The filter used to select the document to update.
-            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/3.3/api/Collection.html#updateOne) for more information. Supported settings are:
+            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/4.0/classes/collection.html#deleteone) for more information. Supported settings are:
+              - `authdb: string`: Specifies the authentication information to be used.
+              - `bsonRegExp: boolean`: Return the BSON regular expressions as BSONRegExp instances.
               - `checkKeys: boolean`: Default: `false` - If true, will throw if bson documents start with $ or include a . in any key value.
               - `collation: object`: Specify collation (MongoDB 3.4 or higher) settings for update operation.
-              - `hint: object`: An optional hint for query optimization.
+              - `comment: string`: A user-provided comment to attach to this command.
+              - `dbName: string`: The database name.
+              - `explain: boolean`: Specifies the verbosity mode for the explain output.
+              - `fullResponse: boolean`: Return the full server response for the command.
+              - `hint: string | object`: An optional hint for query optimization.
               - `ignoreUndefined: boolean`: Default: `false` - Specify if the BSON serializer should ignore undefined fields.
-              - `j: boolean`: Specify a journal write concern.
-              - `w: number | string`: The write concern
-              - `wtimeout: number`: The write concern timeout.
+              - `let: object`: Map of parameter names and values that can be accessed using `$$var` (requires MongoDB 5.0).
+              - `maxTimeMS: number`: Specifies a cumulative time limit in milliseconds for processing operations on the cursor.
+              - `noResponse: boolean`: Admin command option.
+              - `ordered: boolean`: If true, when an insert fails, don't execute the remaining writes. If false, continue with remaining inserts when one fails.
+              - `readConcern: object`: Specify a read concern and level for the collection. (only MongoDB 3.2 or higher supported).
+              - `readPreference: string | object`: The read preference.
+              - `retryWrites: boolean`: Should retry failed writes.
+              - `serializeFunctions: boolean`: Default: `false` - Serialize the javascript functions.
+              - `willRetryWrites: boolean`: Option whether to retry writes.
+              - `writeConcern: object`: An object that expresses the write concern.
 
             #### Examples
 
@@ -217,16 +244,43 @@ _ref:
 
             #### Properties
             - `query: object`: __Required__ - A MongoDB query object.
-            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/3.3/api/Collection.html#find) for more information. Supported settings are:
-              - `limit: number`: Sets the limit of documents returned in the query.
-              - `sort array | object`: Set to sort the documents coming back from the query.
-              - `projection: object`: The fields to return in the query. Object of fields to either include or exclude (one of, not both), `{'a':1, 'b': 1}` or `{'a': 0, 'b': 0}`.
-              - `skip: number`: Set to skip N documents ahead in your query (useful for pagination).
-              - `hint: object`: Tell the query to use specific indexes in the query. Object of indexes to use, `{'_id':1}`.
-              - `comment: string`: Add a [comment](https://docs.mongodb.com/manual/reference/operator/query/comment/index.html) to the query. These comments are visible in the MongoDB profile log, making them easier to interpret.
-              - `readPreference: string | object`: The preferred read preference.
-              - `maxTimeMS: number`: Number of milliseconds to wait before aborting the query.
+            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/4.0/classes/collection.html#find) for more information. Supported settings are:
+              - `allowDiskUse: boolean`: Allows disk use for blocking sort operations exceeding 100MB memory. (MongoDB 3.2 or higher)
+              - `allowPartialResults: boolean`: For queries against a sharded collection, allows the command (or subsequent getMore commands) to return partial results, rather than an error, if one or more queried shards are available.
+              - `authdb: string`: Specifies the authentication information to be used.
+              - `awaitData: boolean`: Specify if the cursor is a tailable-await cursor. Requires `tailable` to be true.
+              - `batchSize: number`: Set the batchSize for the getMoreCommand when iterating over the query results.
+              - `bsonRegExp: boolean`: Return the BSON regular expressions as BSONRegExp instances.
+              - `checkKeys: boolean`: The serializer will check if keys are valid.
               - `collation: object`: Specify collation (MongoDB 3.4 or higher) settings for update operation.
+              - `comment: string | object`: Add a [comment](https://docs.mongodb.com/manual/reference/operator/query/comment/index.html) to the query. These comments are visible in the MongoDB profile log, making them easier to interpret.
+              - `dbName: string`: The database name.
+              - `explain: boolean`: Specifies the verbosity mode for the explain output.
+              - `fullResponse: boolean`: Return the full server response for the command.
+              - `hint: string | object`: Tell the query to use specific indexes in the query. Object of indexes to use, `{'_id':1}`.
+              - `ignoreUndefined: boolean`: Default: `true` - Serialize will not emit undefined fields.
+              - `let: object`: Map of parameter names and values that can be accessed using `$$var` (requires MongoDB 5.0).
+              - `limit: number`: Sets the limit of documents returned in the query.
+              - `max: object`: The exclusive upper bound for a specific index.
+              - `maxAwaitTimeMS: number`: The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor query. Requires `tailable` and `awaitData` to be true.
+              - `maxTimeMS: number`: Number of milliseconds to wait before aborting the command.
+              - `min: object`: The inclusive lower bound for a specific index.
+              - `noCursorTimeout: boolean`: The server normally times out idle cursors after an inactivity period (10 minutes) to prevent excess memory use. Set this option to prevent that.
+              - `noResponse: boolean`: Admin command option.
+              - `projection: object`: The fields to return in the query. Object of fields to either include or exclude (one of, not both), `{'a':1, 'b': 1}` or `{'a': 0, 'b': 0}`.
+              - `readConcern: object`: Specify a read concern and level for the collection. (only MongoDB 3.2 or higher supported).
+              - `readPreference: string | object`: The preferred read preference.
+              - `retryWrites: boolean`: Should retry failed writes.
+              - `returnKey: boolean`: If true, returns only the index keys in the resulting documents.
+              - `serializeFunctions: boolean`: Default: `false` - Serialize the javascript functions.
+              - `showRecordId: boolean`: Determine whether to return the record identifier for each document. If true, adds a field $recordId to the returned documents.
+              - `singleBatch: boolean`: Default: `false` - Determines whether to close the cursor after the first batch.
+              - `skip: number`: Set to skip N documents ahead in your query (useful for pagination).
+              - `sort: array | object`: Set to sort the documents coming back from the query.
+              - `tailable: boolean`: Specify if the cursor is tailable.
+              - `timeout: boolean`: Specify if the cursor can timeout.
+              - `willRetryWrites: boolean`: Option whether to retry writes.
+              - `writeConcern: object`: An object that expresses the write concern.
 
             #### Examples
 
@@ -257,16 +311,43 @@ _ref:
 
             #### Properties
             - `query: object`: __Required__ - A MongoDB query object.
-            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/3.3/api/Collection.html#find) for more information. Supported settings are:
-              - `limit: number`: Sets the limit of documents returned in the query.
-              - `sort: array | object`: Set to sort the documents coming back from the query.
-              - `projection: object`: The fields to return in the query. Object of fields to either include or exclude (one of, not both), `{'a':1, 'b': 1}` or `{'a': 0, 'b': 0}`.
-              - `skip: number`: Set to skip N documents ahead in your query (useful for pagination).
-              - `hint: object`: Tell the query to use specific indexes in the query. Object of indexes to use, `{'_id':1}`.
-              - `comment: string`: Add a [comment](https://docs.mongodb.com/manual/reference/operator/query/comment/index.html) to the query. These comments are visible in the MongoDB profile log, making them easier to interpret.
-              - `readPreference: string | object`: The preferred read preference.
-              - `maxTimeMS: number`: Number of milliseconds to wait before aborting the query.
+            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/4.0/classes/collection.html#findone) for more information. Supported settings are:
+              - `allowDiskUse: boolean`: Allows disk use for blocking sort operations exceeding 100MB memory. (MongoDB 3.2 or higher)
+              - `allowPartialResults: boolean`: For queries against a sharded collection, allows the command (or subsequent getMore commands) to return partial results, rather than an error, if one or more queried shards are available.
+              - `authdb: string`: Specifies the authentication information to be used.
+              - `awaitData: boolean`: Specify if the cursor is a tailable-await cursor. Requires `tailable` to be true.
+              - `batchSize: number`: Set the batchSize for the getMoreCommand when iterating over the query results.
+              - `bsonRegExp: boolean`: Return the BSON regular expressions as BSONRegExp instances.
+              - `checkKeys: boolean`: The serializer will check if keys are valid.
               - `collation: object`: Specify collation (MongoDB 3.4 or higher) settings for update operation.
+              - `comment: string | object`: Add a [comment](https://docs.mongodb.com/manual/reference/operator/query/comment/index.html) to the query. These comments are visible in the MongoDB profile log, making them easier to interpret.
+              - `dbName: string`: The database name.
+              - `explain: boolean`: Specifies the verbosity mode for the explain output.
+              - `fullResponse: boolean`: Return the full server response for the command.
+              - `hint: string | object`: Tell the query to use specific indexes in the query. Object of indexes to use, `{'_id':1}`.
+              - `ignoreUndefined: boolean`: Default: `true` - Serialize will not emit undefined fields.
+              - `let: object`: Map of parameter names and values that can be accessed using `$$var` (requires MongoDB 5.0).
+              - `limit: number`: Sets the limit of documents returned in the query.
+              - `max: object`: The exclusive upper bound for a specific index.
+              - `maxAwaitTimeMS: number`: The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor query. Requires `tailable` and `awaitData` to be true.
+              - `maxTimeMS: number`: Number of milliseconds to wait before aborting the command.
+              - `min: object`: The inclusive lower bound for a specific index.
+              - `noCursorTimeout: boolean`: The server normally times out idle cursors after an inactivity period (10 minutes) to prevent excess memory use. Set this option to prevent that.
+              - `noResponse: boolean`: Admin command option.
+              - `projection: object`: The fields to return in the query. Object of fields to either include or exclude (one of, not both), `{'a':1, 'b': 1}` or `{'a': 0, 'b': 0}`.
+              - `readConcern: object`: Specify a read concern and level for the collection. (only MongoDB 3.2 or higher supported).
+              - `readPreference: string | object`: The preferred read preference.
+              - `retryWrites: boolean`: Should retry failed writes.
+              - `returnKey: boolean`: If true, returns only the index keys in the resulting documents.
+              - `serializeFunctions: boolean`: Default: `false` - Serialize the javascript functions.
+              - `showRecordId: boolean`: Determine whether to return the record identifier for each document. If true, adds a field $recordId to the returned documents.
+              - `singleBatch: boolean`: Default: `false` - Determines whether to close the cursor after the first batch.
+              - `skip: number`: Set to skip N documents ahead in your query (useful for pagination).
+              - `sort: array | object`: Set to sort the documents coming back from the query.
+              - `tailable: boolean`: Specify if the cursor is tailable.
+              - `timeout: boolean`: Specify if the cursor can timeout.
+              - `willRetryWrites: boolean`: Option whether to retry writes.
+              - `writeConcern: object`: An object that expresses the write concern.
 
             #### Examples
 
@@ -287,15 +368,27 @@ _ref:
 
             #### Properties
             - `docs: object[]`: __Required__ - The array of documents to be inserted.
-            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/3.3/api/Collection.html#insertMany) for more information. Supported settings are:
+            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/4.0/classes/collection.html#insertmany) for more information. Supported settings are:
+              - `authdb: string`: Specifies the authentication information to be used.
+              - `bsonRegExp: boolean`: Return the BSON regular expressions as BSONRegExp instances.
               - `bypassDocumentValidation: boolean`: Default: `false` - Allow driver to bypass schema validation in MongoDB 3.2 or higher
               - `checkKeys: boolean`: Default: `true` - If true, will throw if bson documents start with $ or include a . in any key value.
-              - `forceServerObjectId: boolean`: Default: `false` - Force server to assign _id values instead of driver.
-              - `j: boolean`: Default: `false` - Specify a journal write concern.
+              - `collation: object`: Specify collation (MongoDB 3.4 or higher) settings for update operation.
+              - `comment: string | object`: Add a [comment](https://docs.mongodb.com/manual/reference/operator/query/comment/index.html) to the query. These comments are visible in the MongoDB profile log, making them easier to interpret.
+              - `dbName: string`: The database name.
+              - `explain: object`: Specifies the verbosity mode for the explain output.
+              - `forcesServerObjectId: boolean`: Default: `false` - Force server to assign _id values instead of driver.
+              - `fullResponse: boolean`: Return the full server response for the command.
               - `ignoreUndefined: boolean`: Default: `false` - Specify if the BSON serializer should ignore undefined fields.
-              - `w: number | string`: The write concern.
-              - `wtimeout: number`: The write concern timeout.
-
+              - `maxTimeMS: number`: Number of milliseconds to wait before aborting the command.
+              - `noResponse: boolean`: Admin command option.
+              - `ordered: boolean`: If true, when an insert fails, don't execute the remaining writes. If false, continue with remaining inserts when one fails.
+              - `readConcern: object`: Specify a read concern and level for the collection. (only MongoDB 3.2 or higher supported).
+              - `readPreference: object`: The preferred read preference.
+              - `retryWrites: boolean`: Should retry failed writes.
+              - `serializeFunctions: boolean`: Default: `false` - Serialize the javascript functions.
+              - `willRetryWrites: boolean`: Option whether to retry writes.
+              - `writeConcern: object`: An object that expresses the write concern.
 
             #### Examples
 
@@ -321,14 +414,26 @@ _ref:
 
             #### Properties
             - `doc: object`: __Required__ - The document to be inserted.
-            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/3.3/api/Collection.html#insertOne) for more information. Supported settings are:
+            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/4.0/classes/collection.html#insertone) for more information. Supported settings are:
+              - `authdb: string`: Specifies the authentication information to be used.
+              - `bsonRegExp: boolean`: Return the BSON regular expressions as BSONRegExp instances.
               - `bypassDocumentValidation: boolean`: Default: `false` - Allow driver to bypass schema validation in MongoDB 3.2 or higher
               - `checkKeys: boolean`: Default: `true` - If true, will throw if bson documents start with $ or include a . in any key value.
-              - `forceServerObjectId: boolean`: Default: `false` - Force server to assign _id values instead of driver.
-              - `j: boolean`: Default: `false` - Specify a journal write concern.
+              - `collation: object`: Specify collation (MongoDB 3.4 or higher) settings for update operation.
+              - `comment: string | object`: Add a [comment](https://docs.mongodb.com/manual/reference/operator/query/comment/index.html) to the query. These comments are visible in the MongoDB profile log, making them easier to interpret.
+              - `dbName: string`: The database name.
+              - `explain: object`: Specifies the verbosity mode for the explain output.
+              - `forcesServerObjectId: boolean`: Default: `false` - Force server to assign _id values instead of driver.
+              - `fullResponse: boolean`: Return the full server response for the command.
               - `ignoreUndefined: boolean`: Default: `false` - Specify if the BSON serializer should ignore undefined fields.
-              - `w: number | string`: The write concern.
-              - `wtimeout: number`: The write concern timeout.
+              - `maxTimeMS: number`: Number of milliseconds to wait before aborting the command.
+              - `noResponse: boolean`: Admin command option.
+              - `readConcern: object`: Specify a read concern and level for the collection. (only MongoDB 3.2 or higher supported).
+              - `readPreference: object`: The preferred read preference.
+              - `retryWrites: boolean`: Should retry failed writes.
+              - `serializeFunctions: boolean`: Default: `false` - Serialize the javascript functions.
+              - `willRetryWrites: boolean`: Option whether to retry writes.
+              - `writeConcern: object`: An object that expresses the write concern.
 
             #### Examples
 
@@ -354,18 +459,29 @@ _ref:
             #### Properties
             - `filter: object`: __Required__ - The filter used to select the document to update.
             - `update: object | object[]`: __Required__ - The update operations to be applied to the document.
-            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/3.3/api/Collection.html#updateOne) for more information. Supported settings are:
+            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/4.0/classes/collection.html#updatemany) for more information. Supported settings are:
               - `arrayFilters: string[]`: Array filters for the [`$[<identifier>]`](https://docs.mongodb.com/manual/reference/operator/update/positional-filtered/) array update operator.
+              - `authdb: string`: Specifies the authentication information to be used.
+              - `bsonRegExp: boolean`: Return the BSON regular expressions as BSONRegExp instances.
               - `bypassDocumentValidation: boolean`: Default: `false` - Allow driver to bypass schema validation in MongoDB 3.2 or higher.
               - `checkKeys: boolean`: Default: `false` - If true, will throw if bson documents start with $ or include a . in any key value.
               - `collation: object`: Specify collation (MongoDB 3.4 or higher) settings for update operation.
-              - `forceServerObjectId: boolean`: Force server to assign _id values instead of driver.
-              - `hint: object`: An optional hint for query optimization.
+              - `comment: string | object`: A user-provided comment to attach to this command.
+              - `dbName: string`: The database name.
+              - `explain: object`: Specifies the verbosity mode for the explain output.
+              - `fullResponse: boolean`: Return the full server response for the command.
+              - `hint: string | object`: An optional hint for query optimization.
               - `ignoreUndefined: boolean`: Default: `false` - Specify if the BSON serializer should ignore undefined fields.
-              - `j: boolean`: Specify a journal write concern.
+              - `let: object`: Map of parameter names and values that can be accessed using `$$var` (requires MongoDB 5.0).
+              - `maxTimeMS: number`: Number of milliseconds to wait before aborting the command.
+              - `noResponse: boolean`: Admin command option.
+              - `readConcern: object`: Specify a read concern and level for the collection. (only MongoDB 3.2 or higher supported).
+              - `readPreference: object`: The preferred read preference.
+              - `retryWrites: boolean`: Should retry failed writes.
+              - `serializeFuntions: boolean`: Default: `false` - Serialize the javascript functions.
               - `upsert: boolean`: Default: `false` - Insert document if no match is found.
-              - `w: number | string`: The write concern.
-              - `wtimeout: number`: The write concern timeout.
+              - `willRetryWrites: boolean`: Option whether to retry writes.
+              - `writeConcern: object`: An object that expresses the write concern.
 
             #### Examples
 
@@ -406,19 +522,29 @@ _ref:
             #### Properties
             - `filter: object`: __Required__ - The filter used to select the document to update.
             - `update: object | object[]`: __Required__ - The update operations to be applied to the document.
-            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/3.3/api/Collection.html#updateOne) for more information. Supported settings are:
-              - `arrayFilters: string[]`: _Array_ - Array filters for the [`$[<identifier>]`](https://docs.mongodb.com/manual/reference/operator/update/positional-filtered/) array update operator.
+            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/4.0/classes/collection.html#updateone) for more information. Supported settings are:
+              - `arrayFilters: object[]`: _Array_ - Array filters for the [`$[<identifier>]`](https://docs.mongodb.com/manual/reference/operator/update/positional-filtered/) array update operator.
+              - `authdb: string`: Specifies the authentication information to be used.
+              - `bsonRegExp: boolean`: Return the BSON regular expressions as BSONRegExp instances.
               - `bypassDocumentValidation: boolean`: Default: `false` - Allow driver to bypass schema validation in MongoDB 3.2 or higher.
               - `checkKeys: boolean`: Default: `false` - If true, will throw if bson documents start with $ or include a . in any key value.
               - `collation: object`: Specify collation (MongoDB 3.4 or higher) settings for update operation.
-              - `forceServerObjectId: boolean`: Force server to assign _id values instead of driver.
-              - `hint: object`: An optional hint for query optimization.
+              - `comment: string | object`: A user-provided comment to attach to this command.
+              - `dbName: string`: The database name.
+              - `explain: object`: Specifies the verbosity mode for the explain output.
+              - `fullResponse: boolean`: Return the full server response for the command.
+              - `hint: string | object`: An optional hint for query optimization.
               - `ignoreUndefined: boolean`: Default: `false` - Specify if the BSON serializer should ignore undefined fields.
-              - `j: boolean`: Specify a journal write concern.
+              - `let: object`: Map of parameter names and values that can be accessed using `$$var` (requires MongoDB 5.0).
+              - `maxTimeMS: number`: Number of milliseconds to wait before aborting the command.
+              - `noResponse: boolean`: Admin command option.
+              - `readConcern: object`: Specify a read concern and level for the collection. (only MongoDB 3.2 or higher supported).
+              - `readPreference: object`: The preferred read preference.
+              - `retryWrites: boolean`: Should retry failed writes.
+              - `serializeFunctions: boolean`: Default: `false` - Serialize the javascript functions.
               - `upsert: boolean`: Default: `false` - Insert document if no match is found.
-              - `w: integer | string`: The write concern
-              - `wtimeout: integer`: The write concern timeout.
-
+              - `willRetryWrites: boolean`: Option whether to retry writes.
+              - `writeConcern: object`: An object that expresses the write concern.
 
             #### Examples
 

--- a/packages/docs/connections/MongoDB.yaml
+++ b/packages/docs/connections/MongoDB.yaml
@@ -105,14 +105,30 @@ _ref:
 
             #### Properties
             - `pipeline: object[]`: __Required__ - Array containing all the aggregation framework commands for the execution.
-            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/3.3/api/Collection.html#aggregate) for more information. Supported settings are:
-              - `readPreference: string | object`: The read preference.
+            - `options: object`: Optional settings. See the [driver docs](https://mongodb.github.io/node-mongodb-native/4.0/classes/collection.html#aggregate) for more information. Supported settings are:
               - `allowDiskUse: boolean`: Default: `false` - Allow disk use on the MongoDB server to store temporary results for the aggregation.
-              - `maxTimeMS: number`: Specifies a cumulative time limit in milliseconds for processing operations on the cursor.
+              - `authdb: string`: Specifies the authentication information to be used.
+              - `batchSize: number`: The number of documents to return per batch.
+              - `bsonRegExp: boolean`: Return the BSON regular expressions as BSONRegExp instances.
               - `bypassDocumentValidation: boolean`: Default: `false` - Allow driver to bypass schema validation in MongoDB 3.2 or higher.
+              - `checkKeys: boolean`: The serializer will check if keys are valid.
               - `collation: object`: Specify collation (MongoDB 3.4 or higher) settings for update operation.
               - `comment: string`: Add a [comment](https://docs.mongodb.com/manual/reference/operator/query/comment/index.html) to the aggregation. These comments are visible in the MongoDB profile log, making them easier to interpret.
+              - `dbName: string`: The database name.
+              - `explain: boolean`: Specifies to return the information on the processing of the pipeline.
+              - `fullResponse: boolean`: Return the full server response for the command.
               - `hint: string | object`: Add an index selection hint to an aggregation command.
+              - `ignoreUndefined: boolean`: Default: `true` - Serialize will not emit undefined fields.
+              - `let: object`: Specifies an object with a list of variables. This allows you to improve command readability by separating the variables from the query text.
+              - `maxAwaitTimeMS: number`: The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor query.
+              - `maxTimeMS: number`: Specifies a cumulative time limit in milliseconds for processing operations on the cursor.
+              - `noResponse: boolean`: Admin command option.
+              - `readConcern: object`: Specifies the level of isolation for read operations.
+              - `readPreference: string | object`: The read preference.
+              - `retryWrites: boolean`: Should retry failed writes.
+              - `serializeFunctions: boolean`: Default: `false` - Serialize the javascript functions.
+              - `willRetryWrites: boolean`: Option whether to retry writes.
+              - `writeConcern: object`: An object that expresses the write concern to use with the $out or $merge stage.
 
             #### Examples
 

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -59,7 +59,7 @@
     "knex": "0.95.6",
     "mingo": "4.1.2",
     "moment": "2.29.1",
-    "mongodb": "3.6.9",
+    "mongodb": "4.1.0",
     "mssql": "7.1.0",
     "mysql": "2.18.1",
     "openid-client": "4.7.4",

--- a/packages/graphql/src/connections/MongoDBCollection/getCollection.js
+++ b/packages/graphql/src/connections/MongoDBCollection/getCollection.js
@@ -18,11 +18,8 @@ import { MongoClient } from 'mongodb';
 
 async function getCollection({ connection }) {
   let client;
-  const { databaseUri, databaseName, collection } = connection;
-  client = new MongoClient(databaseUri, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-  });
+  const { collection, databaseUri, databaseName, options } = connection;
+  client = new MongoClient(databaseUri, options);
   await client.connect();
   try {
     const db = client.db(databaseName);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3306,7 +3306,7 @@ __metadata:
     knex: 0.95.6
     mingo: 4.1.2
     moment: 2.29.1
-    mongodb: 3.6.9
+    mongodb: 4.1.0
     mssql: 7.1.0
     mysql: 2.18.1
     openid-client: 4.7.4


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable
-->

Closes #696

### What are the changes and their implications?

Updated the mongodb driver to 4.1.0 and the options for MongoDBAggregation documentation.

The following options are no longer used within the respective commands:

- DeleteMany, DeleteOne

   - j: boolean
   - w: number | string
   - wtimeout: number

- InsertMany, InsertOne, UpdateMany, UpdateOne

   - forceServerObjectId: boolean
   - j: boolean
   - w: integer | string
   - wtimeout: integer

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [x] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
