### PR TITLE
Authentication fixes

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,3 @@
 {
-  "recommendations": [
-    "arcanis.vscode-zipfs",
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
-    "samuelcolvin.jinjahtml"
-  ]
+  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode", "samuelcolvin.jinjahtml"]
 }

--- a/packages/server-dev/lib/auth/Auth.js
+++ b/packages/server-dev/lib/auth/Auth.js
@@ -24,7 +24,7 @@ import authConfig from '../../build/auth.json';
 function Auth({ children, session }) {
   if (authConfig.configured === true) {
     return (
-      <AuthConfigured session={session} authConfig={authConfig}>
+      <AuthConfigured serverSession={session} authConfig={authConfig}>
         {(auth) => children(auth)}
       </AuthConfigured>
     );

--- a/packages/server-dev/lib/auth/AuthConfigured.js
+++ b/packages/server-dev/lib/auth/AuthConfigured.js
@@ -15,14 +15,23 @@
 */
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { SessionProvider, signIn, signOut, useSession } from 'next-auth/react';
 
 function Session({ children }) {
+  const wasAuthenticated = useRef(false);
   const { data: session, status } = useSession();
   // If session is passed to SessionProvider from getServerSideProps
   // we won't have a loading state here.
   // But 404 uses getStaticProps so we have this for 404.
+
+  useEffect(() => {
+    if (wasAuthenticated.current && status === 'unauthenticated') {
+      window.location.reload();
+    }
+    wasAuthenticated.current = wasAuthenticated.current || status === 'authenticated';
+  }, [status]);
+
   if (status === 'loading') {
     return '';
   }

--- a/packages/server-dev/lib/auth/AuthConfigured.js
+++ b/packages/server-dev/lib/auth/AuthConfigured.js
@@ -18,6 +18,8 @@
 import React, { useEffect, useRef } from 'react';
 import { SessionProvider, signIn, signOut, useSession } from 'next-auth/react';
 
+import lowdefyConfig from '../../build/config.json';
+
 function Session({ children }) {
   const wasAuthenticated = useRef(false);
   const { data: session, status } = useSession();
@@ -40,9 +42,12 @@ function Session({ children }) {
 
 function AuthConfigured({ authConfig, children, serverSession }) {
   const auth = { signIn, signOut, authConfig };
-
+  let basePath = process.env.LOWDEFY_BASE_PATH ?? lowdefyConfig.basePath;
+  if (basePath) {
+    basePath = `${basePath}/api/auth`;
+  }
   return (
-    <SessionProvider session={serverSession}>
+    <SessionProvider session={serverSession} basePath={basePath}>
       <Session>
         {(session) => {
           auth.session = session;

--- a/packages/server-dev/lib/auth/AuthConfigured.js
+++ b/packages/server-dev/lib/auth/AuthConfigured.js
@@ -23,17 +23,17 @@ import lowdefyConfig from '../../build/config.json';
 function Session({ children }) {
   const wasAuthenticated = useRef(false);
   const { data: session, status } = useSession();
-  // If session is passed to SessionProvider from getServerSideProps
-  // we won't have a loading state here.
-  // But 404 uses getStaticProps so we have this for 404.
+  wasAuthenticated.current = wasAuthenticated.current || status === 'authenticated';
 
   useEffect(() => {
     if (wasAuthenticated.current && status === 'unauthenticated') {
       window.location.reload();
     }
-    wasAuthenticated.current = wasAuthenticated.current || status === 'authenticated';
   }, [status]);
 
+  // If session is passed to SessionProvider from getServerSideProps
+  // we won't have a loading state here.
+  // But 404 uses getStaticProps so we have this for 404.
   if (status === 'loading') {
     return '';
   }

--- a/packages/server-dev/pages/api/auth/[...nextauth].js
+++ b/packages/server-dev/pages/api/auth/[...nextauth].js
@@ -36,6 +36,11 @@ export const authOptions = getNextAuthConfig(
 
 export default async function auth(req, res) {
   if (authJson.configured === true) {
+    // Required for emails in corporate networks, see:
+    // https://next-auth.js.org/tutorials/avoid-corporate-link-checking-email-provider
+    if (req.method === 'HEAD') {
+      return res.status(200).end();
+    }
     return await NextAuth(req, res, authOptions);
   }
 

--- a/packages/server/lib/auth/Auth.js
+++ b/packages/server/lib/auth/Auth.js
@@ -24,7 +24,7 @@ import authConfig from '../../build/auth.json';
 function Auth({ children, session }) {
   if (authConfig.configured === true) {
     return (
-      <AuthConfigured session={session} authConfig={authConfig}>
+      <AuthConfigured serverSession={session} authConfig={authConfig}>
         {(auth) => children(auth)}
       </AuthConfigured>
     );

--- a/packages/server/lib/auth/AuthConfigured.js
+++ b/packages/server/lib/auth/AuthConfigured.js
@@ -15,14 +15,23 @@
 */
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { SessionProvider, signIn, signOut, useSession } from 'next-auth/react';
 
 function Session({ children }) {
+  const wasAuthenticated = useRef(false);
   const { data: session, status } = useSession();
   // If session is passed to SessionProvider from getServerSideProps
   // we won't have a loading state here.
   // But 404 uses getStaticProps so we have this for 404.
+
+  useEffect(() => {
+    if (wasAuthenticated.current && status === 'unauthenticated') {
+      window.location.reload();
+    }
+    wasAuthenticated.current = wasAuthenticated.current || status === 'authenticated';
+  }, [status]);
+
   if (status === 'loading') {
     return '';
   }

--- a/packages/server/lib/auth/AuthConfigured.js
+++ b/packages/server/lib/auth/AuthConfigured.js
@@ -18,6 +18,8 @@
 import React, { useEffect, useRef } from 'react';
 import { SessionProvider, signIn, signOut, useSession } from 'next-auth/react';
 
+import lowdefyConfig from '../../build/config.json';
+
 function Session({ children }) {
   const wasAuthenticated = useRef(false);
   const { data: session, status } = useSession();
@@ -40,9 +42,12 @@ function Session({ children }) {
 
 function AuthConfigured({ authConfig, children, serverSession }) {
   const auth = { signIn, signOut, authConfig };
-
+  let basePath = process.env.LOWDEFY_BASE_PATH ?? lowdefyConfig.basePath;
+  if (basePath) {
+    basePath = `${basePath}/api/auth`;
+  }
   return (
-    <SessionProvider session={serverSession}>
+    <SessionProvider session={serverSession} basePath={basePath}>
       <Session>
         {(session) => {
           auth.session = session;

--- a/packages/server/lib/auth/AuthConfigured.js
+++ b/packages/server/lib/auth/AuthConfigured.js
@@ -23,17 +23,17 @@ import lowdefyConfig from '../../build/config.json';
 function Session({ children }) {
   const wasAuthenticated = useRef(false);
   const { data: session, status } = useSession();
-  // If session is passed to SessionProvider from getServerSideProps
-  // we won't have a loading state here.
-  // But 404 uses getStaticProps so we have this for 404.
+  wasAuthenticated.current = wasAuthenticated.current || status === 'authenticated';
 
   useEffect(() => {
     if (wasAuthenticated.current && status === 'unauthenticated') {
       window.location.reload();
     }
-    wasAuthenticated.current = wasAuthenticated.current || status === 'authenticated';
   }, [status]);
 
+  // If session is passed to SessionProvider from getServerSideProps
+  // we won't have a loading state here.
+  // But 404 uses getStaticProps so we have this for 404.
   if (status === 'loading') {
     return '';
   }

--- a/packages/server/next.config.js
+++ b/packages/server/next.config.js
@@ -2,7 +2,7 @@ const withLess = require('next-with-less');
 const lowdefyConfig = require('./build/config.json');
 
 module.exports = withLess({
-  basePath: process.env.LOWDEFY_BASE_PATH || lowdefyConfig.basePath,
+  basePath: process.env.LOWDEFY_BASE_PATH ?? lowdefyConfig.basePath,
   reactStrictMode: true,
   webpack: (config, { isServer }) => {
     if (!isServer) {

--- a/packages/server/pages/api/auth/[...nextauth].js
+++ b/packages/server/pages/api/auth/[...nextauth].js
@@ -36,6 +36,11 @@ export const authOptions = getNextAuthConfig(
 
 export default async function auth(req, res) {
   if (authJson.configured === true) {
+    // Required for emails in corporate networks, see:
+    // https://next-auth.js.org/tutorials/avoid-corporate-link-checking-email-provider
+    if (req.method === 'HEAD') {
+      return res.status(200).end();
+    }
     return await NextAuth(req, res, authOptions);
   }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?

This PR makes the following changes:
- A 200 API response is sent on head requests - this is required for email authentication on corporate networks: https://next-auth.js.org/tutorials/avoid-corporate-link-checking-email-provider
- The server-side session was not passed to the SessionProvider component, causing an extra network request to fetch the session on initial page load
- The window is now reloaded if a client was authenticated, and is no longer authenticated. This is to prevent the user looking at a stale page, and then failing to make requests on the page because they are unauthenticated.
- The basePath needed to be provided to the SessionProvider

## Checklist

- [X] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [X] Code has been formatted with Prettier
- [X] Edits from maintainers are allowed
