### PR TITLE
fix(client): On mount async method should always be called.

### DIFF
--- a/packages/client/src/MountEvents.js
+++ b/packages/client/src/MountEvents.js
@@ -30,8 +30,7 @@ const MountEvents = ({ children, context, triggerEvent, triggerEventAsync }) => 
         setError(err);
       }
     };
-    mount(); // TODO: check only run once.
-    return () => {};
+    mount();
   }, [context]);
 
   if (error) throw error;

--- a/packages/client/src/MountEvents.js
+++ b/packages/client/src/MountEvents.js
@@ -20,23 +20,18 @@ const MountEvents = ({ children, context, triggerEvent, triggerEventAsync }) => 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   useEffect(() => {
-    let mounted = true;
     setLoading(true);
     const mount = async () => {
       try {
         await triggerEvent();
-        if (mounted) {
-          triggerEventAsync();
-          setLoading(false);
-        }
+        triggerEventAsync();
+        setLoading(false);
       } catch (err) {
         setError(err);
       }
     };
     mount(); // TODO: check only run once.
-    return () => {
-      mounted = false;
-    };
+    return () => {};
   }, [context]);
 
   if (error) throw error;


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes ~#ISSUE_NUMBER~

### What are the changes and their implications?

The onMount async event was not triggered if the block was unmounted before the event started. This caused an issue because the progress bar done event was not dispatched. The `onMountAsync` and `onInitAsync` event will now always be triggered, even if the block is unmounted before the event is started.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
