### PR TITLE
fix(docs): correct filePath for ControlledList

### DIFF
--- a/packages/docs/blocks/list/ControlledList.yaml
+++ b/packages/docs/blocks/list/ControlledList.yaml
@@ -18,7 +18,7 @@ _ref:
     block_type: ControlledList
     category: list
     schema: ../plugins/blocks/blocks-antd/src/blocks/ControlledList/schema.json
-    filePath: blocks/ControlledList/ControlledList.yaml
+    filePath: blocks/list/ControlledList.yaml
     description_content: |
       The ControlledList block renders a content area for all items in the array into the list card and provides easy UI elements to add or remove items in the list. All list blocks create a array in state at their block `id`. The list content areas are rendered for each index in the array. See the [List Concept](/lists) page for a detailed description on how to work with lists.
     areas:

--- a/packages/docs/connections/AxiosHttp.yaml
+++ b/packages/docs/connections/AxiosHttp.yaml
@@ -30,7 +30,7 @@ _ref:
 
             The same properties can be set on both connections and requests. The properties will be merged, with the request properties overwriting connection properties. This allows properties like authentication headers and the baseURL to be set on the connection, with request specific properties like the request.
 
-            >Secrets like authentication headers and API keys should be stored using the [`_secret`](operators/secret.md) operator.
+            >Secrets like authentication headers and API keys should be stored using the [`_secret`](_secret) operator.
 
             ## Connections
 


### PR DESCRIPTION
Closes #1289 

### What are the changes and their implications?

The filePath variable for the ControlledList block in the docs has been corrected, thereby remediating the 404 bug described in #1289 

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [x] Documentation added/updated
- [ ] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
