### PR TITLE
fix: Allow cellRenderer in Aggrid to render html.

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -3113,6 +3113,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@emotion/jest", "virtual:573fe255dffc9c89f4f7aa60da718603753ee98acc55d6772bbd0ebdcf07f9183fb8e54b4f3f2246c538a14ead402db8d2e076039c667d1538702638a0cc87b8#npm:11.9.1"],\
             ["@lowdefy/block-dev", "workspace:packages/utils/block-dev"],\
             ["@lowdefy/block-utils", "workspace:packages/utils/block-utils"],\
+            ["@lowdefy/helpers", "workspace:packages/utils/helpers"],\
             ["@lowdefy/jest-yaml-transform", "workspace:packages/utils/jest-yaml-transform"],\
             ["@swc/cli", "virtual:babee6e81435a5d101529cd67f2c6b175f4db37a4ab0b58df15adf73dd11be8917ac14caf44ab4e6882a92c61661055072365b349016e85173e049f006fc2305#npm:0.1.57"],\
             ["@swc/core", "npm:1.2.194"],\
@@ -3917,6 +3918,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@lowdefy/server-dev", "workspace:packages/server-dev"],\
             ["@lowdefy/actions-core", "workspace:packages/plugins/actions/actions-core"],\
             ["@lowdefy/api", "workspace:packages/api"],\
+            ["@lowdefy/blocks-aggrid", "workspace:packages/plugins/blocks/blocks-aggrid"],\
             ["@lowdefy/blocks-antd", "workspace:packages/plugins/blocks/blocks-antd"],\
             ["@lowdefy/blocks-basic", "workspace:packages/plugins/blocks/blocks-basic"],\
             ["@lowdefy/blocks-color-selectors", "workspace:packages/plugins/blocks/blocks-color-selectors"],\

--- a/packages/plugins/blocks/blocks-aggrid/package.json
+++ b/packages/plugins/blocks/blocks-aggrid/package.json
@@ -55,6 +55,7 @@
     "@ag-grid-community/core": "27.3.0",
     "@ag-grid-community/react": "27.3.0",
     "@lowdefy/block-utils": "4.0.0-alpha.17",
+    "@lowdefy/helpers": "4.0.0-alpha.17",
     "react": "18.1.0",
     "react-dom": "18.1.0"
   },

--- a/packages/plugins/blocks/blocks-aggrid/src/AgGrid.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/AgGrid.js
@@ -18,6 +18,8 @@ import React from 'react';
 
 import { AgGridReact } from '@ag-grid-community/react';
 import { AllCommunityModules } from '@ag-grid-community/all-modules';
+import { renderHtml } from '@lowdefy/block-utils';
+import { type } from '@lowdefy/helpers';
 
 class AgGrid extends React.Component {
   constructor(props) {
@@ -121,10 +123,24 @@ class AgGrid extends React.Component {
   }
 
   render() {
-    const { quickFilterValue, ...someProperties } = this.props.properties;
+    const { quickFilterValue, columnDefs, ...someProperties } = this.props.properties;
     if (quickFilterValue && quickFilterValue === '') {
       this.gridApi.setQuickFilter(quickFilterValue); // check if empty string matches all
     }
+    const newColDefs = (columnDefs || []).map((col) => {
+      if (type.isFunction(col.cellRenderer)) {
+        return {
+          ...col,
+          cellRenderer: (params) => {
+            return renderHtml({
+              html: col.cellRenderer(params),
+              methods: this.props.methods,
+            });
+          },
+        };
+      }
+      return col;
+    });
     return (
       <AgGridReact
         onFilterChanged={this.onFilterChanged}
@@ -134,6 +150,7 @@ class AgGrid extends React.Component {
         onCellClicked={this.onCellClicked}
         onGridReady={this.onGridReady}
         modules={AllCommunityModules}
+        columnDefs={newColDefs}
         {...someProperties}
       />
     );

--- a/packages/plugins/blocks/blocks-aggrid/src/AgGridInput.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/AgGridInput.js
@@ -18,6 +18,8 @@ import React from 'react';
 
 import { AgGridReact } from '@ag-grid-community/react';
 import { AllCommunityModules } from '@ag-grid-community/all-modules';
+import { renderHtml } from '@lowdefy/block-utils';
+import { type } from '@lowdefy/helpers';
 
 class AgGridInput extends React.Component {
   constructor(props) {
@@ -170,10 +172,24 @@ class AgGridInput extends React.Component {
   }
 
   render() {
-    const { quickFilterValue, ...someProperties } = this.props.properties;
+    const { quickFilterValue, columnDefs, ...someProperties } = this.props.properties;
     if (quickFilterValue && quickFilterValue === '') {
       this.gridApi.setQuickFilter(quickFilterValue); // check if empty string matches all
     }
+    const newColDefs = (columnDefs || []).map((col) => {
+      if (type.isFunction(col.cellRenderer)) {
+        return {
+          ...col,
+          cellRenderer: (params) => {
+            return renderHtml({
+              html: col.cellRenderer(params),
+              methods: this.props.methods,
+            });
+          },
+        };
+      }
+      return col;
+    });
     return (
       <AgGridReact
         onSelectionChanged={this.onSelectionChanged}
@@ -185,6 +201,7 @@ class AgGridInput extends React.Component {
         onCellValueChanged={this.onCellValueChanged}
         postSort={this.postSort}
         modules={AllCommunityModules}
+        columnDefs={newColDefs}
         {...someProperties}
         rowData={this.props.value}
       />

--- a/packages/server-dev/package.json
+++ b/packages/server-dev/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@lowdefy/actions-core": "4.0.0-alpha.17",
     "@lowdefy/api": "4.0.0-alpha.17",
+    "@lowdefy/blocks-aggrid": "4.0.0-alpha.17",
     "@lowdefy/blocks-antd": "4.0.0-alpha.17",
     "@lowdefy/blocks-basic": "4.0.0-alpha.17",
     "@lowdefy/blocks-color-selectors": "4.0.0-alpha.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2224,6 +2224,7 @@ __metadata:
     "@emotion/jest": 11.9.1
     "@lowdefy/block-dev": 4.0.0-alpha.17
     "@lowdefy/block-utils": 4.0.0-alpha.17
+    "@lowdefy/helpers": 4.0.0-alpha.17
     "@lowdefy/jest-yaml-transform": 4.0.0-alpha.17
     "@swc/cli": 0.1.57
     "@swc/core": 1.2.194
@@ -2923,6 +2924,7 @@ __metadata:
   dependencies:
     "@lowdefy/actions-core": 4.0.0-alpha.17
     "@lowdefy/api": 4.0.0-alpha.17
+    "@lowdefy/blocks-aggrid": 4.0.0-alpha.17
     "@lowdefy/blocks-antd": 4.0.0-alpha.17
     "@lowdefy/blocks-basic": 4.0.0-alpha.17
     "@lowdefy/blocks-color-selectors": 4.0.0-alpha.17


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?
AgGrid removed support for rendering html strings in v27. This PR uses lowdefy `renderHtml` to render dompurified html in AgGrid cells.
See https://github.com/ag-grid/ag-grid/issues/5226

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
