### PR TITLE
Throw error when user runs v3 app using v4 CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,6 +47,7 @@
     "decompress-targz": "4.1.1",
     "dotenv": "16.0.3",
     "ora": "6.1.2",
+    "semver": "7.3.8",
     "uuid": "9.0.0",
     "yaml": "2.2.1"
   },

--- a/packages/cli/src/utils/checkForUpdatedVersions.js
+++ b/packages/cli/src/utils/checkForUpdatedVersions.js
@@ -17,11 +17,26 @@
 import axios from 'axios';
 
 async function checkForUpdatedVersions({ cliVersion, lowdefyVersion, print }) {
+  if (lowdefyVersion === 'local') {
+    return;
+  }
   if (isExperimentalVersion(cliVersion) || isExperimentalVersion(lowdefyVersion)) {
     print.warn(`
 ---------------------------------------------------
   You are using an experimental version of Lowdefy.
   Features may change at any time.
+---------------------------------------------------`);
+    return;
+  }
+  if (getMajorVersion(lowdefyVersion) === '3') {
+    print.warn(`
+---------------------------------------------------
+  You are attempting to run a version 3 app with the version 4 cli.
+  Please update your app to version 4 using the migration guide.
+  View the migration guide here:
+    https://docs.lowdefy.com/v3-to-v4
+  Alternatively, run the app with the version 3 cli.
+  To do this, run 'npx lowdefy@3'.
 ---------------------------------------------------`);
     return;
   }
@@ -35,7 +50,7 @@ async function checkForUpdatedVersions({ cliVersion, lowdefyVersion, print }) {
 -------------------------------------------------------------
   You are not using the latest version of the Lowdefy CLI.
   Please update to version ${latestVersion}.
-  To always use the latest version, run 'npx lowdefy@latest'.
+  To always use the latest version, run 'pnpx lowdefy@4'.
 -------------------------------------------------------------`);
     }
     if (lowdefyVersion && lowdefyVersion !== latestVersion) {
@@ -54,6 +69,10 @@ async function checkForUpdatedVersions({ cliVersion, lowdefyVersion, print }) {
 
 function isExperimentalVersion(version) {
   return version.includes('alpha') || version.includes('beta') || version.includes('rc');
+}
+
+function getMajorVersion(version) {
+  return version.split('.')[0];
 }
 
 export default checkForUpdatedVersions;

--- a/packages/cli/src/utils/checkForUpdatedVersions.js
+++ b/packages/cli/src/utils/checkForUpdatedVersions.js
@@ -15,10 +15,28 @@
 */
 
 import axios from 'axios';
+import semver from 'semver';
 
 async function checkForUpdatedVersions({ cliVersion, lowdefyVersion, print }) {
   if (lowdefyVersion === 'local') {
     return;
+  }
+  if (!semver.valid(lowdefyVersion)) {
+    throw new Error(`
+---------------------------------------------------
+  Version ${lowdefyVersion} is not a valid version.
+---------------------------------------------------`);
+  }
+  if (semver.major(lowdefyVersion) === 3) {
+    throw new Error(`
+---------------------------------------------------
+  You are attempting to run a version 3 app with the version 4 CLI.
+  Please update your app to version 4 using the migration guide.
+  View the migration guide here:
+    https://docs.lowdefy.com/v3-to-v4
+  Alternatively, run the app with the version 3 CLI.
+  To do this, run 'npx lowdefy@3'.
+---------------------------------------------------`);
   }
   if (isExperimentalVersion(cliVersion) || isExperimentalVersion(lowdefyVersion)) {
     print.warn(`
@@ -28,18 +46,7 @@ async function checkForUpdatedVersions({ cliVersion, lowdefyVersion, print }) {
 ---------------------------------------------------`);
     return;
   }
-  if (getMajorVersion(lowdefyVersion) === '3') {
-    print.warn(`
----------------------------------------------------
-  You are attempting to run a version 3 app with the version 4 cli.
-  Please update your app to version 4 using the migration guide.
-  View the migration guide here:
-    https://docs.lowdefy.com/v3-to-v4
-  Alternatively, run the app with the version 3 cli.
-  To do this, run 'npx lowdefy@3'.
----------------------------------------------------`);
-    return;
-  }
+
   const registryUrl = 'https://registry.npmjs.org/lowdefy';
   try {
     const packageInfo = await axios.get(registryUrl);
@@ -69,10 +76,6 @@ async function checkForUpdatedVersions({ cliVersion, lowdefyVersion, print }) {
 
 function isExperimentalVersion(version) {
   return version.includes('alpha') || version.includes('beta') || version.includes('rc');
-}
-
-function getMajorVersion(version) {
-  return version.split('.')[0];
 }
 
 export default checkForUpdatedVersions;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,7 @@ importers:
       dotenv: 16.0.3
       jest: 28.1.0
       ora: 6.1.2
+      semver: 7.3.8
       uuid: 9.0.0
       yaml: 2.2.1
     dependencies:
@@ -178,6 +179,7 @@ importers:
       decompress-targz: 4.1.1
       dotenv: 16.0.3
       ora: 6.1.2
+      semver: 7.3.8
       uuid: 9.0.0
       yaml: 2.2.1
     devDependencies:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?
This PR adds an error that is thrown when a user tries to run a version 3 app using the version 4 CLI. It adds a dependency on semver, which is used to validate the version and to get the major version.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
