### PR TITLE
Add default for catch when try is defined for an event and catch is not.

### DIFF
--- a/packages/build/src/build/buildPages/buildBlock/buildEvents.js
+++ b/packages/build/src/build/buildPages/buildBlock/buildEvents.js
@@ -74,6 +74,9 @@ function buildEvents(block, pageContext) {
           }". Received ${JSON.stringify(block.events[key].try)}`
         );
       }
+      if (type.isNone(block.events[key].catch)) {
+        block.events[key].catch = [];
+      }
       if (!type.isArray(block.events[key].catch)) {
         throw new Error(
           `Catch actions must be an array at "${block.blockId}" in event "${key}.catch" on page "${

--- a/packages/build/src/build/buildPages/buildBlock/buildEvents.test.js
+++ b/packages/build/src/build/buildPages/buildBlock/buildEvents.test.js
@@ -146,14 +146,14 @@ test('block events actions as try array and catch not defined.', () => {
       },
     ],
   };
-  expect(() =>
-    buildPages({
-      components,
-      context,
-    })
-  ).toThrow(
-    'Catch actions must be an array at "block_1" in event "onClick.catch" on page "page_1". Received undefined'
-  );
+  const res = buildPages({ components, context });
+  expect(get(res, 'pages.0.areas.content.blocks.0.events.onClick.try')).toEqual([
+    {
+      id: 'action_1',
+      type: 'Reset',
+    },
+  ]);
+  expect(get(res, 'pages.0.areas.content.blocks.0.events.onClick.catch')).toEqual([]);
 });
 
 test('block events actions try not an array', () => {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes ~#ISSUE_NUMBER~

### What are the changes and their implications?
When try is defined on an event, and catch is not, catch will be set to be an empty array.
This stops an error from being thrown when try is used without catch, and adds default behaviour for this case.

## Checklist

- [x] Pull request is made to the "develop" branch
- [x] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
