### PR TITLE
fix(blocks-qr): Don't call start and stop if scanner is not running.

### DIFF
--- a/packages/plugins/blocks/blocks-qr/src/blocks/QRScanner/QRScanner.js
+++ b/packages/plugins/blocks/blocks-qr/src/blocks/QRScanner/QRScanner.js
@@ -44,6 +44,7 @@ class QRScanner extends React.Component {
     this.onNewScanResult = this.onNewScanResult.bind(this);
     this.onStart = this.onStart.bind(this);
     this.onStop = this.onStop.bind(this);
+    this.scanning = false;
   }
 
   onNewScanResult(decodedText, decodedResult) {
@@ -52,19 +53,25 @@ class QRScanner extends React.Component {
   }
 
   onStart() {
-    this.html5QrCode?.start(
-      { facingMode: this.props.properties.facingMode || 'environment' },
-      {
-        ...{ aspectRatio: 1 },
-        ...this.props.properties,
-        ...{ formatsToSupport: codes[this.props.properties.formatsToSupport] },
-      },
-      this.onNewScanResult
-    );
+    if (!this.scanning) {
+      this.scanning = true;
+      this.html5QrCode?.start(
+        { facingMode: this.props.properties.facingMode || 'environment' },
+        {
+          ...{ aspectRatio: 1 },
+          ...this.props.properties,
+          ...{ formatsToSupport: codes[this.props.properties.formatsToSupport] },
+        },
+        this.onNewScanResult
+      );
+    }
   }
 
   onStop() {
-    this.html5QrCode?.stop();
+    if (this.scanning) {
+      this.scanning = false;
+      this.html5QrCode?.stop();
+    }
   }
 
   componentDidMount() {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?
QRScanner block should only call stop when active and start when not active.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
