### PR TITLE
fix: _user: true should return null if logged out.

### DIFF
--- a/packages/operators/src/getFromObject.test.js
+++ b/packages/operators/src/getFromObject.test.js
@@ -94,6 +94,18 @@ test('get a field from an object, key as param, not found returns null', () => {
   expect(res).toEqual(null);
 });
 
+test('get from null', () => {
+  const params = 'string';
+  const res = getFromObject({
+    params,
+    object: null,
+    arrayIndices: defaultArrayIndices,
+    operator,
+    location,
+  });
+  expect(res).toEqual(null);
+});
+
 test('If key is null, null is returned', () => {
   const params = { key: null };
   const res = getFromObject({
@@ -140,6 +152,18 @@ test('get an entire object, params all', () => {
     location,
   });
   expect(res).toEqual(defaultObject);
+});
+
+test('get an entire object, object is null', () => {
+  const params = true;
+  const res = getFromObject({
+    params,
+    object: null,
+    arrayIndices: defaultArrayIndices,
+    operator,
+    location,
+  });
+  expect(res).toEqual(null);
 });
 
 test('copy results', () => {

--- a/packages/operators/src/webParser.js
+++ b/packages/operators/src/webParser.js
@@ -71,7 +71,7 @@ class WebParser {
           requests: this.context.requests,
           runtime: 'browser',
           state: this.context.state,
-          user: user ?? {},
+          user,
         });
         return res;
       } catch (e) {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes ~#ISSUE_NUMBER~

### What are the changes and their implications?

The `_user: true` operator expression should return null, not and empty object.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
