### PR TITLE
fix(cli): Set shell process option true when spawning pnpm command on windows.

### DIFF
--- a/packages/cli/src/commands/dev/runDevServer.js
+++ b/packages/cli/src/commands/dev/runDevServer.js
@@ -24,6 +24,8 @@ async function runDevServer({ context, directory }) {
     stdOutLineHandler: createStdOutLineHandler({ context }),
     processOptions: {
       cwd: directory,
+      // https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high
+      shell: process.platform === 'win32',
       env: {
         ...process.env,
         LOWDEFY_BUILD_REF_RESOLVER: context.options.refResolver,

--- a/packages/cli/src/commands/start/runStart.js
+++ b/packages/cli/src/commands/start/runStart.js
@@ -24,6 +24,8 @@ async function runStart({ context, directory }) {
     stdOutLineHandler: createStdOutLineHandler({ context }),
     processOptions: {
       cwd: directory,
+      // https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high
+      shell: process.platform === 'win32',
       env: {
         ...process.env,
         LOWDEFY_LOG_LEVEL: context.options.logLevel,

--- a/packages/cli/src/utils/installServer.js
+++ b/packages/cli/src/utils/installServer.js
@@ -25,6 +25,8 @@ async function installServer({ context, directory }) {
       stdOutLineHandler: (line) => context.print.debug(line),
       processOptions: {
         cwd: directory,
+        // https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high
+        shell: process.platform === 'win32',
       },
     });
   } catch (error) {

--- a/packages/cli/src/utils/runLowdefyBuild.js
+++ b/packages/cli/src/utils/runLowdefyBuild.js
@@ -26,6 +26,8 @@ async function runLowdefyBuild({ context, directory }) {
       stdOutLineHandler: createStdOutLineHandler({ context }),
       processOptions: {
         cwd: directory,
+        // https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high
+        shell: process.platform === 'win32',
         env: {
           ...process.env,
           LOWDEFY_BUILD_REF_RESOLVER: context.options.refResolver,

--- a/packages/cli/src/utils/runNextBuild.js
+++ b/packages/cli/src/utils/runNextBuild.js
@@ -36,6 +36,8 @@ async function runNextBuild({ context, directory }) {
       args: ['run', 'build:next'],
       stdOutLineHandler: createStdOutLineHandler({ context }),
       processOptions: {
+        // https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high
+        shell: process.platform === 'win32',
         cwd: directory,
       },
       env: {


### PR DESCRIPTION
… windows.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?

The CLI is failing to run on latest versions of Node.js on windows to the security fix for CVE-2024-27980. We need to set the `shell` process option true to spawn a `.cmd` file.

https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high

## Checklist

- [ ] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [ ] Code has been formatted with Prettier
- [ ] Edits from maintainers are allowed
