### PR TITLE
Axios http agent options

### DIFF
--- a/packages/docs/connections/AxiosHttp.yaml
+++ b/packages/docs/connections/AxiosHttp.yaml
@@ -59,22 +59,26 @@ _ref:
             - `headers: object`: An object with custom headers to be sent sent with the request. The object keys should be header names, and the values should be the string header values.
             - `params: object`: An object with URL parameters to be sent with the request.
             - `data: string | object`: The data to be sent as the request body. Only applicable for request methods `'put'`, `'post'`, and `'patch'`. Can be an object or a string in the format `'Country=Brasil&City=Belo Horizonte'`.
-            - `timeout: number`: Default: `0` (no timeout) - The number of milliseconds before the request times out. If the request takes longer than `timeout`, the request will be aborted. Set to `0` for no timeout.
             - `auth: object`: Indicates that HTTP Basic authorization should be used, and supplies credentials. This will set an `Authorization` header, overwriting any existing `Authorization` custom headers you have set using `headers`. Only HTTP Basic auth is configurable through this parameter, for Bearer tokens and such, use `Authorization` custom headers instead. The `auth` object should have the following fields:
               - `username: string`
               - `password: string`
-
-            - `responseType: enum`: Default: `'json'` - The type of data that the server will respond with. Options are:
-              - `'document'`
-              - `'json'`
-              - `'text'`
-            - `responseEncoding: string`: Default: `'utf8'` - Indicates encoding to use for decoding responses.
+            - `httpAgentOptions: object`: Options to pass to the Node.js [`http.Agent`](https://nodejs.org/api/http.html#http_class_http_agent) class.
+            - `httpsAgentOptions: object`: Options to pass to the Node.js [`https.Agent`](https://nodejs.org/api/http.html#http_class_http_agent) class.
             - `maxContentLength: number`: Defines the max size of the http response content allowed in bytes.
             - `maxRedirects: number`: Defines the maximum number of redirects to follow. If set to 0, no redirects will be followed.
             - `proxy: object`: Defines the hostname and port of the proxy server. The `proxy` object should have the following fields:
               - `host: string`: Host IP address (eg. `'127.0.0.1'`).
               - `port: number`: Port number.
               - `auth: object`: Object with username and password.
+            - `responseType: enum`: Default: `'json'` - The type of data that the server will respond with. Options are:
+              - `'document'`
+              - `'json'`
+              - `'text'`
+            - `responseEncoding: string`: Default: `'utf8'` - Indicates encoding to use for decoding responses.
+            - `timeout: number`: Default: `0` (no timeout) - The number of milliseconds before the request times out. If the request takes longer than `timeout`, the request will be aborted. Set to `0` for no timeout.
+            - `transformRequest: function`: A function to transform the request data before it is sent. Receives `data` and `headers` as arguments and should return the data to be sent.
+            - `transformResponse: function`: A function to transform the received data. Receives `data` as an argument and should return the transformed data.
+            - `validateStatus: function`: A function to validate whether the response should complete successfully given a status code. Receives `status` as an argument and should `true` if the status code is valid.
 
 
             #### Examples

--- a/packages/graphql/src/connections/AxiosHttp/AxiosHttp/AxiosHttp.js
+++ b/packages/graphql/src/connections/AxiosHttp/AxiosHttp/AxiosHttp.js
@@ -14,6 +14,9 @@
   limitations under the License.
 */
 
+import http from 'http';
+import https from 'https';
+
 import axios from 'axios';
 import { mergeObjects } from '@lowdefy/helpers';
 
@@ -22,6 +25,12 @@ import schema from '../AxiosHttpSchema.json';
 async function axiosHTTP({ request, connection }) {
   try {
     const config = mergeObjects([connection, request]);
+    if (config.httpAgentOptions) {
+      config.httpAgent = new http.Agent(config.httpAgentOptions);
+    }
+    if (config.httpsAgentOptions) {
+      config.httpsAgent = new https.Agent(config.httpsAgentOptions);
+    }
     const res = await axios(config);
     const { status, statusText, headers, method, path, data } = res;
     return { status, statusText, headers, method, path, data };

--- a/packages/graphql/src/connections/AxiosHttp/AxiosHttp/AxiosHttp.test.js
+++ b/packages/graphql/src/connections/AxiosHttp/AxiosHttp/AxiosHttp.test.js
@@ -125,3 +125,41 @@ test('other error', async () => {
     'The "url" argument must be of type string. Received type boolean (true)'
   );
 });
+
+test('https Agent options in request', async () => {
+  const request = {
+    url: 'https://postman-echo.com/get',
+    httpsAgentOptions: { keepAlive: true },
+  };
+  const connection = {};
+  const res = await resolver({ request, connection });
+  expect(res.headers.connection).toEqual('keep-alive');
+});
+
+test('https Agent options in connection', async () => {
+  const request = {
+    url: 'https://postman-echo.com/get',
+  };
+  const connection = { httpsAgentOptions: { keepAlive: true } };
+  const res = await resolver({ request, connection });
+  expect(res.headers.connection).toEqual('keep-alive');
+});
+
+test('http Agent options in request', async () => {
+  const request = {
+    url: 'http://postman-echo.com/get',
+    httpAgentOptions: { keepAlive: true },
+  };
+  const connection = {};
+  const res = await resolver({ request, connection });
+  expect(res.headers.connection).toEqual('keep-alive');
+});
+
+test('http Agent options in connection', async () => {
+  const request = {
+    url: 'http://postman-echo.com/get',
+  };
+  const connection = { httpAgentOptions: { keepAlive: true } };
+  const res = await resolver({ request, connection });
+  expect(res.headers.connection).toEqual('keep-alive');
+});


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes #794 

### What are the changes and their implications?

This PR adds `httpAgentOptions` and `httpsAgentOptions` to the AxiosHttp request, that can be used to specify the options passed to the Node.js `http.Agent` and `https.Agent` classes.

It also adds documentation for functions that can now be passed to AxiosHttp using the `_function` operator.

## Checklist

- [x] Pull request is made to the "develop" branch
- [x] Tests added
- [x] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed

https://www.loom.com/share/f46ef1ca2534416080266245e0bc3610