### PR TITLE
fix(cli): Use renderer served from blocks server url if configured.

### DIFF
--- a/packages/cli/src/commands/dev/getExpress.js
+++ b/packages/cli/src/commands/dev/getExpress.js
@@ -57,9 +57,16 @@ async function getExpress({ context, gqlServer }) {
   // serve webpack files
   app.use(express.static(path.resolve(__dirname, 'shell')));
 
-  // serve version for renderer module federation
-  app.use('/api/dev/version', (req, res) => {
-    res.json(context.lowdefyVersion);
+  // Serve rendererRemoteEntryUrl for renderer module federation
+  app.use('/api/dev/rendererRemoteEntryUrl', (req, res) => {
+    let rendererRemoteEntryUrl;
+
+    if (context.options.blocksServerUrl) {
+      rendererRemoteEntryUrl = `${context.options.blocksServerUrl}/renderer/remoteEntry.js`;
+    } else {
+      rendererRemoteEntryUrl = `https://blocks-cdn.lowdefy.com/v${context.lowdefyVersion}/renderer/remoteEntry.js`;
+    }
+    res.json(rendererRemoteEntryUrl);
   });
 
   // Redirect all 404 to index.html with status 200

--- a/packages/cli/src/commands/dev/shell/bootstrap.js
+++ b/packages/cli/src/commands/dev/shell/bootstrap.js
@@ -18,9 +18,9 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Loading, loadWebpackFederatedModule, useDynamicScript } from '@lowdefy/block-tools';
 
-function Shell({ version }) {
+function Shell({ rendererRemoteEntryUrl }) {
   const { ready, failed } = useDynamicScript({
-    src: `https://blocks-cdn.lowdefy.com/v${version}/renderer/remoteEntry.js`,
+    src: rendererRemoteEntryUrl,
   });
 
   if (!ready) {
@@ -40,10 +40,13 @@ function Shell({ version }) {
   );
 }
 
-const getVersion = async () => {
-  return (await fetch(`/api/dev/version`)).json();
+const getRendererRemoteEntryUrl = async () => {
+  return (await fetch(`/api/dev/rendererRemoteEntryUrl`)).json();
 };
 
-getVersion().then((version) => {
-  ReactDOM.render(<Shell version={version} />, document.getElementById('root'));
+getRendererRemoteEntryUrl().then((rendererRemoteEntryUrl) => {
+  ReactDOM.render(
+    <Shell rendererRemoteEntryUrl={rendererRemoteEntryUrl} />,
+    document.getElementById('root')
+  );
 });

--- a/packages/docs/concepts/cli.yaml
+++ b/packages/docs/concepts/cli.yaml
@@ -162,6 +162,8 @@ _ref:
               - `@lowdefy/blocks-markdown` to be hosted at `{BLOCK_SERVER_URL}/blocks-markdown/`.
               - `@lowdefy/blocks-echarts` to be hosted at `{BLOCK_SERVER_URL}/blocks-echarts/`.
 
+            If you wish to run the CLI dev server, the `@lowdefy/renderer` package build artifacts (located in the `dist` directory) should also be served from `{BLOCK_SERVER_URL}/renderer/`.
+
       - _ref:
           path: templates/navigation_buttons.yaml
           vars:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes #840

### What are the changes and their implications?

See #668

If the `--blocks-server-url` CLI option is set, the `dev` command will now use the renderer component served from the configured url.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [x] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
