### PR TITLE
fix: Log server install output at debug level.

### DIFF
--- a/packages/cli/src/utils/installServer.js
+++ b/packages/cli/src/utils/installServer.js
@@ -27,10 +27,10 @@ async function installServer({ context, directory }) {
     await spawnProcess({
       command: context.packageManagerCmd,
       args: args[context.packageManager],
+      stdOutLineHandler: (line) => context.print.debug(line),
       processOptions: {
         cwd: directory,
       },
-      silent: false,
     });
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes ~#ISSUE_NUMBER~

### What are the changes and their implications?

This fixes the `installServer` process in CLI to output the npm or yarn install output at the log level. This output was previously at the info level. This was broken in #1304 so that no output was logged. 

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [x] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
