### PR TITLE
fix(client): Fix setupLink - createLink needs lowdefy for input.

### DIFF
--- a/packages/client/src/initLowdefyContext.js
+++ b/packages/client/src/initLowdefyContext.js
@@ -57,7 +57,7 @@ function initLowdefyContext({ Components, config, router, stage, types, window }
   lowdefy._internal.window = window;
   lowdefy._internal.document = window.document;
   lowdefy._internal.router = router;
-  lowdefy._internal.link = setupLink(router, window);
+  lowdefy._internal.link = setupLink(lowdefy);
   lowdefy._internal.updateBlock = (blockId) =>
     lowdefy._internal.updaters[blockId] && lowdefy._internal.updaters[blockId]();
   lowdefy._internal.components.Link = createLinkComponent(lowdefy, Components.Link);

--- a/packages/client/src/setupLink.js
+++ b/packages/client/src/setupLink.js
@@ -16,7 +16,8 @@
 
 import { createLink } from '@lowdefy/engine';
 
-function setupLink(router, window) {
+function setupLink(lowdefy) {
+  const { router, window } = lowdefy._internal;
   const backLink = () => router.back();
   const disabledLink = () => {};
   const newOriginLink = ({ url, query, newTab }) => {
@@ -30,7 +31,7 @@ function setupLink(router, window) {
     if (newTab) {
       return window
         .open(
-          `${window.location.origin}${router.basePath}${pathname}${query ? `?${query}` : ''}`,
+          `${window.location.origin}${lowdefy.basePath}${pathname}${query ? `?${query}` : ''}`,
           '_blank'
         )
         .focus();
@@ -45,7 +46,7 @@ function setupLink(router, window) {
   const noLink = () => {
     throw new Error(`Invalid Link.`);
   };
-  return createLink({ backLink, disabledLink, router, newOriginLink, noLink, sameOriginLink });
+  return createLink({ backLink, disabledLink, lowdefy, newOriginLink, noLink, sameOriginLink });
 }
 
 export default setupLink;


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes ~#ISSUE_NUMBER~

### What are the changes and their implications?

The `createLink` function needs access to the `lowdefy` object to be able to set inputs. This was removed in a previous change to the `setupLink` function. This PR restores the previous `setupLink` function.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
