### PR TITLE
fix(actions-core): Fix Throw action error message if params are not a…

### DIFF
--- a/packages/plugins/actions/actions-core/src/actions/Throw.js
+++ b/packages/plugins/actions/actions-core/src/actions/Throw.js
@@ -27,6 +27,9 @@ class ThrowActionError extends Error {
 }
 
 function Throw({ methods: { getBlockId, getPageId }, params }) {
+  if (!type.isObject(params)) {
+    throw new Error(`Invalid Throw, check action params. Received "${JSON.stringify(params)}".`);
+  }
   if (params.throw === false || type.isNone(params.throw)) {
     return;
   }

--- a/packages/plugins/actions/actions-core/src/actions/Throw.js
+++ b/packages/plugins/actions/actions-core/src/actions/Throw.js
@@ -28,10 +28,14 @@ class ThrowActionError extends Error {
 
 function Throw({ methods: { getBlockId, getPageId }, params }) {
   if (!type.isObject(params)) {
-    throw new Error(`Invalid Throw, check action params. Received "${JSON.stringify(params)}".`);
+    throw new Error(
+      `Throw action params should be an object. Received "${JSON.stringify(params)}".`
+    );
   }
-  if (params.throw === false || type.isNone(params.throw)) {
-    return;
+  if (!type.isNone(params.throw) && !type.isBoolean(params.throw)) {
+    throw new Error(
+      `Throw action "throw" param should be an boolean. Received "${JSON.stringify(params.throw)}".`
+    );
   }
   if (params.throw === true) {
     throw new ThrowActionError(params.message, {
@@ -40,7 +44,6 @@ function Throw({ methods: { getBlockId, getPageId }, params }) {
       pageId: getPageId(),
     });
   }
-  throw new Error(`Invalid Throw, check action params. Received "${JSON.stringify(params)}".`);
 }
 
 export default Throw;

--- a/packages/plugins/actions/actions-core/src/actions/Throw.test.js
+++ b/packages/plugins/actions/actions-core/src/actions/Throw.test.js
@@ -100,14 +100,14 @@ test('Throw no params', async () => {
         type: 'Throw',
       },
       error: {
-        error: new TypeError("Cannot read properties of undefined (reading 'throw')"),
+        error: new TypeError('Invalid Throw, check action params. Received "undefined".'),
         index: 0,
         type: 'Throw',
       },
     },
     responses: {
       throw: {
-        error: new TypeError("Cannot read properties of undefined (reading 'throw')"),
+        error: new TypeError('Invalid Throw, check action params. Received "undefined".'),
         type: 'Throw',
         index: 0,
       },
@@ -120,7 +120,7 @@ test('Throw no params', async () => {
     Array [
       Array [
         Object {
-          "content": "Cannot read properties of undefined (reading 'throw')",
+          "content": "Invalid Throw, check action params. Received \\"undefined\\".",
           "duration": 6,
           "status": "error",
         },

--- a/packages/plugins/actions/actions-core/src/actions/Throw.test.js
+++ b/packages/plugins/actions/actions-core/src/actions/Throw.test.js
@@ -100,14 +100,14 @@ test('Throw no params', async () => {
         type: 'Throw',
       },
       error: {
-        error: new TypeError('Invalid Throw, check action params. Received "undefined".'),
+        error: new TypeError('Throw action params should be an object. Received "undefined".'),
         index: 0,
         type: 'Throw',
       },
     },
     responses: {
       throw: {
-        error: new TypeError('Invalid Throw, check action params. Received "undefined".'),
+        error: new TypeError('Throw action params should be an object. Received "undefined".'),
         type: 'Throw',
         index: 0,
       },
@@ -120,7 +120,7 @@ test('Throw no params', async () => {
     Array [
       Array [
         Object {
-          "content": "Invalid Throw, check action params. Received \\"undefined\\".",
+          "content": "Throw action params should be an object. Received \\"undefined\\".",
           "duration": 6,
           "status": "error",
         },
@@ -129,7 +129,7 @@ test('Throw no params', async () => {
   `);
 });
 
-test('Throw throw true no message or metaData', async () => {
+test('Throw params.throw true, no message or metaData', async () => {
   const rootBlock = {
     id: 'block:root:root:0',
     blockId: 'root',
@@ -207,7 +207,7 @@ test('Throw throw true no message or metaData', async () => {
   `);
 });
 
-test('Throw throw true message no metaData', async () => {
+test('Throw params.throw true, message and  no metaData', async () => {
   const rootBlock = {
     id: 'block:root:root:0',
     blockId: 'root',
@@ -285,7 +285,7 @@ test('Throw throw true message no metaData', async () => {
   `);
 });
 
-test('Throw throw true message metaData string', async () => {
+test('Throw params.throw true, message and  metaData string', async () => {
   const rootBlock = {
     id: 'block:root:root:0',
     blockId: 'root',
@@ -371,7 +371,7 @@ test('Throw throw true message metaData string', async () => {
   `);
 });
 
-test('Throw throw true message metaData object', async () => {
+test('Throw params.throw true, message and metaData object', async () => {
   const rootBlock = {
     id: 'block:root:root:0',
     blockId: 'root',
@@ -457,7 +457,7 @@ test('Throw throw true message metaData object', async () => {
   `);
 });
 
-test('Throw throw false', async () => {
+test('Throw params.throw false', async () => {
   const rootBlock = {
     id: 'block:root:root:0',
     blockId: 'root',
@@ -513,7 +513,63 @@ test('Throw throw false', async () => {
   expect(displayMessage.mock.calls).toMatchInlineSnapshot(`Array []`);
 });
 
-test('Throw throw invalid', async () => {
+test('Throw params.throw null', async () => {
+  const rootBlock = {
+    id: 'block:root:root:0',
+    blockId: 'root',
+    meta: {
+      category: 'container',
+    },
+    areas: {
+      content: {
+        blocks: [
+          {
+            id: 'block:root:button:0',
+            blockId: 'button',
+            type: 'Button',
+            meta: {
+              category: 'display',
+            },
+            events: {
+              onClick: [
+                {
+                  id: 'throw',
+                  type: 'Throw',
+                  params: { throw: null },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  };
+  const context = await testContext({
+    lowdefy,
+    rootBlock,
+  });
+  const button = context._internal.RootBlocks.map['block:root:button:0'];
+  await button.triggerEvent({ name: 'onClick' });
+  expect(button.Events.events.onClick.history[0]).toEqual({
+    blockId: 'button',
+    bounced: false,
+    event: undefined,
+    eventName: 'onClick',
+    responses: {
+      throw: {
+        type: 'Throw',
+        response: undefined,
+        index: 0,
+      },
+    },
+    endTimestamp: { date: 0 },
+    startTimestamp: { date: 0 },
+    success: true,
+  });
+  expect(displayMessage.mock.calls).toMatchInlineSnapshot(`Array []`);
+});
+
+test('Throw params.throw should be a boolean.', async () => {
   const rootBlock = {
     id: 'block:root:root:0',
     blockId: 'root',
@@ -556,7 +612,7 @@ test('Throw throw invalid', async () => {
     error: {
       error: {
         type: 'Throw',
-        error: new Error('Invalid Throw, check action params. Received "{"throw":"invalid"}".'),
+        error: new Error('Throw action "throw" param should be an boolean. Received ""invalid"".'),
         index: 0,
       },
       action: {
@@ -570,7 +626,7 @@ test('Throw throw invalid', async () => {
     responses: {
       throw: {
         type: 'Throw',
-        error: new Error('Invalid Throw, check action params. Received "{"throw":"invalid"}".'),
+        error: new Error('Throw action "throw" param should be an boolean. Received ""invalid"".'),
         index: 0,
       },
     },
@@ -582,7 +638,7 @@ test('Throw throw invalid', async () => {
     Array [
       Array [
         Object {
-          "content": "Invalid Throw, check action params. Received \\"{\\"throw\\":\\"invalid\\"}\\".",
+          "content": "Throw action \\"throw\\" param should be an boolean. Received \\"\\"invalid\\"\\".",
           "duration": 6,
           "status": "error",
         },

--- a/packages/utils/ajv/jest.config.js
+++ b/packages/utils/ajv/jest.config.js
@@ -4,7 +4,7 @@ export default {
   collectCoverageFrom: ['src/**/*.js'],
   coverageDirectory: 'coverage',
   coveragePathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/src/index.js'],
-  coverageReporters: [['lcov', { projectRoot: '../..' }], 'text', 'clover'],
+  coverageReporters: [['lcov', { projectRoot: '../../..' }], 'text', 'clover'],
   errorOnDeprecated: true,
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/dist/'],

--- a/packages/utils/block-utils/jest.config.js
+++ b/packages/utils/block-utils/jest.config.js
@@ -4,7 +4,7 @@ export default {
   collectCoverageFrom: ['src/**/*.{js,jsx}'],
   coverageDirectory: 'coverage',
   coveragePathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/test/', '<rootDir>/src/index.js'],
-  coverageReporters: [['lcov', { projectRoot: '../..' }], 'text', 'clover'],
+  coverageReporters: [['lcov', { projectRoot: '../../..' }], 'text', 'clover'],
   errorOnDeprecated: true,
   testEnvironment: 'jsdom',
   testPathIgnorePatterns: ['<rootDir>/dist/'],

--- a/packages/utils/helpers/jest.config.js
+++ b/packages/utils/helpers/jest.config.js
@@ -4,7 +4,7 @@ export default {
   collectCoverageFrom: ['src/**/*.js'],
   coverageDirectory: 'coverage',
   coveragePathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/src/index.js'],
-  coverageReporters: [['lcov', { projectRoot: '../..' }], 'text', 'clover'],
+  coverageReporters: [['lcov', { projectRoot: '../../..' }], 'text', 'clover'],
   errorOnDeprecated: true,
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/dist/'],

--- a/packages/utils/node-utils/jest.config.js
+++ b/packages/utils/node-utils/jest.config.js
@@ -4,7 +4,7 @@ export default {
   collectCoverageFrom: ['src/**/*.js'],
   coverageDirectory: 'coverage',
   coveragePathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/src/index.js'],
-  coverageReporters: [['lcov', { projectRoot: '../..' }], 'text', 'clover'],
+  coverageReporters: [['lcov', { projectRoot: '../../..' }], 'text', 'clover'],
   errorOnDeprecated: true,
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/dist/'],

--- a/packages/utils/nunjucks/jest.config.js
+++ b/packages/utils/nunjucks/jest.config.js
@@ -4,7 +4,7 @@ export default {
   collectCoverageFrom: ['src/**/*.js'],
   coverageDirectory: 'coverage',
   coveragePathIgnorePatterns: ['<rootDir>/dist/'],
-  coverageReporters: [['lcov', { projectRoot: '../..' }], 'text', 'clover'],
+  coverageReporters: [['lcov', { projectRoot: '../../..' }], 'text', 'clover'],
   errorOnDeprecated: true,
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/dist/'],


### PR DESCRIPTION
…n object.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes ~#ISSUE_NUMBER~

### What are the changes and their implications?

The throw action now has a better error message if the params are not an object.

## Checklist

- [x] Pull request is made to the "develop" branch
- [x] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
