### PR TITLE
fix(blocks-antd): Check if option exists before checking tag.

### DIFF
--- a/packages/plugins/blocks/blocks-antd/src/blocks/MultipleSelector/MultipleSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/MultipleSelector/MultipleSelector.js
@@ -34,10 +34,10 @@ const tagRender = (props, option, methods, components) => {
       methods={methods}
       onClose={onClose}
       properties={{
-        title: label,
+        title: label ?? '',
         ...(option?.tag ?? {}),
         closable,
-        style: { marginRight: 3, ...(option.tag?.style ?? {}) },
+        style: { marginRight: 3, ...(option?.tag?.style ?? {}) },
       }}
     />
   );
@@ -82,11 +82,13 @@ const MultipleSelector = ({
               }
               maxTagCount={properties.maxTagCount}
               notFoundContent={fetchState ? 'Loading' : 'Not found'}
-              placeholder={get(properties, 'placeholder', { default: 'Select items' })}
+              placeholder={
+                loading ? 'Loading...' : get(properties, 'placeholder', { default: 'Select items' })
+              }
               showArrow={get(properties, 'showArrow', { default: true })}
               size={properties.size}
               status={validation.status}
-              value={getValueIndex(value, uniqueValueOptions, true)}
+              value={loading ? [] : getValueIndex(value, uniqueValueOptions, true)}
               suffixIcon={
                 properties.suffixIcon && (
                   <Icon


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?

This PR adds a fix to the MultipleSelector block to check if an option exists before checking if there is a tag. This PR also adds a loading message to the placeholder while the options are loading.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
