### PR TITLE
fix:  Remove unnecessary warning message on build "_id is used but not defined"

### DIFF
--- a/.changeset/mighty-vans-repair.md
+++ b/.changeset/mighty-vans-repair.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/build': patch
+---
+
+Remove unnecessary warning message on build "\_id is used but not defined".

--- a/packages/build/src/build/buildTypes.js
+++ b/packages/build/src/build/buildTypes.js
@@ -25,6 +25,9 @@ function buildTypeClass(
   Object.keys(counts).forEach((typeName) => {
     if (!definitions[typeName]) {
       if (warnIfMissing) {
+        if (typeName === '_id') {
+          return;
+        }
         context.logger.warn(`${typeClass} type "${typeName}" was used but is not defined.`);
         return;
       }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes #ISSUE_NUMBER

### What are the changes and their implications?

## Checklist

- [ ] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
