### PR TITLE
chore(blocks-antd): Refactor tabs to update to items prop.

### DIFF
--- a/packages/plugins/blocks/blocks-antd/src/blocks/Tabs/Tabs.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Tabs/Tabs.js
@@ -58,25 +58,20 @@ const TabsBlock = ({ blockId, components: { Icon }, events, content, methods, pr
         methods.triggerEvent({ name: 'onTabScroll', event: { direction } })
       }
       onTabClick={(key) => methods.triggerEvent({ name: 'onTabClick', event: { key } })}
+      items={tabs.map((tab) => ({
+        id: `${blockId}_${tab.key}`,
+        key: tab.key,
+        disabled: tab.disabled,
+        label: (
+          <span className={methods.makeCssClass(tab.titleStyle)}>
+            {tab.icon && <Icon blockId={`${blockId}_icon`} events={events} properties={tab.icon} />}
+            {tab.title ?? tab.key}
+          </span>
+        ),
+        children: content[tab.key] && content[tab.key](),
+      }))}
       {...additionalProps}
-    >
-      {tabs.map((tab) => (
-        <Tabs.TabPane
-          disabled={tab.disabled}
-          key={tab.key}
-          tab={
-            <span className={methods.makeCssClass(tab.titleStyle)}>
-              {tab.icon && (
-                <Icon blockId={`${blockId}_icon`} events={events} properties={tab.icon} />
-              )}
-              {tab.title ?? tab.key}
-            </span>
-          }
-        >
-          {content[tab.key] && content[tab.key]()}
-        </Tabs.TabPane>
-      ))}
-    </Tabs>
+    />
   );
 };
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?
Refactor tabs to update to items prop. Older version of Tabs pane is deprecated.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
