### PR TITLE
fix(api): Fix "too many files open" error in api.

### DIFF
--- a/packages/api/src/context/createApiContext.js
+++ b/packages/api/src/context/createApiContext.js
@@ -17,8 +17,9 @@
 import createAuthorize from './createAuthorize.js';
 import createReadConfigFile from './createReadConfigFile.js';
 
-async function createApiContext({
+function createApiContext({
   buildDirectory,
+  config,
   connections,
   logger,
   operators,
@@ -26,7 +27,6 @@ async function createApiContext({
   session,
 }) {
   const readConfigFile = createReadConfigFile({ buildDirectory });
-  const config = await readConfigFile('config.json');
   return {
     authorize: createAuthorize({ session }),
     config,

--- a/packages/server-dev/pages/api/auth/[...nextauth].js
+++ b/packages/server-dev/pages/api/auth/[...nextauth].js
@@ -15,16 +15,20 @@
 */
 
 import NextAuth from 'next-auth';
-import { getNextAuthConfig } from '@lowdefy/api';
+import { createApiContext, getNextAuthConfig } from '@lowdefy/api';
 
 import authJson from '../../../build/auth.json';
+import config from '../../../build/config.json';
 import adapters from '../../../build/plugins/auth/adapters.js';
 import callbacks from '../../../build/plugins/auth/callbacks.js';
 import events from '../../../build/plugins/auth/events.js';
 import providers from '../../../build/plugins/auth/providers.js';
 
 export const authOptions = getNextAuthConfig(
-  { logger: console }, // TODO: make createApiContext synchronous
+  createApiContext({
+    config,
+    logger: console,
+  }),
   { authJson, plugins: { adapters, callbacks, events, providers } }
 );
 

--- a/packages/server-dev/pages/api/page/[pageId].js
+++ b/packages/server-dev/pages/api/page/[pageId].js
@@ -15,12 +15,15 @@
 */
 
 import { createApiContext, getPageConfig } from '@lowdefy/api';
+
+import config from '../../../build/config.json';
 import getServerSession from '../../../lib/auth/getServerSession.js';
 
 export default async function handler(req, res) {
   const session = await getServerSession({ req, res });
-  const apiContext = await createApiContext({
+  const apiContext = createApiContext({
     buildDirectory: './build',
+    config,
     logger: console,
     session,
   });

--- a/packages/server-dev/pages/api/request/[pageId]/[requestId].js
+++ b/packages/server-dev/pages/api/request/[pageId]/[requestId].js
@@ -17,6 +17,7 @@
 import { callRequest, createApiContext } from '@lowdefy/api';
 import { getSecretsFromEnv } from '@lowdefy/node-utils';
 
+import config from '../../../../build/config.json';
 import connections from '../../../../build/plugins/connections.js';
 import getServerSession from '../../../../lib/auth/getServerSession.js';
 import operators from '../../../../build/plugins/operators/server.js';
@@ -27,8 +28,9 @@ export default async function handler(req, res) {
       throw new Error('Only POST requests are supported.');
     }
     const session = await getServerSession({ req, res });
-    const apiContext = await createApiContext({
+    const apiContext = createApiContext({
       buildDirectory: './build',
+      config,
       connections,
       logger: console,
       operators,

--- a/packages/server-dev/pages/api/root.js
+++ b/packages/server-dev/pages/api/root.js
@@ -16,12 +16,14 @@
 
 import { createApiContext, getRootConfig } from '@lowdefy/api';
 
+import config from '../../build/config.json';
 import getServerSession from '../../lib/auth/getServerSession.js';
 
 export default async function handler(req, res) {
   const session = await getServerSession({ req, res });
-  const apiContext = await createApiContext({
+  const apiContext = createApiContext({
     buildDirectory: './build',
+    config,
     logger: console,
     session,
   });

--- a/packages/server/pages/404.js
+++ b/packages/server/pages/404.js
@@ -16,11 +16,15 @@
 import path from 'path';
 import { createApiContext, getPageConfig, getRootConfig } from '@lowdefy/api';
 
+import config from '../build/config.json';
 import Page from '../lib/Page.js';
 
 export async function getStaticProps() {
   // Important to give absolute path so Next can trace build files
-  const apiContext = await createApiContext({ buildDirectory: path.join(process.cwd(), 'build') });
+  const apiContext = createApiContext({
+    buildDirectory: path.join(process.cwd(), 'build'),
+    config,
+  });
 
   const [rootConfig, pageConfig] = await Promise.all([
     getRootConfig(apiContext),

--- a/packages/server/pages/[pageId].js
+++ b/packages/server/pages/[pageId].js
@@ -17,6 +17,7 @@
 import path from 'path';
 import { createApiContext, getPageConfig, getRootConfig } from '@lowdefy/api';
 
+import config from '../build/config.json';
 import getServerSession from '../lib/auth/getServerSession.js';
 import Page from '../lib/Page.js';
 
@@ -24,8 +25,9 @@ export async function getServerSideProps(context) {
   const { pageId } = context.params;
   const session = await getServerSession(context);
   // Important to give absolute path so Next can trace build files
-  const apiContext = await createApiContext({
+  const apiContext = createApiContext({
     buildDirectory: path.join(process.cwd(), 'build'),
+    config,
     logger: console,
     session,
   });

--- a/packages/server/pages/api/auth/[...nextauth].js
+++ b/packages/server/pages/api/auth/[...nextauth].js
@@ -15,16 +15,20 @@
 */
 
 import NextAuth from 'next-auth';
-import { getNextAuthConfig } from '@lowdefy/api';
+import { createApiContext, getNextAuthConfig } from '@lowdefy/api';
 
 import authJson from '../../../build/auth.json';
+import config from '../../../build/config.json';
 import adapters from '../../../build/plugins/auth/adapters.js';
 import callbacks from '../../../build/plugins/auth/callbacks.js';
 import events from '../../../build/plugins/auth/events.js';
 import providers from '../../../build/plugins/auth/providers.js';
 
 export const authOptions = getNextAuthConfig(
-  { logger: console }, // TODO: make createApiContext synchronous
+  createApiContext({
+    config,
+    logger: console,
+  }),
   { authJson, plugins: { adapters, callbacks, events, providers } }
 );
 

--- a/packages/server/pages/api/request/[pageId]/[requestId].js
+++ b/packages/server/pages/api/request/[pageId]/[requestId].js
@@ -18,9 +18,9 @@ import path from 'path';
 import { callRequest, createApiContext } from '@lowdefy/api';
 import { getSecretsFromEnv } from '@lowdefy/node-utils';
 
-import getServerSession from '../../../../lib/auth/getServerSession.js';
-
+import config from '../../../../build/config.json';
 import connections from '../../../../build/plugins/connections.js';
+import getServerSession from '../../../../lib/auth/getServerSession.js';
 import operators from '../../../../build/plugins/operators/server.js';
 
 export default async function handler(req, res) {
@@ -30,8 +30,9 @@ export default async function handler(req, res) {
     }
     const session = await getServerSession({ req, res });
     // Important to give absolute path so Next can trace build files
-    const apiContext = await createApiContext({
+    const apiContext = createApiContext({
       buildDirectory: path.join(process.cwd(), 'build'),
+      config,
       connections,
       // logger: console,
       logger: { debug: () => {} },

--- a/packages/server/pages/index.js
+++ b/packages/server/pages/index.js
@@ -17,6 +17,7 @@
 import path from 'path';
 import { createApiContext, getPageConfig, getRootConfig } from '@lowdefy/api';
 
+import config from '../build/config.json';
 import getServerSession from '../lib/auth/getServerSession.js';
 import Page from '../lib/Page.js';
 
@@ -24,8 +25,9 @@ export async function getServerSideProps(context) {
   const session = await getServerSession(context);
 
   // Important to give absolute path so Next can trace build files
-  const apiContext = await createApiContext({
+  const apiContext = createApiContext({
     buildDirectory: path.join(process.cwd(), 'build'),
+    config,
     logger: console,
     session,
   });


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes ~#ISSUE_NUMBER~

### What are the changes and their implications?

This PR fixes an error "too many files open" which is caused by opening the `config.json` file multiple times when creating the API context.

It changes the file read to an import in the Next server.

This means `createApiContext` is now syncronous, which was needed in the auth api to use a configured logger.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
