### PR TITLE
feat(blocks-antd): Add autoClearSearchValue property to MultipleSelec…

### DIFF
--- a/.changeset/famous-stingrays-suffer.md
+++ b/.changeset/famous-stingrays-suffer.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/blocks-antd': minor
+---
+
+Add autoClearSearchValue property to MultipleSelector block.

--- a/packages/plugins/blocks/blocks-antd/src/blocks/MultipleSelector/MultipleSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/MultipleSelector/MultipleSelector.js
@@ -71,6 +71,7 @@ const MultipleSelector = ({
             <Select
               id={`${blockId}_input`}
               allowClear={properties.allowClear !== false}
+              autoClearSearchValue={properties.autoClearSearchValue}
               autoFocus={properties.autoFocus}
               bordered={properties.bordered}
               className={methods.makeCssClass([{ width: '100%' }, properties.inputStyle])}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/MultipleSelector/schema.json
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/MultipleSelector/schema.json
@@ -9,6 +9,11 @@
         "default": true,
         "description": "Allow the user to clear the selected value, sets the value to null."
       },
+      "autoClearSearchValue": {
+        "type": "boolean",
+        "default": true,
+        "description": "Whether the current search will be cleared on selecting an item."
+      },
       "autoFocus": {
         "type": "boolean",
         "default": false,


### PR DESCRIPTION
…tor block.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

Closes #ISSUE_NUMBER

### What are the changes and their implications?

This PR adds the `autoClearSearchValue` property to the `MultipleSelector` block, which preserves the search input on item selection if set to false.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [x] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
