### PR TITLE
fix: Cache API file reads across all requests.

### DIFF
--- a/packages/api/src/context/createApiContext.js
+++ b/packages/api/src/context/createApiContext.js
@@ -21,12 +21,13 @@ function createApiContext({
   buildDirectory,
   config,
   connections,
+  fileCache,
   logger,
   operators,
   secrets,
   session,
 }) {
-  const readConfigFile = createReadConfigFile({ buildDirectory });
+  const readConfigFile = createReadConfigFile({ buildDirectory, fileCache });
   return {
     authorize: createAuthorize({ session }),
     config,

--- a/packages/api/src/context/createReadConfigFile.js
+++ b/packages/api/src/context/createReadConfigFile.js
@@ -18,7 +18,7 @@ import path from 'path';
 import { cachedPromises } from '@lowdefy/helpers';
 import { getFileExtension, readFile } from '@lowdefy/node-utils';
 
-function createReadConfigFile({ buildDirectory }) {
+function createReadConfigFile({ buildDirectory, fileCache }) {
   async function readConfigFile(filePath) {
     const fileContent = await readFile(path.resolve(buildDirectory, filePath));
     if (getFileExtension(filePath) === 'json') {
@@ -26,7 +26,10 @@ function createReadConfigFile({ buildDirectory }) {
     }
     return fileContent;
   }
-  return cachedPromises(readConfigFile);
+  return cachedPromises({
+    cache: fileCache,
+    getter: readConfigFile,
+  });
 }
 
 export default createReadConfigFile;

--- a/packages/api/src/context/createReadConfigFile.test.js
+++ b/packages/api/src/context/createReadConfigFile.test.js
@@ -27,9 +27,10 @@ jest.unstable_mockModule('@lowdefy/node-utils', () => {
 test('createReadConfigFile', async () => {
   const nodeUtils = await import('@lowdefy/node-utils');
 
+  const fileCache = new Map();
   nodeUtils.readFile.mockImplementation(() => Promise.resolve('config value'));
   const createReadConfigFile = (await import('./createReadConfigFile.js')).default;
-  const readConfigFile = createReadConfigFile({ buildDirectory: '/build' });
+  const readConfigFile = createReadConfigFile({ buildDirectory: '/build', fileCache });
   const res = await readConfigFile('file');
   expect(res).toEqual('config value');
 });

--- a/packages/build/src/utils/readConfigFile.js
+++ b/packages/build/src/utils/readConfigFile.js
@@ -22,7 +22,10 @@ function createReadConfigFile({ directories }) {
   async function readConfigFile(filePath) {
     return readFile(path.resolve(directories.config, filePath));
   }
-  return cachedPromises(readConfigFile);
+  return cachedPromises({
+    cache: new Map(),
+    getter: readConfigFile,
+  });
 }
 
 export default createReadConfigFile;

--- a/packages/server-dev/lib/fileCache.js
+++ b/packages/server-dev/lib/fileCache.js
@@ -14,14 +14,7 @@
   limitations under the License.
 */
 
-async function getPageConfig({ authorize, readConfigFile }, { pageId }) {
-  const pageConfig = await readConfigFile(`pages/${pageId}/${pageId}.json`);
-  if (pageConfig && authorize(pageConfig)) {
-    // eslint-disable-next-line no-unused-vars
-    const { auth, ...rest } = pageConfig;
-    return { ...rest };
-  }
-  return null;
-}
-
-export default getPageConfig;
+export default {
+  get: () => undefined,
+  set: () => undefined,
+};

--- a/packages/server-dev/pages/api/auth/[...nextauth].js
+++ b/packages/server-dev/pages/api/auth/[...nextauth].js
@@ -22,11 +22,13 @@ import config from '../../../build/config.json';
 import adapters from '../../../build/plugins/auth/adapters.js';
 import callbacks from '../../../build/plugins/auth/callbacks.js';
 import events from '../../../build/plugins/auth/events.js';
+import fileCache from '../../../lib/fileCache.js';
 import providers from '../../../build/plugins/auth/providers.js';
 
 export const authOptions = getNextAuthConfig(
   createApiContext({
     config,
+    fileCache,
     logger: console,
   }),
   { authJson, plugins: { adapters, callbacks, events, providers } }

--- a/packages/server-dev/pages/api/page/[pageId].js
+++ b/packages/server-dev/pages/api/page/[pageId].js
@@ -17,6 +17,7 @@
 import { createApiContext, getPageConfig } from '@lowdefy/api';
 
 import config from '../../../build/config.json';
+import fileCache from '../../../lib/fileCache.js';
 import getServerSession from '../../../lib/auth/getServerSession.js';
 
 export default async function handler(req, res) {
@@ -24,6 +25,7 @@ export default async function handler(req, res) {
   const apiContext = createApiContext({
     buildDirectory: './build',
     config,
+    fileCache,
     logger: console,
     session,
   });

--- a/packages/server-dev/pages/api/request/[pageId]/[requestId].js
+++ b/packages/server-dev/pages/api/request/[pageId]/[requestId].js
@@ -19,6 +19,7 @@ import { getSecretsFromEnv } from '@lowdefy/node-utils';
 
 import config from '../../../../build/config.json';
 import connections from '../../../../build/plugins/connections.js';
+import fileCache from '../../../../lib/fileCache.js';
 import getServerSession from '../../../../lib/auth/getServerSession.js';
 import operators from '../../../../build/plugins/operators/server.js';
 
@@ -32,6 +33,7 @@ export default async function handler(req, res) {
       buildDirectory: './build',
       config,
       connections,
+      fileCache,
       logger: console,
       operators,
       secrets: getSecretsFromEnv(),

--- a/packages/server-dev/pages/api/root.js
+++ b/packages/server-dev/pages/api/root.js
@@ -17,6 +17,7 @@
 import { createApiContext, getRootConfig } from '@lowdefy/api';
 
 import config from '../../build/config.json';
+import fileCache from '../../lib/fileCache.js';
 import getServerSession from '../../lib/auth/getServerSession.js';
 
 export default async function handler(req, res) {
@@ -24,6 +25,7 @@ export default async function handler(req, res) {
   const apiContext = createApiContext({
     buildDirectory: './build',
     config,
+    fileCache,
     logger: console,
     session,
   });

--- a/packages/server/lib/fileCache.js
+++ b/packages/server/lib/fileCache.js
@@ -14,14 +14,8 @@
   limitations under the License.
 */
 
-async function getPageConfig({ authorize, readConfigFile }, { pageId }) {
-  const pageConfig = await readConfigFile(`pages/${pageId}/${pageId}.json`);
-  if (pageConfig && authorize(pageConfig)) {
-    // eslint-disable-next-line no-unused-vars
-    const { auth, ...rest } = pageConfig;
-    return { ...rest };
-  }
-  return null;
-}
+import { LRUCache } from '@lowdefy/helpers';
 
-export default getPageConfig;
+const fileCache = new LRUCache({ maxSize: 100 });
+
+export default fileCache;

--- a/packages/server/pages/404.js
+++ b/packages/server/pages/404.js
@@ -17,6 +17,7 @@ import path from 'path';
 import { createApiContext, getPageConfig, getRootConfig } from '@lowdefy/api';
 
 import config from '../build/config.json';
+import fileCache from '../lib/fileCache.js';
 import Page from '../lib/Page.js';
 
 export async function getStaticProps() {
@@ -24,6 +25,8 @@ export async function getStaticProps() {
   const apiContext = createApiContext({
     buildDirectory: path.join(process.cwd(), 'build'),
     config,
+    fileCache,
+    logger: console,
   });
 
   const [rootConfig, pageConfig] = await Promise.all([

--- a/packages/server/pages/[pageId].js
+++ b/packages/server/pages/[pageId].js
@@ -18,6 +18,7 @@ import path from 'path';
 import { createApiContext, getPageConfig, getRootConfig } from '@lowdefy/api';
 
 import config from '../build/config.json';
+import fileCache from '../lib/fileCache.js';
 import getServerSession from '../lib/auth/getServerSession.js';
 import Page from '../lib/Page.js';
 
@@ -28,6 +29,7 @@ export async function getServerSideProps(context) {
   const apiContext = createApiContext({
     buildDirectory: path.join(process.cwd(), 'build'),
     config,
+    fileCache,
     logger: console,
     session,
   });

--- a/packages/server/pages/api/auth/[...nextauth].js
+++ b/packages/server/pages/api/auth/[...nextauth].js
@@ -17,16 +17,18 @@
 import NextAuth from 'next-auth';
 import { createApiContext, getNextAuthConfig } from '@lowdefy/api';
 
-import authJson from '../../../build/auth.json';
-import config from '../../../build/config.json';
 import adapters from '../../../build/plugins/auth/adapters.js';
+import authJson from '../../../build/auth.json';
 import callbacks from '../../../build/plugins/auth/callbacks.js';
+import config from '../../../build/config.json';
 import events from '../../../build/plugins/auth/events.js';
+import fileCache from '../../../lib/fileCache.js';
 import providers from '../../../build/plugins/auth/providers.js';
 
 export const authOptions = getNextAuthConfig(
   createApiContext({
     config,
+    fileCache,
     logger: console,
   }),
   { authJson, plugins: { adapters, callbacks, events, providers } }

--- a/packages/server/pages/api/request/[pageId]/[requestId].js
+++ b/packages/server/pages/api/request/[pageId]/[requestId].js
@@ -22,6 +22,7 @@ import config from '../../../../build/config.json';
 import connections from '../../../../build/plugins/connections.js';
 import getServerSession from '../../../../lib/auth/getServerSession.js';
 import operators from '../../../../build/plugins/operators/server.js';
+import fileCache from '../../../../lib/fileCache.js';
 
 export default async function handler(req, res) {
   try {
@@ -34,6 +35,7 @@ export default async function handler(req, res) {
       buildDirectory: path.join(process.cwd(), 'build'),
       config,
       connections,
+      fileCache,
       // logger: console,
       logger: { debug: () => {} },
       operators,

--- a/packages/server/pages/index.js
+++ b/packages/server/pages/index.js
@@ -18,6 +18,7 @@ import path from 'path';
 import { createApiContext, getPageConfig, getRootConfig } from '@lowdefy/api';
 
 import config from '../build/config.json';
+import fileCache from '../lib/fileCache.js';
 import getServerSession from '../lib/auth/getServerSession.js';
 import Page from '../lib/Page.js';
 
@@ -28,6 +29,7 @@ export async function getServerSideProps(context) {
   const apiContext = createApiContext({
     buildDirectory: path.join(process.cwd(), 'build'),
     config,
+    fileCache,
     logger: console,
     session,
   });

--- a/packages/utils/helpers/src/LRUCache.js
+++ b/packages/utils/helpers/src/LRUCache.js
@@ -1,0 +1,52 @@
+/*
+  Copyright 2020-2022 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// https://stackoverflow.com/a/46432113/8295949
+// Implementation of Least Recently Updated cache.
+// It uses the fact that the implementation of Map keep track of item insertion order
+class LRUCache {
+  constructor({ maxSize = 100 } = {}) {
+    this.maxSize = maxSize;
+    this.cache = new Map();
+  }
+
+  get(key) {
+    const item = this.cache.get(key);
+    if (item) {
+      // Refresh key.
+      this.cache.delete(key);
+      this.cache.set(key, item);
+    }
+    return item;
+  }
+
+  set(key, val) {
+    if (this.cache.has(key)) {
+      // Refresh key
+      this.cache.delete(key);
+    } else if (this.cache.size === this.maxSize) {
+      // Evict oldest
+      this.cache.delete(this.first());
+    }
+    this.cache.set(key, val);
+  }
+
+  first() {
+    return this.cache.keys().next().value;
+  }
+}
+
+export default LRUCache;

--- a/packages/utils/helpers/src/cachedPromises.js
+++ b/packages/utils/helpers/src/cachedPromises.js
@@ -14,13 +14,14 @@
   limitations under the License.
 */
 
-function createCachedPromises(getter) {
-  const cache = new Map();
-
+function createCachedPromises({ getter, cache }) {
   function cachedPromises(key) {
-    if (cache.has(key)) {
-      return Promise.resolve(cache.get(key));
+    const cached = cache.get(key);
+
+    if (cached) {
+      return Promise.resolve(cached);
     }
+
     const promise = getter(key);
     cache.set(key, promise);
     return Promise.resolve(promise);

--- a/packages/utils/helpers/src/cachedPromises.test.js
+++ b/packages/utils/helpers/src/cachedPromises.test.js
@@ -18,8 +18,9 @@ import createCachedPromises from './cachedPromises.js';
 import wait from './wait.js';
 
 test('cachedPromises calls getter with key', async () => {
+  const cache = new Map();
   const getter = jest.fn(() => Promise.resolve('value'));
-  const cachedGetter = createCachedPromises(getter);
+  const cachedGetter = createCachedPromises({ cache, getter });
   const promise = cachedGetter('key');
   expect(`${promise}`).toEqual('[object Promise]');
   const result = await promise;
@@ -28,8 +29,10 @@ test('cachedPromises calls getter with key', async () => {
 });
 
 test('cachedPromises only calls getter once', async () => {
+  const cache = new Map();
+
   const getter = jest.fn(() => Promise.resolve('value'));
-  const cachedGetter = createCachedPromises(getter);
+  const cachedGetter = createCachedPromises({ cache, getter });
   const result1 = await cachedGetter('key');
   expect(result1).toEqual('value');
   const result2 = await cachedGetter('key');
@@ -38,11 +41,13 @@ test('cachedPromises only calls getter once', async () => {
 });
 
 test('getter is called once if first call has not yet resolved', async () => {
+  const cache = new Map();
+
   const getter = jest.fn(async () => {
     await wait(10);
     return 'value';
   });
-  const cachedGetter = createCachedPromises(getter);
+  const cachedGetter = createCachedPromises({ cache, getter });
   const promise1 = cachedGetter('key');
   const promise2 = cachedGetter('key');
   expect(getter.mock.calls).toEqual([['key']]);

--- a/packages/utils/helpers/src/index.js
+++ b/packages/utils/helpers/src/index.js
@@ -17,6 +17,7 @@
 import applyArrayIndices from './applyArrayIndices.js';
 import cachedPromises from './cachedPromises.js';
 import get from './get.js';
+import LRUCache from './LRUCache.js';
 import mergeObjects from './mergeObjects.js';
 import omit from './omit.js';
 import serializer from './serializer.js';
@@ -32,6 +33,7 @@ export {
   applyArrayIndices,
   cachedPromises,
   get,
+  LRUCache,
   mergeObjects,
   omit,
   serializer,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes ~#ISSUE_NUMBER~

### What are the changes and their implications?

This PR fixs the file read cache in the API which was not working. Files are now cached over all server requests. A least recently updated file cache is also added.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
