### PR TITLE
feat(engine): Set request to null and update before calling request.

### DIFF
--- a/packages/api/src/routes/request/callRequest.js
+++ b/packages/api/src/routes/request/callRequest.js
@@ -27,9 +27,12 @@ import getRequestConfig from './getRequestConfig.js';
 import getRequestResolver from './getRequestResolver.js';
 import validateSchemas from './validateSchemas.js';
 
-async function callRequest(context, { pageId, payload, requestId }) {
+async function callRequest(context, { blockId, pageId, payload, requestId }) {
   const { logger } = context;
-  logger.debug({ route: 'request', params: { pageId, payload, requestId } }, 'Started request');
+  logger.debug(
+    { route: 'request', params: { blockId, pageId, payload, requestId } },
+    'Started request'
+  );
   const requestConfig = await getRequestConfig(context, { pageId, requestId });
   const connectionConfig = await getConnectionConfig(context, { requestConfig });
   authorizeRequest(context, { requestConfig });

--- a/packages/engine/src/Requests.js
+++ b/packages/engine/src/Requests.js
@@ -30,11 +30,11 @@ class Requests {
     });
   }
 
-  callRequests({ actions, arrayIndices, event, params } = {}) {
+  callRequests({ actions, arrayIndices, blockId, event, params } = {}) {
     if (type.isObject(params) && params.all === true) {
       return Promise.all(
         Object.keys(this.requestConfig).map((requestId) =>
-          this.callRequest({ requestId, event, arrayIndices })
+          this.callRequest({ arrayIndices, blockId, event, requestId })
         )
       );
     }
@@ -44,68 +44,70 @@ class Requests {
     if (type.isArray(params)) requestIds = params;
 
     const requests = requestIds.map((requestId) =>
-      this.callRequest({ actions, requestId, event, arrayIndices })
+      this.callRequest({ actions, requestId, blockId, event, arrayIndices })
     );
     this.context._internal.update(); // update to render request reset
     return Promise.all(requests);
   }
 
-  callRequest({ actions, arrayIndices, event, requestId }) {
-    const request = this.requestConfig[requestId];
-    if (!request) {
-      const error = new Error(`Configuration Error: Request ${requestId} not defined on page.`);
-      this.context.requests[requestId] = {
-        loading: false,
-        response: null,
-        error: [error],
-      };
-      return Promise.reject(error);
+  async callRequest({ actions, arrayIndices, blockId, event, requestId }) {
+    const requestConfig = this.requestConfig[requestId];
+    if (!this.context.requests[requestId]) {
+      this.context.requests[requestId] = [];
     }
-
-    // reset request to init loading state
-    this.context.requests[requestId] = {
-      loading: true,
-      response: null,
-      error: this.context.requests[requestId] ? this.context.requests[requestId].error : [],
-    };
-
+    if (!requestConfig) {
+      const error = new Error(`Configuration Error: Request ${requestId} not defined on page.`);
+      this.context.requests[requestId].unshift({
+        blockId: 'block_id',
+        error,
+        loading: false,
+        requestId,
+        response: null,
+      });
+      throw error;
+    }
     const { output: payload, errors: parserErrors } = this.context._internal.parser.parse({
       actions,
       event,
       arrayIndices,
-      input: request.payload,
+      input: requestConfig.payload,
       location: requestId,
     });
-
-    // TODO: We are throwing this error differently to the request does not exist error
     if (parserErrors.length > 0) {
       throw parserErrors[0];
     }
-
-    return this.fetch({ requestId, payload });
+    const request = {
+      blockId,
+      loading: true,
+      payload,
+      requestId,
+      response: null,
+    };
+    this.context.requests[requestId].unshift(request);
+    return this.fetch(request);
   }
 
-  async fetch({ requestId, payload }) {
-    this.context.requests[requestId].loading = true;
-
+  async fetch(request) {
+    request.loading = true;
     try {
       const response = await this.context._internal.lowdefy._internal.callRequest({
+        blockId: request.blockId,
         pageId: this.context.pageId,
-        payload: serializer.serialize(payload),
-        requestId,
+        payload: serializer.serialize(request.payload),
+        requestId: request.requestId,
       });
       const deserializedResponse = serializer.deserialize(
         get(response, 'response', {
           default: null,
         })
       );
-      this.context.requests[requestId].response = deserializedResponse;
-      this.context.requests[requestId].loading = false;
+      request.response = deserializedResponse;
+      request.loading = false;
       this.context._internal.update();
       return deserializedResponse;
     } catch (error) {
-      this.context.requests[requestId].error.unshift(error);
-      this.context.requests[requestId].loading = false;
+      request.error = error;
+      request.loading = false;
       this.context._internal.update();
       throw error;
     }

--- a/packages/engine/src/actions/createGetRequestDetails.test.js
+++ b/packages/engine/src/actions/createGetRequestDetails.test.js
@@ -116,11 +116,15 @@ test('getRequestDetails params is true', async () => {
       },
       b: {
         response: {
-          req_one: {
-            error: [],
-            loading: false,
-            response: 1,
-          },
+          req_one: [
+            {
+              blockId: 'button',
+              loading: false,
+              payload: {},
+              requestId: 'req_one',
+              response: 1,
+            },
+          ],
         },
         index: 1,
         type: 'Action',
@@ -177,11 +181,15 @@ test('getRequestDetails params is req_one', async () => {
         type: 'Request',
       },
       b: {
-        response: {
-          error: [],
-          loading: false,
-          response: 1,
-        },
+        response: [
+          {
+            blockId: 'button',
+            loading: false,
+            payload: {},
+            requestId: 'req_one',
+            response: 1,
+          },
+        ],
         index: 1,
         type: 'Action',
       },
@@ -366,11 +374,15 @@ test('getRequestDetails params.all is true', async () => {
       },
       b: {
         response: {
-          req_one: {
-            error: [],
-            loading: false,
-            response: 1,
-          },
+          req_one: [
+            {
+              blockId: 'button',
+              loading: false,
+              payload: {},
+              requestId: 'req_one',
+              response: 1,
+            },
+          ],
         },
         index: 1,
         type: 'Action',
@@ -505,11 +517,15 @@ test('getRequestDetails params.key is req_one', async () => {
         type: 'Request',
       },
       b: {
-        response: {
-          error: [],
-          loading: false,
-          response: 1,
-        },
+        response: [
+          {
+            blockId: 'button',
+            loading: false,
+            payload: {},
+            requestId: 'req_one',
+            response: 1,
+          },
+        ],
         index: 1,
         type: 'Action',
       },

--- a/packages/engine/src/actions/createRequest.js
+++ b/packages/engine/src/actions/createRequest.js
@@ -14,9 +14,15 @@
   limitations under the License.
 */
 
-function createRequest({ actions, arrayIndices, context, event }) {
+function createRequest({ actions, arrayIndices, blockId, context, event }) {
   return async function request(params) {
-    return await context._internal.Requests.callRequests({ actions, arrayIndices, event, params });
+    return await context._internal.Requests.callRequests({
+      actions,
+      arrayIndices,
+      blockId,
+      event,
+      params,
+    });
   };
 }
 

--- a/packages/engine/src/actions/createRequest.test.js
+++ b/packages/engine/src/actions/createRequest.test.js
@@ -101,11 +101,15 @@ test('Request call one request', async () => {
   });
   const button = context._internal.RootBlocks.map['button'];
   const promise = button.triggerEvent({ name: 'onClick' });
-  expect(context.requests.req_one).toEqual({
-    error: [],
-    loading: true,
-    response: null,
-  });
+  expect(context.requests.req_one).toEqual([
+    {
+      blockId: 'button',
+      loading: true,
+      payload: {},
+      requestId: 'req_one',
+      response: null,
+    },
+  ]);
   const res = await promise;
   expect(res).toEqual({
     blockId: 'button',
@@ -137,6 +141,9 @@ test('Request call all requests', async () => {
       {
         id: 'req_two',
         type: 'Fetch',
+        payload: {
+          x: 1,
+        },
       },
     ],
     blocks: [
@@ -156,29 +163,49 @@ test('Request call all requests', async () => {
   const button = context._internal.RootBlocks.map['button'];
   const promise = button.triggerEvent({ name: 'onClick' });
   expect(context.requests).toEqual({
-    req_one: {
-      error: [],
-      loading: true,
-      response: null,
-    },
-    req_two: {
-      error: [],
-      loading: true,
-      response: null,
-    },
+    req_one: [
+      {
+        blockId: 'button',
+        loading: true,
+        payload: {},
+        requestId: 'req_one',
+        response: null,
+      },
+    ],
+    req_two: [
+      {
+        blockId: 'button',
+        loading: true,
+        payload: {
+          x: 1,
+        },
+        requestId: 'req_two',
+        response: null,
+      },
+    ],
   });
   const res = await promise;
   expect(context.requests).toEqual({
-    req_one: {
-      error: [],
-      loading: false,
-      response: 1,
-    },
-    req_two: {
-      error: [],
-      loading: false,
-      response: 2,
-    },
+    req_one: [
+      {
+        blockId: 'button',
+        loading: false,
+        payload: {},
+        requestId: 'req_one',
+        response: 1,
+      },
+    ],
+    req_two: [
+      {
+        blockId: 'button',
+        loading: false,
+        payload: {
+          x: 1,
+        },
+        requestId: 'req_two',
+        response: 2,
+      },
+    ],
   });
   expect(res).toEqual({
     blockId: 'button',
@@ -210,6 +237,7 @@ test('Request call array of requests', async () => {
       {
         id: 'req_two',
         type: 'Fetch',
+        payload: { x: 1 },
       },
     ],
     blocks: [
@@ -229,29 +257,49 @@ test('Request call array of requests', async () => {
   const button = context._internal.RootBlocks.map['button'];
   const promise = button.triggerEvent({ name: 'onClick' });
   expect(context.requests).toEqual({
-    req_one: {
-      error: [],
-      loading: true,
-      response: null,
-    },
-    req_two: {
-      error: [],
-      loading: true,
-      response: null,
-    },
+    req_one: [
+      {
+        blockId: 'button',
+        loading: true,
+        payload: {},
+        requestId: 'req_one',
+        response: null,
+      },
+    ],
+    req_two: [
+      {
+        blockId: 'button',
+        loading: true,
+        payload: {
+          x: 1,
+        },
+        requestId: 'req_two',
+        response: null,
+      },
+    ],
   });
   const res = await promise;
   expect(context.requests).toEqual({
-    req_one: {
-      error: [],
-      loading: false,
-      response: 1,
-    },
-    req_two: {
-      error: [],
-      loading: false,
-      response: 2,
-    },
+    req_one: [
+      {
+        blockId: 'button',
+        loading: false,
+        payload: {},
+        requestId: 'req_one',
+        response: 1,
+      },
+    ],
+    req_two: [
+      {
+        blockId: 'button',
+        loading: false,
+        payload: {
+          x: 1,
+        },
+        requestId: 'req_two',
+        response: 2,
+      },
+    ],
   });
   expect(res).toEqual({
     blockId: 'button',
@@ -283,6 +331,7 @@ test('Request pass if params are none', async () => {
       {
         id: 'req_two',
         type: 'Fetch',
+        payload: { x: 1 },
       },
     ],
     blocks: [
@@ -330,11 +379,16 @@ test('Request call request error', async () => {
   });
   const button = context._internal.RootBlocks.map['button'];
   const res = await button.triggerEvent({ name: 'onClick' });
-  expect(context.requests.req_error).toEqual({
-    error: [new Error('Request error')],
-    loading: false,
-    response: null,
-  });
+  expect(context.requests.req_error).toEqual([
+    {
+      blockId: 'button',
+      error: new Error('Request error'),
+      loading: false,
+      payload: {},
+      requestId: 'req_error',
+      response: null,
+    },
+  ]);
   expect(res).toEqual({
     blockId: 'button',
     bounced: false,

--- a/packages/engine/test/Requests.test.js
+++ b/packages/engine/test/Requests.test.js
@@ -294,6 +294,23 @@ test('update function should be called', async () => {
   expect(updateFunction).toHaveBeenCalledTimes(1);
 });
 
+test('update function should be called before all requests are fired and once for every request return', async () => {
+  const pageConfig = getPageConfig();
+  const updateFunction = jest.fn();
+  const context = await testContext({
+    lowdefy,
+    pageConfig,
+  });
+  context._internal.update = updateFunction;
+  await context._internal.Requests.callRequests({
+    actions: { params: ['req_one', 'req_two'] },
+    arrayIndices,
+    event,
+    params: { all: true },
+  });
+  expect(updateFunction).toHaveBeenCalledTimes(3);
+});
+
 test('update function should be called if error', async () => {
   const pageConfig = getPageConfig();
   const updateFunction = jest.fn();

--- a/packages/engine/test/getContext.test.js
+++ b/packages/engine/test/getContext.test.js
@@ -91,7 +91,6 @@ test('page is required input', async () => {
 });
 
 test('memoize context and reset', async () => {
-  const resetContext = { reset: true, setReset: () => {} };
   const lowdefy = getLowdefy();
   const page = {
     id: 'pageId',

--- a/packages/plugins/operators/operators-js/src/operators/client/request.js
+++ b/packages/plugins/operators/operators-js/src/operators/client/request.js
@@ -26,12 +26,12 @@ function _request({ arrayIndices, params, requests, location }) {
   }
   const splitKey = params.split('.');
   const [requestId, ...keyParts] = splitKey;
-  if (requestId in requests && !requests[requestId].loading) {
+  if (requestId in requests && !requests[requestId][0].loading) {
     if (splitKey.length === 1) {
-      return serializer.copy(requests[requestId].response);
+      return serializer.copy(requests[requestId][0].response);
     }
     const key = keyParts.reduce((acc, value) => (acc === '' ? value : acc.concat('.', value)), '');
-    return get(requests[requestId].response, applyArrayIndices(arrayIndices, key), {
+    return get(requests[requestId][0].response, applyArrayIndices(arrayIndices, key), {
       copy: true,
       default: null,
     });

--- a/packages/plugins/operators/operators-js/src/operators/client/request.test.js
+++ b/packages/plugins/operators/operators-js/src/operators/client/request.test.js
@@ -56,21 +56,27 @@ const context = {
   eventLog: [{ eventLog: true }],
   id: 'id',
   requests: {
-    arr: {
-      response: [{ a: 'request a1' }, { a: 'request a2' }],
-      loading: false,
-      error: [],
-    },
-    number: {
-      response: 500,
-      loading: false,
-      error: [],
-    },
-    string: {
-      response: 'request String',
-      loading: false,
-      error: [],
-    },
+    arr: [
+      {
+        response: [{ a: 'request a1' }, { a: 'request a2' }],
+        loading: false,
+        error: [],
+      },
+    ],
+    number: [
+      {
+        response: 500,
+        loading: false,
+        error: [],
+      },
+    ],
+    string: [
+      {
+        response: 'request String',
+        loading: false,
+        error: [],
+      },
+    ],
   },
   state: { state: true },
 };

--- a/packages/server-dev/pages/api/request/[pageId]/[requestId].js
+++ b/packages/server-dev/pages/api/request/[pageId]/[requestId].js
@@ -36,9 +36,9 @@ export default async function handler(req, res) {
       session,
     });
 
-    const { pageId, requestId } = req.query;
+    const { blockId, pageId, requestId } = req.query;
     const { payload } = req.body;
-    const response = await callRequest(apiContext, { pageId, payload, requestId });
+    const response = await callRequest(apiContext, { blockId, pageId, payload, requestId });
     res.status(200).json(response);
   } catch (error) {
     res.status(500).json({ name: error.name, message: error.message });

--- a/packages/server/pages/api/request/[pageId]/[requestId].js
+++ b/packages/server/pages/api/request/[pageId]/[requestId].js
@@ -38,9 +38,9 @@ export default async function handler(req, res) {
       session,
     });
 
-    const { pageId, requestId } = req.query;
+    const { blockId, pageId, requestId } = req.query;
     const { payload } = req.body;
-    const response = await callRequest(apiContext, { pageId, payload, requestId });
+    const response = await callRequest(apiContext, { blockId, pageId, payload, requestId });
     res.status(200).json(response);
   } catch (error) {
     res.status(500).json({ name: error.name, message: error.message });


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?
When a request is called, set the `response` to `null` before firing request and call update. This makes loading states on requests easy to implement. Also add payload and blockId to `[context.requests[requestId]`.

## Checklist

- [x] Pull request is made to the "develop" branch
- [x] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
