### PR TITLE
fix(blocks-antd): Set ant-tabs-tabpane-hidden class to display none.

### DIFF
--- a/packages/plugins/blocks/blocks-antd/src/blocks/Tabs/style.less
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Tabs/style.less
@@ -15,3 +15,8 @@
 */
 
 @import 'antd/lib/tabs/style/index.less';
+
+//! Remove with ant v5 update
+.ant-tabs-tabpane-hidden {
+  display: none;
+}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?

This PR sets ant-tabs-tabpane-hidden class to display none to handle the Tabs block stacking bug.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
