### PR TITLE
Drawer enhancements.

### DIFF
--- a/.changeset/red-mayflies-fold.md
+++ b/.changeset/red-mayflies-fold.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/blocks-antd': patch
+---
+
+Drawer block enhancements. Add afterOpenChange and afterClose methods.

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Drawer/Drawer.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Drawer/Drawer.js
@@ -70,7 +70,7 @@ const DrawerBlock = ({ blockId, content, properties, methods, rename, onClose })
       handleToggle({ openState, methods, rename, setOpen })
     );
     methods.registerMethod(get(rename, 'methods.setOpen', { default: 'setOpen' }), ({ open }) =>
-      setOpenState({ open, methods, rename, setOpen })
+      setOpenState({ open: Boolean(open), methods, rename, setOpen })
     );
   });
 

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Drawer/Drawer.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Drawer/Drawer.js
@@ -19,27 +19,61 @@ import { Drawer } from 'antd';
 import { get } from '@lowdefy/helpers';
 import { blockDefaultProps } from '@lowdefy/block-utils';
 
-const triggerSetOpen = ({ state, setOpen, methods, rename }) => {
-  if (!state) {
-    methods.triggerEvent({ name: get(rename, 'events.onClose', { default: 'onClose' }) });
+async function handleClose({ methods, rename, setOpen }) {
+  const response = await methods.triggerEvent({
+    name: get(rename, 'events.onClose', { default: 'onClose' }),
+  });
+  if (response.success === false || response.bounced === true) {
+    return;
   }
-  if (state) {
-    methods.triggerEvent({ name: get(rename, 'events.onOpen', { default: 'onOpen' }) });
-  }
+  setOpen(false);
+}
+
+function handleOpen({ methods, rename, setOpen }) {
+  methods.triggerEvent({ name: get(rename, 'events.onOpen', { default: 'onOpen' }) });
+  setOpen(true);
+}
+
+function handleToggle({ openState, methods, rename, setOpen }) {
   methods.triggerEvent({ name: get(rename, 'events.onToggle', { default: 'onToggle' }) });
-  setOpen(state);
-};
+  if (openState) {
+    handleClose({ methods, rename, setOpen });
+  } else {
+    handleOpen({ methods, rename, setOpen });
+  }
+}
+
+function handleAfterOpenChange({ drawerOpen, methods, rename }) {
+  methods.triggerEvent({
+    name: get(rename, 'events.afterOpenChange', { default: 'afterOpenChange' }),
+    event: { drawerOpen },
+  });
+  if (!drawerOpen) {
+    methods.triggerEvent({
+      name: get(rename, 'events.afterClose', { default: 'afterClose' }),
+    });
+  }
+}
+
+function setOpenState({ open, methods, rename, setOpen }) {
+  if (open) {
+    handleOpen({ methods, rename, setOpen });
+  } else {
+    handleClose({ methods, rename, setOpen });
+  }
+}
 
 const DrawerBlock = ({ blockId, content, properties, methods, rename, onClose }) => {
   const [openState, setOpen] = useState(false);
   useEffect(() => {
     methods.registerMethod(get(rename, 'methods.toggleOpen', { default: 'toggleOpen' }), () =>
-      triggerSetOpen({ state: !openState, setOpen, methods, rename })
+      handleToggle({ openState, methods, rename, setOpen })
     );
     methods.registerMethod(get(rename, 'methods.setOpen', { default: 'setOpen' }), ({ open }) =>
-      triggerSetOpen({ state: !!open, setOpen, methods, rename })
+      setOpenState({ open, methods, rename, setOpen })
     );
   });
+
   return (
     <Drawer
       id={blockId}
@@ -49,7 +83,7 @@ const DrawerBlock = ({ blockId, content, properties, methods, rename, onClose })
       mask={properties.mask}
       maskClosable={properties.maskClosable}
       title={properties.title}
-      visible={openState}
+      open={openState}
       width={properties.width}
       height={properties.height}
       zIndex={properties.zIndex}
@@ -57,14 +91,14 @@ const DrawerBlock = ({ blockId, content, properties, methods, rename, onClose })
       keyboard={properties.keyboard}
       onClose={
         onClose ||
-        (async () => {
-          const response = await methods.triggerEvent({ name: 'onClose' });
-          if (response.success === false) return;
-          if (response.bounced !== true) {
-            triggerSetOpen({ state: false, setOpen, methods, rename });
-          }
-        })
+        (() =>
+          handleClose({
+            methods,
+            rename,
+            setOpen,
+          }))
       }
+      afterOpenChange={(drawerOpen) => handleAfterOpenChange({ drawerOpen, methods, rename })}
       drawerStyle={methods.makeCssClass(properties.drawerStyle, true)}
       headerStyle={methods.makeCssClass(properties.headerStyle, true)}
       bodyStyle={methods.makeCssClass(properties.bodyStyle, true)}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Drawer/Drawer.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Drawer/Drawer.js
@@ -19,7 +19,7 @@ import { Drawer } from 'antd';
 import { get } from '@lowdefy/helpers';
 import { blockDefaultProps } from '@lowdefy/block-utils';
 
-async function handleClose({ methods, rename, setOpen }) {
+const handleClose = async ({ methods, rename, setOpen }) => {
   const response = await methods.triggerEvent({
     name: get(rename, 'events.onClose', { default: 'onClose' }),
   });
@@ -27,23 +27,23 @@ async function handleClose({ methods, rename, setOpen }) {
     return;
   }
   setOpen(false);
-}
+};
 
-function handleOpen({ methods, rename, setOpen }) {
+const handleOpen = ({ methods, rename, setOpen }) => {
   methods.triggerEvent({ name: get(rename, 'events.onOpen', { default: 'onOpen' }) });
   setOpen(true);
-}
+};
 
-function handleToggle({ openState, methods, rename, setOpen }) {
+const handleToggle = ({ openState, methods, rename, setOpen }) => {
   methods.triggerEvent({ name: get(rename, 'events.onToggle', { default: 'onToggle' }) });
   if (openState) {
     handleClose({ methods, rename, setOpen });
   } else {
     handleOpen({ methods, rename, setOpen });
   }
-}
+};
 
-function handleAfterOpenChange({ drawerOpen, methods, rename }) {
+const handleAfterOpenChange = ({ drawerOpen, methods, rename }) => {
   methods.triggerEvent({
     name: get(rename, 'events.afterOpenChange', { default: 'afterOpenChange' }),
     event: { drawerOpen },
@@ -53,15 +53,15 @@ function handleAfterOpenChange({ drawerOpen, methods, rename }) {
       name: get(rename, 'events.afterClose', { default: 'afterClose' }),
     });
   }
-}
+};
 
-function setOpenState({ open, methods, rename, setOpen }) {
+const setOpenState = ({ open, methods, rename, setOpen }) => {
   if (open) {
     handleOpen({ methods, rename, setOpen });
   } else {
     handleClose({ methods, rename, setOpen });
   }
-}
+};
 
 const DrawerBlock = ({ blockId, content, properties, methods, rename, onClose }) => {
   const [openState, setOpen] = useState(false);

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Drawer/schema.json
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Drawer/schema.json
@@ -107,6 +107,14 @@
       "onOpen": {
         "type": "array",
         "description": "Trigger actions when drawer is opened."
+      },
+      "afterClose": {
+        "type": "array",
+        "description": "Trigger actions after drawer is closed."
+      },
+      "afterOpenChange": {
+        "type": "array",
+        "description": "Trigger actions after drawer is opened."
       }
     }
   }


### PR DESCRIPTION
- Previous `triggerSetOpen` function split into dedicated functions. This should improve code maintainability, and fixes and issue where the `onClose` event would be executed twice.
- Added new `afterOpenChange` events. The actions in these events execute after the drawer's closing animation is done.
- Use of `open` instead of `visible` to match the new Ant Design API convention (and makes `afterOpenChange` work).

## Checklist
- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [x] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
