### PR TITLE
Fix validation when using a dynamic approach to setting required.

### DIFF
--- a/packages/engine/src/Blocks.js
+++ b/packages/engine/src/Blocks.js
@@ -342,7 +342,9 @@ class Blocks {
             : 'This field is required',
         };
         const validation =
-          block.required === false ? block.validate : [requiredValidation, ...block.validate];
+          block.requiredEval.output === false
+            ? block.validate
+            : [requiredValidation, ...block.validate];
         block.validationEval = {
           output: {
             status: null,

--- a/packages/engine/test/Block/validate.test.js
+++ b/packages/engine/test/Block/validate.test.js
@@ -1019,3 +1019,109 @@ test('drop showValidation on RootBlocks.resetValidation()', async () => {
   expect(text1.showValidation).toBe(false);
   expect(text2.showValidation).toBe(false);
 });
+
+test('dynamic required on input to return validation error when required evaluates to true on RootBlock.validate(match)', async () => {
+  const pageConfig = {
+    id: 'root',
+    type: 'Box',
+    events: {
+      onInit: [
+        {
+          id: 'init',
+          type: 'SetState',
+          params: { is_required: true },
+        },
+      ],
+    },
+    blocks: [
+      {
+        type: 'TextInput',
+        id: 'text',
+        required: {
+          _state: 'is_required',
+        },
+      },
+    ],
+  };
+  const context = await testContext({
+    lowdefy,
+    pageConfig,
+  });
+  const { text } = context._internal.RootBlocks.map;
+  expect(context.state).toEqual({
+    text: null,
+    is_required: true,
+  });
+  expect(context._internal.RootBlocks.validate(match)).toEqual([
+    {
+      blockId: 'text',
+      validation: { errors: ['This field is required'], status: 'error', warnings: [] },
+    },
+  ]);
+  text.setValue('a');
+  expect(context._internal.RootBlocks.validate(match)).toEqual([]);
+  text.setValue('');
+  expect(context._internal.RootBlocks.validate(match)).toEqual([
+    {
+      blockId: 'text',
+      validation: { errors: ['This field is required'], status: 'error', warnings: [] },
+    },
+  ]);
+  context._internal.State.set('is_required', false);
+  text.setValue('');
+  expect(context._internal.RootBlocks.validate(match)).toEqual([]);
+});
+
+test('dynamic required on input to return validation error when required evaluates to a message on RootBlock.validate(match)', async () => {
+  const pageConfig = {
+    id: 'root',
+    type: 'Box',
+    events: {
+      onInit: [
+        {
+          id: 'init',
+          type: 'SetState',
+          params: { is_required_message: 'Custom Message' },
+        },
+      ],
+    },
+    blocks: [
+      {
+        type: 'TextInput',
+        id: 'text',
+        required: {
+          _state: 'is_required_message',
+        },
+      },
+    ],
+  };
+  const context = await testContext({
+    lowdefy,
+    pageConfig,
+  });
+  const { text } = context._internal.RootBlocks.map;
+  expect(context.state).toEqual({
+    text: null,
+    is_required_message: 'Custom Message',
+  });
+  expect(context._internal.RootBlocks.validate(match)).toEqual([
+    {
+      blockId: 'text',
+      validation: { errors: ['Custom Message'], status: 'error', warnings: [] },
+    },
+  ]);
+  text.setValue('a');
+  expect(context._internal.RootBlocks.validate(match)).toEqual([]);
+  text.setValue('');
+  expect(context._internal.RootBlocks.validate(match)).toEqual([
+    {
+      blockId: 'text',
+      validation: { errors: ['Custom Message'], status: 'error', warnings: [] },
+    },
+  ]);
+  context._internal.State.set('is_required_message', false);
+  text.setValue('');
+  expect(context._internal.RootBlocks.validate(match)).toEqual([]);
+  text.setValue('a');
+  expect(context._internal.RootBlocks.validate(match)).toEqual([]);
+});


### PR DESCRIPTION

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes #1465 

### What are the changes and their implications?
This PR fixes the validation bug which appeared when required was set dynamically. This bug caused validation to occur when required evaluated to false, which is not the desired behaviour. 

## Checklist

- [x] Pull request is made to the "develop" branch
- [x] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
