### PR TITLE
Fix serialization of dates and errors

### DIFF
--- a/packages/api/src/routes/request/callRequest.test.js
+++ b/packages/api/src/routes/request/callRequest.test.js
@@ -352,7 +352,7 @@ test('deserialize inputs', async () => {
   await callRequest(context, {
     blockId: 'contextId',
     payload: {
-      date: { _date: 0 },
+      date: { '~d': 0 },
     },
     pageId: 'pageId',
     requestId: 'requestId',

--- a/packages/build/src/build/addKeys.js
+++ b/packages/build/src/build/addKeys.js
@@ -22,16 +22,16 @@ function recAddKeys(object, key, keyMap, parentId) {
   const id = makeId();
   keyMap[id] = {
     key,
-    _r_: object._r_,
-    _k_parent: parentId,
+    '~r': object['~r'],
+    '~k_parent': parentId,
   };
-  Object.defineProperty(object, '_k_', {
+  Object.defineProperty(object, '~k', {
     value: id,
     enumerable: false,
     writable: true,
     configurable: true,
   });
-  delete object._r_;
+  delete object['~r'];
   Object.keys(object).forEach((nextKey) => {
     if (type.isObject(object[nextKey])) {
       recAddKeys(object[nextKey], `${key}.${nextKey}`, keyMap, id);

--- a/packages/build/src/build/addKeys.test.js
+++ b/packages/build/src/build/addKeys.test.js
@@ -22,24 +22,24 @@ const context = testContext();
 test('mutate keyMap and components', async () => {
   const addKeys = (await import('./addKeys.js')).default;
   const components = {
-    _r_: '1',
+    '~r': '1',
     pages: [
       {
         id: 'A',
         type: 'Box',
-        _r_: '2',
+        '~r': '2',
         blocks: [
-          { _r_: '3', id: 'A1', type: 'Button' },
-          { _r_: '7', id: 'A2', type: 'Button' },
+          { '~r': '3', id: 'A1', type: 'Button' },
+          { '~r': '7', id: 'A2', type: 'Button' },
         ],
       },
       {
         id: 'B',
         type: 'Box',
-        _r_: '5',
+        '~r': '5',
         blocks: [
-          { _r_: '4', id: 'B1', type: 'Button' },
-          { _r_: '6', id: 'B2', type: 'Button', properties: { _r_: '10', title: 'X' } },
+          { '~r': '4', id: 'B1', type: 'Button' },
+          { '~r': '6', id: 'B2', type: 'Button', properties: { '~r': '10', title: 'X' } },
         ],
       },
     ],
@@ -47,59 +47,59 @@ test('mutate keyMap and components', async () => {
   addKeys({ components, context });
   expect(context.keyMap).toEqual({
     2: {
-      _k_parent: '1',
-      _r_: '1',
+      '~k_parent': '1',
+      '~r': '1',
       key: 'root',
     },
     3: {
-      _k_parent: '2',
-      _r_: '2',
+      '~k_parent': '2',
+      '~r': '2',
       key: 'root.pages[0:A:Box]',
     },
     4: {
-      _k_parent: '3',
-      _r_: '3',
+      '~k_parent': '3',
+      '~r': '3',
       key: 'root.pages[0:A:Box].blocks[0:A1:Button]',
     },
     5: {
-      _k_parent: '3',
-      _r_: '7',
+      '~k_parent': '3',
+      '~r': '7',
       key: 'root.pages[0:A:Box].blocks[1:A2:Button]',
     },
     6: {
-      _k_parent: '2',
-      _r_: '5',
+      '~k_parent': '2',
+      '~r': '5',
       key: 'root.pages[1:B:Box]',
     },
     7: {
-      _k_parent: '6',
-      _r_: '4',
+      '~k_parent': '6',
+      '~r': '4',
       key: 'root.pages[1:B:Box].blocks[0:B1:Button]',
     },
     8: {
-      _k_parent: '6',
-      _r_: '6',
+      '~k_parent': '6',
+      '~r': '6',
       key: 'root.pages[1:B:Box].blocks[1:B2:Button]',
     },
     9: {
-      _k_parent: '8',
-      _r_: '10',
+      '~k_parent': '8',
+      '~r': '10',
       key: 'root.pages[1:B:Box].blocks[1:B2:Button].properties',
     },
   });
   expect(JSON.parse(serializer.serializeToString(components))).toEqual({
-    _k_: '2',
+    '~k': '2',
     pages: [
       {
-        _k_: '3',
+        '~k': '3',
         blocks: [
           {
-            _k_: '4',
+            '~k': '4',
             id: 'A1',
             type: 'Button',
           },
           {
-            _k_: '5',
+            '~k': '5',
             id: 'A2',
             type: 'Button',
           },
@@ -108,19 +108,19 @@ test('mutate keyMap and components', async () => {
         type: 'Box',
       },
       {
-        _k_: '6',
+        '~k': '6',
         blocks: [
           {
-            _k_: '7',
+            '~k': '7',
             id: 'B1',
             type: 'Button',
           },
           {
-            _k_: '8',
+            '~k': '8',
             id: 'B2',
             type: 'Button',
             properties: {
-              _k_: '9',
+              '~k': '9',
               title: 'X',
             },
           },

--- a/packages/build/src/build/buildRefs/recursiveBuild.js
+++ b/packages/build/src/build/buildRefs/recursiveBuild.js
@@ -76,7 +76,7 @@ async function recursiveBuild({ context, refDef, count, referencedFrom }) {
 
     const reviver = (_, value) => {
       if (!type.isObject(value)) return value;
-      Object.defineProperty(value, '_r_', {
+      Object.defineProperty(value, '~r', {
         value: refDef.id,
         enumerable: false,
         writable: true,

--- a/packages/docs/migration/v3-to-v4.yaml
+++ b/packages/docs/migration/v3-to-v4.yaml
@@ -209,6 +209,8 @@ _ref:
 
                 The `_format` operator has been replaced with the [`_intl`](/_intl) and [`_moment`](/_moment) operator, with some minor schema changes.
 
+                The format of dates in the output of the  [`_json.stringify`](/_json) and [`_yaml.stringify`](/_yaml) operators, as well as in URL query parameters has changed from `_date: {iso_date_string}` to `~d: {iso_date_string}`.
+
                 ## Block Loading States
 
                 The page loading states in version 4 have been improved. In general apps should load a lot faster. Blocks will now be a lot less likely to show a loading state and rather render as normal, and render their children. Input blocks will be disabled while in a loading state. This contributes to users seeing useful content sooner, and to less layout shifts once the app finishes loading.

--- a/packages/operators/src/buildParser.js
+++ b/packages/operators/src/buildParser.js
@@ -42,8 +42,8 @@ class BuildParser {
     const errors = [];
     const reviver = (_, value) => {
       if (!type.isObject(value)) return value;
-      // TODO: pass _r_ in errors. Build does not have _k_.
-      if (type.isString(value._r_)) return value;
+      // TODO: pass ~r in errors. Build does not have ~k.
+      if (type.isString(value['~r'])) return value;
       if (Object.keys(value).length !== 1) return value;
       const key = Object.keys(value)[0];
       if (!key.startsWith(operatorPrefix)) return value;

--- a/packages/operators/src/serverParser.js
+++ b/packages/operators/src/serverParser.js
@@ -42,9 +42,9 @@ class ServerParser {
     const errors = [];
     const reviver = (_, value) => {
       if (!type.isObject(value)) return value;
-      // TODO: pass _k_ in errors.
-      // const _k_ = value._k_;
-      delete value._k_;
+      // TODO: pass ~k in errors.
+      // const _k = value['~k'];
+      delete value['~k'];
       if (Object.keys(value).length !== 1) return value;
 
       const key = Object.keys(value)[0];

--- a/packages/operators/src/serverParser.test.js
+++ b/packages/operators/src/serverParser.test.js
@@ -68,8 +68,8 @@ test('parse location not string', () => {
   );
 });
 
-test('operator returns value and removes _k_', () => {
-  const input = { a: { _test: { params: true, _k_: 'c' }, _k_: 'b' }, _k_: 'a' };
+test('operator returns value and removes ~k', () => {
+  const input = { a: { _test: { params: true, '~k': 'c' }, '~k': 'b' }, '~k': 'a' };
   const parser = new ServerParser({ operators, payload, secrets, user });
   const res = parser.parse({ args, input, location });
   expect(res.output).toEqual({ a: 'test' });

--- a/packages/operators/src/webParser.js
+++ b/packages/operators/src/webParser.js
@@ -41,9 +41,9 @@ class WebParser {
       this.context._internal.lowdefy;
     const reviver = (_, value) => {
       if (!type.isObject(value)) return value;
-      // TODO: pass _k_ in errors.
-      // const _k_ = value._k_;
-      delete value._k_;
+      // TODO: pass ~k in errors.
+      // const _k = value['~k'];
+      delete value['~k'];
 
       if (Object.keys(value).length !== 1) return value;
 

--- a/packages/operators/src/webParser.test.js
+++ b/packages/operators/src/webParser.test.js
@@ -108,8 +108,8 @@ test('parse location not string', () => {
   );
 });
 
-test('operator returns value and removes _k_', () => {
-  const input = { a: { _test: { params: true, _k_: 'c' }, _k_: 'b' }, _k_: 'a' };
+test('operator returns value and removes ~k', () => {
+  const input = { a: { _test: { params: true, '~k': 'c' }, '~k': 'b' }, '~k': 'a' };
   const location = 'location.$';
   const parser = new WebParser({ context, operators });
   const res = parser.parse({ actions, args, arrayIndices, event, input, location });

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBAggregation/MongoDBAggregation.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBAggregation/MongoDBAggregation.test.js
@@ -99,7 +99,7 @@ test('aggregation match dates', async () => {
     pipeline: [
       {
         $match: {
-          date: { $gt: { _date: '2020-01-15' } },
+          date: { $gt: { '~d': '2020-01-15' } },
         },
       },
     ],
@@ -114,11 +114,11 @@ test('aggregation match dates', async () => {
   expect(res).toEqual([
     {
       _id: 2,
-      date: { _date: 1580515200000 },
+      date: new Date('2020-02-01'),
     },
     {
       _id: 3,
-      date: { _date: 1583020800000 },
+      date: new Date('2020-03-01'),
     },
   ]);
 });

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/serialize.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/serialize.test.js
@@ -17,23 +17,12 @@
 import { ObjectId } from 'mongodb';
 import { serialize, deserialize } from './serialize.js';
 
-test('serialize dates', () => {
+test('serialize with  dates', () => {
   const object = {
     date: new Date(0),
     array: [new Date(0)],
   };
   expect(serialize(object)).toEqual({
-    date: { _date: 0 },
-    array: [{ _date: 0 }],
-  });
-});
-
-test('deserialize dates', () => {
-  const object = {
-    date: { _date: 0 },
-    array: [{ _date: 0 }],
-  };
-  expect(deserialize(object)).toEqual({
     date: new Date(0),
     array: [new Date(0)],
   });

--- a/packages/plugins/operators/operators-js/src/operators/shared/json.test.js
+++ b/packages/plugins/operators/operators-js/src/operators/shared/json.test.js
@@ -77,7 +77,7 @@ test('_json.parse array', () => {
 test('_json.parse date array', () => {
   expect(
     json({
-      params: '[{ "_date": "1970-01-01T00:00:00.000Z"},{ "_date": "1970-01-01T00:00:00.001Z"}]',
+      params: '[{ "~d": "1970-01-01T00:00:00.000Z"},{ "~d": "1970-01-01T00:00:00.001Z"}]',
       location: 'locationId',
       methodName: 'parse',
     })
@@ -87,7 +87,7 @@ test('_json.parse date array', () => {
 test('_json.parse date as object', () => {
   expect(
     json({
-      params: '{ "_date": "1970-01-01T00:00:00.000Z"}',
+      params: '{ "~d": "1970-01-01T00:00:00.000Z"}',
       location: 'locationId',
       methodName: 'parse',
     })
@@ -97,7 +97,7 @@ test('_json.parse date as object', () => {
 test('_json.parse date in object', () => {
   expect(
     json({
-      params: '{"a": { "_date": "1970-01-01T00:00:00.000Z"} }',
+      params: '{"a": { "~d": "1970-01-01T00:00:00.000Z"} }',
       location: 'locationId',
       methodName: 'parse',
     })
@@ -141,7 +141,7 @@ test('_json.stringify undefined', () => {
 
 test('_json.stringify date', () => {
   expect(json({ params: [new Date(0)], location: 'locationId', methodName: 'stringify' })).toEqual(
-    '{ "_date": "1970-01-01T00:00:00.000Z" }'
+    '{ "~d": "1970-01-01T00:00:00.000Z" }'
   );
 });
 
@@ -166,10 +166,10 @@ test('_json.stringify date array', () => {
   ).toMatchInlineSnapshot(`
     "[
       {
-        \\"_date\\": \\"1970-01-01T00:00:00.000Z\\"
+        \\"~d\\": \\"1970-01-01T00:00:00.000Z\\"
       },
       {
-        \\"_date\\": \\"1970-01-01T00:00:00.001Z\\"
+        \\"~d\\": \\"1970-01-01T00:00:00.001Z\\"
       }
     ]"
   `);
@@ -180,7 +180,7 @@ test('_json.stringify date object', () => {
     .toMatchInlineSnapshot(`
     "{
       \\"a\\": {
-        \\"_date\\": \\"1970-01-01T00:00:00.000Z\\"
+        \\"~d\\": \\"1970-01-01T00:00:00.000Z\\"
       }
     }"
   `);
@@ -205,7 +205,7 @@ test('_json.stringify object params with options', () => {
   ).toMatchInlineSnapshot(`
     "{
       \\"a\\": {
-        \\"_date\\": 101
+        \\"~d\\": 101
       }
     }"
   `);

--- a/packages/plugins/operators/operators-yaml/src/operators/shared/yaml.test.js
+++ b/packages/plugins/operators/operators-yaml/src/operators/shared/yaml.test.js
@@ -83,8 +83,8 @@ test('_yaml.parse date array', () => {
   expect(
     yaml({
       params: [
-        `- _date: "1970-01-01T00:00:00.000Z"
-- _date: "1970-01-01T00:00:00.001Z"`,
+        `- ~d: "1970-01-01T00:00:00.000Z"
+- ~d: "1970-01-01T00:00:00.001Z"`,
       ],
       location: 'locationId',
       methodName: 'parse',
@@ -95,7 +95,7 @@ test('_yaml.parse date array', () => {
 test('_yaml.parse date as object', () => {
   expect(
     yaml({
-      params: [`_date: "1970-01-01T00:00:00.000Z"`],
+      params: [`~d: "1970-01-01T00:00:00.000Z"`],
       location: 'locationId',
       methodName: 'parse',
     })
@@ -107,7 +107,7 @@ test('_yaml.parse date object', () => {
     yaml({
       params: [
         `a:
-  _date: "1970-01-01T00:00:00.000Z"`,
+  ~d: "1970-01-01T00:00:00.000Z"`,
       ],
       location: 'locationId',
       methodName: 'parse',
@@ -164,7 +164,7 @@ test('_yaml.stringify undefined', () => {
 test('_yaml.stringify date', () => {
   expect(yaml({ params: [new Date(0)], location: 'locationId', methodName: 'stringify' }))
     .toMatchInlineSnapshot(`
-    "_date: 1970-01-01T00:00:00.000Z
+    "~d: 1970-01-01T00:00:00.000Z
     "
   `);
 });
@@ -183,8 +183,8 @@ test('_yaml.stringify date array', () => {
   expect(
     yaml({ params: [[new Date(0), new Date(1)]], location: 'locationId', methodName: 'stringify' })
   ).toMatchInlineSnapshot(`
-    "- _date: 1970-01-01T00:00:00.000Z
-    - _date: 1970-01-01T00:00:00.001Z
+    "- ~d: 1970-01-01T00:00:00.000Z
+    - ~d: 1970-01-01T00:00:00.001Z
     "
   `);
 });
@@ -193,7 +193,7 @@ test('_yaml.stringify date object', () => {
   expect(yaml({ params: [{ a: new Date(0) }], location: 'locationId', methodName: 'stringify' }))
     .toMatchInlineSnapshot(`
     "a:
-      _date: 1970-01-01T00:00:00.000Z
+      ~d: 1970-01-01T00:00:00.000Z
     "
   `);
 });
@@ -208,9 +208,9 @@ test('_yaml.stringify date object', () => {
 //     })
 //   ).toMatchInlineSnapshot(`
 //     "b:
-//       _date: 1970-01-01T00:00:00.000Z
+//       ~d: 1970-01-01T00:00:00.000Z
 //     a:
-//       _date: 1970-01-01T00:00:00.000Z
+//       ~d: 1970-01-01T00:00:00.000Z
 //     "
 //   `);
 // });
@@ -224,9 +224,9 @@ test('_yaml.stringify date object', () => {
 //     })
 //   ).toMatchInlineSnapshot(`
 //     "b:
-//       _date: 1970-01-01T00:00:00.000Z
+//       ~d: 1970-01-01T00:00:00.000Z
 //     a:
-//       _date: 1970-01-01T00:00:00.000Z
+//       ~d: 1970-01-01T00:00:00.000Z
 //     "
 //   `);
 // });
@@ -240,9 +240,9 @@ test('_yaml.stringify date object', () => {
 //     })
 //   ).toMatchInlineSnapshot(`
 //     "a:
-//       _date: 1970-01-01T00:00:00.000Z
+//       ~d: 1970-01-01T00:00:00.000Z
 //     b:
-//       _date: 1970-01-01T00:00:00.000Z
+//       ~d: 1970-01-01T00:00:00.000Z
 //     "
 //   `);
 // });

--- a/packages/server-dev/manager/watchers/nextBuildWatcher.mjs
+++ b/packages/server-dev/manager/watchers/nextBuildWatcher.mjs
@@ -47,7 +47,7 @@ async function sha1(filePath) {
     content = JSON.stringify(
       JSON.parse(content, (_, value) => {
         if (!type.isObject(value)) return value;
-        delete value._k_;
+        delete value['~k'];
         return value;
       })
     );

--- a/packages/utils/helpers/src/serializer.js
+++ b/packages/utils/helpers/src/serializer.js
@@ -20,9 +20,9 @@ import type from './type.js';
 import stableStringify from './stableStringify.js';
 
 const makeReplacer = (customReplacer, isoStringDates) => (key, value) => {
-  let dateReplacer = (date) => ({ _date: date.valueOf() });
+  let dateReplacer = (date) => ({ '~d': date.valueOf() });
   if (isoStringDates) {
-    dateReplacer = (date) => ({ _date: date.toISOString() });
+    dateReplacer = (date) => ({ '~d': date.toISOString() });
   }
   let newValue = value;
   if (customReplacer) {
@@ -30,7 +30,7 @@ const makeReplacer = (customReplacer, isoStringDates) => (key, value) => {
   }
   if (type.isError(newValue)) {
     return {
-      _error: {
+      '~e': {
         name: newValue.name,
         message: newValue.message,
         value: newValue.toString(),
@@ -45,17 +45,17 @@ const makeReplacer = (customReplacer, isoStringDates) => (key, value) => {
         newValue[k] = dateReplacer(newValue[k]);
       }
     });
-    if (newValue._r_) {
-      Object.defineProperty(newValue, '_r_', {
-        value: newValue._r_,
+    if (newValue['~r']) {
+      Object.defineProperty(newValue, '~r', {
+        value: newValue['~r'],
         enumerable: true,
         writable: true,
         configurable: true,
       });
     }
-    if (newValue._k_) {
-      Object.defineProperty(newValue, '_k_', {
-        value: newValue._k_,
+    if (newValue['~k']) {
+      Object.defineProperty(newValue, '~k', {
+        value: newValue['~k'],
         enumerable: true,
         writable: true,
         configurable: true,
@@ -77,17 +77,17 @@ const makeReplacer = (customReplacer, isoStringDates) => (key, value) => {
 const makeReviver = (customReviver) => (key, value) => {
   let newValue = value;
   if (type.isObject(newValue)) {
-    if (newValue._r_) {
-      Object.defineProperty(newValue, '_r_', {
-        value: newValue._r_,
+    if (newValue['~r']) {
+      Object.defineProperty(newValue, '~r', {
+        value: newValue['~r'],
         enumerable: false,
         writable: true,
         configurable: true,
       });
     }
-    if (newValue._k_) {
-      Object.defineProperty(newValue, '_k_', {
-        value: newValue._k_,
+    if (newValue['~k']) {
+      Object.defineProperty(newValue, '~k', {
+        value: newValue['~k'],
         enumerable: false,
         writable: true,
         configurable: true,
@@ -98,19 +98,13 @@ const makeReviver = (customReviver) => (key, value) => {
     newValue = customReviver(key, value);
   }
   if (type.isObject(newValue)) {
-    if (!type.isUndefined(newValue._error)) {
-      const error = new Error(newValue._error.message);
-      error.name = newValue._error.name;
+    if (!type.isUndefined(newValue['~e'])) {
+      const error = new Error(newValue['~e'].message);
+      error.name = newValue['~e'].name;
       return error;
     }
-    if (!type.isUndefined(newValue._date)) {
-      if (type.isInt(newValue._date)) {
-        return new Date(newValue._date);
-      }
-      if (newValue._date === 'now') {
-        return newValue;
-      }
-      const result = new Date(newValue._date);
+    if (!type.isUndefined(newValue['~d'])) {
+      const result = new Date(newValue['~d']);
       if (!type.isDate(result)) {
         return newValue;
       }
@@ -124,9 +118,9 @@ const serialize = (json, options = {}) => {
   if (type.isUndefined(json)) return json;
   if (type.isDate(json)) {
     if (options.isoStringDates) {
-      return { _date: json.toISOString() };
+      return { '~d': json.toISOString() };
     }
-    return { _date: json.valueOf() };
+    return { '~d': json.valueOf() };
   }
   return JSON.parse(JSON.stringify(json, makeReplacer(options.replacer, options.isoStringDates)));
 };
@@ -136,9 +130,9 @@ const serializeToString = (json, options = {}) => {
 
   if (type.isDate(json)) {
     if (options.isoStringDates) {
-      return `{ "_date": "${json.toISOString()}" }`;
+      return `{ "~d": "${json.toISOString()}" }`;
     }
-    return `{ "_date": ${json.valueOf()} }`;
+    return `{ "~d": ${json.valueOf()} }`;
   }
   if (options.stable) {
     return stableStringify(json, {

--- a/packages/utils/helpers/src/serializer.test.js
+++ b/packages/utils/helpers/src/serializer.test.js
@@ -16,27 +16,27 @@
 
 import serializer from './serializer.js';
 
-test('serialize convert object js date to _date', () => {
+test('serialize convert object js date to ~d', () => {
   let object = {
     a: new Date(0),
   };
-  expect(serializer.serialize(object)).toEqual({ a: { _date: 0 } });
+  expect(serializer.serialize(object)).toEqual({ a: { '~d': 0 } });
   object = {
     a: { b: { c: new Date(120) } },
   };
-  expect(serializer.serialize(object)).toEqual({ a: { b: { c: { _date: 120 } } } });
+  expect(serializer.serialize(object)).toEqual({ a: { b: { c: { '~d': 120 } } } });
 });
 
-test('serialize convert array js date to _date', () => {
+test('serialize convert array js date to ~d', () => {
   let object = {
     a: [new Date(0)],
   };
-  expect(serializer.serialize(object)).toEqual({ a: [{ _date: 0 }] });
+  expect(serializer.serialize(object)).toEqual({ a: [{ '~d': 0 }] });
   object = {
     a: [{ b: new Date(0), c: [null, new Date(10)], d: [{ e: new Date(20) }] }],
   };
   expect(serializer.serialize(object)).toEqual({
-    a: [{ b: { _date: 0 }, c: [null, { _date: 10 }], d: [{ e: { _date: 20 } }] }],
+    a: [{ b: { '~d': 0 }, c: [null, { '~d': 10 }], d: [{ e: { '~d': 20 } }] }],
   });
 });
 
@@ -50,14 +50,14 @@ test('serialize should not change a string date', () => {
 });
 
 test('serialize a date should return a serialized date', () => {
-  expect(serializer.serialize(new Date(0))).toEqual({ _date: 0 });
+  expect(serializer.serialize(new Date(0))).toEqual({ '~d': 0 });
 });
 
 test('serialize array of dates should return a serialized array', () => {
   expect(serializer.serialize([new Date(0), new Date(1), new Date(2)])).toEqual([
-    { _date: 0 },
-    { _date: 1 },
-    { _date: 2 },
+    { '~d': 0 },
+    { '~d': 1 },
+    { '~d': 2 },
   ]);
 });
 
@@ -72,31 +72,27 @@ test('serialize primitives should pass', () => {
   expect(serializer.serialize(undefined)).toEqual(undefined);
 });
 
-test('serializeToString convert object js date to _date', () => {
+test('serializeToString convert object js date to ~d', () => {
   let object = {
     a: new Date(0),
   };
-  expect(serializer.serializeToString(object)).toMatchInlineSnapshot(`"{\\"a\\":{\\"_date\\":0}}"`);
+  expect(serializer.serializeToString(object)).toEqual('{"a":{"~d":0}}');
   object = {
     a: { b: { c: new Date(120) } },
   };
-  expect(serializer.serializeToString(object)).toMatchInlineSnapshot(
-    `"{\\"a\\":{\\"b\\":{\\"c\\":{\\"_date\\":120}}}}"`
-  );
+  expect(serializer.serializeToString(object)).toEqual('{"a":{"b":{"c":{"~d":120}}}}');
 });
 
 test('serializeToString convert array js date to _date', () => {
   let object = {
     a: [new Date(0)],
   };
-  expect(serializer.serializeToString(object)).toMatchInlineSnapshot(
-    `"{\\"a\\":[{\\"_date\\":0}]}"`
-  );
+  expect(serializer.serializeToString(object)).toEqual('{"a":[{"~d":0}]}');
   object = {
     a: [{ b: new Date(0), c: [null, new Date(10)], d: [{ e: new Date(20) }] }],
   };
-  expect(serializer.serializeToString(object)).toMatchInlineSnapshot(
-    `"{\\"a\\":[{\\"b\\":{\\"_date\\":0},\\"c\\":[null,{\\"_date\\":10}],\\"d\\":[{\\"e\\":{\\"_date\\":20}}]}]}"`
+  expect(serializer.serializeToString(object)).toEqual(
+    '{"a":[{"b":{"~d":0},"c":[null,{"~d":10}],"d":[{"e":{"~d":20}}]}]}'
   );
 });
 
@@ -104,33 +100,29 @@ test('serializeToString should not change a string date', () => {
   let object = {
     a: '2019-11-18T09:51:30.152Z',
   };
-  expect(serializer.serializeToString(object)).toMatchInlineSnapshot(
-    `"{\\"a\\":\\"2019-11-18T09:51:30.152Z\\"}"`
-  );
+  expect(serializer.serializeToString(object)).toEqual('{"a":"2019-11-18T09:51:30.152Z"}');
   object = ['2019-11-18T09:51:30.152Z'];
-  expect(serializer.serializeToString(object)).toMatchInlineSnapshot(
-    `"[\\"2019-11-18T09:51:30.152Z\\"]"`
-  );
+  expect(serializer.serializeToString(object)).toEqual('["2019-11-18T09:51:30.152Z"]');
 });
 
 test('serializeToString a date should return a serialized date', () => {
-  expect(serializer.serializeToString(new Date(0))).toMatchInlineSnapshot(`"{ \\"_date\\": 0 }"`);
+  expect(serializer.serializeToString(new Date(0))).toEqual('{ "~d": 0 }');
 });
 
 test('serialize array of dates should return a serialized array', () => {
-  expect(
-    serializer.serializeToString([new Date(0), new Date(1), new Date(2)])
-  ).toMatchInlineSnapshot(`"[{\\"_date\\":0},{\\"_date\\":1},{\\"_date\\":2}]"`);
+  expect(serializer.serializeToString([new Date(0), new Date(1), new Date(2)])).toEqual(
+    '[{"~d":0},{"~d":1},{"~d":2}]'
+  );
 });
 
 test('serializeToString primitives should pass', () => {
-  expect(serializer.serializeToString('a')).toMatchInlineSnapshot(`"\\"a\\""`);
-  expect(serializer.serializeToString(0)).toMatchInlineSnapshot(`"0"`);
-  expect(serializer.serializeToString(1)).toMatchInlineSnapshot(`"1"`);
-  expect(serializer.serializeToString(-0.1)).toMatchInlineSnapshot(`"-0.1"`);
-  expect(serializer.serializeToString(false)).toMatchInlineSnapshot(`"false"`);
-  expect(serializer.serializeToString(true)).toMatchInlineSnapshot(`"true"`);
-  expect(serializer.serializeToString(null)).toMatchInlineSnapshot(`"null"`);
+  expect(serializer.serializeToString('a')).toEqual('"a"');
+  expect(serializer.serializeToString(0)).toEqual('0');
+  expect(serializer.serializeToString(1)).toEqual('1');
+  expect(serializer.serializeToString(-0.1)).toEqual('-0.1');
+  expect(serializer.serializeToString(false)).toEqual('false');
+  expect(serializer.serializeToString(true)).toEqual('true');
+  expect(serializer.serializeToString(null)).toEqual('null');
   expect(serializer.serializeToString(undefined)).toEqual(undefined);
 });
 
@@ -189,26 +181,26 @@ test('serializeToString space option', () => {
 
 test('deserialize convert _date object to js date', () => {
   let object = {
-    a: { _date: 0 },
+    a: { '~d': 0 },
   };
   expect(serializer.deserialize(object)).toEqual({ a: new Date(0) });
   object = {
-    a: { b: { c: { _date: 120 } } },
+    a: { b: { c: { '~d': 120 } } },
   };
   expect(serializer.deserialize(object)).toEqual({ a: { b: { c: new Date(120) } } });
   object = {
-    a: { _date: '1970-01-01T00:00:00.000Z' },
+    a: { '~d': '1970-01-01T00:00:00.000Z' },
   };
   expect(serializer.deserialize(object)).toEqual({ a: new Date(0) });
 });
 
 test('deserialize convert _date in array to js date', () => {
   let object = {
-    a: [{ _date: 0 }],
+    a: [{ '~d': 0 }],
   };
   expect(serializer.deserialize(object)).toEqual({ a: [new Date(0)] });
   object = {
-    a: [{ b: { _date: 0 }, c: [null, { _date: 10 }], d: [{ e: { _date: 20 } }] }],
+    a: [{ b: { '~d': 0 }, c: [null, { '~d': 10 }], d: [{ e: { '~d': 20 } }] }],
   };
   expect(serializer.deserialize(object)).toEqual({
     a: [{ b: new Date(0), c: [null, new Date(10)], d: [{ e: new Date(20) }] }],
@@ -225,17 +217,17 @@ test('deserialize should not change a string date', () => {
 });
 
 test('deserialize a _date date should return a js date', () => {
-  expect(serializer.deserialize({ _date: 0 })).toEqual(new Date(0));
-  expect(serializer.deserialize({ _date: '1970-01-01T00:00:00.000Z' })).toEqual(new Date(0));
+  expect(serializer.deserialize({ '~d': 0 })).toEqual(new Date(0));
+  expect(serializer.deserialize({ '~d': '1970-01-01T00:00:00.000Z' })).toEqual(new Date(0));
 });
 
 test('deserialize array of _date dates should return a js date array', () => {
-  expect(serializer.deserialize([{ _date: 0 }, { _date: 1 }, { _date: 2 }])).toEqual([
+  expect(serializer.deserialize([{ '~d': 0 }, { '~d': 1 }, { '~d': 2 }])).toEqual([
     new Date(0),
     new Date(1),
     new Date(2),
   ]);
-  expect(serializer.deserialize({ a: [{ _date: '1970-01-01T00:00:00.000Z' }] })).toEqual({
+  expect(serializer.deserialize({ a: [{ '~d': '1970-01-01T00:00:00.000Z' }] })).toEqual({
     a: [new Date(0)],
   });
 });
@@ -252,26 +244,26 @@ test('deserialize primitives should pass', () => {
 });
 
 test('deserializeFromString convert object js date to _date', () => {
-  let object = `{ "a":{ "_date":0}}`;
+  let object = `{ "a":{ "~d":0}}`;
   expect(serializer.deserializeFromString(object)).toEqual({
     a: new Date(0),
   });
-  object = `{"a":{"b":{"c":{"_date":120}}}}`;
+  object = `{"a":{"b":{"c":{"~d":120}}}}`;
   expect(serializer.deserializeFromString(object)).toEqual({
     a: { b: { c: new Date(120) } },
   });
-  object = `{ "a":{ "_date":"1970-01-01T00:00:00.000Z"}}`;
+  object = `{ "a":{ "~d":"1970-01-01T00:00:00.000Z"}}`;
   expect(serializer.deserializeFromString(object)).toEqual({
     a: new Date(0),
   });
 });
 
 test('deserializeFromString convert array js date to _date', () => {
-  let object = `{"a":[{"_date":0}]}`;
+  let object = `{"a":[{"~d":0}]}`;
   expect(serializer.deserializeFromString(object)).toEqual({
     a: [new Date(0)],
   });
-  object = `{"a":[{"b":{"_date":0},"c":[null,{"_date":10}],"d":[{"e":{"_date":20}}]}]}`;
+  object = `{"a":[{"b":{"~d":0},"c":[null,{"~d":10}],"d":[{"e":{"~d":20}}]}]}`;
   expect(serializer.deserializeFromString(object)).toEqual({
     a: [{ b: new Date(0), c: [null, new Date(10)], d: [{ e: new Date(20) }] }],
   });
@@ -287,16 +279,16 @@ test('deserializeFromString should not change a string date', () => {
 });
 
 test('deserializeFromString a date should return a serialized date', () => {
-  expect(serializer.deserializeFromString(`{"_date":0}`)).toEqual(new Date(0));
+  expect(serializer.deserializeFromString(`{"~d":0}`)).toEqual(new Date(0));
 });
 
 test('deserializeFromString array of dates should return a serialized array', () => {
-  expect(serializer.deserializeFromString(`[{"_date":0},{"_date":1},{"_date":2}]`)).toEqual([
+  expect(serializer.deserializeFromString(`[{"~d":0},{"~d":1},{"~d":2}]`)).toEqual([
     new Date(0),
     new Date(1),
     new Date(2),
   ]);
-  expect(serializer.deserializeFromString(`[{"_date":"1970-01-01T00:00:00.000Z"}]`)).toEqual([
+  expect(serializer.deserializeFromString(`[{"~d":"1970-01-01T00:00:00.000Z"}]`)).toEqual([
     new Date(0),
   ]);
 });
@@ -310,7 +302,7 @@ test('deserializeFromString primitives should pass', () => {
   expect(serializer.deserializeFromString(`true`)).toEqual(true);
   expect(serializer.deserializeFromString(`null`)).toEqual(null);
   expect(() => {
-    serializer.deserializeFromString(`undefined}`);
+    serializer.deserializeFromString(`undefined`);
   }).toThrow(); // does not work with undefined
 });
 
@@ -365,7 +357,7 @@ test('copy with custom reviver', () => {
 test('deserializeFromString with custom reviver', () => {
   const reviver = (key, value) => (key === 'a' ? 'x' : value);
   expect(
-    serializer.deserializeFromString('{ "a": 1, "b": 2, "c": {"_date": 120 } }', { reviver })
+    serializer.deserializeFromString('{ "a": 1, "b": 2, "c": {"~d": 120 } }', { reviver })
   ).toEqual({
     a: 'x',
     b: 2,
@@ -375,7 +367,7 @@ test('deserializeFromString with custom reviver', () => {
 
 test('deserialize with custom reviver', () => {
   const reviver = (key, value) => (key === 'a' ? 'x' : value);
-  expect(serializer.deserialize({ a: 1, b: 2, c: { _date: 120 } }, { reviver })).toEqual({
+  expect(serializer.deserialize({ a: 1, b: 2, c: { '~d': 120 } }, { reviver })).toEqual({
     a: 'x',
     b: 2,
     c: new Date(120),
@@ -394,7 +386,7 @@ test('copy with custom replacer', () => {
 test('serializeToString with custom replacer', () => {
   const replacer = (key, value) => (key === 'a' ? 'x' : value);
   expect(serializer.serializeToString({ a: 1, b: 2, c: new Date(120) }, { replacer })).toEqual(
-    '{"a":"x","b":2,"c":{"_date":120}}'
+    '{"a":"x","b":2,"c":{"~d":120}}'
   );
 });
 
@@ -403,130 +395,112 @@ test('serialize with custom replacer', () => {
   expect(serializer.serialize({ a: 1, b: 2, c: new Date(120) }, { replacer })).toEqual({
     a: 'x',
     b: 2,
-    c: { _date: 120 },
-  });
-});
-
-test('should not deserialize _date now', () => {
-  expect(serializer.copy({ _date: 'now' })).toEqual({ _date: 'now' });
-  expect(serializer.copy([{ _date: 'now' }])).toEqual([{ _date: 'now' }]);
-  expect(serializer.copy({ a: { _date: 'now' } })).toEqual({ a: { _date: 'now' } });
-
-  expect(serializer.deserialize({ _date: 'now' })).toEqual({ _date: 'now' });
-  expect(serializer.deserialize([{ _date: 'now' }])).toEqual([{ _date: 'now' }]);
-  expect(serializer.deserialize({ a: { _date: 'now' } })).toEqual({ a: { _date: 'now' } });
-
-  expect(serializer.deserializeFromString('{ "_date": "now" }')).toEqual({ _date: 'now' });
-  expect(serializer.deserializeFromString('[{ "_date": "now" }]')).toEqual([{ _date: 'now' }]);
-  expect(serializer.deserializeFromString('{ "a": { "_date": "now" } }')).toEqual({
-    a: { _date: 'now' },
+    c: { '~d': 120 },
   });
 });
 
 test('deserialize should pass invalid date through without error', () => {
-  expect(serializer.copy({ _date: 'invalid' })).toEqual({ _date: 'invalid' });
-  expect(serializer.copy([{ _date: 'invalid' }])).toEqual([{ _date: 'invalid' }]);
-  expect(serializer.copy({ a: { _date: 'invalid' } })).toEqual({ a: { _date: 'invalid' } });
+  expect(serializer.copy({ '~d': 'invalid' })).toEqual({ '~d': 'invalid' });
+  expect(serializer.copy([{ '~d': 'invalid' }])).toEqual([{ '~d': 'invalid' }]);
+  expect(serializer.copy({ a: { '~d': 'invalid' } })).toEqual({ a: { '~d': 'invalid' } });
 
-  expect(serializer.deserialize({ _date: 'invalid' })).toEqual({ _date: 'invalid' });
-  expect(serializer.deserialize([{ _date: 'invalid' }])).toEqual([{ _date: 'invalid' }]);
-  expect(serializer.deserialize({ a: { _date: 'invalid' } })).toEqual({ a: { _date: 'invalid' } });
+  expect(serializer.deserialize({ '~d': 'invalid' })).toEqual({ '~d': 'invalid' });
+  expect(serializer.deserialize([{ '~d': 'invalid' }])).toEqual([{ '~d': 'invalid' }]);
+  expect(serializer.deserialize({ a: { '~d': 'invalid' } })).toEqual({ a: { '~d': 'invalid' } });
 
-  expect(serializer.deserializeFromString('{ "_date": "invalid" }')).toEqual({ _date: 'invalid' });
-  expect(serializer.deserializeFromString('[{ "_date": "invalid" }]')).toEqual([
-    { _date: 'invalid' },
-  ]);
-  expect(serializer.deserializeFromString('{ "a": { "_date": "invalid" } }')).toEqual({
-    a: { _date: 'invalid' },
+  expect(serializer.deserializeFromString('{ "~d": "invalid" }')).toEqual({ '~d': 'invalid' });
+  expect(serializer.deserializeFromString('[{ "~d": "invalid" }]')).toEqual([{ '~d': 'invalid' }]);
+  expect(serializer.deserializeFromString('{ "a": { "~d": "invalid" } }')).toEqual({
+    a: { '~d': 'invalid' },
   });
 });
 
 test('serialize isoStringDates', () => {
   expect(serializer.serialize(new Date(0), { isoStringDates: true })).toEqual({
-    _date: '1970-01-01T00:00:00.000Z',
+    '~d': '1970-01-01T00:00:00.000Z',
   });
   expect(serializer.serialize({ a: new Date(0) }, { isoStringDates: true })).toEqual({
-    a: { _date: '1970-01-01T00:00:00.000Z' },
+    a: { '~d': '1970-01-01T00:00:00.000Z' },
   });
   expect(serializer.serialize({ a: [new Date(0)] }, { isoStringDates: true })).toEqual({
-    a: [{ _date: '1970-01-01T00:00:00.000Z' }],
+    a: [{ '~d': '1970-01-01T00:00:00.000Z' }],
   });
 });
 
 test('serializeToString isoStringDates', () => {
   expect(serializer.serializeToString(new Date(0), { isoStringDates: true })).toEqual(
-    '{ "_date": "1970-01-01T00:00:00.000Z" }'
+    '{ "~d": "1970-01-01T00:00:00.000Z" }'
   );
   expect(serializer.serializeToString({ a: new Date(0) }, { isoStringDates: true })).toEqual(
-    '{"a":{"_date":"1970-01-01T00:00:00.000Z"}}'
+    '{"a":{"~d":"1970-01-01T00:00:00.000Z"}}'
   );
   expect(serializer.serializeToString({ a: [new Date(0)] }, { isoStringDates: true })).toEqual(
-    '{"a":[{"_date":"1970-01-01T00:00:00.000Z"}]}'
+    '{"a":[{"~d":"1970-01-01T00:00:00.000Z"}]}'
   );
 });
 
-test('serialize convert Error to _error', () => {
+test('serialize convert Error to ~e', () => {
   let object = {
     a: new Error('Test error'),
   };
   expect(serializer.serialize(object)).toEqual({
-    a: { _error: { message: 'Test error', name: 'Error', value: 'Error: Test error' } },
+    a: { '~e': { message: 'Test error', name: 'Error', value: 'Error: Test error' } },
   });
 });
 
-test('serializeToString convert Error to _error', () => {
+test('serializeToString convert Error to ~e', () => {
   let object = {
     a: new Error('Test error'),
   };
   expect(serializer.serializeToString(object)).toEqual(
-    '{"a":{"_error":{"name":"Error","message":"Test error","value":"Error: Test error"}}}'
+    '{"a":{"~e":{"name":"Error","message":"Test error","value":"Error: Test error"}}}'
   );
 });
 
-test('deserialize revive _error to Error', () => {
+test('deserialize revive ~e to Error', () => {
   let object = {
-    a: { _error: { message: 'Test error', name: 'Error', value: 'Error: Test error' } },
+    a: { '~e': { message: 'Test error', name: 'Error', value: 'Error: Test error' } },
   };
   expect(serializer.deserialize(object)).toEqual({
     a: new Error('Test error'),
   });
 });
 
-test('deserializeFromString revive _error to Error', () => {
+test('deserializeFromString revive ~e to Error', () => {
   let object =
-    '{"a": {"_error": {"message": "Test error", "name": "Error", "value": "Error: Test error"}}}';
+    '{"a": {"~e": {"message": "Test error", "name": "Error", "value": "Error: Test error"}}}';
   expect(serializer.deserializeFromString(object)).toEqual({
     a: new Error('Test error'),
   });
 });
-test('deserialize with _k_ and _r_ values', () => {
+test('deserialize with ~k and ~r values', () => {
   let object = {
     x: 1,
-    _k_: 'a',
+    '~k': 'a',
   };
   let res = serializer.deserialize(object);
   expect(res).toEqual({
     x: 1,
   });
-  expect(res._k_).toEqual('a');
+  expect(res['~k']).toEqual('a');
   expect(Object.keys(res)).toEqual(['x']);
   object = {
     x: 1,
-    _r_: 'a',
+    '~r': 'a',
   };
   res = serializer.deserialize(object);
   expect(res).toEqual({
     x: 1,
   });
-  expect(res._r_).toEqual('a');
+  expect(res['~r']).toEqual('a');
   expect(Object.keys(res)).toEqual(['x']);
 });
 
-test('serialize with _k_ and _r_ values', () => {
+test('serialize with ~k and ~r values', () => {
   let object = {
     x: 1,
   };
-  Object.defineProperty(object, '_k_', {
+  Object.defineProperty(object, '~k', {
     value: 'a',
     enumerable: false,
     writable: true,
@@ -535,12 +509,12 @@ test('serialize with _k_ and _r_ values', () => {
   let res = serializer.serialize(object);
   expect(res).toEqual({
     x: 1,
-    _k_: 'a',
+    '~k': 'a',
   });
   object = {
     x: 1,
   };
-  Object.defineProperty(object, '_r_', {
+  Object.defineProperty(object, '~r', {
     value: 'a',
     enumerable: false,
     writable: true,
@@ -549,29 +523,25 @@ test('serialize with _k_ and _r_ values', () => {
   res = serializer.serialize(object);
   expect(res).toEqual({
     x: 1,
-    _r_: 'a',
+    '~r': 'a',
   });
 });
 
-test('deserialize with _k_ and _r_ value first', () => {
+test('deserialize with ~k and ~r value first', () => {
   let object = {
-    y: { _date: 'now', _k_: 'b' },
-    _k_: 'a',
+    y: { '~d': 0, '~k': 'b' },
+    '~k': 'a',
   };
   let res = serializer.deserialize(object);
   expect(res).toEqual({
-    y: {
-      _date: 'now',
-    },
+    y: new Date(0),
   });
   object = {
-    y: { _date: 'now', _r_: 'b' },
-    _r_: 'a',
+    y: { '~d': 0, '~r': 'b' },
+    '~r': 'a',
   };
   res = serializer.deserialize(object);
   expect(res).toEqual({
-    y: {
-      _date: 'now',
-    },
+    y: new Date(0),
   });
 });


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->


### What are the changes and their implications?

This PR changes the format of dates and errors used by the serializer helper function. Previously, the serialiser used the `{"_date": "iso_date_string"}` format to represent dates when serialised to JSON, but this caused bugs due to interactions with the `_date` operator. 

The serialiser is used extensively, including in the build process, and it was modifying the user `_date` operator configuration.

The serialiser now uses the `{"~d": "iso_date_string"}` to represent dates, and therefore doesn't interfere with the `_date` operator.

The serialisation of errors was also changed to `~e`, and the `_r_` and `_k_` config keys were renamed to `~r` and `~k`.

## Checklist

- [x] Pull request is made to the "develop" branch
- [x] Tests added
- [x] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
