### PR TITLE
fix: Support .yml in lowdefy.yaml file.

### DIFF
--- a/packages/cli/src/utils/getLowdefyYaml.js
+++ b/packages/cli/src/utils/getLowdefyYaml.js
@@ -20,7 +20,10 @@ import { readFile } from '@lowdefy/node-utils';
 import YAML from 'js-yaml';
 
 async function getLowdefyYaml({ baseDirectory, command }) {
-  const lowdefyYaml = await readFile(path.resolve(baseDirectory, 'lowdefy.yaml'));
+  let lowdefyYaml = await readFile(path.resolve(baseDirectory, 'lowdefy.yaml'));
+  if (!lowdefyYaml) {
+    lowdefyYaml = await readFile(path.resolve(baseDirectory, 'lowdefy.yml'));
+  }
   if (!lowdefyYaml) {
     if (!['init', 'clean-cache'].includes(command)) {
       throw new Error(

--- a/packages/cli/src/utils/getLowdefyYaml.test.js
+++ b/packages/cli/src/utils/getLowdefyYaml.test.js
@@ -61,7 +61,10 @@ test('get version from yaml file, base dir specified', async () => {
 
 test('could not find lowdefy.yaml in cwd', async () => {
   readFile.mockImplementation((filePath) => {
-    if (filePath === path.resolve(process.cwd(), 'lowdefy.yaml')) {
+    if (
+      filePath === path.resolve(process.cwd(), 'lowdefy.yaml') ||
+      filePath === path.resolve(process.cwd(), 'lowdefy.yml')
+    ) {
       return null;
     }
     return `
@@ -75,7 +78,10 @@ test('could not find lowdefy.yaml in cwd', async () => {
 
 test('could not find lowdefy.yaml in base dir', async () => {
   readFile.mockImplementation((filePath) => {
-    if (filePath === path.resolve(process.cwd(), 'baseDir/lowdefy.yaml')) {
+    if (
+      filePath === path.resolve(process.cwd(), 'baseDir/lowdefy.yaml') ||
+      filePath === path.resolve(process.cwd(), 'baseDir/lowdefy.yml')
+    ) {
       return null;
     }
     return `
@@ -177,4 +183,17 @@ test('could not find lowdefy.yaml in base dir, command is "init" or "clean-cache
   expect(config).toEqual({
     cliConfig: {},
   });
+});
+
+test('support yml extension', async () => {
+  readFile.mockImplementation((filePath) => {
+    if (filePath === path.resolve(process.cwd(), 'lowdefy.yml')) {
+      return `
+      lowdefy: 1.0.0
+      `;
+    }
+    return null;
+  });
+  const config = await getLowdefyYaml({ baseDirectory });
+  expect(config).toEqual({ lowdefyVersion: '1.0.0', cliConfig: {} });
 });

--- a/packages/docs/concepts/lowdefy-schema.yaml
+++ b/packages/docs/concepts/lowdefy-schema.yaml
@@ -201,6 +201,10 @@ _ref:
 
             The `_ref` operator can also be extended with custom JavaScript functions. A `resolver` function can be specified, which can overwrite the default way configuration files are read from the filesystem. A `transformer` function can be used to transform the value returned by the `_ref` operator.
 
+            ## YAML file extensions
+
+            Both files with the `.yaml` and `.yml` file extensions are supported as YAML files.
+
             ## JSON instead of YAML
 
             Since you can reference JSON files, you can build your app using JSON instead of YAML files. The `lowdefy.yaml` file needs to be a YAML file, but all other configuration can be in referenced JSON files. It also makes sense to use JSON instead of YAML if you are generating configuration using code.


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes #902

### What are the changes and their implications?

The `.yml` file extension is widely used for YAML files, as we do support `.yml` files in referenced files.

`lowdefy.yml` files are now valid Lowdefy configuration files.

## Checklist

- [x] Pull request is made to the "develop" branch
- [x] Tests added
- [x] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
