### PR TITLE
fix : Fix variable name mismatches and reference to Google Sheets in tutorial documentation

### DIFF
--- a/packages/docs/tutorial/tutorial-actions-operators.yaml
+++ b/packages/docs/tutorial/tutorial-actions-operators.yaml
@@ -406,7 +406,7 @@ _ref:
 
             ## Up next
 
-            Our app doesn't save the form data anywhere when the submit button is clicked. In the next section we will set up a Google Sheets connection, and make a request to save the data in the sheet.
+            Our app doesn't save the form data anywhere when the submit button is clicked. In the next section we will set up a connection and a request to save the data in a local SQLite database.
 
       - _ref:
           path: templates/navigation_buttons.yaml

--- a/packages/docs/tutorial/tutorial-requests-sql.yaml
+++ b/packages/docs/tutorial/tutorial-requests-sql.yaml
@@ -187,9 +187,9 @@ _ref:
                             - id: validate
                               type: Validate
                             ################ -------- Copy from here -------- ################
-                            - id: save_data # Make a request to the SQLite database
+                            - id: save_new_ticket # Make a request to the SQLite database
                               type: Request
-                              params: save_data
+                              params: save_new_ticket
                             - id: reset # Reset the form once data has been submitted
                               type: Reset
                             ################ ------- Copy to here ----------- ################

--- a/packages/docs/tutorial/tutorial-requests-sql.yaml
+++ b/packages/docs/tutorial/tutorial-requests-sql.yaml
@@ -77,7 +77,7 @@ _ref:
 
                 ##### `.env`
                 ```
-                LOWDEFY_SECRET_FILENAME= __ABSOLUTE_PATH_TO_SQLITE_DB_FILE__
+                LOWDEFY_SECRET_SQLITE_FILENAME= __ABSOLUTE_PATH_TO_SQLITE_DB_FILE__
                 ```
 
                 #### 5.2.3. Setting the connection environment variable secrets


### PR DESCRIPTION
### What are the changes and their implications?

In the tutorial "4. Interactive pages with actions and operators" :
 - replaces the wrong reference to Google Sheets with a reference to SQLite

In the tutorial "6. Saving data to SQL", fixes :
 - a mismatch between the name of the secret in the .env file and the name used in the page file.
 - a mismatch between the name used for the id of the request : `save_new_ticket` and the name used to reference the request in the next step.

Both problems caused errors.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [x] Documentation added/updated
- [ ] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
