### PR TITLE
BREAKING CHANGE Upgrade change-case dependency to 5.4.0.

### DIFF
--- a/.changeset/real-keys-decide.md
+++ b/.changeset/real-keys-decide.md
@@ -1,0 +1,22 @@
+---
+'@lowdefy/operators-change-case': major
+---
+
+Upgrade change-case dependency to 5.4.0
+
+This is a breaking change and effects the `_change_case` operator.
+
+Changes to the `_change_case` operator:
+
+- Options splitRegex and stripRegexp are no longer supported.
+- paramCase has been renamed to kebabCase
+- headerCase has been renamed to trainCase
+- The following options have been added:
+
+  - locale
+  - mergeAmbiguousCharacters
+  - prefixCharacters
+  - split
+  - suffixCharacters
+
+- Added pascalSnakeCase which transforms a string into a string of capitalized words with underscores between words.

--- a/packages/docs/migration/v3-to-v4.yaml
+++ b/packages/docs/migration/v3-to-v4.yaml
@@ -412,3 +412,37 @@ _ref:
                 The `LOWDEFY_SERVER_PUBLIC_DIRECTORY` and `LOWDEFY_SERVER_BUILD_DIRECTORY` are no longer supported because configuration is bundled with the server at build time.
 
                 The `LOWDEFY_SERVER_PORT` environment variable has been replaced by the `PORT` environment variable.
+
+                ## _change_case
+
+                The options splitRegex and stripRegex are no longer supported in v4 and the following have been renamed:
+                  - paramCase to kebabCase
+                  - headerCase to trainCase
+
+                ###### Version 3:
+
+                ```yaml
+                _change_case.paramCase:
+                  on: example string
+                ```
+
+                ###### Version 4:
+
+                ```yaml
+                _change_case.kebabCase:
+                  on: example string
+                ```
+
+                ###### Version 3:
+
+                ```yaml
+                _change_case.headerCase:
+                  on: example string
+                ```
+
+                ###### Version 4:
+
+                ```yaml
+                _change_case.trainCase:
+                  on: example string
+                ```

--- a/packages/docs/operators/_change_case.yaml
+++ b/packages/docs/operators/_change_case.yaml
@@ -25,11 +25,14 @@ _ref:
       The `_change_case` operator takes `on` and `options` as arguments.
       The `on` argument is the input to be transformed and can be a `string`,  `array` or `object`.
       The `options` argument is an object with the following properties:
-        - `splitRegexp`: The regular expression used to split `on` into word segments. Can be a `string` or an `object` with `pattern` and `flags`.
-        - `stripRegexp`: The regular expression used to remove extraneous characters (default: `/[^A-Z0-9]/gi`). Can be a `string` or an `object` with `pattern` and `flags`.
-        - `delimiter`: Value used between words (e.g. " ").
-        - `convertValues`: Only used when `on` is an object. Toggles whether the object values are converted to the new case (`true`) or left as-is (`false`). Default `true`.
         - `convertKeys`: Only used when `on` is an object. Toggles whether the object keys are converted to the new case (`true`) or left as-is (`false`). Default `false`.
+        - `convertValues`: Only used when `on` is an object. Toggles whether the object values are converted to the new case (`true`) or left as-is (`false`). Default `true`.
+        - `delimiter`: Value used between words (e.g. " ").
+        - `locale`: Lower/upper according to specified locale, defaults to host environment. Set to false to disable.
+        - `mergeAmbiguousCharacters`: By default, pascalCase and snakeCase separate ambiguous characters with _. To merge them instead, set mergeAmbiguousCharacters to true.
+        - `prefixCharacters``: A string that specifies characters to retain at the beginning of the string. Defaults to "".
+        - `split`: A function to define how the input is split into words.
+        - `suffixCharacters``: A string that specifies characters to retain at the end of the string. Defaults to "".
 
       The `on` argument behaves as follows:
       ###### string
@@ -87,45 +90,21 @@ _ref:
       ```
       Returns: `{ "foo": "bar" }`
 
-      ###### String with options.splitRegexp string:
+      ###### Object with options.SPLT:
       ```yaml
-      _change_case.sentenceCase:
-        on: 'foo8ar'
+      _change_case.capitalCase:
+        on: this123is_an example string
         options:
-          splitRegexp: '([a-z])([A-Z0-9])'
+          split:
+            _function:
+              __string.split:
+                - __string.replace:
+                    - __args: 0
+                    - '123'
+                    - '_'
+                - '_'
       ```
-      Returns: `"Foo 8ar"`
-
-      ###### String with options.stripRegexp string:
-      ```yaml
-      _change_case.sentenceCase:
-        on: 'FOO8AR'
-        options:
-          stripRegexp: '[^A-Z]'
-      ```
-      Returns: `"Foo ar"`
-
-      ###### String with options.splitRegexp object:
-      ```yaml
-      _change_case.sentenceCase:
-        on: 'foo8ar'
-        options:
-          splitRegexp:
-            pattern: '([a-z])([A-Z0-9])'
-            flags: 'gi'
-      ```
-      Returns: `"F oo 8a r"`
-
-      ###### String with options.stripRegexp object:
-      ```yaml
-      _change_case.sentenceCase:
-        on: 'foo8ar'
-        options:
-          stripRegexp:
-            pattern: '[^A-Z]'
-            flags: gi
-      ```
-      Returns: `"Foo ar"`
+      Returns: `This Is An example string`
 
     methods:
       - name: camelCase
@@ -147,6 +126,7 @@ _ref:
             on: 'my_variable'
           ```
           Returns: `"myVariable"`
+
       - name: capitalCase
         types: |
           ```
@@ -166,6 +146,7 @@ _ref:
             on: 'my_variable'
           ```
           Returns:  `"My Variable"`
+
       - name: constantCase
         types: |
           ```
@@ -206,7 +187,7 @@ _ref:
           ```
           Returns: `"my.variable"`
 
-      - name: headerCase
+      - name: kebabCase
         types: |
           ```
           ({on: string, options: object}): string
@@ -217,14 +198,14 @@ _ref:
           ([on: array, options: object]): array
           ```
         description: |
-          The `_change_case.headerCase` method transforms `on` into a dash separated string of capitalized words.
+          The `_change_case.kebabCase` method transforms `on` into a lower cased string with dashes between words.
         examples: |
-          ###### Transform snake_case variable to headerCase:
+          ###### Transform snake_case variable to kebabCase:
           ```yaml
-          _change_case.headerCase:
+          _change_case.kebabCase:
             on: 'my_variable'
           ```
-          Returns: `"My-Variable"`
+          Returns: `"my-variable"`
 
       - name: noCase
         types: |
@@ -246,26 +227,6 @@ _ref:
           ```
           Returns: `"my variable"`
 
-      - name: paramCase
-        types: |
-          ```
-          ({on: string, options: object}): string
-          ([on: string, options: object]): string
-          ({on: object, options: object}): object
-          ([on: object, options: object]): object
-          ({on: array, options: object}): array
-          ([on: array, options: object]): array
-          ```
-        description: |
-          The `_change_case.paramCase` method transforms `on` into a lower cased string with dashes between words.
-        examples: |
-          ###### Transform snake_case variable to paramCase:
-          ```yaml
-          _change_case.paramCase:
-            on: 'my_variable'
-          ```
-          Returns: `"my-variable"`
-
       - name: pascalCase
         types: |
           ```
@@ -286,6 +247,26 @@ _ref:
           ```
           Returns: `"MyVariable"`
 
+      - name: pascalSnakeCase
+        types: |
+          ```
+          ({on: string, options: object}): string
+          ([on: string, options: object]): string
+          ({on: object, options: object}): object
+          ([on: object, options: object]): object
+          ({on: array, options: object}): array
+          ([on: array, options: object]): array
+          ```
+        description: |
+          The `_change_case.pascalSnakeCase` method transforms `on` into a string of capitalized words with underscores between words.
+        examples: |
+          ###### Transform snake_case variable to pascalSnakeCase:
+          ```yaml
+          _change_case.pascalCase:
+            on: 'my_variable'
+          ```
+          Returns: `"My_Variable"`
+
       - name: pathCase
         types: |
           ```
@@ -304,7 +285,7 @@ _ref:
           _change_case.pathCase:
             on: 'my_variable'
           ```
-          Returns:
+          Returns: `my/variable`
 
       - name: sentenceCase
         types: |
@@ -345,3 +326,23 @@ _ref:
             on: 'My variable'
           ```
           Returns: `"my_variable"`
+
+      - name: trainCase
+        types: |
+          ```
+          ({on: string, options: object}): string
+          ([on: string, options: object]): string
+          ({on: object, options: object}): object
+          ([on: object, options: object]): object
+          ({on: array, options: object}): array
+          ([on: array, options: object]): array
+          ```
+        description: |
+          The `_change_case.trainCase` method transforms `on` into a dash separated string of capitalized words.
+        examples: |
+          ###### Transform snake_case variable to trainCase:
+          ```yaml
+          _change_case.trainCase:
+            on: 'my_variable'
+          ```
+          Returns: `"My-Variable"`

--- a/packages/plugins/operators/operators-change-case/package.json
+++ b/packages/plugins/operators/operators-change-case/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@lowdefy/helpers": "4.0.0-rc.15",
     "@lowdefy/operators": "4.0.0-rc.15",
-    "change-case": "4.1.2"
+    "change-case": "5.4.0"
   },
   "devDependencies": {
     "@swc/cli": "0.1.63",

--- a/packages/plugins/operators/operators-change-case/src/operators/shared/change_case.js
+++ b/packages/plugins/operators/operators-change-case/src/operators/shared/change_case.js
@@ -19,13 +19,14 @@ import {
   capitalCase,
   constantCase,
   dotCase,
-  headerCase,
+  kebabCase,
   noCase,
-  paramCase,
   pascalCase,
+  pascalSnakeCase,
   pathCase,
   sentenceCase,
   snakeCase,
+  trainCase,
 } from 'change-case';
 import { get, type } from '@lowdefy/helpers';
 import { runClass } from '@lowdefy/operators';
@@ -35,31 +36,14 @@ const changeCase = {
   capitalCase,
   constantCase,
   dotCase,
-  headerCase,
+  kebabCase,
   noCase,
-  paramCase,
   pascalCase,
+  pascalSnakeCase,
   pathCase,
   sentenceCase,
   snakeCase,
-};
-
-const prepRegex = (prop, location) => {
-  const regex = type.isString(prop) ? { pattern: prop } : prop;
-  if (!type.isObject(regex)) {
-    throw new Error(
-      `Operator Error: regex must be string or an object. Received ${JSON.stringify(
-        prop
-      )} at ${location}.`
-    );
-  }
-  try {
-    return new RegExp(regex.pattern, regex.flags ?? 'gm');
-  } catch (e) {
-    throw new Error(
-      `Operator Error: ${e.message}. Received: ${JSON.stringify(prop)} at ${location}.`
-    );
-  }
+  trainCase,
 };
 
 const prep = (args, { location }) => {
@@ -70,14 +54,6 @@ const prep = (args, { location }) => {
         options
       )} at ${location}.`
     );
-  }
-  if (type.isObject(options)) {
-    if (options.splitRegexp) {
-      options.splitRegexp = prepRegex(options.splitRegexp, location);
-    }
-    if (options.stripRegexp) {
-      options.stripRegexp = prepRegex(options.stripRegexp, location);
-    }
   }
   return args;
 };

--- a/packages/plugins/operators/operators-change-case/src/operators/shared/change_case.test.js
+++ b/packages/plugins/operators/operators-change-case/src/operators/shared/change_case.test.js
@@ -50,6 +50,76 @@ test('_change_case.capitalCase [string, {delimiter: "-"}]', () => {
   ).toEqual('Test-String');
 });
 
+test('_change_case.capitalCase on: string, options: {prefixCharacters: "_"}', () => {
+  expect(
+    change_case({
+      params: {
+        on: '_test string',
+        options: {
+          prefixCharacters: '_',
+        },
+      },
+      location: 'locationId',
+      methodName: 'capitalCase',
+    })
+  ).toEqual('_Test String');
+});
+
+test('_change_case.capitalCase on: string, options: {suffixCharacters: "_"}', () => {
+  expect(
+    change_case({
+      params: {
+        on: '_test string_',
+        options: {
+          suffixCharacters: '_',
+        },
+      },
+      location: 'locationId',
+      methodName: 'capitalCase',
+    })
+  ).toEqual('Test String_');
+});
+
+test('_change_case.capitalCase on: string, options: {locale: "tr"}', () => {
+  expect(
+    change_case({
+      params: {
+        on: 'this is a test string',
+        options: {
+          locale: 'tr',
+        },
+      },
+      location: 'locationId',
+      methodName: 'capitalCase',
+    })
+  ).toEqual('This İs A Test String');
+});
+
+test('_change_case.capitalCase on: string, options: {split}', () => {
+  expect(
+    change_case({
+      params: {
+        on: 'test string',
+        options: {
+          split: (input) => input.split('t s'),
+        },
+      },
+      location: 'locationId',
+      methodName: 'capitalCase',
+    })
+  ).toEqual('Tes Tring');
+});
+
+test('_change_case.capitalCase [string, {delimiter: "-"}]', () => {
+  expect(
+    change_case({
+      params: ['test string', { delimiter: '-' }],
+      location: 'locationId',
+      methodName: 'capitalCase',
+    })
+  ).toEqual('Test-String');
+});
+
 test('_change_case.capitalCase on: string, options: [] throw', () => {
   expect(() =>
     change_case({
@@ -61,116 +131,6 @@ test('_change_case.capitalCase on: string, options: [] throw', () => {
       methodName: 'capitalCase',
     })
   ).toThrow('Operator Error: options must be an object.');
-});
-
-test('_change_case.sentenceCase on: string, options: {splitRegexp: "([a-z])([A-Z0-9])"}', () => {
-  expect(
-    change_case({
-      params: {
-        on: 'word2019',
-      },
-      location: 'locationId',
-      methodName: 'sentenceCase',
-    })
-  ).toEqual('Word2019');
-  expect(
-    change_case({
-      params: {
-        on: 'word2019',
-        options: {
-          splitRegexp: '([a-z])([A-Z0-9])',
-        },
-      },
-      location: 'locationId',
-      methodName: 'sentenceCase',
-    })
-  ).toEqual('Word 2019');
-  expect(
-    change_case({
-      params: {
-        on: 'word2019',
-        options: {
-          splitRegexp: {
-            pattern: '([a-z])([A-Z0-9])',
-            flags: 'gi',
-          },
-        },
-      },
-      location: 'locationId',
-      methodName: 'sentenceCase',
-    })
-  ).toEqual('W or d2019');
-});
-
-test('_change_case.capitalCase on: string, invalid regex throw', () => {
-  expect(() =>
-    change_case({
-      params: {
-        on: testString,
-        options: {
-          splitRegexp: '(a',
-        },
-      },
-      location: 'locationId',
-      methodName: 'capitalCase',
-    })
-  ).toThrow('Operator Error: Invalid regular expression');
-});
-
-test('_change_case.capitalCase on: string, regex not string or object throw', () => {
-  expect(() =>
-    change_case({
-      params: {
-        on: testString,
-        options: {
-          splitRegexp: [],
-        },
-      },
-      location: 'locationId',
-      methodName: 'capitalCase',
-    })
-  ).toThrowErrorMatchingInlineSnapshot(
-    `"Operator Error: regex must be string or an object. Received [] at locationId."`
-  );
-});
-
-test('_change_case.sentenceCase on: string, options: {stripRegexp: "[^A-Z]"}', () => {
-  expect(
-    change_case({
-      params: {
-        on: 'word2019',
-      },
-      location: 'locationId',
-      methodName: 'sentenceCase',
-    })
-  ).toEqual('Word2019');
-  expect(
-    change_case({
-      params: {
-        on: 'word2019',
-        options: {
-          stripRegexp: '[^A-Z]',
-        },
-      },
-      location: 'locationId',
-      methodName: 'sentenceCase',
-    })
-  ).toEqual('');
-  expect(
-    change_case({
-      params: {
-        on: 'word2019',
-        options: {
-          stripRegexp: {
-            pattern: '[^A-Z]',
-            flags: 'gi',
-          },
-        },
-      },
-      location: 'locationId',
-      methodName: 'sentenceCase',
-    })
-  ).toEqual('Word');
 });
 
 test('_change_case.capitalCase on: array, options: {delimiter: "-"}', () => {
@@ -392,9 +352,9 @@ test('_change_case.(AllMethods) on: string', () => {
         on: testString,
       },
       location: 'locationId',
-      methodName: 'headerCase',
+      methodName: 'kebabCase',
     })
-  ).toEqual('Test-String');
+  ).toEqual('test-string');
   expect(
     change_case({
       params: {
@@ -410,18 +370,18 @@ test('_change_case.(AllMethods) on: string', () => {
         on: testString,
       },
       location: 'locationId',
-      methodName: 'paramCase',
+      methodName: 'pascalCase',
     })
-  ).toEqual('test-string');
+  ).toEqual('TestString');
   expect(
     change_case({
       params: {
         on: testString,
       },
       location: 'locationId',
-      methodName: 'pascalCase',
+      methodName: 'pascalSnakeCase',
     })
-  ).toEqual('TestString');
+  ).toEqual('Test_String');
   expect(
     change_case({
       params: {
@@ -449,6 +409,15 @@ test('_change_case.(AllMethods) on: string', () => {
       methodName: 'snakeCase',
     })
   ).toEqual('test_string');
+  expect(
+    change_case({
+      params: {
+        on: testString,
+      },
+      location: 'locationId',
+      methodName: 'trainCase',
+    })
+  ).toEqual('Test-String');
 });
 
 test('_change_case.(AllMethods) on: object', () => {
@@ -494,9 +463,9 @@ test('_change_case.(AllMethods) on: object', () => {
         on: testObject,
       },
       location: 'locationId',
-      methodName: 'headerCase',
+      methodName: 'kebabCase',
     })
-  ).toEqual({ field_1: 'Test-String-1', field_2: 'Test-String-2' });
+  ).toEqual({ field_1: 'test-string-1', field_2: 'test-string-2' });
   expect(
     change_case({
       params: {
@@ -512,18 +481,18 @@ test('_change_case.(AllMethods) on: object', () => {
         on: testObject,
       },
       location: 'locationId',
-      methodName: 'paramCase',
+      methodName: 'pascalCase',
     })
-  ).toEqual({ field_1: 'test-string-1', field_2: 'test-string-2' });
+  ).toEqual({ field_1: 'TestString_1', field_2: 'TestString_2' });
   expect(
     change_case({
       params: {
         on: testObject,
       },
       location: 'locationId',
-      methodName: 'pascalCase',
+      methodName: 'pascalSnakeCase',
     })
-  ).toEqual({ field_1: 'TestString_1', field_2: 'TestString_2' });
+  ).toEqual({ field_1: 'Test_String_1', field_2: 'Test_String_2' });
   expect(
     change_case({
       params: {
@@ -551,6 +520,15 @@ test('_change_case.(AllMethods) on: object', () => {
       methodName: 'snakeCase',
     })
   ).toEqual({ field_1: 'test_string_1', field_2: 'test_string_2' });
+  expect(
+    change_case({
+      params: {
+        on: testObject,
+      },
+      location: 'locationId',
+      methodName: 'trainCase',
+    })
+  ).toEqual({ field_1: 'Test-String-1', field_2: 'Test-String-2' });
 });
 
 test('_change_case.(AllMethods) on: array', () => {
@@ -596,9 +574,9 @@ test('_change_case.(AllMethods) on: array', () => {
         on: testArray,
       },
       location: 'locationId',
-      methodName: 'headerCase',
+      methodName: 'kebabCase',
     })
-  ).toEqual(['Test-String-1', 'Test-String-2', 'Test-String-3']);
+  ).toEqual(['test-string-1', 'test-string-2', 'test-string-3']);
   expect(
     change_case({
       params: {
@@ -614,18 +592,18 @@ test('_change_case.(AllMethods) on: array', () => {
         on: testArray,
       },
       location: 'locationId',
-      methodName: 'paramCase',
+      methodName: 'pascalCase',
     })
-  ).toEqual(['test-string-1', 'test-string-2', 'test-string-3']);
+  ).toEqual(['TestString_1', 'TestString_2', 'TestString_3']);
   expect(
     change_case({
       params: {
         on: testArray,
       },
       location: 'locationId',
-      methodName: 'pascalCase',
+      methodName: 'pascalSnakeCase',
     })
-  ).toEqual(['TestString_1', 'TestString_2', 'TestString_3']);
+  ).toEqual(['Test_String_1', 'Test_String_2', 'Test_String_3']);
   expect(
     change_case({
       params: {
@@ -653,4 +631,13 @@ test('_change_case.(AllMethods) on: array', () => {
       methodName: 'snakeCase',
     })
   ).toEqual(['test_string_1', 'test_string_2', 'test_string_3']);
+  expect(
+    change_case({
+      params: {
+        on: testArray,
+      },
+      location: 'locationId',
+      methodName: 'trainCase',
+    })
+  ).toEqual(['Test-String-1', 'Test-String-2', 'Test-String-3']);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1420,8 +1420,8 @@ importers:
         specifier: 4.0.0-rc.15
         version: link:../../../operators
       change-case:
-        specifier: 4.1.2
-        version: 4.1.2
+        specifier: 5.4.0
+        version: 5.4.0
     devDependencies:
       '@swc/cli':
         specifier: 0.1.63
@@ -6575,13 +6575,6 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  /camel-case@4.1.2:
-    resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
-    dependencies:
-      pascal-case: 3.1.2
-      tslib: 2.6.2
-    dev: false
-
   /camelcase-keys@6.2.2:
     resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
     engines: {node: '>=8'}
@@ -6601,14 +6594,6 @@ packages:
 
   /caniuse-lite@1.0.30001546:
     resolution: {integrity: sha512-zvtSJwuQFpewSyRrI3AsftF6rM0X80mZkChIt1spBGEvRglCrjTniXvinc8JKRoqTwXAgvqTImaN9igfSMtUBw==}
-
-  /capital-case@1.0.4:
-    resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.6.2
-      upper-case-first: 2.0.2
-    dev: false
 
   /ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -6634,21 +6619,8 @@ packages:
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
     dev: false
 
-  /change-case@4.1.2:
-    resolution: {integrity: sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==}
-    dependencies:
-      camel-case: 4.1.2
-      capital-case: 1.0.4
-      constant-case: 3.0.4
-      dot-case: 3.0.4
-      header-case: 2.0.4
-      no-case: 3.0.4
-      param-case: 3.0.4
-      pascal-case: 3.1.2
-      path-case: 3.0.4
-      sentence-case: 3.0.4
-      snake-case: 3.0.4
-      tslib: 2.4.1
+  /change-case@5.4.0:
+    resolution: {integrity: sha512-11YRFf0f4pI+ROHUfq64WivyrcNSrZjdDt2qgVxvAObtj/Pwnu5uAKObHRbN9uAhaDFkvkqcKVEl8Dxnmx+N7w==}
     dev: false
 
   /char-regex@1.0.2:
@@ -6887,14 +6859,6 @@ packages:
 
   /console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
-    dev: false
-
-  /constant-case@3.0.4:
-    resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.6.2
-      upper-case: 2.0.2
     dev: false
 
   /content-disposition@0.5.4:
@@ -7379,13 +7343,6 @@ packages:
     dependencies:
       dom-serializer: 0.2.2
       domelementtype: 1.3.1
-
-  /dot-case@3.0.4:
-    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.6.2
-    dev: false
 
   /dotenv@16.3.1:
     resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
@@ -8829,13 +8786,6 @@ packages:
       hast-util-parse-selector: 3.1.1
       property-information: 6.3.0
       space-separated-tokens: 2.0.2
-    dev: false
-
-  /header-case@2.0.4:
-    resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
-    dependencies:
-      capital-case: 1.0.4
-      tslib: 2.6.2
     dev: false
 
   /highlight.js@10.7.3:
@@ -10308,12 +10258,6 @@ packages:
     dependencies:
       js-tokens: 4.0.0
 
-  /lower-case@2.0.2:
-    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
   /lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
@@ -11231,13 +11175,6 @@ packages:
       - '@babel/core'
       - babel-plugin-macros
 
-  /no-case@3.0.4:
-    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
-    dependencies:
-      lower-case: 2.0.2
-      tslib: 2.6.2
-    dev: false
-
   /node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
     dev: false
@@ -11654,13 +11591,6 @@ packages:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
     dev: false
 
-  /param-case@3.0.4:
-    resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
-    dependencies:
-      dot-case: 3.0.4
-      tslib: 2.6.2
-    dev: false
-
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -11694,20 +11624,6 @@ packages:
 
   /parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
-
-  /pascal-case@3.1.2:
-    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.6.2
-    dev: false
-
-  /path-case@3.0.4:
-    resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
-    dependencies:
-      dot-case: 3.0.4
-      tslib: 2.6.2
-    dev: false
 
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -13255,14 +13171,6 @@ packages:
     dependencies:
       lru-cache: 6.0.0
 
-  /sentence-case@3.0.4:
-    resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.6.2
-      upper-case-first: 2.0.2
-    dev: false
-
   /serialize-javascript@6.0.1:
     resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
     dependencies:
@@ -13353,13 +13261,6 @@ packages:
       wcwidth: 1.0.1
       yargs: 15.4.1
     dev: true
-
-  /snake-case@3.0.4:
-    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
-    dependencies:
-      dot-case: 3.0.4
-      tslib: 2.6.2
-    dev: false
 
   /socks-proxy-agent@6.2.1:
     resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
@@ -14131,10 +14032,6 @@ packages:
     resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
     dev: false
 
-  /tslib@2.4.1:
-    resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
-    dev: false
-
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
@@ -14423,18 +14320,6 @@ packages:
       browserslist: 4.22.1
       escalade: 3.1.1
       picocolors: 1.0.0
-
-  /upper-case-first@2.0.2:
-    resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
-  /upper-case@2.0.2:
-    resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
-    dependencies:
-      tslib: 2.6.2
-    dev: false
 
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}


### PR DESCRIPTION

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes #ISSUE_NUMBER

### What are the changes and their implications?
This PR upgrades the change-case dependency to 5.4.0

This is a breaking change and effects the `_change_case` operator.

Changes to the `_change_case` operator:

- Options splitRegex and stripRegexp are no longer supported.
- paramCase has been renamed to kebabCase
- headerCase has been renamed to trainCase
- The following options have been added:

  - locale
  - mergeAmbiguousCharacters
  - prefixCharacters
  - split
  - suffixCharacters

- Added pascalSnakeCase which transforms a string into a string of capitalized words with underscores between words.

## Checklist

- [x] Pull request is made to the "develop" branch
- [x] Tests added
- [x] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
