### PR TITLE
Add Marker Clusterers to Google Map block.

### DIFF
--- a/packages/plugins/blocks/blocks-google-maps/README.md
+++ b/packages/plugins/blocks/blocks-google-maps/README.md
@@ -7,6 +7,7 @@ To use this block, define a [@googlemaps/react-wrapper](https://www.npmjs.com/pa
 - [Map](https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions)
 - [Heatmap](https://developers.google.com/maps/documentation/javascript/reference/visualization#HeatmapLayerOptions)
 - [Markers](https://developers.google.com/maps/documentation/javascript/reference/marker#MarkerOptions)
+- [Marker Clusterers](https://developers.google.com/maps/documentation/javascript/marker-clustering)
 
 ### Properties
 
@@ -22,12 +23,39 @@ To use this block, define a [@googlemaps/react-wrapper](https://www.npmjs.com/pa
 - `markers: markerOptions[]`: A list of Markers with marker options, see more [Javascript API Markers](https://developers.google.com/maps/documentation/javascript/markers).
   - `position: { lat: number, lng: number }`: Position of marker on map.
   - `label: string`: Label displayed on marker.
+- `markerClusterers: markerClustererOptions[]`: A list of MarkerClusterers with marker clusterer options.
+  - `markers: markerOptions[]`: A list of Markers with marker options, see more [Javascript API Markers](https://developers.google.com/maps/documentation/javascript/markers).
+    - `position: { lat: number, lng: number }`: Position of marker on map.
+    - `label: string`: Label displayed on marker.
+  - `options: markerClustererOptions`: All other [marker clusterer options](https://react-google-maps-api-docs.netlify.app/#markerclusterer).
 - `infoWindow: infoWindowOptions`: All infoWindow options, see [infoWindow options](https://developers.google.com/maps/documentation/javascript/reference/info-window#InfoWindowOptions).
   - `position: { lat: number, lng: number }`: Position of infoWindow on map.
   - `visible: boolean`: When visible is true, blocks inside infoWindow content area will be rendered.
 
 ### Events
 
+- `onBoundsChanged`: Trigger onBoundsChanged actions when the bounds of the map is changed. returns `_event`
+object:
+  - `bounds`:
+    - `east`: latitudinal coordinate
+    - `north`: longitudinal coordinate
+    - `south`: longitudinal coordinate
+    - `west`: latitudinal coordinate
+  - `center`:
+    - `lat`: latitudinal coordinate
+    - `lng`: longitudinal coordinate
+  - `zoom`: zoom level
+- `onCenterChanged`: Trigger onCenterChanged actions when the center of the map is changed. returns `_event`
+object:
+  - `bounds`:
+    - `east`: latitudinal coordinate
+    - `north`: longitudinal coordinate
+    - `south`: longitudinal coordinate
+    - `west`: latitudinal coordinate
+  - `center`:
+    - `lat`: latitudinal coordinate
+    - `lng`: longitudinal coordinate
+  - `zoom`: zoom level
 - `onClick`: Trigger onClick actions when the map is clicked, returns `_event` object:
   - `domEvent`: event object
   - `latLng`:
@@ -36,7 +64,9 @@ To use this block, define a [@googlemaps/react-wrapper](https://www.npmjs.com/pa
   - `pixel`:
     - `x`: x position on map block
     - `y`: y position on map block
-- `onClickMarker`: Trigger onClickMarker actions when a marker is clicked, returns `_event` object:
+- `onClusterClick`: Trigger onClusterClick actions when a cluster is clicked, returns `_event`
+- `onMarkerClick`: Trigger onMarkerClick actions when a marker is clicked, returns `_event`
+object:
   - `domEvent`: event object
   - `latLng`:
     - `lat`: latitudinal coordinate
@@ -44,13 +74,26 @@ To use this block, define a [@googlemaps/react-wrapper](https://www.npmjs.com/pa
   - `pixel`:
     - `x`: x position on map block
     - `y`: y position on map block
-- `onZoomChanged`: Trigger onZoomChanged actions when the zoom on the map is changed.
+- `onZoomChanged`: Trigger onZoomChanged actions when the zoom on the map is changed. returns `_event`
+object:
+  - `bounds`:
+    - `east`: latitudinal coordinate
+    - `north`: longitudinal coordinate
+    - `south`: longitudinal coordinate
+    - `west`: latitudinal coordinate
+  - `center`:
+    - `lat`: latitudinal coordinate
+    - `lng`: longitudinal coordinate
+  - `zoom`: zoom level
 
 ### Methods
 
 - `fitBounds`: Fit map to given bounds.
   - `bounds: { lat: number, lng: number } []`: A list of the coordinate positions of the boundary points.
   - `zoom: number`: Map zoom level.
+- `getBounds`: Returns the bounds of the map.
+- `getCenter`: Returns the center of the map.
+- `getZoom`: Returns the zoom of the map.
 
 ## Examples
 
@@ -328,6 +371,126 @@ To use this block, define a [@googlemaps/react-wrapper](https://www.npmjs.com/pa
               center:
                 lat: -35.344
                 lng: 31.036
+    ```
+
+7. Add a marker clusterer:
+
+    ```yaml
+    - id: google_maps_script_7
+      type: GoogleMapsScript
+      properties:
+        libraries:
+          - visualization
+        apiKey:
+          _build.env: GOOGLE_MAPS_API_KEY
+      blocks:
+        - id: google_maps_7
+          type: GoogleMapsHeatmap
+          properties:
+            map:
+              disableDefaultUI: true
+            markerClusterers:
+              - markers:
+                  - position:
+                      lat: 34.091158
+                      lng: -118.2795188
+                  - position:
+                      lat: 34.0771192
+                      lng: -118.2587199
+                  - position:
+                      lat: 34.083527
+                      lng: -118.370157
+                  - position:
+                      lat: 34.0951843
+                      lng: -118.283107
+                  - position:
+                      lat: 34.1033401
+                      lng: -118.2875469
+                  - position:
+                      lat: 34.035798
+                      lng: -118.251288
+                  - position:
+                      lat: 34.0776068
+                      lng: -118.2646526
+                  - position:
+                      lat: 34.0919263
+                      lng: -118.2820544
+                  - position:
+                      lat: 34.0568525
+                      lng: -118.3646369
+                  - position:
+                      lat: 34.0285781
+                      lng: -118.4115541
+                  - position:
+                      lat: 34.017339
+                      lng: -118.278469
+                  - position:
+                      lat: 34.0764288
+                      lng: -118.3661624
+                  - position:
+                      lat: 33.9925942
+                      lng: -118.4232475
+                  - position:
+                      lat: 34.0764345
+                      lng: -118.3730332
+                  - position:
+                      lat: 34.093981
+                      lng: -118.327638
+                  - position:
+                      lat: 34.056385
+                      lng: -118.2508724
+                  - position:
+                      lat: 34.107701
+                      lng: -118.2667943
+                  - position:
+                      lat: 34.0450139
+                      lng: -118.2388682
+                  - position:
+                      lat: 34.1031997
+                      lng: -118.2586152
+                  - position:
+                      lat: 34.0828183
+                      lng: -118.3241586
+                options:
+                  averageCenter: true
+                  zoomOnClick: false
+                  minimumClusterSize: 3
+                  maxZoom: 13
+    ```
+
+8. Call method getZoom:
+
+    ```yaml
+    - id: google_maps_script_8
+      type: GoogleMapsScript
+      properties:
+        apiKey:
+          _build.env: GOOGLE_MAPS_API_KEY
+      blocks:
+        - id: google_maps_8
+          type: GoogleMaps
+          properties:
+            map:
+              options:
+                panControl: true
+                zoomControl: true
+                fullscreenControl: true
+              zoom: 14
+              center:
+                lat: -25.344
+                lng: 131.036
+          events:
+            onClick:
+              - id: get_zoom
+                type: CallMethod
+                params:
+                  blockId: google_maps_8
+                  method: getZoom
+              - id: get_zoom_result
+                type: SetState
+                params:
+                  zoom:
+                    _actions: get_zoom.response
     ```
 <!--
 7. Trigger fitBounds using the onLoad event:

--- a/packages/plugins/blocks/blocks-google-maps/README.md
+++ b/packages/plugins/blocks/blocks-google-maps/README.md
@@ -34,7 +34,7 @@ To use this block, define a [@googlemaps/react-wrapper](https://www.npmjs.com/pa
 
 ### Events
 
-- `onBoundsChanged`: Trigger onBoundsChanged actions when the bounds of the map is changed. returns `_event`
+- `onBoundsChanged`: Trigger onBoundsChanged actions when the bounds of the map are changed, returns `_event`
 object:
   - `bounds`:
     - `east`: latitudinal coordinate
@@ -45,7 +45,7 @@ object:
     - `lat`: latitudinal coordinate
     - `lng`: longitudinal coordinate
   - `zoom`: zoom level
-- `onCenterChanged`: Trigger onCenterChanged actions when the center of the map is changed. returns `_event`
+- `onCenterChanged`: Trigger onCenterChanged actions when the center of the map is changed, returns `_event`
 object:
   - `bounds`:
     - `east`: latitudinal coordinate

--- a/packages/plugins/blocks/blocks-google-maps/README.md
+++ b/packages/plugins/blocks/blocks-google-maps/README.md
@@ -385,7 +385,7 @@ object:
           _build.env: GOOGLE_MAPS_API_KEY
       blocks:
         - id: google_maps_7
-          type: GoogleMapsHeatmap
+          type: GoogleMaps
           properties:
             map:
               disableDefaultUI: true

--- a/packages/plugins/blocks/blocks-google-maps/src/blocks/GoogleMaps/GoogleMaps.json
+++ b/packages/plugins/blocks/blocks-google-maps/src/blocks/GoogleMaps/GoogleMaps.json
@@ -85,6 +85,70 @@
           }
         }
       },
+      "markerClusterers": {
+        "type": "array",
+        "description": "A list of Marker Clusterers with marker clusterer options.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "markers": {
+              "type": "array",
+              "description": "A list of Markers with marker options.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "position": {
+                    "type": "object",
+                    "properties": {
+                      "lat": {
+                        "type": "number",
+                        "description": "Lateral coordinate."
+                      },
+                      "lng": {
+                        "type": "number",
+                        "description": "Longitudinal coordinate."
+                      }
+                    }
+                  },
+                  "label": {
+                    "type": "string",
+                    "description": "Label displayed on marker."
+                  }
+                }
+              }
+            },
+            "options": {
+              "type": "object",
+              "properties": {
+                "averageCenter": {
+                  "type": "boolean",
+                  "description": "Whether the position of a cluster marker should be the average position of all markers in the cluster."
+                },
+                "gridSize": {
+                  "type": "number",
+                  "description": "The grid size of a cluster in pixels."
+                },
+                "maxZoom": {
+                  "type": "number",
+                  "description": "The maximum zoom level at which clustering is enabled."
+                },
+                "minimumClusterSize": {
+                  "type": "number",
+                  "description": "The minimum number of markers needed to form a cluster."
+                },
+                "styles": {
+                  "type": "array",
+                  "description": "Styles of the cluster markers to be used."
+                },
+                "zoomOnClick": {
+                  "type": "boolean",
+                  "description": "Whether to zoom the map when a cluster marker is clicked."
+                }
+              }
+            }
+          }
+        }
+      },
       "infoWindow": {
         "type": "object",
         "description": "infoWindow options, see <a href='https://developers.google.com/maps/documentation/javascript/reference/info-window#InfoWindowOptions'>more</a>.",
@@ -118,6 +182,14 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+      "onBoundsChanged": {
+        "type": "array",
+        "description": "Trigger actions when the bounds of the map are changed."
+      },
+      "onCenterChanged": {
+        "type": "array",
+        "description": "Trigger actions when the center of the map is changed."
+      },
       "onClick": {
         "type": "array",
         "description": "Trigger actions when the map is clicked."

--- a/packages/plugins/blocks/blocks-google-maps/src/blocks/Map.js
+++ b/packages/plugins/blocks/blocks-google-maps/src/blocks/Map.js
@@ -32,6 +32,7 @@ const MAP_DEFAULTS = {
 };
 
 const MAP_PROPS = {
+  zoom: null,
   center: {
     lat: 0,
     lng: 0,
@@ -78,8 +79,14 @@ const Map = ({ blockId, children, content, methods, properties }) => {
     (properties.markers ?? []).map((marker) => {
       bounds.extend(marker.position);
     });
-    if (!properties.map?.center && !properties.map?.zoom) {
+    (properties.markerClusterers ?? []).map((markerClusterer) => {
+      (markerClusterer.markers ?? []).map((marker) => {
+        bounds.extend(marker.position);
+      });
+    });
+    if (!properties.map?.center && !properties.map?.zoom && MAP_PROPS.zoom === null) {
       map.fitBounds(bounds);
+      MAP_PROPS.zoom = map.getZoom();
     }
   }
 
@@ -91,13 +98,17 @@ const Map = ({ blockId, children, content, methods, properties }) => {
     MAP_PROPS.center = properties.map.center;
   }
 
+  if (properties.map?.zoom && properties.map.zoom !== MAP_PROPS.zoom) {
+    MAP_PROPS.zoom = properties.map.zoom;
+  }
+
   return (
     <GoogleMap
       {...properties.map} // https://react-google-maps-api-docs.netlify.app/#googlemap
       id={blockId}
       mapContainerClassName={methods.makeCssClass([STYLE_DEFAULTS, properties.style])}
       center={MAP_PROPS.center}
-      zoom={properties.map?.zoom ?? MAP_DEFAULTS.zoom}
+      zoom={MAP_PROPS.zoom}
       onLoad={(newMap, event) => {
         setMap(newMap);
         setBounds(new window.google.maps.LatLngBounds());


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?
This PR adds the ability to add marker clusterers to the google map block. Marker Clusterers can be added under the markerClusterers property of the GoogleMaps block. 
This PR also includes a fix for zoom not working when an initial center and zoom are not supplied in the block config. 

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [x] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
