### PR TITLE
fix(blocksAntd): Fix typo in Paragraph input copyable text property.

### DIFF
--- a/packages/blocks/blocksAntd/src/blocks/MultipleSelector/MultipleSelector.json
+++ b/packages/blocks/blocksAntd/src/blocks/MultipleSelector/MultipleSelector.json
@@ -226,7 +226,7 @@
         }
       }
     },
-    "actions": {
+    "events": {
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/packages/blocks/blocksAntd/src/blocks/ParagraphInput/ParagraphInput.js
+++ b/packages/blocks/blocksAntd/src/blocks/ParagraphInput/ParagraphInput.js
@@ -46,11 +46,11 @@ const ParagraphInput = ({ blockId, events, properties, methods, value }) => {
       copyable={
         type.isObject(properties.copyable)
           ? {
-              text: properties.copyable.test || value,
+              text: properties.copyable.text || value,
               onCopy: () => {
                 methods.triggerEvent({
                   name: 'onCopy',
-                  event: { value: properties.copyable.test || value },
+                  event: { value: properties.copyable.text || value },
                 });
               },
               icon:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes None

### What are the changes and their implications?

This PR fixes a typo in the `ParagraphInput` block which would have prevented the `copyable.text` property from working

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
