### PR TITLE
fix(blocksAntd): Copyable fix added to Paragraph and Title blocks.

### DIFF
--- a/packages/blocks/blocksAntd/src/blocks/Paragraph/Paragraph.js
+++ b/packages/blocks/blocksAntd/src/blocks/Paragraph/Paragraph.js
@@ -31,11 +31,11 @@ const ParagraphBlock = ({ blockId, events, properties, methods }) => (
     copyable={
       type.isObject(properties.copyable)
         ? {
-            text: properties.copyable.text,
+            text: properties.copyable.text || properties.content,
             onCopy: () => {
               methods.triggerEvent({
                 name: 'onCopy',
-                event: { value: properties.copyable.text },
+                event: { value: properties.copyable.text || properties.content },
               });
             },
             icon:
@@ -64,7 +64,15 @@ const ParagraphBlock = ({ blockId, events, properties, methods }) => (
               )),
             tooltips: properties.copyable.tooltips,
           }
-        : properties.copyable
+        : properties.copyable && {
+            text: properties.content,
+            onCopy: () => {
+              methods.triggerEvent({
+                name: 'onCopy',
+                event: { value: properties.content },
+              });
+            },
+          }
     }
     delete={properties.delete}
     disabled={properties.disabled}

--- a/packages/blocks/blocksAntd/src/blocks/Title/Title.js
+++ b/packages/blocks/blocksAntd/src/blocks/Title/Title.js
@@ -35,11 +35,11 @@ const TitleBlock = ({ blockId, events, properties, methods }) => {
       copyable={
         type.isObject(properties.copyable)
           ? {
-              text: properties.copyable.text,
+              text: properties.copyable.text || properties.content,
               onCopy: () => {
                 methods.triggerEvent({
                   name: 'onCopy',
-                  event: { value: properties.copyable.text },
+                  event: { value: properties.copyable.text || properties.content },
                 });
               },
               icon:
@@ -68,7 +68,15 @@ const TitleBlock = ({ blockId, events, properties, methods }) => {
                 )),
               tooltips: properties.copyable.tooltips,
             }
-          : properties.copyable
+          : properties.copyable && {
+              text: properties.content,
+              onCopy: () => {
+                methods.triggerEvent({
+                  name: 'onCopy',
+                  event: { value: properties.content },
+                });
+              },
+            }
       }
       delete={properties.delete}
       disabled={properties.disabled}

--- a/packages/docs/blocks/display/Title.yaml
+++ b/packages/docs/blocks/display/Title.yaml
@@ -20,11 +20,13 @@ _ref:
     schema: ../blocks/blocksAntd/src/blocks/Title/Title.json
     filePath: blocks/display/Title.yaml
     init_state_values:
+      __type_block.properties.copyable: boolean
+      __type_block.properties.ellipsis: boolean
+      __boolean_block.properties.copyable: false
+      __boolean_block.properties.ellipsis: false
       __type_block.properties.value: number
       __number_block.properties.value: 33.3
     init_property_values:
       content: A title block.
     description_content: |
       A title component. Corresponds to html h1, h2, h3 and h4 elements.
-
-      


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?

Paragraph and Title blocks no longer return `[object object]` when copying text.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [x] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
