### PR TITLE
Add missing events to S3Upload block schemas

### DIFF
--- a/.changeset/honest-goats-arrive.md
+++ b/.changeset/honest-goats-arrive.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/plugin-aws': patch
+---
+
+Add missing events to S3Upload block schemas.

--- a/packages/plugins/plugins/plugin-aws/src/blocks/S3UploadButton/schema.json
+++ b/packages/plugins/plugins/plugin-aws/src/blocks/S3UploadButton/schema.json
@@ -78,6 +78,22 @@
         "type": "array",
         "description": "Triggered when the upload state is changing."
       },
+      "onProgress": {
+        "type": "array",
+        "description": "Triggered when the upload state is in progress."
+      },
+      "onSuccess": {
+        "type": "array",
+        "description": "Triggered when the upload state is done uploading."
+      },
+      "onRemove": {
+        "type": "array",
+        "description": "Triggered when the upload has been removed."
+      },
+      "onError": {
+        "type": "array",
+        "description": "Triggered when the upload has failed."
+      },
       "onClick": {
         "type": "array",
         "description": "Triggered when the upload button is clicked."

--- a/packages/plugins/plugins/plugin-aws/src/blocks/S3UploadDragger/schema.json
+++ b/packages/plugins/plugins/plugin-aws/src/blocks/S3UploadDragger/schema.json
@@ -75,6 +75,22 @@
       "onChange": {
         "type": "array",
         "description": "Triggered when the upload state is changing."
+      },
+      "onProgress": {
+        "type": "array",
+        "description": "Triggered when the upload state is in progress."
+      },
+      "onSuccess": {
+        "type": "array",
+        "description": "Triggered when the upload state is done uploading."
+      },
+      "onRemove": {
+        "type": "array",
+        "description": "Triggered when the upload has been removed."
+      },
+      "onError": {
+        "type": "array",
+        "description": "Triggered when the upload has failed."
       }
     }
   }

--- a/packages/plugins/plugins/plugin-aws/src/blocks/S3UploadPhoto/schema.json
+++ b/packages/plugins/plugins/plugin-aws/src/blocks/S3UploadPhoto/schema.json
@@ -73,6 +73,22 @@
       "onChange": {
         "type": "array",
         "description": "Triggered when the upload state is changing."
+      },
+      "onProgress": {
+        "type": "array",
+        "description": "Triggered when the upload state is in progress."
+      },
+      "onSuccess": {
+        "type": "array",
+        "description": "Triggered when the upload state is done uploading."
+      },
+      "onRemove": {
+        "type": "array",
+        "description": "Triggered when the upload has been removed."
+      },
+      "onError": {
+        "type": "array",
+        "description": "Triggered when the upload has failed."
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible, please:
 - Make the Pull Request to the "develop" branch.
 - Link an issue via "Closes #ISSUE_NUMBER".
 - Describe your changes and their implications. If the changes cause breaking changes in Lowdefy configuration, please state this.
 - Please allow edits from maintainers on your pull request. You can read more here:
    - https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 - Follow the checklist and complete everything that is applicable.
-->

### What are the changes and their implications?

Adds the missing `onProgress`, `onSuccess`, `onRemove` and `onError` events to the `S3UploadButton`, `S3UploadDragger` and `S3UploadPhoto` block schemas.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [x] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
