### PR TITLE
fix(api): Use lowdefy get,set helpers in auth user fields.

### DIFF
--- a/packages/api/src/routes/auth/callbacks/addUserFieldsToSession.js
+++ b/packages/api/src/routes/auth/callbacks/addUserFieldsToSession.js
@@ -13,16 +13,17 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
+import { get, set } from '@lowdefy/helpers';
 
 function addUserFieldsToSession({ session, token, authConfig, user }) {
   if (token) {
     Object.keys(authConfig.userFields).forEach((fieldName) => {
-      session.user[fieldName] = token[fieldName];
+      set(session.user, fieldName, get(token, fieldName));
     });
   }
   if (user) {
     Object.keys(authConfig.userFields).forEach((fieldName) => {
-      session.user[fieldName] = user[fieldName];
+      set(session.user, fieldName, get(user, fieldName));
     });
   }
 }

--- a/packages/api/src/routes/auth/callbacks/addUserFieldsToToken.js
+++ b/packages/api/src/routes/auth/callbacks/addUserFieldsToToken.js
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-import { get } from '@lowdefy/helpers';
+import { get, set } from '@lowdefy/helpers';
 
 function addUserFieldsToToken({ account, authConfig, logger, profile, token, user }) {
   const objects = { account, profile, user };
@@ -26,7 +26,7 @@ function addUserFieldsToToken({ account, authConfig, logger, profile, token, use
         value
       )} as "${lowdefyFieldName}"`
     );
-    token[lowdefyFieldName] = value;
+    set(token, lowdefyFieldName, value);
   });
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?

Using the `set` helper functions allows to use dot notation in the `auth.userFields` config. Previously, this did not work as expected:
```yaml
auth:
  userFields:
    profile.name: name
    profile.picture: picture
```

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
