### PR TITLE
Fix default return for api operator

### DIFF
--- a/packages/plugins/operators/operators-js/src/operators/client/api.js
+++ b/packages/plugins/operators/operators-js/src/operators/client/api.js
@@ -32,7 +32,7 @@ function _api({ params, apiResponses, location }) {
     const key = keyParts.join('.');
     return get(apiResponses[endpoint][0], key, {
       copy: true,
-      default: null,
+      default: apiResponses[endpoint][0],
     });
   }
 


### PR DESCRIPTION
### What are the changes and their implications?

Changed default return for the `_api` operator from null to the result of the API call.

## Checklist

- [ ] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [ ] Code has been formatted with Prettier
- [ ] Edits from maintainers are allowed
