### PR TITLE
Docs: Keep Throw action the same as v3.

### DIFF
--- a/packages/docs/actions/Throw.yaml
+++ b/packages/docs/actions/Throw.yaml
@@ -40,7 +40,7 @@ _ref:
     examples: |
       ###### Throw with custom message:
       ```yaml
-      - id: foo_trow
+      - id: foo_throw
         type: Throw
         params:
           throw:
@@ -52,7 +52,7 @@ _ref:
 
       ###### Throw with metaData:
       ```yaml
-      - id: foo_trow
+      - id: foo_throw
         type: Throw
         params:
           throw:
@@ -65,7 +65,7 @@ _ref:
       ```
       ###### Override custom message:
       ```yaml
-      - id: foo_trow
+      - id: foo_throw
         type: Throw
         messages:
           error: Meh.
@@ -78,7 +78,7 @@ _ref:
       ```
       ###### Fail silently:
       ```yaml
-      - id: foo_trow
+      - id: foo_throw
         type: Throw
         messages:
           error: false

--- a/packages/docs/actions/Throw.yaml
+++ b/packages/docs/actions/Throw.yaml
@@ -15,9 +15,9 @@
 _ref:
   path: templates/actions.yaml.njk
   vars:
-    pageId: Break
-    pageTitle: Break
-    filePath: actions/Break.yaml
+    pageId: Throw
+    pageTitle: Throw
+    filePath: actions/Throw.yaml
     types: |
       ```
       (params: {
@@ -29,19 +29,19 @@ _ref:
     description: |
       ##### TODO: This page needs to be updated.
 
-      The `Break` action is used throw an error to the user and log to the console. If `throw: true`, the `Break`
-      action will throw an error, and this will stop the execution of actions that are defined after it. If the action does not thrown, the `Break` action will do nothing and the actions defined after it will be executed.
+      The `Throw` action is used throw an error to the user and log to the console. If `throw: true`, the `Throw`
+      action will throw an error, and this will stop the execution of actions that are defined after it. If the action does not thrown, the `Throw` action will do nothing and the actions defined after it will be executed.
 
     params: |
-      - `throw: boolean`: Breaks an error and stops the action chain when `true` or continues the action chain when `false` or undefined.
+      - `throw: boolean`: Throws an error and stops the action chain when `true` or continues the action chain when `false` or undefined.
       - `message: string`: The error message to show to the user and log to the console if `throw: true`. This message can be overridden by setting the action's `messages.error`.
       - `metaData: any`: Data to log to the console if `throw: true`.
 
     examples: |
-      ###### Break with custom message:
+      ###### Throw with custom message:
       ```yaml
-      - id: throw
-        type: Break
+      - id: foo_trow
+        type: Throw
         params:
           throw:
             _eq:
@@ -50,10 +50,10 @@ _ref:
           message: Nooooooooooooooooo
       ```
 
-      ###### Break with metaData:
+      ###### Throw with metaData:
       ```yaml
-      - id: throw
-        type: Break
+      - id: foo_trow
+        type: Throw
         params:
           throw:
             _eq:
@@ -65,8 +65,8 @@ _ref:
       ```
       ###### Override custom message:
       ```yaml
-      - id: throw
-        type: Break
+      - id: foo_trow
+        type: Throw
         messages:
           error: Meh.
         params:
@@ -78,8 +78,8 @@ _ref:
       ```
       ###### Fail silently:
       ```yaml
-      - id: throw
-        type: Break
+      - id: foo_trow
+        type: Throw
         messages:
           error: false
         params:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?
For v4 we considered renaming `Throw` to `Break` and then not throwing an error but just breaking the action chain. After some consideration, we've decided to support both. Thus, keep `Throw` as implemented in v3 and add `Break` as an additional feature in the future.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [x] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
