### PR TITLE
fix(blocksAntd): Divider not to render empty title, closes #790

### DIFF
--- a/packages/blocks/blocksAntd/src/blocks/Divider/Divider.js
+++ b/packages/blocks/blocksAntd/src/blocks/Divider/Divider.js
@@ -27,7 +27,7 @@ const DividerBlock = ({ blockId, properties, methods }) => (
     type={properties.type}
     plain={properties.plain}
   >
-    <RenderHtml html={properties.title} methods={methods} />
+    {properties.title && <RenderHtml html={properties.title} methods={methods} />}
   </Divider>
 );
 

--- a/packages/blocks/blocksAntd/tests/__snapshots__/Divider.mock.test.js.snap
+++ b/packages/blocks/blocksAntd/tests/__snapshots__/Divider.mock.test.js.snap
@@ -4,16 +4,7 @@ exports[`Mock render - default - value[0] - default 1`] = `
 Array [
   Array [
     Object {
-      "children": <RenderHtml
-        methods={
-          Object {
-            "makeCssClass": [MockFunction],
-            "registerEvent": [Function],
-            "registerMethod": [Function],
-            "triggerEvent": [Function],
-          }
-        }
-      />,
+      "children": undefined,
       "dashed": undefined,
       "id": "default",
       "orientation": undefined,
@@ -30,16 +21,7 @@ exports[`Mock render - properties.dashed: true - value[0] - default 1`] = `
 Array [
   Array [
     Object {
-      "children": <RenderHtml
-        methods={
-          Object {
-            "makeCssClass": [MockFunction],
-            "registerEvent": [Function],
-            "registerMethod": [Function],
-            "triggerEvent": [Function],
-          }
-        }
-      />,
+      "children": undefined,
       "dashed": true,
       "id": "properties.dashed: true",
       "orientation": undefined,

--- a/packages/blocks/blocksAntd/tests/__snapshots__/Divider.test.js.snap
+++ b/packages/blocks/blocksAntd/tests/__snapshots__/Divider.test.js.snap
@@ -2,30 +2,18 @@
 
 exports[`Render default - value[0] 1`] = `
 <div
-  className="ant-divider ant-divider-horizontal ant-divider-with-text ant-divider-with-text-center"
+  className="ant-divider ant-divider-horizontal"
   id="default"
   role="separator"
->
-  <span
-    className="ant-divider-inner-text"
-  >
-    
-  </span>
-</div>
+/>
 `;
 
 exports[`Render properties.dashed: true - value[0] 1`] = `
 <div
-  className="ant-divider ant-divider-horizontal ant-divider-with-text ant-divider-with-text-center ant-divider-dashed"
+  className="ant-divider ant-divider-horizontal ant-divider-dashed"
   id="properties.dashed: true"
   role="separator"
->
-  <span
-    className="ant-divider-inner-text"
-  >
-    
-  </span>
-</div>
+/>
 `;
 
 exports[`Render properties.orientation: center - value[0] 1`] = `


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes #790

### What are the changes and their implications?

Divider title should only render if defined.

## Checklist

- [x] Pull request is made to the "develop" branch
- [x] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
