### PR TITLE
Fix url query

### DIFF
--- a/packages/client/src/initLowdefyContext.js
+++ b/packages/client/src/initLowdefyContext.js
@@ -14,8 +14,6 @@
   limitations under the License.
 */
 
-import { urlQuery } from '@lowdefy/helpers';
-
 import callRequest from './callRequest.js';
 import createIcon from './createIcon.js';
 import createAuthMethods from './auth/createAuthMethods.js';
@@ -53,9 +51,7 @@ function initLowdefyContext({ auth, Components, config, router, stage, types, wi
   lowdefy.lowdefyGlobal = config.rootConfig.lowdefyGlobal;
   lowdefy.menus = config.rootConfig.menus;
   lowdefy.pageId = config.pageConfig.pageId;
-  lowdefy.urlQuery = urlQuery.parse(window.location.search.slice(1));
   lowdefy.user = auth?.session?.user ?? null;
-
   lowdefy._internal.globals = {
     document: window.document,
     fetch: window.fetch,

--- a/packages/engine/src/actions/createGetUrlQuery.js
+++ b/packages/engine/src/actions/createGetUrlQuery.js
@@ -15,13 +15,22 @@
 */
 
 import getFromObject from './getFromObject.js';
+import { urlQuery } from '@lowdefy/helpers';
 
 function createGetUrlQuery({ arrayIndices, blockId, context }) {
   return function getUrlQuery(params) {
+    const { window } = context._internal.lowdefy._internal.globals;
+    if (!window?.location) {
+      throw new Error(
+        `Browser window.location not available for getUrlQuery. Received: ${JSON.stringify(
+          params
+        )} on blockId: ${blockId}.`
+      );
+    }
     return getFromObject({
       arrayIndices,
       location: blockId,
-      object: context._internal.lowdefy.urlQuery,
+      object: urlQuery.parse(window.location.search.slice(1)),
       method: 'getUrlQuery',
       params,
     });

--- a/packages/engine/src/actions/createGetUrlQuery.test.js
+++ b/packages/engine/src/actions/createGetUrlQuery.test.js
@@ -24,9 +24,9 @@ const lowdefy = {
         return getUrlQuery(params);
       },
     },
-  },
-  urlQuery: {
-    some: 'data',
+    globals: {
+      window: { location: { search: '?some=data' } },
+    },
   },
 };
 

--- a/packages/engine/src/createLink.js
+++ b/packages/engine/src/createLink.js
@@ -38,7 +38,7 @@ function createLink({ backLink, disabledLink, lowdefy, newOriginLink, noLink, sa
         pathname,
         query,
         setInput: () => {
-          lowdefy.inputs[`page:${lowdefy.home.pageId}`] = props.input || {};
+          lowdefy.inputs[`page:${lowdefy.home.pageId}`] = props.input ?? {};
         },
       });
     }
@@ -48,7 +48,7 @@ function createLink({ backLink, disabledLink, lowdefy, newOriginLink, noLink, sa
         pathname: `/${props.pageId}`,
         query,
         setInput: () => {
-          lowdefy.inputs[`page:${props.pageId}`] = props.input || {};
+          lowdefy.inputs[`page:${props.pageId}`] = props.input ?? {};
         },
       });
     }

--- a/packages/operators/src/webParser.js
+++ b/packages/operators/src/webParser.js
@@ -37,7 +37,7 @@ class WebParser {
       throw new Error('Operator parser location must be a string.');
     }
     const errors = [];
-    const { basePath, home, inputs, lowdefyGlobal, menus, pageId, urlQuery, user, _internal } =
+    const { basePath, home, inputs, lowdefyGlobal, menus, pageId, user, _internal } =
       this.context._internal.lowdefy;
     const reviver = (_, value) => {
       if (!type.isObject(value) || Object.keys(value).length !== 1) return value;
@@ -71,7 +71,6 @@ class WebParser {
           requests: this.context.requests,
           runtime: 'browser',
           state: this.context.state,
-          urlQuery: urlQuery ?? {},
           user: user ?? {},
         });
         return res;

--- a/packages/operators/src/webParser.test.js
+++ b/packages/operators/src/webParser.test.js
@@ -32,7 +32,6 @@ const context = {
       inputs: { id: true },
       lowdefyGlobal: { global: true },
       menus: [{ menus: true }],
-      urlQuery: { urlQuery: true },
       user: { user: true },
       home: {
         pageId: 'home.pageId',
@@ -224,9 +223,6 @@ test('operator returns value', () => {
                       "menus": true,
                     },
                   ],
-                  "urlQuery": Object {
-                    "urlQuery": true,
-                  },
                   "user": Object {
                     "user": true,
                   },
@@ -270,9 +266,6 @@ test('operator returns value', () => {
           "runtime": "browser",
           "state": Object {
             "state": true,
-          },
-          "urlQuery": Object {
-            "urlQuery": true,
           },
           "user": Object {
             "user": true,

--- a/packages/plugins/operators/operators-js/src/operators/client/url_query.js
+++ b/packages/plugins/operators/operators-js/src/operators/client/url_query.js
@@ -15,12 +15,21 @@
 */
 
 import { getFromObject } from '@lowdefy/operators';
+import { urlQuery } from '@lowdefy/helpers';
 
-function _url_query({ arrayIndices, location, params, urlQuery }) {
+function _url_query({ arrayIndices, globals, location, params }) {
+  const { window } = globals;
+  if (!window?.location) {
+    throw new Error(
+      `Operator Error: Browser window.location not available for _url_query. Received: ${JSON.stringify(
+        params
+      )} at ${location}.`
+    );
+  }
   return getFromObject({
     arrayIndices,
     location,
-    object: urlQuery,
+    object: urlQuery.parse(window.location.search.slice(1)),
     operator: '_url_query',
     params,
   });

--- a/packages/plugins/operators/operators-js/src/operators/client/url_query.test.js
+++ b/packages/plugins/operators/operators-js/src/operators/client/url_query.test.js
@@ -20,24 +20,22 @@ jest.mock('@lowdefy/operators', () => ({
   getFromObject: jest.fn(),
 }));
 
-const input = {};
+const globals = { window: { location: { search: '?some=value' } } };
 
 test('url_query calls getFromObject', async () => {
   const lowdefyOperators = await import('@lowdefy/operators');
   url_query({
     arrayIndices: [0],
+    globals,
     location: 'location',
     params: 'params',
-    urlQuery: { urlQuery: true },
   });
   expect(lowdefyOperators.getFromObject.mock.calls).toEqual([
     [
       {
         arrayIndices: [0],
         location: 'location',
-        object: {
-          urlQuery: true,
-        },
+        object: { some: 'value' },
         operator: '_url_query',
         params: 'params',
       },

--- a/packages/server-dev/manager/utils/BatchChanges.mjs
+++ b/packages/server-dev/manager/utils/BatchChanges.mjs
@@ -15,6 +15,8 @@
 */
 /* eslint-disable no-console */
 
+import { type } from '@lowdefy/helpers';
+
 class BatchChanges {
   constructor({ fn, minDelay }) {
     this._call = this._call.bind(this);
@@ -27,7 +29,7 @@ class BatchChanges {
   }
 
   newChange(...args) {
-    this.args.push(args);
+    this.args.push(args.filter((arg) => type.isString(arg))); // filter for string paths since chokidar also returns an stats object on windows.
     this.delay = this.minDelay;
     this._startTimer();
   }


### PR DESCRIPTION
### What are the changes and their implications?
urlQuery to be read directly form `window.location.search` instead of from lowdefy object, so we remove the duplication.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
