### PR TITLE
fix: Fix server pnpm installs.

### DIFF
--- a/packages/cli/src/utils/installServer.js
+++ b/packages/cli/src/utils/installServer.js
@@ -21,7 +21,7 @@ async function installServer({ context, directory }) {
   try {
     await spawnProcess({
       command: context.pnpmCmd,
-      args: ['install'],
+      args: ['install', '--no-frozen-lockfile'],
       stdOutLineHandler: (line) => context.print.debug(line),
       processOptions: {
         cwd: directory,

--- a/packages/server-dev/.npmrc
+++ b/packages/server-dev/.npmrc
@@ -1,2 +1,1 @@
 strict-peer-dependencies=false
-save-prefix = ''

--- a/packages/server-dev/manager/processes/installPlugins.mjs
+++ b/packages/server-dev/manager/processes/installPlugins.mjs
@@ -21,7 +21,7 @@ function installPlugins({ logger, packageManagerCmd }) {
     logger.info({ print: 'spin' }, 'Installing plugins...');
     await spawnProcess({
       command: packageManagerCmd,
-      args: ['install'],
+      args: ['install', '--no-frozen-lockfile'],
       stdOutLineHandler: (line) => logger.debug(line),
     });
     logger.info({ print: 'log' }, 'Installed plugins.');

--- a/packages/server-dev/package.json
+++ b/packages/server-dev/package.json
@@ -31,7 +31,8 @@
     "pages/*",
     "public/*",
     "next.config.js",
-    ".eslintrc.yaml"
+    ".eslintrc.yaml",
+    ".npmrc"
   ],
   "scripts": {
     "start": "node manager/run.mjs",

--- a/packages/server/.npmrc
+++ b/packages/server/.npmrc
@@ -1,2 +1,1 @@
 strict-peer-dependencies=false
-save-prefix = ''

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,7 +31,8 @@
     "pages/*",
     "public/*",
     "next.config.js",
-    ".eslintrc.yaml"
+    ".eslintrc.yaml",
+    ".npmrc"
   ],
   "scripts": {
     "build:lowdefy": "node lowdefy/build.mjs",


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes ~#ISSUE_NUMBER~

### What are the changes and their implications?

This PR adds a `.npmrc` file to both server packages with `strict-peer-dependencies=false` so that builds do not break when plugins with missing peer dependencies are installed. pnpm will still warn on missing dependencies, which is the same behaviour as yarn.

The  `--no-frozen-lockfile` option is also passed to pnpm when installing the server from CLI to add plugins, since without this builds fail in CI environments. We are installing new packages, so we expect the lockfile to change.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
