### PR TITLE
Fix v3 undefined version error when calling lowdefy init.

### DIFF
--- a/packages/cli/src/utils/getLowdefyYaml.js
+++ b/packages/cli/src/utils/getLowdefyYaml.js
@@ -19,13 +19,13 @@ import { get, type } from '@lowdefy/helpers';
 import { readFile } from '@lowdefy/node-utils';
 import YAML from 'js-yaml';
 
-async function getLowdefyYaml({ baseDirectory, command }) {
+async function getLowdefyYaml({ baseDirectory, requiresLowdefyYaml }) {
   let lowdefyYaml = await readFile(path.resolve(baseDirectory, 'lowdefy.yaml'));
   if (!lowdefyYaml) {
     lowdefyYaml = await readFile(path.resolve(baseDirectory, 'lowdefy.yml'));
   }
   if (!lowdefyYaml) {
-    if (!['init', 'clean-cache'].includes(command)) {
+    if (requiresLowdefyYaml) {
       throw new Error(
         `Could not find "lowdefy.yaml" file in specified base directory ${baseDirectory}.`
       );

--- a/packages/cli/src/utils/getLowdefyYaml.test.js
+++ b/packages/cli/src/utils/getLowdefyYaml.test.js
@@ -42,7 +42,7 @@ test('get version from yaml file', async () => {
     }
     return null;
   });
-  const config = await getLowdefyYaml({ baseDirectory });
+  const config = await getLowdefyYaml({ baseDirectory, requiresLowdefyYaml: true });
   expect(config).toEqual({ lowdefyVersion: '1.0.0', cliConfig: {} });
 });
 
@@ -71,7 +71,7 @@ test('could not find lowdefy.yaml in cwd', async () => {
     lowdefy: 1.0.0
     `;
   });
-  await expect(getLowdefyYaml({ baseDirectory })).rejects.toThrow(
+  await expect(getLowdefyYaml({ baseDirectory, requiresLowdefyYaml: true })).rejects.toThrow(
     'Could not find "lowdefy.yaml" file in specified base directory'
   );
 });
@@ -89,7 +89,10 @@ test('could not find lowdefy.yaml in base dir', async () => {
     `;
   });
   await expect(
-    getLowdefyYaml({ baseDirectory: path.resolve(process.cwd(), './baseDir') })
+    getLowdefyYaml({
+      baseDirectory: path.resolve(process.cwd(), './baseDir'),
+      requiresLowdefyYaml: true,
+    })
   ).rejects.toThrow('Could not find "lowdefy.yaml" file in specified base directory');
 });
 
@@ -104,7 +107,7 @@ test('lowdefy.yaml is invalid yaml', async () => {
     }
     return null;
   });
-  await expect(getLowdefyYaml({ baseDirectory })).rejects.toThrow(
+  await expect(getLowdefyYaml({ baseDirectory, requiresLowdefyYaml: true })).rejects.toThrow(
     'Could not parse "lowdefy.yaml" file. Received error '
   );
 });
@@ -120,7 +123,7 @@ test('No version specified', async () => {
     }
     return null;
   });
-  await expect(getLowdefyYaml({ baseDirectory })).rejects.toThrow(
+  await expect(getLowdefyYaml({ baseDirectory, requiresLowdefyYaml: true })).rejects.toThrow(
     'No version specified in "lowdefy.yaml" file. Specify a version in the "lowdefy" field.'
   );
 });
@@ -134,7 +137,7 @@ test('Version is not a string', async () => {
     }
     return null;
   });
-  await expect(getLowdefyYaml({ baseDirectory })).rejects.toThrow(
+  await expect(getLowdefyYaml({ baseDirectory, requiresLowdefyYaml: true })).rejects.toThrow(
     'Version number specified in "lowdefy.yaml" file is not valid. Received 1.'
   );
 });
@@ -148,7 +151,7 @@ test('Version is not a valid version number', async () => {
     }
     return null;
   });
-  await expect(getLowdefyYaml({ baseDirectory })).rejects.toThrow(
+  await expect(getLowdefyYaml({ baseDirectory, requiresLowdefyYaml: true })).rejects.toThrow(
     'Version number specified in "lowdefy.yaml" file is not valid. Received "v1-0-3".'
   );
 });
@@ -173,13 +176,9 @@ test('get cliConfig', async () => {
   });
 });
 
-test('could not find lowdefy.yaml in base dir, command is "init" or "clean-cache"', async () => {
+test('could not find lowdefy.yaml in base dir, command is "init" or "clean-cache", requiresLowdefyYaml is false', async () => {
   readFile.mockImplementation(() => null);
-  let config = await getLowdefyYaml({ command: 'init', baseDirectory });
-  expect(config).toEqual({
-    cliConfig: {},
-  });
-  config = await getLowdefyYaml({ command: 'clean-cache', baseDirectory });
+  let config = await getLowdefyYaml({ baseDirectory, requiresLowdefyYaml: false });
   expect(config).toEqual({
     cliConfig: {},
   });
@@ -194,6 +193,6 @@ test('support yml extension', async () => {
     }
     return null;
   });
-  const config = await getLowdefyYaml({ baseDirectory });
+  const config = await getLowdefyYaml({ baseDirectory, requiresLowdefyYaml: true });
   expect(config).toEqual({ lowdefyVersion: '1.0.0', cliConfig: {} });
 });

--- a/packages/cli/src/utils/startUp.js
+++ b/packages/cli/src/utils/startUp.js
@@ -17,7 +17,7 @@
 import path from 'path';
 import { type } from '@lowdefy/helpers';
 
-import checkForUpdatedVersions from './checkForUpdatedVersions';
+import validateVersion from './validateVersion';
 import getCliJson from './getCliJson';
 import getDirectories from './getDirectories';
 import getLowdefyYaml from './getLowdefyYaml';
@@ -47,7 +47,7 @@ async function startUp({ context, options = {}, command }) {
   context.cacheDirectory = cacheDirectory;
   context.outputDirectory = outputDirectory;
 
-  await checkForUpdatedVersions(context);
+  await validateVersion(context);
 
   context.sendTelemetry = getSendTelemetry(context);
 

--- a/packages/cli/src/utils/startUp.js
+++ b/packages/cli/src/utils/startUp.js
@@ -33,6 +33,7 @@ async function startUp({ context, options = {}, command }) {
   context.commandLineOptions = options;
   context.print = createPrint();
   context.baseDirectory = path.resolve(options.baseDirectory || process.cwd());
+  context.requiresLowdefyYaml = !['init', 'clean-cache'].includes(command.name());
 
   const { cliConfig, lowdefyVersion } = await getLowdefyYaml(context);
   context.cliConfig = cliConfig;

--- a/packages/cli/src/utils/startUp.test.js
+++ b/packages/cli/src/utils/startUp.test.js
@@ -66,6 +66,7 @@ test('startUp, options empty', async () => {
     options: { cliConfig: true },
     outputDirectory: path.resolve(process.cwd(), './.lowdefy/build'),
     print,
+    requiresLowdefyYaml: true,
     sendTelemetry: 'sendTelemetry',
   });
   expect(validateVersion).toHaveBeenCalledTimes(1);
@@ -88,6 +89,7 @@ test('startUp, options undefined', async () => {
     lowdefyVersion: 'lowdefyVersion',
     options: { cliConfig: true },
     outputDirectory: path.resolve(process.cwd(), './.lowdefy/build'),
+    requiresLowdefyYaml: true,
     print,
     sendTelemetry: 'sendTelemetry',
   });
@@ -110,6 +112,7 @@ test('startUp, options baseDirectory', async () => {
       baseDirectory: './baseDirectory',
     },
     outputDirectory: path.resolve(process.cwd(), 'baseDirectory/.lowdefy/build'),
+    requiresLowdefyYaml: true,
     sendTelemetry: 'sendTelemetry',
     print,
   });
@@ -132,6 +135,7 @@ test('startUp, options outputDirectory', async () => {
       outputDirectory: './outputDirectory',
     },
     outputDirectory: path.resolve(process.cwd(), 'outputDirectory'),
+    requiresLowdefyYaml: true,
     sendTelemetry: 'sendTelemetry',
     print,
   });
@@ -166,6 +170,7 @@ test('startUp, options baseDirectory and outputDirectory', async () => {
       outputDirectory: './outputDirectory',
     },
     outputDirectory: path.resolve(process.cwd(), 'outputDirectory'),
+    requiresLowdefyYaml: true,
     sendTelemetry: 'sendTelemetry',
     print,
   });
@@ -187,8 +192,67 @@ test('startUp, no lowdefyVersion returned', async () => {
     options: {},
     outputDirectory: path.resolve(process.cwd(), './.lowdefy/build'),
     print,
+    requiresLowdefyYaml: true,
     sendTelemetry: 'sendTelemetry',
   });
   expect(validateVersion).toHaveBeenCalledTimes(1);
   expect(print.log.mock.calls).toEqual([["Running 'lowdefy test'."]]);
+});
+
+test('startUp, requiresLowdefyYaml false with command "init"', async () => {
+  getLowdefyYaml.mockImplementationOnce(() => ({ cliConfig: {} }));
+  const context = {};
+  await startUp({
+    context,
+    options: {},
+    command: {
+      name: () => 'init',
+    },
+  });
+  expect(context).toEqual({
+    appId: 'appId',
+    baseDirectory: path.resolve(process.cwd()),
+    cacheDirectory: path.resolve(process.cwd(), './.lowdefy/.cache'),
+    cliConfig: {},
+    cliVersion: 'cliVersion',
+    command: 'init',
+    commandLineOptions: {},
+    lowdefyVersion: undefined,
+    options: {},
+    outputDirectory: path.resolve(process.cwd(), './.lowdefy/build'),
+    print,
+    requiresLowdefyYaml: false,
+    sendTelemetry: 'sendTelemetry',
+  });
+  expect(validateVersion).toHaveBeenCalledTimes(1);
+  expect(print.log.mock.calls).toEqual([["Running 'lowdefy init'."]]);
+});
+
+test('startUp, requiresLowdefyYaml false with command "clean-cache"', async () => {
+  getLowdefyYaml.mockImplementationOnce(() => ({ cliConfig: {} }));
+  const context = {};
+  await startUp({
+    context,
+    options: {},
+    command: {
+      name: () => 'clean-cache',
+    },
+  });
+  expect(context).toEqual({
+    appId: 'appId',
+    baseDirectory: path.resolve(process.cwd()),
+    cacheDirectory: path.resolve(process.cwd(), './.lowdefy/.cache'),
+    cliConfig: {},
+    cliVersion: 'cliVersion',
+    command: 'clean-cache',
+    commandLineOptions: {},
+    lowdefyVersion: undefined,
+    options: {},
+    outputDirectory: path.resolve(process.cwd(), './.lowdefy/build'),
+    print,
+    requiresLowdefyYaml: false,
+    sendTelemetry: 'sendTelemetry',
+  });
+  expect(validateVersion).toHaveBeenCalledTimes(1);
+  expect(print.log.mock.calls).toEqual([["Running 'lowdefy clean-cache'."]]);
 });

--- a/packages/cli/src/utils/startUp.test.js
+++ b/packages/cli/src/utils/startUp.test.js
@@ -16,7 +16,7 @@
 
 import path from 'path';
 import startUp from './startUp';
-import checkForUpdatedVersions from './checkForUpdatedVersions';
+import validateVersion from './validateVersion';
 import createPrint from './print';
 // eslint-disable-next-line no-unused-vars
 import getLowdefyYaml from './getLowdefyYaml';
@@ -43,7 +43,7 @@ jest.mock('./print', () => {
 });
 jest.mock('../../package.json', () => ({ version: 'cliVersion' }));
 jest.mock('./getSendTelemetry', () => () => 'sendTelemetry');
-jest.mock('./checkForUpdatedVersions', () => jest.fn(() => 'checkForUpdatedVersions'));
+jest.mock('./validateVersion', () => jest.fn(() => 'validateVersion'));
 
 const print = createPrint();
 
@@ -68,7 +68,7 @@ test('startUp, options empty', async () => {
     print,
     sendTelemetry: 'sendTelemetry',
   });
-  expect(checkForUpdatedVersions).toHaveBeenCalledTimes(1);
+  expect(validateVersion).toHaveBeenCalledTimes(1);
   expect(print.log.mock.calls).toEqual([
     ["Running 'lowdefy test'. Lowdefy app version lowdefyVersion."],
   ]);
@@ -189,6 +189,6 @@ test('startUp, no lowdefyVersion returned', async () => {
     print,
     sendTelemetry: 'sendTelemetry',
   });
-  expect(checkForUpdatedVersions).toHaveBeenCalledTimes(1);
+  expect(validateVersion).toHaveBeenCalledTimes(1);
   expect(print.log.mock.calls).toEqual([["Running 'lowdefy test'."]]);
 });

--- a/packages/cli/src/utils/validateVersion.js
+++ b/packages/cli/src/utils/validateVersion.js
@@ -17,15 +17,15 @@
 import axios from 'axios';
 import semver from 'semver';
 
-async function validateVersion({ cliVersion, command, lowdefyVersion, print }) {
-  if (['init'].includes(command)) {
+async function validateVersion({
+  cliVersion,
+  command,
+  lowdefyVersion,
+  print,
+  requiresLowdefyYaml,
+}) {
+  if (!requiresLowdefyYaml) {
     return;
-  }
-  if (!lowdefyVersion) {
-    throw new Error(`
----------------------------------------------------
-  Please specify a Lowdefy version.
----------------------------------------------------`);
   }
   if (!semver.valid(lowdefyVersion)) {
     throw new Error(`

--- a/packages/cli/src/utils/validateVersion.js
+++ b/packages/cli/src/utils/validateVersion.js
@@ -17,7 +17,16 @@
 import axios from 'axios';
 import semver from 'semver';
 
-async function checkForUpdatedVersions({ cliVersion, command, lowdefyVersion, print }) {
+async function validateVersion({ cliVersion, command, lowdefyVersion, print }) {
+  if (['init'].includes(command)) {
+    return;
+  }
+  if (!lowdefyVersion) {
+    throw new Error(`
+---------------------------------------------------
+  Please specify a Lowdefy version.
+---------------------------------------------------`);
+  }
   if (!semver.valid(lowdefyVersion)) {
     throw new Error(`
 ---------------------------------------------------
@@ -61,4 +70,4 @@ async function checkForUpdatedVersions({ cliVersion, command, lowdefyVersion, pr
   }
 }
 
-export default checkForUpdatedVersions;
+export default validateVersion;


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?
This PR renames `checkForUpdatedVersions` to `validateVersion`. It also adds a check to skip the version validation if the `init` command has been used. This check is similar to the one used in `getLowdefyYaml`.

## Checklist

- [ ] Pull request is made to the "develop" branch
- [x] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
