### PR TITLE
 DateTimeSelector to use onSelect for better UX.

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -86,6 +86,7 @@
     "@lowdefy/connection-stripe": "4.0.0-alpha.36",
     "@lowdefy/operators-change-case": "4.0.0-alpha.36",
     "@lowdefy/operators-diff": "4.0.0-alpha.36",
+    "@lowdefy/operators-moment": "4.0.0-alpha.36",
     "@lowdefy/operators-mql": "4.0.0-alpha.36",
     "@lowdefy/operators-nunjucks": "4.0.0-alpha.36",
     "@lowdefy/operators-uuid": "4.0.0-alpha.36",

--- a/packages/plugins/blocks/blocks-antd/src/blocks/DateTimeSelector/DateTimeSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/DateTimeSelector/DateTimeSelector.js
@@ -81,7 +81,9 @@ const DateTimeSelector = ({
                 minuteStep: properties.minuteStep || 5,
                 secondStep: properties.secondStep || 30,
               }}
-              onChange={(newVal) => {
+              onSelect={(newVal) => {
+                // NOTE: we use on select instead of onChange to make the block UX
+                // more like the DataSelector which changes date on click and not on ok.
                 methods.setValue(
                   !newVal
                     ? null


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?
To improve UX on `DateTimeSelector`, we are changing the select behaviour to change state value `onSelect` instead of `onChange` which requires the user to click ok before the state value is updated.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
