### PR TITLE
docs: Update AxiosHttp.yaml

### DIFF
--- a/packages/docs/connections/AxiosHttp.yaml
+++ b/packages/docs/connections/AxiosHttp.yaml
@@ -161,9 +161,9 @@ _ref:
                 type: AxiosHttp
                 properties:
                   url: myapp.com/api/count
-                headers:
-                  X-Api-Key:
-                    _secret: API_KEY
+                  headers:
+                    X-Api-Key:
+                      _secret: API_KEY
             # ...
             requests:
               - id: get_count


### PR DESCRIPTION
Closes #1352

The 'headers' key should be nested under the key 'properties', in the current docs it appears at the same indentation level and that throws a Schema error.



<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes #ISSUE_NUMBER

### What are the changes and their implications?

## Checklist

- [x] Pull request is made to the "develop" branch
- [-] Tests added
- [-] Documentation added/updated
- [-] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
