### PR TITLE
Pagination bug fix

### DIFF
--- a/.changeset/giant-geese-reflect.md
+++ b/.changeset/giant-geese-reflect.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/blocks-antd': patch
+---
+
+Bug fix for Pagination block intial pageSize value

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Pagination/Pagination.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Pagination/Pagination.js
@@ -83,7 +83,6 @@ PaginationBlock.meta = {
   valueType: 'object',
   initValue: {
     current: 1,
-    pageSize: 10,
     skip: 0,
   },
   category: 'input',


### PR DESCRIPTION
Closes #N/A

### What are the changes and their implications?
Unset initial pageSize value for Pagination block, fixes a bug where it would not use the initial value as specified in the pageSizeOptions property.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
