### PR TITLE
fix(server-dev): Fix dev server not running next build.

### DIFF
--- a/packages/server-dev/manager/watchers/envWatcher.mjs
+++ b/packages/server-dev/manager/watchers/envWatcher.mjs
@@ -26,8 +26,8 @@ function envWatcher(context) {
   };
   return setupWatcher({
     callback,
-    watchPaths: [path.join(context.directories.config, '.env')],
     watchDotfiles: true,
+    watchPaths: [path.join(context.directories.config, '.env')],
   });
 }
 

--- a/packages/server-dev/manager/watchers/nextBuildWatcher.mjs
+++ b/packages/server-dev/manager/watchers/nextBuildWatcher.mjs
@@ -83,6 +83,7 @@ async function nextBuildWatcher(context) {
 
   return setupWatcher({
     callback,
+    watchDotfiles: true,
     watchPaths: [
       path.join(context.directories.build, 'plugins'),
       path.join(context.directories.build, 'config.json'),


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes ~#ISSUE_NUMBER~

### What are the changes and their implications?

By default, `setupWatcher` ignores dotfiles, and directories that start with a `.`. But the lowdefy build outputs are in `.lowdefy/dev` directory, and therefore dotfiles should not be ignored.

## Checklist

- [ ] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [ ] Code has been formatted with Prettier
- [ ] Edits from maintainers are allowed
