### PR TITLE
fix(graphql): Update AxiosHttp schema to allow for data arrays

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -74,4 +74,6 @@ packageExtensions:
     dependencies:
       webpack: "*"
 
+nodeLinker: pnp
+
 yarnPath: .yarn/releases/yarn-sources.cjs

--- a/packages/docs/connections/AxiosHttp.yaml
+++ b/packages/docs/connections/AxiosHttp.yaml
@@ -56,9 +56,9 @@ _ref:
               - `'put'`
               - `'patch'`
             - `baseURL: string`: `baseURL` will be prepended to `url` unless `url` is absolute. It can be convenient to set `baseURL` for an axios connection to pass relative URLs to requests or mutations using that connection.
-            - `headers: object`: An object with custom headers to be sent sent with the request. The object keys should be header names, and the values should be the string header values.
+            - `headers: object`: An object with custom headers to be sent with the request. The object keys should be header names, and the values should be the string header values.
             - `params: object`: An object with URL parameters to be sent with the request.
-            - `data: string | object`: The data to be sent as the request body. Only applicable for request methods `'put'`, `'post'`, and `'patch'`. Can be an object or a string in the format `'Country=Brasil&City=Belo Horizonte'`.
+            - `data: string | object | array`: The data to be sent as the request body. Only applicable for request methods `'put'`, `'post'`, and `'patch'`. Can be an object, array or a string in the format `'Country=Brasil&City=Belo Horizonte'`.
             - `auth: object`: Indicates that HTTP Basic authorization should be used, and supplies credentials. This will set an `Authorization` header, overwriting any existing `Authorization` custom headers you have set using `headers`. Only HTTP Basic auth is configurable through this parameter, for Bearer tokens and such, use `Authorization` custom headers instead. The `auth` object should have the following fields:
               - `username: string`
               - `password: string`

--- a/packages/graphql/src/connections/AxiosHttp/AxiosHttp.test.js
+++ b/packages/graphql/src/connections/AxiosHttp/AxiosHttp.test.js
@@ -69,3 +69,21 @@ test('url is not a string', () => {
     'AxiosHttp property "url" should be a string.'
   );
 });
+
+test('data is a string', () => {
+  const connection = {
+    method: 'post',
+    url: 'https://example.com/api',
+    data: 'value',
+  };
+  expect(validate({ schema, data: connection })).toEqual({ valid: true });
+});
+
+test('data is an array', () => {
+  const connection = {
+    method: 'post',
+    url: 'https://example.com/api',
+    data: [{ key: 'value' }],
+  };
+  expect(validate({ schema, data: connection })).toEqual({ valid: true });
+});

--- a/packages/graphql/src/connections/AxiosHttp/AxiosHttpSchema.json
+++ b/packages/graphql/src/connections/AxiosHttp/AxiosHttpSchema.json
@@ -12,15 +12,7 @@
     },
     "method": {
       "type": "string",
-      "enum": [
-        "get",
-        "delete",
-        "head",
-        "options",
-        "post",
-        "put",
-        "patch"
-      ],
+      "enum": ["get", "delete", "head", "options", "post", "put", "patch"],
       "description": "The request method to be used when making the request",
       "errorMessage": {
         "type": "AxiosHttp property \"method\" should be a string.",
@@ -36,7 +28,7 @@
     },
     "headers": {
       "type": "object",
-      "description": "An object with custom headers to be sent sent with the request. The object keys should be header names, and the values should be the string header values.",
+      "description": "An object with custom headers to be sent with the request. The object keys should be header names, and the values should be the string header values.",
       "errorMessage": {
         "type": "AxiosHttp property \"headers\" should be an object."
       }
@@ -49,11 +41,7 @@
       }
     },
     "data": {
-      "type": ["string", "object"],
-      "description": "The data to be sent as the request body. Only applicable for request methods 'put', 'post', and 'patch'. Can be an object or a string in the format 'Country=USA&City=New York'.",
-      "errorMessage": {
-        "type": "AxiosHttp property \"data\" should be an object or string."
-      }
+      "description": "The data to be sent as the request body. Only applicable for request methods 'put', 'post', and 'patch'. Can be an object, array or a string in the format 'Country=USA&City=New York'."
     },
     "timeout": {
       "type": "number",
@@ -81,7 +69,6 @@
             "type": "AxiosHttp property \"auth.password\" should be a string."
           }
         }
-
       },
       "errorMessage": {
         "type": "AxiosHttp property \"auth\" should be an object."
@@ -89,11 +76,7 @@
     },
     "responseType": {
       "type": "string",
-      "enum": [
-        "json",
-        "document",
-        "text"
-      ],
+      "enum": ["json", "document", "text"],
       "description": "The type of data that the server should respond with.",
       "default": "json",
       "errorMessage": {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes #1158

### What are the changes and their implications?

This PR updates the JSON Schema to allow for arrays passed to the data property, as the schema was to restrictive and was causing errors.

## Checklist

- [x] Pull request is made to the "develop" branch
- [x] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
