### PR TITLE
fix(blocks-antd): Fix confirm modal button icons, closes #1160

### DIFF
--- a/packages/docs/templates/blocks/propertiesFormTransformer.js
+++ b/packages/docs/templates/blocks/propertiesFormTransformer.js
@@ -70,7 +70,7 @@ const button = (path) => ({
   },
   properties: {
     size: 'small',
-    title: 'button:',
+    title: `${path}:`,
     inner: true,
   },
   blocks: [

--- a/packages/docs/templates/test/button.test.js
+++ b/packages/docs/templates/test/button.test.js
@@ -108,7 +108,7 @@ test('button propertiesFormTransformer', () => {
         "properties": Object {
           "inner": true,
           "size": "small",
-          "title": "button:",
+          "title": "block.properties.field:",
         },
         "type": "Card",
       },

--- a/packages/plugins/blocks/blocks-antd/src/blocks/ConfirmModal/ConfirmModal.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/ConfirmModal/ConfirmModal.js
@@ -38,8 +38,32 @@ const ConfirmModal = ({ blockId, events, content, components: { Icon }, methods,
         className: methods.makeCssClass(properties.modalStyle),
         closable: properties.closable,
         okText: properties.okText || 'Ok',
-        okButtonProps: properties.okButton,
-        cancelButtonProps: properties.cancelButton,
+        okButtonProps:
+          properties.okButton && properties.okButton.icon
+            ? {
+                ...properties.okButton,
+                icon: properties.okButton.icon && (
+                  <Icon
+                    blockId={`${blockId}_ok_icon`}
+                    events={events}
+                    properties={properties.okButton.icon}
+                  />
+                ),
+              }
+            : properties.okButton,
+        cancelButtonProps:
+          properties.cancelButton && properties.cancelButton.icon
+            ? {
+                ...properties.cancelButton,
+                icon: properties.cancelButton.icon && (
+                  <Icon
+                    blockId={`${blockId}_ok_icon`}
+                    events={events}
+                    properties={properties.cancelButton.icon}
+                  />
+                ),
+              }
+            : properties.cancelButton,
         cancelText: properties.cancelText || 'Cancel',
         centered: properties.centered || false,
         mask: properties.mask !== undefined ? properties.mask : true,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes #1160 

### What are the changes and their implications?
Icons now work for `ConfirmModal`. Fix on docs.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [x] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
