### PR TITLE
fix: Fix next-auth getServerSession.

### DIFF
--- a/packages/server-dev/lib/auth/getServerSession.js
+++ b/packages/server-dev/lib/auth/getServerSession.js
@@ -14,12 +14,13 @@
   limitations under the License.
 */
 
-import { getSession } from 'next-auth/react';
+import { unstable_getServerSession } from 'next-auth/next';
+import { authOptions } from '../../pages/api/auth/[...nextauth].js';
 import authJson from '../../build/auth.json';
 
-async function getServerSession(context) {
+async function getServerSession({ req, res }) {
   if (authJson.configured === true) {
-    return await getSession(context);
+    return await unstable_getServerSession(req, res, authOptions);
   }
   return undefined;
 }

--- a/packages/server-dev/pages/api/auth/[...nextauth].js
+++ b/packages/server-dev/pages/api/auth/[...nextauth].js
@@ -23,16 +23,17 @@ import callbacks from '../../../build/plugins/auth/callbacks.js';
 import events from '../../../build/plugins/auth/events.js';
 import providers from '../../../build/plugins/auth/providers.js';
 
-// TODO: make createApiContext synchronous
-export default async function auth(req, res) {
+export const authOptions = getNextAuthConfig(
+  { logger: console }, // TODO: make createApiContext synchronous
+  { authJson, plugins: { adapters, callbacks, events, providers } }
+)
+
+export default async function auth({ req, res }) {
   if (authJson.configured === true) {
     return await NextAuth(
       req,
       res,
-      getNextAuthConfig(
-        { logger: console },
-        { authJson, plugins: { adapters, callbacks, events, providers } }
-      )
+      authOptions
     );
   }
 

--- a/packages/server-dev/pages/api/page/[pageId].js
+++ b/packages/server-dev/pages/api/page/[pageId].js
@@ -18,7 +18,7 @@ import { createApiContext, getPageConfig } from '@lowdefy/api';
 import getServerSession from '../../../lib/auth/getServerSession.js';
 
 export default async function handler(req, res) {
-  const session = await getServerSession({ req });
+  const session = await getServerSession({ req, res });
   const apiContext = await createApiContext({
     buildDirectory: './build',
     logger: console,

--- a/packages/server-dev/pages/api/request/[pageId]/[requestId].js
+++ b/packages/server-dev/pages/api/request/[pageId]/[requestId].js
@@ -26,7 +26,7 @@ export default async function handler(req, res) {
     if (req.method !== 'POST') {
       throw new Error('Only POST requests are supported.');
     }
-    const session = await getServerSession({ req });
+    const session = await getServerSession({ req, res });
     const apiContext = await createApiContext({
       buildDirectory: './build',
       connections,

--- a/packages/server-dev/pages/api/root.js
+++ b/packages/server-dev/pages/api/root.js
@@ -19,7 +19,7 @@ import { createApiContext, getRootConfig } from '@lowdefy/api';
 import getServerSession from '../../lib/auth/getServerSession.js';
 
 export default async function handler(req, res) {
-  const session = await getServerSession({ req });
+  const session = await getServerSession({ req, res });
   const apiContext = await createApiContext({
     buildDirectory: './build',
     logger: console,

--- a/packages/server/lib/auth/getServerSession.js
+++ b/packages/server/lib/auth/getServerSession.js
@@ -14,12 +14,13 @@
   limitations under the License.
 */
 
-import { getSession } from 'next-auth/react';
+import { unstable_getServerSession } from 'next-auth/next';
+import { authOptions } from '../../pages/api/auth/[...nextauth].js';
 import authJson from '../../build/auth.json';
 
-async function getServerSession(context) {
+async function getServerSession({ req, res }) {
   if (authJson.configured === true) {
-    return await getSession(context);
+    return await unstable_getServerSession(req, res, authOptions);
   }
   return undefined;
 }

--- a/packages/server/pages/api/auth/[...nextauth].js
+++ b/packages/server/pages/api/auth/[...nextauth].js
@@ -23,15 +23,17 @@ import callbacks from '../../../build/plugins/auth/callbacks.js';
 import events from '../../../build/plugins/auth/events.js';
 import providers from '../../../build/plugins/auth/providers.js';
 
+export const authOptions = getNextAuthConfig(
+  { logger: console }, // TODO: make createApiContext synchronous
+  { authJson, plugins: { adapters, callbacks, events, providers } }
+)
+
 export default async function auth(req, res) {
   if (authJson.configured === true) {
     return await NextAuth(
       req,
       res,
-      getNextAuthConfig(
-        { logger: console },
-        { authJson, plugins: { adapters, callbacks, events, providers } }
-      )
+      authOptions
     );
   }
 

--- a/packages/server/pages/api/request/[pageId]/[requestId].js
+++ b/packages/server/pages/api/request/[pageId]/[requestId].js
@@ -28,7 +28,7 @@ export default async function handler(req, res) {
     if (req.method !== 'POST') {
       throw new Error('Only POST requests are supported.');
     }
-    const session = await getServerSession({ req });
+    const session = await getServerSession({ req, res });
     // Important to give absolute path so Next can trace build files
     const apiContext = await createApiContext({
       buildDirectory: path.join(process.cwd(), 'build'),


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes ~#ISSUE_NUMBER~

### What are the changes and their implications?
https://next-auth.js.org/configuration/nextjs
https://github.com/nextauthjs/next-auth/issues/1535
This PR changes the getServerSession function to use the unstable_getServerSession function, which does not make an additional fetch request to the auth api to get the session. This can have large performance and reliability benefits. 

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
