### PR TITLE
fix(blocks-antd): Add onChange to DateTimeSelector.

### DIFF
--- a/packages/plugins/blocks/blocks-antd/src/blocks/DateTimeSelector/DateTimeSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/DateTimeSelector/DateTimeSelector.js
@@ -41,6 +41,17 @@ const DateTimeSelector = ({
     : properties.timeFormat === 'HH'
     ? 'hour'
     : 'minute';
+  const onChange = (newVal) => {
+    methods.setValue(
+      !newVal
+        ? null
+        : moment
+            .utc(newVal.add(properties.selectUTC ? newVal.utcOffset() : 0, 'minutes'))
+            .startOf(timeUnit)
+            .toDate()
+    );
+    methods.triggerEvent({ name: 'onChange' });
+  };
   return (
     <Label
       blockId={blockId}
@@ -81,19 +92,12 @@ const DateTimeSelector = ({
                 minuteStep: properties.minuteStep || 5,
                 secondStep: properties.secondStep || 30,
               }}
-              onSelect={(newVal) => {
+              onChange={onChange}
+              onSelect={
                 // NOTE: we use on select instead of onChange to make the block UX
                 // more like the DataSelector which changes date on click and not on ok.
-                methods.setValue(
-                  !newVal
-                    ? null
-                    : moment
-                        .utc(newVal.add(properties.selectUTC ? newVal.utcOffset() : 0, 'minutes'))
-                        .startOf(timeUnit)
-                        .toDate()
-                );
-                methods.triggerEvent({ name: 'onChange' });
-              }}
+                onChange
+              }
               value={
                 !type.isDate(value)
                   ? null


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?

This PR adds onChange to the DateTimeSelector. This fixes the allowClear bug that prevented a user from clearing a selected date time.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
