### PR TITLE
Validate on regex match and move showValidation to blocks.

### DIFF
--- a/packages/engine/src/State.js
+++ b/packages/engine/src/State.js
@@ -38,7 +38,6 @@ class State {
     Object.keys(frozenCopy).forEach((key) => {
       this.set(key, frozenCopy[key]);
     });
-    this.context.showValidationErrors = false;
   }
 
   freezeState() {

--- a/packages/engine/src/getContext.js
+++ b/packages/engine/src/getContext.js
@@ -81,7 +81,6 @@ const getContext = async ({ block, contextId, lowdefy }) => {
     lowdefy,
     pageId: lowdefy.pageId,
     rootBlock: blockData(block), // filter block to prevent circular structure
-    showValidationErrors: false,
     state: {},
     update: () => {}, // Initialize update since Requests might call it during context creation
     updateListeners: new Set(),

--- a/packages/engine/test/Actions/CallMethod.test.js
+++ b/packages/engine/test/Actions/CallMethod.test.js
@@ -23,8 +23,9 @@ const RealDate = Date;
 const mockDate = jest.fn(() => ({ date: 0 }));
 mockDate.now = jest.fn(() => 0);
 
-// Comment out to use console.log
+// Comment out to use console
 console.log = () => {};
+console.error = () => {};
 
 beforeAll(() => {
   global.Date = mockDate;

--- a/packages/engine/test/Actions/JsAction.test.js
+++ b/packages/engine/test/Actions/JsAction.test.js
@@ -24,8 +24,9 @@ const RealDate = Date;
 const mockDate = jest.fn(() => ({ date: 0 }));
 mockDate.now = jest.fn(() => 0);
 
-// Comment out to use console.log
-// console.log = () => {};
+// Comment out to use console
+console.log = () => {};
+console.error = () => {};
 
 beforeAll(() => {
   global.Date = mockDate;

--- a/packages/engine/test/Actions/Link.test.js
+++ b/packages/engine/test/Actions/Link.test.js
@@ -27,8 +27,9 @@ const RealDate = Date;
 const mockDate = jest.fn(() => ({ date: 0 }));
 mockDate.now = jest.fn(() => 0);
 
-// Comment out to use console.log
+// Comment out to use console
 console.log = () => {};
+console.error = () => {};
 
 beforeEach(() => {
   global.Date = mockDate;

--- a/packages/engine/test/Actions/Request.test.js
+++ b/packages/engine/test/Actions/Request.test.js
@@ -76,8 +76,9 @@ const RealDate = Date;
 const mockDate = jest.fn(() => ({ date: 0 }));
 mockDate.now = jest.fn(() => 0);
 
-// Comment out to use console.log
+// Comment out to use console
 console.log = () => {};
+console.error = () => {};
 
 beforeAll(() => {
   global.Date = mockDate;

--- a/packages/engine/test/Actions/Throw.test.js
+++ b/packages/engine/test/Actions/Throw.test.js
@@ -30,8 +30,9 @@ const RealDate = Date;
 const mockDate = jest.fn(() => ({ date: 0 }));
 mockDate.now = jest.fn(() => 0);
 
-// Comment out to use console.log
+// Comment out to use console
 console.log = () => {};
+console.error = () => {};
 
 beforeEach(() => {
   displayMessage.mockReset();

--- a/packages/engine/test/Actions/Validate.test.js
+++ b/packages/engine/test/Actions/Validate.test.js
@@ -29,8 +29,9 @@ const RealDate = Date;
 const mockDate = jest.fn(() => ({ date: 0 }));
 mockDate.now = jest.fn(() => 0);
 
-// Comment out to use console.log
+// Comment out to use console
 console.log = () => {};
+console.error = () => {};
 
 beforeEach(() => {
   displayMessage.mockReset();
@@ -88,7 +89,7 @@ test('Validate required field', async () => {
     rootBlock,
   });
   const { button, text1 } = context.RootBlocks.map;
-  expect(text1.validationEval.output).toEqual({
+  expect(text1.eval.validation).toEqual({
     errors: ['This field is required'],
     status: null,
     warnings: [],
@@ -120,7 +121,7 @@ test('Validate required field', async () => {
     startTimestamp: { date: 0 },
     endTimestamp: { date: 0 },
   });
-  expect(text1.validationEval.output).toEqual({
+  expect(text1.eval.validation).toEqual({
     errors: ['This field is required'],
     status: 'error',
     warnings: [],
@@ -155,7 +156,7 @@ test('Validate required field', async () => {
     startTimestamp: { date: 0 },
     endTimestamp: { date: 0 },
   });
-  expect(text1.validationEval.output).toEqual({
+  expect(text1.eval.validation).toEqual({
     errors: [],
     status: 'success',
     warnings: [],
@@ -226,7 +227,7 @@ test('Validate all fields', async () => {
     rootBlock,
   });
   const { button, text1, text2 } = context.RootBlocks.map;
-  expect(text1.validationEval.output).toEqual({
+  expect(text1.eval.validation).toEqual({
     errors: ['text1 does not match pattern "text1"'],
     status: null,
     warnings: [],
@@ -258,12 +259,12 @@ test('Validate all fields', async () => {
     startTimestamp: { date: 0 },
     endTimestamp: { date: 0 },
   });
-  expect(text1.validationEval.output).toEqual({
+  expect(text1.eval.validation).toEqual({
     errors: ['text1 does not match pattern "text1"'],
     status: 'error',
     warnings: [],
   });
-  expect(text2.validationEval.output).toEqual({
+  expect(text2.eval.validation).toEqual({
     errors: ['text2 does not match pattern "text2"'],
     status: 'error',
     warnings: [],
@@ -309,12 +310,12 @@ test('Validate all fields', async () => {
     startTimestamp: { date: 0 },
     endTimestamp: { date: 0 },
   });
-  expect(text1.validationEval.output).toEqual({
+  expect(text1.eval.validation).toEqual({
     errors: [],
     status: 'success',
     warnings: [],
   });
-  expect(text2.validationEval.output).toEqual({
+  expect(text2.eval.validation).toEqual({
     errors: ['text2 does not match pattern "text2"'],
     status: 'error',
     warnings: [],
@@ -349,12 +350,12 @@ test('Validate all fields', async () => {
     startTimestamp: { date: 0 },
     endTimestamp: { date: 0 },
   });
-  expect(text1.validationEval.output).toEqual({
+  expect(text1.eval.validation).toEqual({
     errors: [],
     status: 'success',
     warnings: [],
   });
-  expect(text2.validationEval.output).toEqual({
+  expect(text2.eval.validation).toEqual({
     errors: [],
     status: 'success',
     warnings: [],
@@ -424,7 +425,7 @@ test('Validate only one field', async () => {
     rootBlock,
   });
   const { button, text1, text2 } = context.RootBlocks.map;
-  expect(text1.validationEval.output).toEqual({
+  expect(text1.eval.validation).toEqual({
     errors: ['text1 does not match pattern "text1"'],
     status: null,
     warnings: [],
@@ -457,14 +458,14 @@ test('Validate only one field', async () => {
     startTimestamp: { date: 0 },
     endTimestamp: { date: 0 },
   });
-  expect(text1.validationEval.output).toEqual({
+  expect(text1.eval.validation).toEqual({
     errors: ['text1 does not match pattern "text1"'],
     status: 'error',
     warnings: [],
   });
-  expect(text2.validationEval.output).toEqual({
+  expect(text2.eval.validation).toEqual({
     errors: ['text2 does not match pattern "text2"'],
-    status: 'error',
+    status: null,
     warnings: [],
   });
   expect(displayMessage.mock.calls).toMatchInlineSnapshot(`
@@ -497,14 +498,14 @@ test('Validate only one field', async () => {
     startTimestamp: { date: 0 },
     endTimestamp: { date: 0 },
   });
-  expect(text1.validationEval.output).toEqual({
+  expect(text1.eval.validation).toEqual({
     errors: [],
     status: 'success',
     warnings: [],
   });
-  expect(text2.validationEval.output).toEqual({
+  expect(text2.eval.validation).toEqual({
     errors: ['text2 does not match pattern "text2"'],
-    status: 'error',
+    status: null,
     warnings: [],
   });
   expect(displayMessage.mock.calls).toMatchInlineSnapshot(`Array []`);
@@ -587,17 +588,17 @@ test('Validate list of fields', async () => {
   });
   const { button, text1, text2, text3 } = context.RootBlocks.map;
   text1.setValue('text1');
-  expect(text1.validationEval.output).toEqual({
+  expect(text1.eval.validation).toEqual({
     errors: [],
     status: null,
     warnings: [],
   });
-  expect(text2.validationEval.output).toEqual({
+  expect(text2.eval.validation).toEqual({
     errors: ['text2 does not match pattern "text2"'],
     status: null,
     warnings: [],
   });
-  expect(text3.validationEval.output).toEqual({
+  expect(text3.eval.validation).toEqual({
     errors: ['text3 does not match pattern "text3"'],
     status: null,
     warnings: [],
@@ -644,19 +645,19 @@ test('Validate list of fields', async () => {
   displayMessage.mockReset();
   displayMessage.mockImplementation(() => closeLoader);
   text2.setValue('text2');
-  expect(text1.validationEval.output).toEqual({
+  expect(text1.eval.validation).toEqual({
     errors: [],
     status: 'success',
     warnings: [],
   });
-  expect(text2.validationEval.output).toEqual({
+  expect(text2.eval.validation).toEqual({
     errors: [],
     status: 'success',
     warnings: [],
   });
-  expect(text3.validationEval.output).toEqual({
+  expect(text3.eval.validation).toEqual({
     errors: ['text3 does not match pattern "text3"'],
-    status: 'error',
+    status: null,
     warnings: [],
   });
   await button.triggerEvent({ name: 'onClick' });
@@ -675,9 +676,9 @@ test('Validate list of fields', async () => {
     startTimestamp: { date: 0 },
     endTimestamp: { date: 0 },
   });
-  expect(text3.validationEval.output).toEqual({
+  expect(text3.eval.validation).toEqual({
     errors: ['text3 does not match pattern "text3"'],
-    status: 'error',
+    status: null,
     warnings: [],
   });
   expect(displayMessage.mock.calls).toMatchInlineSnapshot(`Array []`);
@@ -703,7 +704,7 @@ test('Invalid Validate params', async () => {
                 {
                   id: 'validate',
                   type: 'Validate',
-                  params: { invalid: true },
+                  params: 1,
                 },
               ],
             },
@@ -725,9 +726,7 @@ test('Invalid Validate params', async () => {
     error: {
       action: {
         id: 'validate',
-        params: {
-          invalid: true,
-        },
+        params: 1,
         type: 'Validate',
       },
       error: {
@@ -808,9 +807,9 @@ test('Validate does not fail on warnings', async () => {
     rootBlock,
   });
   const { button, text1 } = context.RootBlocks.map;
-  expect(text1.validationEval.output).toEqual({
+  expect(text1.eval.validation).toEqual({
     errors: [],
-    status: 'warning',
+    status: null,
     warnings: ['text1 does not match pattern "text1"'],
   });
   await button.triggerEvent({ name: 'onClick' });
@@ -827,5 +826,357 @@ test('Validate does not fail on warnings', async () => {
     success: true,
     startTimestamp: { date: 0 },
     endTimestamp: { date: 0 },
+  });
+  expect(text1.eval.validation).toEqual({
+    errors: [],
+    status: 'warning',
+    warnings: ['text1 does not match pattern "text1"'],
+  });
+});
+
+test('Validate on nested objects using params.regex string', async () => {
+  const rootBlock = {
+    blockId: 'root',
+    meta: {
+      category: 'context',
+    },
+    areas: {
+      content: {
+        blocks: [
+          {
+            blockId: 'obj.text1',
+            type: 'TextInput',
+            meta: {
+              category: 'input',
+              valueType: 'string',
+            },
+            validate: [
+              {
+                pass: { _regex: { pattern: 'text1', key: 'text1' } },
+                message: 'text1 does not match pattern "text1"',
+              },
+            ],
+          },
+          {
+            blockId: 'text2',
+            type: 'TextInput',
+            meta: {
+              category: 'input',
+              valueType: 'string',
+            },
+            validate: [
+              {
+                pass: { _regex: { pattern: 'text2', key: 'text2' } },
+                message: 'text2 does not match pattern "text2"',
+              },
+            ],
+          },
+          {
+            blockId: 'button',
+            type: 'Button',
+            meta: {
+              category: 'display',
+            },
+            events: {
+              onClick: [
+                {
+                  id: 'validate',
+                  type: 'Validate',
+                  params: {
+                    regex: '^obj.*1$',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  };
+  const context = await testContext({
+    lowdefy,
+    rootBlock,
+  });
+  const { button, 'obj.text1': text1 } = context.RootBlocks.map;
+  expect(text1.eval.validation).toEqual({
+    errors: ['text1 does not match pattern "text1"'],
+    status: null,
+    warnings: [],
+  });
+  await button.triggerEvent({ name: 'onClick' });
+  expect(button.Events.events.onClick.history[0]).toEqual({
+    blockId: 'button',
+    error: {
+      error: { type: 'Validate', error: new Error('Your input has 1 validation error.'), index: 0 },
+      action: { id: 'validate', type: 'Validate', params: { regex: '^obj.*1$' } },
+    },
+    eventName: 'onClick',
+    responses: {
+      validate: {
+        type: 'Validate',
+        error: new Error('Your input has 1 validation error.'),
+        index: 0,
+      },
+    },
+    endTimestamp: { date: 0 },
+    startTimestamp: { date: 0 },
+    success: false,
+  });
+  expect(text1.eval.validation).toEqual({
+    errors: ['text1 does not match pattern "text1"'],
+    status: 'error',
+    warnings: [],
+  });
+});
+
+test('Validate on nested objects using params.regex array', async () => {
+  const rootBlock = {
+    blockId: 'root',
+    meta: {
+      category: 'context',
+    },
+    areas: {
+      content: {
+        blocks: [
+          {
+            blockId: 'obj.text1',
+            type: 'TextInput',
+            meta: {
+              category: 'input',
+              valueType: 'string',
+            },
+            validate: [
+              {
+                pass: { _regex: { pattern: 'text1', key: 'text1' } },
+                message: 'text1 does not match pattern "text1"',
+              },
+            ],
+          },
+          {
+            blockId: 'obj.abc1',
+            type: 'TextInput',
+            meta: {
+              category: 'input',
+              valueType: 'string',
+            },
+            validate: [
+              {
+                pass: { _regex: { pattern: 'abc1', key: 'abc1' } },
+                message: 'abc1 does not match pattern "abc1"',
+              },
+            ],
+          },
+          {
+            blockId: 'text2',
+            type: 'TextInput',
+            meta: {
+              category: 'input',
+              valueType: 'string',
+            },
+            validate: [
+              {
+                pass: { _regex: { pattern: 'text2', key: 'text2' } },
+                message: 'text2 does not match pattern "text2"',
+              },
+            ],
+          },
+          {
+            blockId: 'button',
+            type: 'Button',
+            meta: {
+              category: 'display',
+            },
+            events: {
+              onClick: [
+                {
+                  id: 'validate',
+                  type: 'Validate',
+                  params: {
+                    regex: ['^obj.*1$'],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  };
+  const context = await testContext({
+    lowdefy,
+    rootBlock,
+  });
+  const { button, text2, 'obj.text1': text1, 'obj.abc1': abc1 } = context.RootBlocks.map;
+  expect(text1.eval.validation).toEqual({
+    errors: ['text1 does not match pattern "text1"'],
+    status: null,
+    warnings: [],
+  });
+  await button.triggerEvent({ name: 'onClick' });
+  expect(button.Events.events.onClick.history[0]).toEqual({
+    blockId: 'button',
+    error: {
+      error: {
+        type: 'Validate',
+        error: new Error('Your input has 2 validation errors.'),
+        index: 0,
+      },
+      action: { id: 'validate', type: 'Validate', params: { regex: ['^obj.*1$'] } },
+    },
+    eventName: 'onClick',
+    responses: {
+      validate: {
+        type: 'Validate',
+        error: new Error('Your input has 2 validation errors.'),
+        index: 0,
+      },
+    },
+    endTimestamp: { date: 0 },
+    startTimestamp: { date: 0 },
+    success: false,
+  });
+  expect(text1.eval.validation).toEqual({
+    errors: ['text1 does not match pattern "text1"'],
+    status: 'error',
+    warnings: [],
+  });
+  expect(abc1.eval.validation).toEqual({
+    errors: ['abc1 does not match pattern "abc1"'],
+    status: 'error',
+    warnings: [],
+  });
+  expect(text2.eval.validation).toEqual({
+    errors: ['text2 does not match pattern "text2"'],
+    status: null,
+    warnings: [],
+  });
+});
+
+test('Validate on nested objects using params.regex array and blockIds', async () => {
+  const rootBlock = {
+    blockId: 'root',
+    meta: {
+      category: 'context',
+    },
+    areas: {
+      content: {
+        blocks: [
+          {
+            blockId: 'obj.text1',
+            type: 'TextInput',
+            meta: {
+              category: 'input',
+              valueType: 'string',
+            },
+            validate: [
+              {
+                pass: { _regex: { pattern: 'text1', key: 'text1' } },
+                message: 'text1 does not match pattern "text1"',
+              },
+            ],
+          },
+          {
+            blockId: 'obj.abc1',
+            type: 'TextInput',
+            meta: {
+              category: 'input',
+              valueType: 'string',
+            },
+            validate: [
+              {
+                pass: { _regex: { pattern: 'abc1', key: 'abc1' } },
+                message: 'abc1 does not match pattern "abc1"',
+              },
+            ],
+          },
+          {
+            blockId: 'text2',
+            type: 'TextInput',
+            meta: {
+              category: 'input',
+              valueType: 'string',
+            },
+            validate: [
+              {
+                pass: { _regex: { pattern: 'text2', key: 'text2' } },
+                message: 'text2 does not match pattern "text2"',
+              },
+            ],
+          },
+          {
+            blockId: 'button',
+            type: 'Button',
+            meta: {
+              category: 'display',
+            },
+            events: {
+              onClick: [
+                {
+                  id: 'validate',
+                  type: 'Validate',
+                  params: {
+                    regex: ['^obj.*t1$'],
+                    blockIds: ['text2'],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  };
+  const context = await testContext({
+    lowdefy,
+    rootBlock,
+  });
+  const { button, text2, 'obj.text1': text1, 'obj.abc1': abc1 } = context.RootBlocks.map;
+  expect(text1.eval.validation).toEqual({
+    errors: ['text1 does not match pattern "text1"'],
+    status: null,
+    warnings: [],
+  });
+  await button.triggerEvent({ name: 'onClick' });
+  expect(button.Events.events.onClick.history[0]).toEqual({
+    blockId: 'button',
+    error: {
+      error: {
+        type: 'Validate',
+        error: new Error('Your input has 2 validation errors.'),
+        index: 0,
+      },
+      action: {
+        id: 'validate',
+        type: 'Validate',
+        params: { regex: ['^obj.*t1$'], blockIds: ['text2'] },
+      },
+    },
+    event: undefined,
+    eventName: 'onClick',
+    responses: {
+      validate: {
+        type: 'Validate',
+        error: new Error('Your input has 2 validation errors.'),
+        index: 0,
+      },
+    },
+    endTimestamp: { date: 0 },
+    startTimestamp: { date: 0 },
+    success: false,
+  });
+  expect(text1.eval.validation).toEqual({
+    errors: ['text1 does not match pattern "text1"'],
+    status: 'error',
+    warnings: [],
+  });
+  expect(text2.eval.validation).toEqual({
+    errors: ['text2 does not match pattern "text2"'],
+    status: 'error',
+    warnings: [],
+  });
+  expect(abc1.eval.validation).toEqual({
+    errors: ['abc1 does not match pattern "abc1"'],
+    status: null,
+    warnings: [],
   });
 });

--- a/packages/engine/test/Actions/Wait.test.js
+++ b/packages/engine/test/Actions/Wait.test.js
@@ -29,6 +29,10 @@ const RealDate = Date;
 const mockDate = jest.fn(() => ({ date: 0 }));
 mockDate.now = jest.fn(() => 0);
 
+// Comment out to use console
+console.log = () => {};
+console.error = () => {};
+
 beforeEach(() => {
   global.Date = mockDate;
   lowdefy.auth.login.mockReset();

--- a/packages/engine/test/Block/Blocks.test.js
+++ b/packages/engine/test/Block/Blocks.test.js
@@ -1,19 +1,19 @@
 /* eslint-disable dot-notation */
 
 /*
-   Copyright 2020-2021 Lowdefy, Inc
+  Copyright 2020-2021 Lowdefy, Inc
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+      http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 */
 
 import { serializer } from '@lowdefy/helpers';

--- a/packages/engine/test/Block/validate.test.js
+++ b/packages/engine/test/Block/validate.test.js
@@ -1,27 +1,27 @@
 /*
-   Copyright 2020-2021 Lowdefy, Inc
+  Copyright 2020-2021 Lowdefy, Inc
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+      http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 */
 
 import testContext from '../testContext';
 
 const pageId = 'one';
+const match = () => true;
 const lowdefy = { pageId };
 
-// Comment out to use console.log
+// Comment out to use console
 console.log = () => {};
-// Comment out to use console.log
 console.error = () => {};
 
 test('parse validate on fields', async () => {
@@ -63,25 +63,24 @@ test('parse validate on fields', async () => {
   const { text } = context.RootBlocks.map;
 
   expect(context.state).toEqual({ text: 'a' });
-  expect(text.validationEval.output).toEqual({ errors: ["Not 'c'"], status: null, warnings: [] });
+  expect(text.eval.validation).toEqual({ errors: ["Not 'c'"], status: null, warnings: [] });
 
-  context.showValidationErrors = true;
-  context.update();
-  expect(text.validationEval.output).toEqual({
+  context.RootBlocks.validate(true, match);
+  expect(text.eval.validation).toEqual({
     errors: ["Not 'c'"],
     status: 'error',
     warnings: [],
   });
 
   text.setValue('c');
-  expect(text.validationEval.output).toEqual({
+  expect(text.eval.validation).toEqual({
     errors: ["Not 'a'"],
     status: 'error',
     warnings: [],
   });
 
   text.setValue('b');
-  expect(text.validationEval.output).toEqual({
+  expect(text.eval.validation).toEqual({
     errors: ["Not 'a'", "Not 'c'"],
     status: 'error',
     warnings: [],
@@ -121,9 +120,8 @@ test('validate should fail if parser has errors', async () => {
   });
   const { text } = context.RootBlocks.map;
 
-  context.showValidationErrors = true;
-  context.update();
-  expect(text.validationEval.output).toEqual({
+  context.RootBlocks.validate(true, match);
+  expect(text.eval.validation).toEqual({
     errors: ['Parser failed'],
     status: 'error',
     warnings: [],
@@ -168,9 +166,8 @@ test('validate, only test where parser failed should fail', async () => {
   });
   const { text } = context.RootBlocks.map;
 
-  context.showValidationErrors = true;
-  context.update();
-  expect(text.validationEval.output).toEqual({
+  context.RootBlocks.validate(true, match);
+  expect(text.eval.validation).toEqual({
     errors: ['Parser failed'],
     status: 'error',
     warnings: [],
@@ -211,20 +208,19 @@ test('parse validate, validate an object not an array', async () => {
   });
   const { text } = context.RootBlocks.map;
   expect(context.state).toEqual({ text: 'a' });
-  expect(text.validationEval.output).toEqual({ errors: ["Not 'c'"], status: null, warnings: [] });
+  expect(text.eval.validation).toEqual({ errors: ["Not 'c'"], status: null, warnings: [] });
 
-  context.showValidationErrors = true;
-  context.update();
-  expect(text.validationEval.output).toEqual({
+  context.RootBlocks.validate(true, match);
+  expect(text.eval.validation).toEqual({
     errors: ["Not 'c'"],
     status: 'error',
     warnings: [],
   });
   text.setValue('c');
-  expect(text.validationEval.output).toEqual({ errors: [], status: 'success', warnings: [] });
+  expect(text.eval.validation).toEqual({ errors: [], status: 'success', warnings: [] });
 });
 
-test('RootBlock.validate() to ignore errors where field not visible', async () => {
+test('RootBlock.validate(true, match) to ignore errors where field not visible', async () => {
   const rootBlock = {
     blockId: 'root',
     meta: {
@@ -288,14 +284,10 @@ test('RootBlock.validate() to ignore errors where field not visible', async () =
     rootBlock,
   });
   const { text, list } = context.RootBlocks.map;
-  expect(context.RootBlocks.validate()).toEqual([]);
+  expect(context.RootBlocks.validate(true, match)).toEqual([]);
 
   text.setValue('1');
-  expect(context.RootBlocks.validate()).toEqual([]);
-
-  context.showValidationErrors = true;
-  context.RootBlocks.update();
-  expect(context.RootBlocks.validate()).toEqual([
+  expect(context.RootBlocks.validate(true, match)).toEqual([
     {
       blockId: 'list',
       validation: { errors: ['Error 123'], status: 'error', warnings: [] },
@@ -303,7 +295,7 @@ test('RootBlock.validate() to ignore errors where field not visible', async () =
   ]);
 
   text.setValue('12');
-  expect(context.RootBlocks.validate()).toEqual([
+  expect(context.RootBlocks.validate(true, match)).toEqual([
     {
       blockId: 'list',
       validation: { errors: ['Error 123'], status: 'error', warnings: [] },
@@ -311,11 +303,11 @@ test('RootBlock.validate() to ignore errors where field not visible', async () =
   ]);
 
   text.setValue('123');
-  expect(context.RootBlocks.validate()).toEqual([]);
+  expect(context.RootBlocks.validate(true, match)).toEqual([]);
 
   text.setValue('12');
   list.pushItem();
-  expect(context.RootBlocks.validate()).toEqual([
+  expect(context.RootBlocks.validate(true, match)).toEqual([
     { blockId: 'list', validation: { errors: ['Error 123'], status: 'error', warnings: [] } },
     {
       blockId: 'list.0.innerText',
@@ -325,7 +317,7 @@ test('RootBlock.validate() to ignore errors where field not visible', async () =
 
   text.setValue('123');
   list.pushItem();
-  expect(context.RootBlocks.validate()).toEqual([
+  expect(context.RootBlocks.validate(true, match)).toEqual([
     {
       blockId: 'list.0.innerText',
       validation: { errors: ['Error 1234'], status: 'error', warnings: [] },
@@ -337,13 +329,13 @@ test('RootBlock.validate() to ignore errors where field not visible', async () =
   ]);
 
   text.setValue('1234');
-  expect(context.RootBlocks.validate()).toEqual([]);
+  expect(context.RootBlocks.validate(true, match)).toEqual([]);
 
   text.setValue('0');
-  expect(context.RootBlocks.validate()).toEqual([]);
+  expect(context.RootBlocks.validate(true, match)).toEqual([]);
 
   text.setValue('12');
-  expect(context.RootBlocks.validate()).toEqual([
+  expect(context.RootBlocks.validate(true, match)).toEqual([
     { blockId: 'list', validation: { errors: ['Error 123'], status: 'error', warnings: [] } },
     {
       blockId: 'list.0.innerText',
@@ -356,7 +348,7 @@ test('RootBlock.validate() to ignore errors where field not visible', async () =
   ]);
 });
 
-test('required on input to return validation error on RootBlock.validate()', async () => {
+test('required on input to return validation error on RootBlock.validate(true, match)', async () => {
   const rootBlock = {
     blockId: 'root',
     meta: {
@@ -386,18 +378,16 @@ test('required on input to return validation error on RootBlock.validate()', asy
   expect(context.state).toEqual({
     text: null,
   });
-  expect(context.RootBlocks.validate()).toEqual([]);
-  context.showValidationErrors = true;
-  expect(context.RootBlocks.validate()).toEqual([
+  expect(context.RootBlocks.validate(true, match)).toEqual([
     {
       blockId: 'text',
       validation: { errors: ['This field is required'], status: 'error', warnings: [] },
     },
   ]);
   text.setValue('a');
-  expect(context.RootBlocks.validate()).toEqual([]);
+  expect(context.RootBlocks.validate(true, match)).toEqual([]);
   text.setValue('');
-  expect(context.RootBlocks.validate()).toEqual([
+  expect(context.RootBlocks.validate(true, match)).toEqual([
     {
       blockId: 'text',
       validation: { errors: ['This field is required'], status: 'error', warnings: [] },
@@ -405,7 +395,7 @@ test('required on input to return validation error on RootBlock.validate()', asy
   ]);
 });
 
-test('required on input to return validation error with priority over validation errors on RootBlock.validate()', async () => {
+test('required on input to return validation error with priority over validation errors on RootBlock.validate(true, match)', async () => {
   const rootBlock = {
     blockId: 'root',
     meta: {
@@ -442,9 +432,7 @@ test('required on input to return validation error with priority over validation
   expect(context.state).toEqual({
     text: null,
   });
-  expect(context.RootBlocks.validate()).toEqual([]);
-  context.showValidationErrors = true;
-  expect(context.RootBlocks.validate()).toEqual([
+  expect(context.RootBlocks.validate(true, match)).toEqual([
     {
       blockId: 'text',
       validation: {
@@ -455,7 +443,7 @@ test('required on input to return validation error with priority over validation
     },
   ]);
   text.setValue('a');
-  expect(context.RootBlocks.validate()).toEqual([
+  expect(context.RootBlocks.validate(true, match)).toEqual([
     {
       blockId: 'text',
       validation: {
@@ -466,9 +454,9 @@ test('required on input to return validation error with priority over validation
     },
   ]);
   text.setValue('1234');
-  expect(context.RootBlocks.validate()).toEqual([]);
+  expect(context.RootBlocks.validate(true, match)).toEqual([]);
   text.setValue('');
-  expect(context.RootBlocks.validate()).toEqual([
+  expect(context.RootBlocks.validate(true, match)).toEqual([
     {
       blockId: 'text',
       validation: {
@@ -480,7 +468,7 @@ test('required on input to return validation error with priority over validation
   ]);
 });
 
-test('nested arrays with validate, and RootBlock.validate() returns all validation errors', async () => {
+test('nested arrays with validate, and RootBlock.validate(true, match) returns all validation errors', async () => {
   const rootBlock = {
     blockId: 'root',
     meta: {
@@ -609,11 +597,7 @@ test('nested arrays with validate, and RootBlock.validate() returns all validati
       { innerList: [], swtch: true },
     ],
   });
-  expect(context.RootBlocks.validate()).toEqual([]);
-
-  context.showValidationErrors = true;
-  context.RootBlocks.update();
-  expect(context.RootBlocks.validate()).toEqual([
+  expect(context.RootBlocks.validate(true, match)).toEqual([
     {
       blockId: 'list.0.swtch',
       validation: {
@@ -672,7 +656,7 @@ test('nested arrays with validate, and RootBlock.validate() returns all validati
     },
   ]);
   text.setValue('1');
-  expect(context.RootBlocks.validate()).toEqual([
+  expect(context.RootBlocks.validate(true, match)).toEqual([
     {
       blockId: 'list.0.swtch',
       validation: {
@@ -715,9 +699,9 @@ test('nested arrays with validate, and RootBlock.validate() returns all validati
     },
   ]);
   text.setValue('12');
-  expect(context.RootBlocks.validate()).toEqual([]);
+  expect(context.RootBlocks.validate(true, match)).toEqual([]);
   text.setValue('0');
-  expect(context.RootBlocks.validate()).toEqual([
+  expect(context.RootBlocks.validate(true, match)).toEqual([
     {
       blockId: 'list.0.swtch',
       validation: {
@@ -818,29 +802,28 @@ test('validation warnings', async () => {
   const { text } = context.RootBlocks.map;
 
   expect(context.state).toEqual({ text: 'a' });
-  expect(text.validationEval.output).toEqual({
+  expect(text.eval.validation).toEqual({
     errors: [],
-    status: 'warning',
+    status: null,
     warnings: ["Not 'c'"],
   });
 
-  context.showValidationErrors = true;
-  context.update();
-  expect(text.validationEval.output).toEqual({
+  context.RootBlocks.validate(true, match);
+  expect(text.eval.validation).toEqual({
     errors: [],
     status: 'warning',
     warnings: ["Not 'c'"],
   });
 
   text.setValue('c');
-  expect(text.validationEval.output).toEqual({
+  expect(text.eval.validation).toEqual({
     errors: [],
     status: 'warning',
     warnings: ["Not 'a'"],
   });
 
   text.setValue('b');
-  expect(text.validationEval.output).toEqual({
+  expect(text.eval.validation).toEqual({
     errors: [],
     status: 'warning',
     warnings: ["Not 'a'", "Not 'c'"],

--- a/packages/engine/test/Events.test.js
+++ b/packages/engine/test/Events.test.js
@@ -57,8 +57,9 @@ const lowdefy = {
   pageId,
 };
 
-// Comment out to use console.log
+// Comment out to use console
 console.log = () => {};
+console.error = () => {};
 
 beforeEach(() => {
   global.Date = mockDate;

--- a/packages/engine/test/Requests.test.js
+++ b/packages/engine/test/Requests.test.js
@@ -80,6 +80,10 @@ const lowdefy = {
   urlQuery: { urlQuery: true },
 };
 
+// Comment out to use console
+console.log = () => {};
+console.error = () => {};
+
 beforeEach(() => {
   mockQuery.mockReset();
   mockQuery.mockImplementation(mockQueryImp);

--- a/packages/engine/test/State.test.js
+++ b/packages/engine/test/State.test.js
@@ -18,7 +18,6 @@ import State from '../src/State';
 
 test('set', () => {
   const context = {
-    showValidationErrors: false,
     state: {},
   };
   const state = new State(context);
@@ -26,26 +25,21 @@ test('set', () => {
   expect(context.state).toEqual({ a: 1 });
 });
 
-test('resetState and clear showValidationErrors flag', () => {
+test('resetState', () => {
   const context = {
-    showValidationErrors: false,
     state: {},
   };
   const state = new State(context);
   state.freezeState();
   expect(context.state).toEqual({});
   state.set('a', 1);
-  context.showValidationErrors = true;
   expect(context.state).toEqual({ a: 1 });
-  expect(context.showValidationErrors).toEqual(true);
   state.resetState();
   expect(context.state).toEqual({});
-  expect(context.showValidationErrors).toEqual(false);
 });
 
 test('freezeState to only set when initialized is false and resetState restores frozenState', () => {
   const context = {
-    showValidationErrors: false,
     state: {},
   };
   const state = new State(context);
@@ -65,7 +59,6 @@ test('freezeState to only set when initialized is false and resetState restores 
 
 test('set on array', () => {
   const context = {
-    showValidationErrors: false,
     state: {},
   };
   const state = new State(context);
@@ -76,7 +69,6 @@ test('set on array', () => {
 
 test('set on array with nested arrays', () => {
   const context = {
-    showValidationErrors: false,
     state: {},
   };
   const state = new State(context);
@@ -89,7 +81,6 @@ test('set on array with nested arrays', () => {
 
 test('del', () => {
   const context = {
-    showValidationErrors: false,
     state: {},
   };
   const state = new State(context);
@@ -100,7 +91,6 @@ test('del', () => {
 
 test('del remove empty object', () => {
   const context = {
-    showValidationErrors: false,
     state: { a: { b: 1 } },
   };
   const state = new State(context);
@@ -111,7 +101,6 @@ test('del remove empty object', () => {
 
 test('del remove nested empty object', () => {
   const context = {
-    showValidationErrors: false,
     state: { a: { b: { c: { d: { e: 1 } } } } },
   };
   const state = new State(context);
@@ -122,7 +111,6 @@ test('del remove nested empty object', () => {
 
 test('del keep nested objects', () => {
   const context = {
-    showValidationErrors: false,
     state: { a: { b: 1, c: 2 } },
   };
   const state = new State(context);
@@ -133,7 +121,6 @@ test('del keep nested objects', () => {
 
 test('swapItems', () => {
   const context = {
-    showValidationErrors: false,
     state: {},
   };
   const state = new State(context);
@@ -144,7 +131,6 @@ test('swapItems', () => {
 
 test('removeItem', () => {
   const context = {
-    showValidationErrors: false,
     state: {},
   };
   const state = new State(context);
@@ -155,7 +141,6 @@ test('removeItem', () => {
 
 test('not an array', () => {
   const context = {
-    showValidationErrors: false,
     state: {},
   };
   const state = new State(context);
@@ -168,7 +153,6 @@ test('not an array', () => {
 
 test('out of array bounds', () => {
   const context = {
-    showValidationErrors: false,
     state: {},
   };
   const state = new State(context);
@@ -185,7 +169,6 @@ test('out of array bounds', () => {
 
 test('combinations', () => {
   const context = {
-    showValidationErrors: false,
     state: {},
   };
   const state = new State(context);

--- a/packages/engine/test/getContext.test.js
+++ b/packages/engine/test/getContext.test.js
@@ -89,7 +89,6 @@ test('create context', async () => {
   expect(context.requests).toEqual({});
   expect(context.pageId).toEqual('pageId');
   expect(context.rootBlock).toBeDefined();
-  expect(context.showValidationErrors).toEqual(false);
   expect(context.state).toEqual({});
   expect(context.update).toBeDefined();
   expect(context.updateListeners).toEqual(new Set());

--- a/packages/engine/test/testContext.js
+++ b/packages/engine/test/testContext.js
@@ -43,7 +43,6 @@ const testContext = async ({ lowdefy, rootBlock, initState = {} }) => {
     rootBlock,
     pageId: rootBlock.blockId,
     // routeHistory: [], // init new routeHistory for each test
-    showValidationErrors: false,
     state: {},
     updateListeners: new Set(),
   };


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible please:
 - Link issue via "Closes #[issue_number]
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable
-->

Closes: #737 

### What are the changes and their implications?

The `Validate` action can now be used to partially validate `state`. This enables the validation of multiple forms per page. `context.showValidationErrors` has also been removed and replaced by `block.showValidation` on a block level.  `showValidation` flags are only raised after Validation has been called on specified blocks.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
