### PR TITLE
fix(server-dev): Fix react hooks used incorrectly.

### DIFF
--- a/packages/server-dev/lib/Page.js
+++ b/packages/server-dev/lib/Page.js
@@ -24,11 +24,11 @@ import usePageConfig from './utils/usePageConfig.js';
 
 const Page = ({ Components, config, pageId, resetContext, router, types }) => {
   const { data: session, status } = useSession();
+  const { data: pageConfig } = usePageConfig(pageId, router.basePath);
 
   if (status === 'loading') {
     return '';
   }
-  const { data: pageConfig } = usePageConfig(pageId, router.basePath);
   if (!pageConfig) {
     router.replace(`/404`);
     return '';


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes ~#ISSUE_NUMBER~

### What are the changes and their implications?

The `usePageConfig` was being used after a conditional return statement, resulting in a `Rendered more hooks than during the previous render.` react error.

## Checklist

- [X] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
