### PR TITLE
fix(docs): Fix AxiosHttp connection type spelling in docs.

### DIFF
--- a/packages/docs/connections/AxiosHttp.yaml
+++ b/packages/docs/connections/AxiosHttp.yaml
@@ -24,7 +24,7 @@ _ref:
         type: MarkdownWithCode
         properties:
           content: |
-            The `AxiosHTTP` connection is used to connect to APIs and web servers using HTTP or HTTPS.
+            The `AxiosHttp` connection is used to connect to APIs and web servers using HTTP or HTTPS.
 
             It uses the [axios](https://github.com/axios/axios) library.
 
@@ -35,14 +35,14 @@ _ref:
             ## Connections
 
             Connection types:
-              - AxiosHTTP
+              - AxiosHttp
 
             ## Requests
 
             Request types:
-              - AxiosHTTP
+              - AxiosHttp
 
-            ### AxiosHTTP
+            ### AxiosHttp
 
             #### Properties
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes ~#ISSUE_NUMBER~

### What are the changes and their implications?

Fixes a typo in the `AxiosHttp` connection docs where the type name was misspelled as `AxiosHTTP`.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [x] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
