### PR TITLE
Add replaceInput property to PhoneNumberInput and TextInput blocks.

### DIFF
--- a/packages/plugins/blocks/blocks-antd/src/blocks/PhoneNumberInput/PhoneNumberInput.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PhoneNumberInput/PhoneNumberInput.js
@@ -189,10 +189,18 @@ const PhoneNumberInput = ({
               placeholder={properties.placeholder}
               size={properties.size}
               status={validation.status}
-              type={'number'}
               value={value?.input}
               onChange={(event) => {
-                const input = event.target.value;
+                var input = event.target.value;
+
+                if (properties.regex) {
+                  const regex = new RegExp(
+                    properties.regex.pattern,
+                    properties.regex.flags || 'gm'
+                  );
+                  input = input.replace(regex, '');
+                }
+
                 const region = value.region;
                 const phone_number = `${region.dial_code}${input}`;
 

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PhoneNumberInput/PhoneNumberInput.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PhoneNumberInput/PhoneNumberInput.js
@@ -193,12 +193,12 @@ const PhoneNumberInput = ({
               onChange={(event) => {
                 var input = event.target.value;
 
-                if (properties.regex) {
+                if (properties.replaceInput) {
                   const regex = new RegExp(
-                    properties.regex.pattern,
-                    properties.regex.flags || 'gm'
+                    properties.replaceInput.pattern,
+                    properties.replaceInput.flags ?? 'gm'
                   );
-                  input = input.replace(regex, '');
+                  input = input.replace(regex, properties.replaceInput.replacement ?? '');
                 }
 
                 const region = value.region;

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PhoneNumberInput/schema.json
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PhoneNumberInput/schema.json
@@ -127,6 +127,23 @@
           "displayType": "yaml"
         }
       },
+      "regex": {
+        "type": "object",
+        "description": "Regex used to sanitize input.",
+        "properties": {
+          "pattern": {
+            "type": "string",
+            "description": "The regular expression pattern to use to sanitize input."
+          },
+          "flags": {
+            "type": "string",
+            "description": "The regex flags to use. The default value is 'gm'"
+          }
+        },
+        "docs": {
+          "displayType": "yaml"
+        }
+      },
       "selectStyle": {
         "type": "object",
         "description": "Css style to applied to selector.",

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PhoneNumberInput/schema.json
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PhoneNumberInput/schema.json
@@ -127,7 +127,7 @@
           "displayType": "yaml"
         }
       },
-      "regex": {
+      "replaceInput": {
         "type": "object",
         "description": "Regex used to sanitize input.",
         "properties": {
@@ -137,7 +137,11 @@
           },
           "flags": {
             "type": "string",
-            "description": "The regex flags to use. The default value is 'gm'"
+            "description": "The regex flags to use. The default value is 'gm'."
+          },
+          "replacement": {
+            "type": "string",
+            "description": "The string used to replace the input that matches the pattern. The default value is ''."
           }
         },
         "docs": {

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PhoneNumberInput/style.less
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PhoneNumberInput/style.less
@@ -15,6 +15,7 @@
 */
 
 @import 'antd/lib/input/style/index.less';
+@import 'antd/lib/select/style/index.less';
 @import '../Label/style.less';
 
 .ldf-phone-number-input {

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TextInput/TextInput.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TextInput/TextInput.js
@@ -57,7 +57,17 @@ const TextInput = ({
               status={validation.status}
               value={value}
               onChange={(event) => {
-                methods.setValue(event.target.value);
+                var input = event.target.value;
+
+                if (properties.regex) {
+                  const regex = new RegExp(
+                    properties.regex.pattern,
+                    properties.regex.flags || 'gm'
+                  );
+                  input = input.replace(regex, '');
+                }
+
+                methods.setValue(input);
                 methods.triggerEvent({ name: 'onChange' });
                 const cStart = event.target.selectionStart;
                 const cEnd = event.target.selectionEnd;

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TextInput/TextInput.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TextInput/TextInput.js
@@ -59,12 +59,12 @@ const TextInput = ({
               onChange={(event) => {
                 var input = event.target.value;
 
-                if (properties.regex) {
+                if (properties.replaceInput) {
                   const regex = new RegExp(
-                    properties.regex.pattern,
-                    properties.regex.flags || 'gm'
+                    properties.replaceInput.pattern,
+                    properties.replaceInput.flags ?? 'gm'
                   );
-                  input = input.replace(regex, '');
+                  input = input.replace(regex, properties.replaceInput.replacement ?? '');
                 }
 
                 methods.setValue(input);

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TextInput/schema.json
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TextInput/schema.json
@@ -109,6 +109,23 @@
           }
         }
       },
+      "regex": {
+        "type": "object",
+        "description": "Regex used to sanitize input.",
+        "properties": {
+          "pattern": {
+            "type": "string",
+            "description": "The regular expression pattern to use to sanitize input."
+          },
+          "flags": {
+            "type": "string",
+            "description": "The regex flags to use. The default value is 'gm'"
+          }
+        },
+        "docs": {
+          "displayType": "yaml"
+        }
+      },
       "size": {
         "type": "string",
         "enum": ["small", "middle", "large"],

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TextInput/schema.json
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TextInput/schema.json
@@ -109,7 +109,7 @@
           }
         }
       },
-      "regex": {
+      "replaceInput": {
         "type": "object",
         "description": "Regex used to sanitize input.",
         "properties": {
@@ -119,7 +119,11 @@
           },
           "flags": {
             "type": "string",
-            "description": "The regex flags to use. The default value is 'gm'"
+            "description": "The regex flags to use. The default value is 'gm'."
+          },
+          "replacement": {
+            "type": "string",
+            "description": "The string used to replace the input that matches the pattern. The default value is ''."
           }
         },
         "docs": {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?
This PR adds an additional property, `replaceInput`, to the PhoneNumberInput and TextInput blocks. This property allows a regular expression to be defined which will be used to sanitise input as the user is typing. 

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [x] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
