### PR TITLE
Fix watch path CLI config for relative paths.

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,5 @@
     "prettier": "2.6.2",
     "turbo": "1.2.14"
   },
-  "packageManager": "pnpm@7.11.0"
+  "packageManager": "pnpm@7.18.1"
 }

--- a/packages/server-dev/manager/watchers/lowdefyBuildWatcher.mjs
+++ b/packages/server-dev/manager/watchers/lowdefyBuildWatcher.mjs
@@ -14,10 +14,14 @@
   limitations under the License.
 */
 
+import path from 'path';
 import getLowdefyVersion from '../utils/getLowdefyVersion.mjs';
 import setupWatcher from '../utils/setupWatcher.mjs';
 
 function lowdefyBuildWatcher(context) {
+  const fixRelativePathConfigDir = (item) =>
+    path.isAbsolute(item) ? item : path.resolve(context.directories.config, item);
+
   const callback = async (filePaths) => {
     const lowdefyYamlModified = filePaths
       .flat()
@@ -37,8 +41,14 @@ function lowdefyBuildWatcher(context) {
   return setupWatcher({
     callback,
     context,
-    ignorePaths: ['**/node_modules/**', ...context.options.watchIgnore],
-    watchPaths: [context.directories.config, ...context.options.watch],
+    ignorePaths: [
+      '**/node_modules/**',
+      ...context.options.watchIgnore.map(fixRelativePathConfigDir),
+    ],
+    watchPaths: [
+      context.directories.config,
+      ...context.options.watch.map(fixRelativePathConfigDir),
+    ],
   });
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes #ISSUE_NUMBER

### What are the changes and their implications?

This PR fixes a bug where the watchPaths CLI config was not working. The paths were based of of the wrong base path.

## Checklist

- [x] Pull request is made to the "develop" branch
- [x] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
