### PR TITLE
User styles

### DIFF
--- a/packages/build/src/build/validateConfig.js
+++ b/packages/build/src/build/validateConfig.js
@@ -25,9 +25,6 @@ function validateConfig({ components }) {
   if (!type.isObject(components.config)) {
     throw new Error('lowdefy.config is not an object.');
   }
-  if (type.isNone(components.config.theme)) {
-    components.config.theme = {};
-  }
   if (type.isString(components.config.basePath)) {
     if (components.config.basePath[0] !== '/') {
       throw Error('Base path must start with "/".');

--- a/packages/build/src/build/validateConfig.test.js
+++ b/packages/build/src/build/validateConfig.test.js
@@ -23,31 +23,7 @@ test('validateConfig no config defined', () => {
   const components = {};
   const result = validateConfig({ components, context });
   expect(result).toEqual({
-    config: {
-      theme: {},
-    },
-  });
-});
-
-test('validate config theme', () => {
-  const components = {
-    config: {
-      theme: {
-        lessVariables: {
-          'primary-color': '#FF00FF',
-        },
-      },
-    },
-  };
-  const result = validateConfig({ components, context });
-  expect(result).toEqual({
-    config: {
-      theme: {
-        lessVariables: {
-          'primary-color': '#FF00FF',
-        },
-      },
-    },
+    config: {},
   });
 });
 
@@ -68,7 +44,6 @@ test('validateConfig config error when basePath does not start with "/".', () =>
   expect(result).toEqual({
     config: {
       basePath: '/base',
-      theme: {},
     },
   });
   components = {

--- a/packages/build/src/build/writePluginImports/writeStyleImports.js
+++ b/packages/build/src/build/writePluginImports/writeStyleImports.js
@@ -14,6 +14,8 @@
   limitations under the License.
 */
 
+import fs from 'fs';
+import path from 'path';
 import { nunjucksFunction } from '@lowdefy/nunjucks';
 
 const template = `@import '@lowdefy/layout/style.less';
@@ -21,13 +23,19 @@ const template = `@import '@lowdefy/layout/style.less';
 {% for style in styles -%}
 @import '{{ style }}';
 {% endfor -%}
+{% if importUserStyles %}
+@import '../../public/styles.less';
+{% endif %}
 `;
 
 async function writeStyleImports({ components, context }) {
   const templateFn = nunjucksFunction(template);
   await context.writeBuildArtifact(
     'plugins/styles.less',
-    templateFn({ styles: components.imports.styles })
+    templateFn({
+      styles: components.imports.styles,
+      importUserStyles: fs.existsSync(path.join(context.directories.config, 'public/styles.less')),
+    })
   );
 }
 

--- a/packages/build/src/lowdefySchema.js
+++ b/packages/build/src/lowdefySchema.js
@@ -761,21 +761,6 @@ export default {
             type: 'App "config.homePageId" should be a string.',
           },
         },
-        theme: {
-          type: 'object',
-          errorMessage: {
-            type: 'App "config.theme" should be an object.',
-          },
-          properties: {
-            lessVariables: {
-              type: 'object',
-              description: 'App theme less variables.',
-              errorMessage: {
-                type: 'App "config.theme.lessVariables" should be an object.',
-              },
-            },
-          },
-        },
       },
     },
     plugins: {

--- a/packages/server-dev/manager/run.mjs
+++ b/packages/server-dev/manager/run.mjs
@@ -53,8 +53,11 @@ The run script does the following:
   - <build-dir>/config.json
   - <server-dir>/package.json
 
-  If app theme or config changes:
+  If app config changes:
     - <build-dir>/config.json changes, rebuild and restart server.
+
+  If user styles change:
+    - <public-dir>/styles.less changes, rebuild and restart server.
 
   If new plugin type in an existing plugin package is used:
     - <build-dir>/plugins/** changes,  rebuild next and restart server.

--- a/packages/server-dev/manager/watchers/nextBuildWatcher.mjs
+++ b/packages/server-dev/manager/watchers/nextBuildWatcher.mjs
@@ -36,6 +36,7 @@ const watchedFiles = [
   'build/plugins/operators/client.js',
   'build/plugins/operators/server.js',
   'build/plugins/styles.less',
+  'public/styles.less',
   'package.json',
 ];
 

--- a/packages/server-dev/next.config.js
+++ b/packages/server-dev/next.config.js
@@ -2,11 +2,6 @@ const withLess = require('next-with-less');
 const lowdefyConfig = require('./build/config.json');
 
 module.exports = withLess({
-  lessLoaderOptions: {
-    lessOptions: {
-      modifyVars: lowdefyConfig.theme.lessVariables,
-    },
-  },
   basePath: process.env.LOWDEFY_BASE_PATH || lowdefyConfig.basePath,
   // reactStrictMode: true,
   webpack: (config, { isServer }) => {

--- a/packages/server/next.config.js
+++ b/packages/server/next.config.js
@@ -4,11 +4,6 @@ const lowdefyConfig = require('./build/config.json');
 // TODO: Trace env and args from cli that is required on the server.
 module.exports = withLess({
   basePath: process.env.LOWDEFY_BASE_PATH || lowdefyConfig.basePath,
-  lessLoaderOptions: {
-    lessOptions: {
-      modifyVars: lowdefyConfig.theme.lessVariables,
-    },
-  },
   reactStrictMode: true,
   webpack: (config, { isServer }) => {
     if (!isServer) {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes #ISSUE_NUMBER

### What are the changes and their implications?

This PR adds support for user defined style ([LESS](https://lesscss.org)) files. If a `styles.less` file is present in the `public` folder, that file will be imported as part of the build.

Other `.less` and `.css` files in the `public` folder can be imported, and `.less` and `.css` can be imported from the dependencies of plugins.

Less variables can be set in the `styles.less` file. In particular, Ant Design V4 theme variables can be set.

As an example:
```less
@import  'antd/lib/style/dark.less';
@import './other.css';
@primary-color: #2ac8bb;
```

 # BREAKING CHANGE for Lowdefy V4 alphas
Support for the `config.theme.lessVariables` config option has been dropped as it can easily be achieved using a `styles.less` file.


## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
