### PR TITLE
JSONata Operator

### DIFF
--- a/.changeset/real-radios-destroy.md
+++ b/.changeset/real-radios-destroy.md
@@ -1,0 +1,8 @@
+---
+'@lowdefy/operators-jsonata': minor
+'@lowdefy/operators': minor
+'@lowdefy/build': minor
+'@lowdefy/docs': minor
+---
+
+Add JSONata operator.

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -86,6 +86,7 @@
     "@lowdefy/connection-stripe": "4.4.0",
     "@lowdefy/operators-change-case": "4.4.0",
     "@lowdefy/operators-diff": "4.4.0",
+    "@lowdefy/operators-jsonata": "4.4.0",
     "@lowdefy/operators-moment": "4.4.0",
     "@lowdefy/operators-mql": "4.4.0",
     "@lowdefy/operators-nunjucks": "4.4.0",

--- a/packages/build/src/scripts/generateDefaultTypes.js
+++ b/packages/build/src/scripts/generateDefaultTypes.js
@@ -44,6 +44,7 @@ const defaultPackages = [
   '@lowdefy/operators-change-case',
   '@lowdefy/operators-diff',
   '@lowdefy/operators-js',
+  '@lowdefy/operators-jsonata',
   '@lowdefy/operators-moment',
   '@lowdefy/operators-mql',
   '@lowdefy/operators-nunjucks',

--- a/packages/docs/menus.yaml
+++ b/packages/docs/menus.yaml
@@ -798,6 +798,9 @@
         - id: _json
           type: MenuLink
           pageId: _json
+        - id: _jsonata
+          type: MenuLink
+          pageId: _jsonata
         - id: _location
           type: MenuLink
           pageId: _location

--- a/packages/docs/operators/_jsonata.yaml
+++ b/packages/docs/operators/_jsonata.yaml
@@ -1,0 +1,187 @@
+# Copyright 2020-2024 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_ref:
+  path: templates/operators.yaml.njk
+  transformer: templates/operatorsMethodTransformer.js
+  vars:
+    pageId: _jsonata
+    pageTitle: _jsonata
+    filePath: operators/_jsonata.yaml
+    description: |
+      The `_jsonata` operator provides a powerful query and transformation language for JSON data using the [JSONata](https://jsonata.org) library.
+    methods:
+      - name: evaluate
+        types: |
+          ```
+          ({on: any, expr: string, bindings?: object}): any
+          ([on: any, expr: string, bindings?: object]): any
+          ```
+        description: |
+          The `_jsonata.evaluate` method evaluates a JSONata expression against input data. JSONata is a lightweight query and transformation language for JSON data that allows you to navigate, query, and transform JSON structures with simple and intuitive expressions.
+        arguments: |
+          ###### object
+            - `on: any`: The input data to evaluate the expression against.
+            - `expr: string`: A JSONata expression string.
+            - `bindings?: object`: Optional bindings object to provide additional variables to the expression.
+        examples: |
+          ###### Basic arithmetic:
+          ```yaml
+          _jsonata.evaluate:
+            on:
+              a: 5
+              b: 3
+            expr: a + b
+          ```
+          Returns: `8`
+
+          ###### String concatenation:
+          ```yaml
+          _jsonata.evaluate:
+            on:
+              firstName: John
+              lastName: Doe
+            expr: firstName & " " & lastName
+          ```
+          Returns: `"John Doe"`
+
+          ###### Array filtering:
+          ```yaml
+          _jsonata.evaluate:
+            on:
+              items: [1, 2, 3, 4, 5]
+            expr: items[$ > 3]
+          ```
+          Returns: `[4, 5]`
+
+          ###### Array mapping:
+          ```yaml
+          _jsonata.evaluate:
+            on:
+              users:
+                - name: Alice
+                  age: 30
+                - name: Bob
+                  age: 25
+            expr: users.name
+          ```
+          Returns: `["Alice", "Bob"]`
+
+          ###### Using bindings:
+          ```yaml
+          _jsonata.evaluate:
+            on:
+              price: 100
+            expr: price * taxRate
+            bindings:
+              taxRate: 1.2
+          ```
+          Returns: `120`
+
+          ###### Aggregation with built-in functions:
+          ```yaml
+          _jsonata.evaluate:
+            on:
+              items: [1, 2, 3, 4, 5]
+            expr: $sum(items)
+          ```
+          Returns: `15`
+
+          ###### Conditional expression:
+          ```yaml
+          _jsonata.evaluate:
+            on:
+              temperature: 25
+            expr: temperature > 20 ? "warm" : "cold"
+          ```
+          Returns: `"warm"`
+
+      - name: transform
+        types: |
+          ```
+          ({on: any, expr: string, bindings?: object}): any
+          ([on: any, expr: string, bindings?: object]): any
+          ```
+        description: |
+          The `_jsonata.transform` method transforms data using a JSONata expression. This is functionally equivalent to `_jsonata.evaluate` but semantically indicates data transformation rather than simple evaluation.
+        arguments: |
+          ###### object
+            - `on: any`: The input data to transform.
+            - `expr: string`: A JSONata transformation expression string.
+            - `bindings?: object`: Optional bindings object to provide additional variables to the expression.
+        examples: |
+          ###### Object transformation:
+          ```yaml
+          _jsonata.transform:
+            on:
+              user:
+                firstName: Jane
+                lastName: Smith
+                email: jane@example.com
+            expr: |
+              {
+                "fullName": user.firstName & " " & user.lastName,
+                "contact": user.email
+              }
+          ```
+          Returns:
+          ```json
+          {
+            "fullName": "Jane Smith",
+            "contact": "jane@example.com"
+          }
+          ```
+
+          ###### Array transformation:
+          ```yaml
+          _jsonata.transform:
+            on:
+              orders:
+                - id: 1
+                  amount: 100
+                - id: 2
+                  amount: 200
+            expr: orders.{ "orderId": id, "total": amount * 1.1 }
+          ```
+          Returns:
+          ```json
+          [
+            { "orderId": 1, "total": 110 },
+            { "orderId": 2, "total": 220 }
+          ]
+          ```
+
+          ###### Complex transformation with aggregation:
+          ```yaml
+          _jsonata.transform:
+            on:
+              user:
+                firstName: Jane
+                lastName: Smith
+              orders:
+                - total: 100
+                - total: 200
+            expr: |
+              {
+                "customer": user.firstName & " " & user.lastName,
+                "totalSpent": $sum(orders.total)
+              }
+          ```
+          Returns:
+          ```json
+          {
+            "customer": "Jane Smith",
+            "totalSpent": 300
+          }
+          ```

--- a/packages/docs/operators/_jsonata.yaml
+++ b/packages/docs/operators/_jsonata.yaml
@@ -19,169 +19,150 @@ _ref:
     pageId: _jsonata
     pageTitle: _jsonata
     filePath: operators/_jsonata.yaml
+    types: |
+      ```
+      (arguments: {on: any, expr: string, bindings?: object}): any
+      ```
     description: |
-      The `_jsonata` operator provides a powerful query and transformation language for JSON data using the [JSONata](https://jsonata.org) library.
-    methods:
-      - name: evaluate
-        types: |
-          ```
-          ({on: any, expr: string, bindings?: object}): any
-          ([on: any, expr: string, bindings?: object]): any
-          ```
-        description: |
-          The `_jsonata.evaluate` method evaluates a JSONata expression against input data. JSONata is a lightweight query and transformation language for JSON data that allows you to navigate, query, and transform JSON structures with simple and intuitive expressions.
-        arguments: |
-          ###### object
-            - `on: any`: The input data to evaluate the expression against.
-            - `expr: string`: A JSONata expression string.
-            - `bindings?: object`: Optional bindings object to provide additional variables to the expression.
-        examples: |
-          ###### Basic arithmetic:
-          ```yaml
-          _jsonata.evaluate:
-            on:
-              a: 5
-              b: 3
-            expr: a + b
-          ```
-          Returns: `8`
+      The `_jsonata` operator provides a powerful query and transformation language for JSON data using the [JSONata](https://jsonata.org) library. JSONata is a lightweight query and transformation language that allows you to navigate, query, and transform JSON structures with simple and intuitive expressions.
+    arguments: |
+      ###### object
+        - `on: any`: The input data to evaluate the expression against.
+        - `expr: string`: A JSONata expression string.
+        - `bindings?: object`: Optional bindings object to provide additional variables to the expression.
+    examples: |
+      ###### Basic arithmetic:
+      ```yaml
+      _jsonata:
+        on:
+          a: 5
+          b: 3
+        expr: a + b
+      ```
+      Returns: `8`
 
-          ###### String concatenation:
-          ```yaml
-          _jsonata.evaluate:
-            on:
-              firstName: John
-              lastName: Doe
-            expr: firstName & " " & lastName
-          ```
-          Returns: `"John Doe"`
+      ###### String concatenation:
+      ```yaml
+      _jsonata:
+        on:
+          firstName: John
+          lastName: Doe
+        expr: firstName & " " & lastName
+      ```
+      Returns: `"John Doe"`
 
-          ###### Array filtering:
-          ```yaml
-          _jsonata.evaluate:
-            on:
-              items: [1, 2, 3, 4, 5]
-            expr: items[$ > 3]
-          ```
-          Returns: `[4, 5]`
+      ###### Array filtering:
+      ```yaml
+      _jsonata:
+        on:
+          items: [1, 2, 3, 4, 5]
+        expr: items[$ > 3]
+      ```
+      Returns: `[4, 5]`
 
-          ###### Array mapping:
-          ```yaml
-          _jsonata.evaluate:
-            on:
-              users:
-                - name: Alice
-                  age: 30
-                - name: Bob
-                  age: 25
-            expr: users.name
-          ```
-          Returns: `["Alice", "Bob"]`
+      ###### Array mapping:
+      ```yaml
+      _jsonata:
+        on:
+          users:
+            - name: Alice
+              age: 30
+            - name: Bob
+              age: 25
+        expr: users.name
+      ```
+      Returns: `["Alice", "Bob"]`
 
-          ###### Using bindings:
-          ```yaml
-          _jsonata.evaluate:
-            on:
-              price: 100
-            expr: price * taxRate
-            bindings:
-              taxRate: 1.2
-          ```
-          Returns: `120`
+      ###### Using bindings for external variables:
+      ```yaml
+      _jsonata:
+        on:
+          price: 100
+        expr: price * taxRate
+        bindings:
+          taxRate: 1.2
+      ```
+      Returns: `120`
 
-          ###### Aggregation with built-in functions:
-          ```yaml
-          _jsonata.evaluate:
-            on:
-              items: [1, 2, 3, 4, 5]
-            expr: $sum(items)
-          ```
-          Returns: `15`
+      ###### Aggregation with built-in functions:
+      ```yaml
+      _jsonata:
+        on:
+          items: [1, 2, 3, 4, 5]
+        expr: $sum(items)
+      ```
+      Returns: `15`
 
-          ###### Conditional expression:
-          ```yaml
-          _jsonata.evaluate:
-            on:
-              temperature: 25
-            expr: temperature > 20 ? "warm" : "cold"
-          ```
-          Returns: `"warm"`
+      ###### Conditional expression:
+      ```yaml
+      _jsonata:
+        on:
+          temperature: 25
+        expr: temperature > 20 ? "warm" : "cold"
+      ```
+      Returns: `"warm"`
 
-      - name: transform
-        types: |
-          ```
-          ({on: any, expr: string, bindings?: object}): any
-          ([on: any, expr: string, bindings?: object]): any
-          ```
-        description: |
-          The `_jsonata.transform` method transforms data using a JSONata expression. This is functionally equivalent to `_jsonata.evaluate` but semantically indicates data transformation rather than simple evaluation.
-        arguments: |
-          ###### object
-            - `on: any`: The input data to transform.
-            - `expr: string`: A JSONata transformation expression string.
-            - `bindings?: object`: Optional bindings object to provide additional variables to the expression.
-        examples: |
-          ###### Object transformation:
-          ```yaml
-          _jsonata.transform:
-            on:
-              user:
-                firstName: Jane
-                lastName: Smith
-                email: jane@example.com
-            expr: |
-              {
-                "fullName": user.firstName & " " & user.lastName,
-                "contact": user.email
-              }
-          ```
-          Returns:
-          ```json
+      ###### Object transformation:
+      ```yaml
+      _jsonata:
+        on:
+          user:
+            firstName: Jane
+            lastName: Smith
+            email: jane@example.com
+        expr: |
           {
-            "fullName": "Jane Smith",
-            "contact": "jane@example.com"
+            "fullName": user.firstName & " " & user.lastName,
+            "contact": user.email
           }
-          ```
+      ```
+      Returns:
+      ```json
+      {
+        "fullName": "Jane Smith",
+        "contact": "jane@example.com"
+      }
+      ```
 
-          ###### Array transformation:
-          ```yaml
-          _jsonata.transform:
-            on:
-              orders:
-                - id: 1
-                  amount: 100
-                - id: 2
-                  amount: 200
-            expr: orders.{ "orderId": id, "total": amount * 1.1 }
-          ```
-          Returns:
-          ```json
-          [
-            { "orderId": 1, "total": 110 },
-            { "orderId": 2, "total": 220 }
-          ]
-          ```
+      ###### Array transformation:
+      ```yaml
+      _jsonata:
+        on:
+          orders:
+            - id: 1
+              amount: 100
+            - id: 2
+              amount: 200
+        expr: orders.{ "orderId": id, "total": amount * 1.1 }
+      ```
+      Returns:
+      ```json
+      [
+        { "orderId": 1, "total": 110 },
+        { "orderId": 2, "total": 220 }
+      ]
+      ```
 
-          ###### Complex transformation with aggregation:
-          ```yaml
-          _jsonata.transform:
-            on:
-              user:
-                firstName: Jane
-                lastName: Smith
-              orders:
-                - total: 100
-                - total: 200
-            expr: |
-              {
-                "customer": user.firstName & " " & user.lastName,
-                "totalSpent": $sum(orders.total)
-              }
-          ```
-          Returns:
-          ```json
+      ###### Complex transformation with aggregation:
+      ```yaml
+      _jsonata:
+        on:
+          user:
+            firstName: Jane
+            lastName: Smith
+          orders:
+            - total: 100
+            - total: 200
+        expr: |
           {
-            "customer": "Jane Smith",
-            "totalSpent": 300
+            "customer": user.firstName & " " & user.lastName,
+            "totalSpent": $sum(orders.total)
           }
-          ```
+      ```
+      Returns:
+      ```json
+      {
+        "customer": "Jane Smith",
+        "totalSpent": 300
+      }
+      ```

--- a/packages/docs/pages.yaml
+++ b/packages/docs/pages.yaml
@@ -210,6 +210,7 @@
 - _ref: operators/_item.yaml
 - _ref: operators/_js.yaml
 - _ref: operators/_json.yaml
+- _ref: operators/_jsonata.yaml
 - _ref: operators/_location.yaml
 - _ref: operators/_log.yaml
 - _ref: operators/_lt.yaml

--- a/packages/plugins/operators/operators-jsonata/README.md
+++ b/packages/plugins/operators/operators-jsonata/README.md
@@ -1,30 +1,37 @@
 # Lowdefy Operators JSONata
 
-JSONata operators for Lowdefy - powerful query and transformation language for JSON data.
+JSONata operator for Lowdefy - powerful query and transformation language for JSON data.
 
 ## Overview
 
 JSONata is a lightweight query and transformation language for JSON data. It provides a simple and intuitive way to navigate, query, and transform JSON structures.
 
-## Operators
+## Operator
 
-### `_jsonata.evaluate`
+### `_jsonata`
 
 Evaluate a JSONata expression against data.
 
 **Syntax:**
+
 ```yaml
-_jsonata.evaluate:
+_jsonata:
   on: <data>
   expr: <string>
-  bindings: <object>  # optional
+  bindings: <object> # optional
 ```
+
+**Parameters:**
+
+- `on`: The input data to evaluate the expression against
+- `expr`: A JSONata expression string
+- `bindings`: Optional object to provide additional variables to the expression
 
 **Examples:**
 
 ```yaml
 # Basic arithmetic
-_jsonata.evaluate:
+_jsonata:
   on:
     a: 5
     b: 3
@@ -32,7 +39,7 @@ _jsonata.evaluate:
 # Returns: 8
 
 # String concatenation
-_jsonata.evaluate:
+_jsonata:
   on:
     firstName: John
     lastName: Doe
@@ -40,14 +47,14 @@ _jsonata.evaluate:
 # Returns: "John Doe"
 
 # Array filtering
-_jsonata.evaluate:
+_jsonata:
   on:
     items: [1, 2, 3, 4, 5]
   expr: items[$ > 3]
 # Returns: [4, 5]
 
 # Array mapping
-_jsonata.evaluate:
+_jsonata:
   on:
     users:
       - name: Alice
@@ -58,32 +65,16 @@ _jsonata.evaluate:
 # Returns: ["Alice", "Bob"]
 
 # With bindings
-_jsonata.evaluate:
+_jsonata:
   on:
     price: 100
   expr: price * taxRate
   bindings:
     taxRate: 1.2
 # Returns: 120
-```
 
-### `_jsonata.transform`
-
-Transform data using a JSONata expression. This is an alias for `evaluate` but semantically indicates data transformation.
-
-**Syntax:**
-```yaml
-_jsonata.transform:
-  on: <data>
-  expr: <string>
-  bindings: <object>  # optional
-```
-
-**Examples:**
-
-```yaml
 # Object transformation
-_jsonata.transform:
+_jsonata:
   on:
     user:
       firstName: Jane
@@ -97,7 +88,7 @@ _jsonata.transform:
 # Returns: { "fullName": "Jane Smith", "contact": "jane@example.com" }
 
 # Array transformation
-_jsonata.transform:
+_jsonata:
   on:
     orders:
       - id: 1
@@ -114,11 +105,11 @@ JSONata provides many powerful features:
 
 - **Path Expressions**: Navigate nested objects and arrays
 - **Predicates**: Filter arrays with conditions
-- **Functions**: Built-in functions like `$sum`, `$count`, `$average`, etc.
+- **Functions**: 60+ built-in functions like `$sum`, `$count`, `$average`, `$map`, `$filter`, etc.
 - **Transformations**: Create new object structures
 - **Conditionals**: Ternary operator for conditional logic
-- **String operations**: Concatenation, substring, etc.
+- **String operations**: Concatenation, substring, regex, etc.
 - **Arithmetic**: Standard math operations
-- **Aggregation**: Sum, count, min, max, etc.
+- **Aggregation**: Sum, count, min, max, average, etc.
 
 For more information on JSONata syntax, visit [https://jsonata.org](https://jsonata.org)

--- a/packages/plugins/operators/operators-jsonata/README.md
+++ b/packages/plugins/operators/operators-jsonata/README.md
@@ -1,0 +1,124 @@
+# Lowdefy Operators JSONata
+
+JSONata operators for Lowdefy - powerful query and transformation language for JSON data.
+
+## Overview
+
+JSONata is a lightweight query and transformation language for JSON data. It provides a simple and intuitive way to navigate, query, and transform JSON structures.
+
+## Operators
+
+### `_jsonata.evaluate`
+
+Evaluate a JSONata expression against data.
+
+**Syntax:**
+```yaml
+_jsonata.evaluate:
+  on: <data>
+  expr: <string>
+  bindings: <object>  # optional
+```
+
+**Examples:**
+
+```yaml
+# Basic arithmetic
+_jsonata.evaluate:
+  on:
+    a: 5
+    b: 3
+  expr: a + b
+# Returns: 8
+
+# String concatenation
+_jsonata.evaluate:
+  on:
+    firstName: John
+    lastName: Doe
+  expr: firstName & " " & lastName
+# Returns: "John Doe"
+
+# Array filtering
+_jsonata.evaluate:
+  on:
+    items: [1, 2, 3, 4, 5]
+  expr: items[$ > 3]
+# Returns: [4, 5]
+
+# Array mapping
+_jsonata.evaluate:
+  on:
+    users:
+      - name: Alice
+        age: 30
+      - name: Bob
+        age: 25
+  expr: users.name
+# Returns: ["Alice", "Bob"]
+
+# With bindings
+_jsonata.evaluate:
+  on:
+    price: 100
+  expr: price * taxRate
+  bindings:
+    taxRate: 1.2
+# Returns: 120
+```
+
+### `_jsonata.transform`
+
+Transform data using a JSONata expression. This is an alias for `evaluate` but semantically indicates data transformation.
+
+**Syntax:**
+```yaml
+_jsonata.transform:
+  on: <data>
+  expr: <string>
+  bindings: <object>  # optional
+```
+
+**Examples:**
+
+```yaml
+# Object transformation
+_jsonata.transform:
+  on:
+    user:
+      firstName: Jane
+      lastName: Smith
+      email: jane@example.com
+  expr: |
+    {
+      "fullName": user.firstName & " " & user.lastName,
+      "contact": user.email
+    }
+# Returns: { "fullName": "Jane Smith", "contact": "jane@example.com" }
+
+# Array transformation
+_jsonata.transform:
+  on:
+    orders:
+      - id: 1
+        amount: 100
+      - id: 2
+        amount: 200
+  expr: orders.{ "orderId": id, "total": amount * 1.1 }
+# Returns: [{ "orderId": 1, "total": 110 }, { "orderId": 2, "total": 220 }]
+```
+
+## JSONata Language Features
+
+JSONata provides many powerful features:
+
+- **Path Expressions**: Navigate nested objects and arrays
+- **Predicates**: Filter arrays with conditions
+- **Functions**: Built-in functions like `$sum`, `$count`, `$average`, etc.
+- **Transformations**: Create new object structures
+- **Conditionals**: Ternary operator for conditional logic
+- **String operations**: Concatenation, substring, etc.
+- **Arithmetic**: Standard math operations
+- **Aggregation**: Sum, count, min, max, etc.
+
+For more information on JSONata syntax, visit [https://jsonata.org](https://jsonata.org)

--- a/packages/plugins/operators/operators-jsonata/jest.config.js
+++ b/packages/plugins/operators/operators-jsonata/jest.config.js
@@ -1,0 +1,31 @@
+export default {
+  projects: [
+    {
+      displayName: 'SERVER',
+      clearMocks: true,
+      collectCoverage: true,
+      collectCoverageFrom: ['src/**/*.js'],
+      coverageDirectory: 'coverage',
+      coveragePathIgnorePatterns: [
+        '<rootDir>/dist/',
+        '<rootDir>/src/test',
+        '<rootDir>/src/index.js',
+        '<rootDir>/src/operatorsBuild.js',
+        '<rootDir>/src/operatorsClient.js',
+        '<rootDir>/src/operatorsServer.js',
+        '<rootDir>/src/types.js',
+      ],
+      coverageReporters: [['lcov', { projectRoot: '../../../..' }], 'text', 'clover'],
+      errorOnDeprecated: true,
+      testEnvironment: 'node',
+      testPathIgnorePatterns: [
+        '<rootDir>/dist/',
+        '<rootDir>/src/test',
+        '<rootDir>/src/operators/client',
+      ],
+      transform: {
+        '^.+\\.(t|j)sx?$': ['@swc/jest', { configFile: '../../../../.swcrc.test' }],
+      },
+    },
+  ],
+};

--- a/packages/plugins/operators/operators-jsonata/package.json
+++ b/packages/plugins/operators/operators-jsonata/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@lowdefy/operators-jsonata",
+  "version": "4.4.0",
+  "license": "Apache-2.0",
+  "description": "JSONata operators for Lowdefy",
+  "homepage": "https://lowdefy.com",
+  "keywords": [
+    "lowdefy",
+    "lowdefy operator",
+    "lowdefy plugin",
+    "jsonata"
+  ],
+  "bugs": {
+    "url": "https://github.com/lowdefy/lowdefy/issues"
+  },
+  "contributors": [
+    {
+      "name": "Machiel van der Walt",
+      "url": "https://github.com/machielvdw"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lowdefy/lowdefy.git"
+  },
+  "type": "module",
+  "exports": {
+    "./operators/client": "./dist/operatorsClient.js",
+    "./operators/server": "./dist/operatorsServer.js",
+    "./types": "./dist/types.js"
+  },
+  "files": [
+    "dist/*"
+  ],
+  "scripts": {
+    "build": "swc src --out-dir dist --config-file ../../../../.swcrc --delete-dir-on-start --copy-files",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm build",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+  },
+  "dependencies": {
+    "@lowdefy/helpers": "4.4.0",
+    "@lowdefy/operators": "4.4.0",
+    "jsonata": "1.8.7"
+  },
+  "devDependencies": {
+    "@jest/globals": "28.1.3",
+    "@swc/cli": "0.1.63",
+    "@swc/core": "1.3.99",
+    "@swc/jest": "0.2.29",
+    "jest": "28.1.3",
+    "jest-environment-jsdom": "28.1.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugins/operators/operators-jsonata/src/operators/shared/jsonata.js
+++ b/packages/plugins/operators/operators-jsonata/src/operators/shared/jsonata.js
@@ -1,0 +1,68 @@
+/*
+  Copyright 2020-2024 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import jsonata from 'jsonata';
+import { type } from '@lowdefy/helpers';
+
+import { runClass } from '@lowdefy/operators';
+
+function evaluate(data, expression, bindings) {
+  if (data === null) {
+    data = {};
+  }
+  if (!type.isString(expression)) {
+    throw new Error('Expression must be a string.');
+  }
+  try {
+    const expr = jsonata(expression);
+    let evalData = data;
+    if (bindings && type.isObject(bindings)) {
+      evalData = { ...data, ...bindings };
+    }
+    const result = expr.evaluate(evalData);
+    // JSONata may add a 'sequence' property to arrays, convert to plain arrays
+    if (type.isArray(result) && result.sequence === true) {
+      return Array.from(result);
+    }
+    return result;
+  } catch (error) {
+    throw new Error(`JSONata evaluation error: ${error.message}`);
+  }
+}
+
+function transform(data, expression, bindings) {
+  return evaluate(data, expression, bindings);
+}
+
+const meta = {
+  evaluate: { namedArgs: ['on', 'expr', 'bindings'], validTypes: ['array', 'object', 'string'] },
+  transform: { namedArgs: ['on', 'expr', 'bindings'], validTypes: ['array', 'object', 'string'] },
+};
+
+const functions = { evaluate, transform };
+
+function _jsonata({ params, location, methodName }) {
+  return runClass({
+    functions,
+    location,
+    meta,
+    methodName,
+    operator: '_jsonata',
+    params,
+  });
+}
+
+export default _jsonata;

--- a/packages/plugins/operators/operators-jsonata/src/operators/shared/jsonata.test.js
+++ b/packages/plugins/operators/operators-jsonata/src/operators/shared/jsonata.test.js
@@ -1,0 +1,220 @@
+/*
+  Copyright 2020-2024 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import jsonata from './jsonata.js';
+
+test('_jsonata.evaluate basic expression', () => {
+  expect(
+    jsonata({
+      params: { on: { a: 1, b: 2 }, expr: 'a + b' },
+      location: 'locationId',
+      methodName: 'evaluate',
+    })
+  ).toEqual(3);
+});
+
+test('_jsonata.evaluate string concatenation', () => {
+  expect(
+    jsonata({
+      params: { on: { firstName: 'John', lastName: 'Doe' }, expr: 'firstName & " " & lastName' },
+      location: 'locationId',
+      methodName: 'evaluate',
+    })
+  ).toEqual('John Doe');
+});
+
+test('_jsonata.evaluate array access', () => {
+  expect(
+    jsonata({
+      params: { on: { items: [1, 2, 3, 4, 5] }, expr: 'items[0]' },
+      location: 'locationId',
+      methodName: 'evaluate',
+    })
+  ).toEqual(1);
+});
+
+test('_jsonata.evaluate array filter', () => {
+  expect(
+    jsonata({
+      params: { on: { items: [1, 2, 3, 4, 5] }, expr: 'items[$ > 3]' },
+      location: 'locationId',
+      methodName: 'evaluate',
+    })
+  ).toEqual([4, 5]);
+});
+
+test('_jsonata.evaluate array map', () => {
+  expect(
+    jsonata({
+      params: {
+        on: { items: [{ name: 'Alice' }, { name: 'Bob' }] },
+        expr: 'items.name',
+      },
+      location: 'locationId',
+      methodName: 'evaluate',
+    })
+  ).toEqual(['Alice', 'Bob']);
+});
+
+test('_jsonata.evaluate with aggregation', () => {
+  expect(
+    jsonata({
+      params: { on: { items: [1, 2, 3, 4, 5] }, expr: '$sum(items)' },
+      location: 'locationId',
+      methodName: 'evaluate',
+    })
+  ).toEqual(15);
+});
+
+test('_jsonata.evaluate nested object access', () => {
+  expect(
+    jsonata({
+      params: {
+        on: { user: { profile: { name: 'Alice' } } },
+        expr: 'user.profile.name',
+      },
+      location: 'locationId',
+      methodName: 'evaluate',
+    })
+  ).toEqual('Alice');
+});
+
+test('_jsonata.evaluate with bindings', () => {
+  expect(
+    jsonata({
+      params: {
+        on: { price: 100 },
+        expr: 'price * taxRate',
+        bindings: { taxRate: 1.2 },
+      },
+      location: 'locationId',
+      methodName: 'evaluate',
+    })
+  ).toEqual(120);
+});
+
+test('_jsonata.evaluate null data defaults to empty object', () => {
+  expect(
+    jsonata({
+      params: { on: null, expr: '$' },
+      location: 'locationId',
+      methodName: 'evaluate',
+    })
+  ).toEqual({});
+});
+
+test('_jsonata.transform basic transformation', () => {
+  expect(
+    jsonata({
+      params: {
+        on: { user: { firstName: 'John', lastName: 'Doe', age: 30 } },
+        expr: '{ "fullName": user.firstName & " " & user.lastName, "age": user.age }',
+      },
+      location: 'locationId',
+      methodName: 'transform',
+    })
+  ).toEqual({ fullName: 'John Doe', age: 30 });
+});
+
+test('_jsonata.transform array transformation', () => {
+  const result = jsonata({
+    params: {
+      on: { orders: [{ id: 1, amount: 100 }, { id: 2, amount: 200 }] },
+      expr: 'orders.{ "orderId": id, "total": amount * 1.1 }',
+    },
+    location: 'locationId',
+    methodName: 'transform',
+  });
+  expect(result).toHaveLength(2);
+  expect(result[0].orderId).toBe(1);
+  expect(result[0].total).toBeCloseTo(110, 5);
+  expect(result[1].orderId).toBe(2);
+  expect(result[1].total).toBeCloseTo(220, 5);
+});
+
+test('_jsonata.evaluate non-string expression throws', () => {
+  expect(() =>
+    jsonata({
+      params: { on: { a: 1 }, expr: 123 },
+      location: 'locationId',
+      methodName: 'evaluate',
+    })
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"Operator Error: _jsonata.evaluate - Expression must be a string. Received: {\\"_jsonata.evaluate\\":{\\"on\\":{\\"a\\":1},\\"expr\\":123}} at locationId."`
+  );
+});
+
+test('_jsonata.evaluate invalid expression throws', () => {
+  expect(() =>
+    jsonata({
+      params: { on: { a: 1 }, expr: 'invalid syntax (((' },
+      location: 'locationId',
+      methodName: 'evaluate',
+    })
+  ).toThrow(/JSONata evaluation error/);
+});
+
+test('_jsonata.evaluate array params', () => {
+  expect(
+    jsonata({
+      params: [{ a: 1, b: 2 }, 'a + b'],
+      location: 'locationId',
+      methodName: 'evaluate',
+    })
+  ).toEqual(3);
+});
+
+test('_jsonata.evaluate conditional expression', () => {
+  expect(
+    jsonata({
+      params: {
+        on: { temperature: 25 },
+        expr: 'temperature > 20 ? "warm" : "cold"',
+      },
+      location: 'locationId',
+      methodName: 'evaluate',
+    })
+  ).toEqual('warm');
+});
+
+test('_jsonata.evaluate with $count function', () => {
+  expect(
+    jsonata({
+      params: {
+        on: { items: ['a', 'b', 'c', 'd'] },
+        expr: '$count(items)',
+      },
+      location: 'locationId',
+      methodName: 'evaluate',
+    })
+  ).toEqual(4);
+});
+
+test('_jsonata.evaluate complex object construction', () => {
+  expect(
+    jsonata({
+      params: {
+        on: {
+          user: { firstName: 'Jane', lastName: 'Smith' },
+          orders: [{ total: 100 }, { total: 200 }],
+        },
+        expr: '{ "user": user.firstName & " " & user.lastName, "totalSpent": $sum(orders.total) }',
+      },
+      location: 'locationId',
+      methodName: 'evaluate',
+    })
+  ).toEqual({ user: 'Jane Smith', totalSpent: 300 });
+});

--- a/packages/plugins/operators/operators-jsonata/src/operators/shared/jsonata.test.js
+++ b/packages/plugins/operators/operators-jsonata/src/operators/shared/jsonata.test.js
@@ -16,47 +16,43 @@
 
 import jsonata from './jsonata.js';
 
-test('_jsonata.evaluate basic expression', () => {
+test('_jsonata basic expression', () => {
   expect(
     jsonata({
       params: { on: { a: 1, b: 2 }, expr: 'a + b' },
       location: 'locationId',
-      methodName: 'evaluate',
     })
   ).toEqual(3);
 });
 
-test('_jsonata.evaluate string concatenation', () => {
+test('_jsonata string concatenation', () => {
   expect(
     jsonata({
       params: { on: { firstName: 'John', lastName: 'Doe' }, expr: 'firstName & " " & lastName' },
       location: 'locationId',
-      methodName: 'evaluate',
     })
   ).toEqual('John Doe');
 });
 
-test('_jsonata.evaluate array access', () => {
+test('_jsonata array access', () => {
   expect(
     jsonata({
       params: { on: { items: [1, 2, 3, 4, 5] }, expr: 'items[0]' },
       location: 'locationId',
-      methodName: 'evaluate',
     })
   ).toEqual(1);
 });
 
-test('_jsonata.evaluate array filter', () => {
+test('_jsonata array filter', () => {
   expect(
     jsonata({
       params: { on: { items: [1, 2, 3, 4, 5] }, expr: 'items[$ > 3]' },
       location: 'locationId',
-      methodName: 'evaluate',
     })
   ).toEqual([4, 5]);
 });
 
-test('_jsonata.evaluate array map', () => {
+test('_jsonata array map', () => {
   expect(
     jsonata({
       params: {
@@ -64,22 +60,20 @@ test('_jsonata.evaluate array map', () => {
         expr: 'items.name',
       },
       location: 'locationId',
-      methodName: 'evaluate',
     })
   ).toEqual(['Alice', 'Bob']);
 });
 
-test('_jsonata.evaluate with aggregation', () => {
+test('_jsonata with aggregation', () => {
   expect(
     jsonata({
       params: { on: { items: [1, 2, 3, 4, 5] }, expr: '$sum(items)' },
       location: 'locationId',
-      methodName: 'evaluate',
     })
   ).toEqual(15);
 });
 
-test('_jsonata.evaluate nested object access', () => {
+test('_jsonata nested object access', () => {
   expect(
     jsonata({
       params: {
@@ -87,12 +81,11 @@ test('_jsonata.evaluate nested object access', () => {
         expr: 'user.profile.name',
       },
       location: 'locationId',
-      methodName: 'evaluate',
     })
   ).toEqual('Alice');
 });
 
-test('_jsonata.evaluate with bindings', () => {
+test('_jsonata with bindings', () => {
   expect(
     jsonata({
       params: {
@@ -101,22 +94,20 @@ test('_jsonata.evaluate with bindings', () => {
         bindings: { taxRate: 1.2 },
       },
       location: 'locationId',
-      methodName: 'evaluate',
     })
   ).toEqual(120);
 });
 
-test('_jsonata.evaluate null data defaults to empty object', () => {
+test('_jsonata null data defaults to empty object', () => {
   expect(
     jsonata({
       params: { on: null, expr: '$' },
       location: 'locationId',
-      methodName: 'evaluate',
     })
   ).toEqual({});
 });
 
-test('_jsonata.transform basic transformation', () => {
+test('_jsonata object transformation', () => {
   expect(
     jsonata({
       params: {
@@ -124,19 +115,22 @@ test('_jsonata.transform basic transformation', () => {
         expr: '{ "fullName": user.firstName & " " & user.lastName, "age": user.age }',
       },
       location: 'locationId',
-      methodName: 'transform',
     })
   ).toEqual({ fullName: 'John Doe', age: 30 });
 });
 
-test('_jsonata.transform array transformation', () => {
+test('_jsonata array transformation', () => {
   const result = jsonata({
     params: {
-      on: { orders: [{ id: 1, amount: 100 }, { id: 2, amount: 200 }] },
+      on: {
+        orders: [
+          { id: 1, amount: 100 },
+          { id: 2, amount: 200 },
+        ],
+      },
       expr: 'orders.{ "orderId": id, "total": amount * 1.1 }',
     },
     location: 'locationId',
-    methodName: 'transform',
   });
   expect(result).toHaveLength(2);
   expect(result[0].orderId).toBe(1);
@@ -145,39 +139,27 @@ test('_jsonata.transform array transformation', () => {
   expect(result[1].total).toBeCloseTo(220, 5);
 });
 
-test('_jsonata.evaluate non-string expression throws', () => {
+test('_jsonata non-string expression throws', () => {
   expect(() =>
     jsonata({
       params: { on: { a: 1 }, expr: 123 },
       location: 'locationId',
-      methodName: 'evaluate',
     })
   ).toThrowErrorMatchingInlineSnapshot(
     `"Operator Error: _jsonata.evaluate - Expression must be a string. Received: {\\"_jsonata.evaluate\\":{\\"on\\":{\\"a\\":1},\\"expr\\":123}} at locationId."`
   );
 });
 
-test('_jsonata.evaluate invalid expression throws', () => {
+test('_jsonata invalid expression throws', () => {
   expect(() =>
     jsonata({
       params: { on: { a: 1 }, expr: 'invalid syntax (((' },
       location: 'locationId',
-      methodName: 'evaluate',
     })
   ).toThrow(/JSONata evaluation error/);
 });
 
-test('_jsonata.evaluate array params', () => {
-  expect(
-    jsonata({
-      params: [{ a: 1, b: 2 }, 'a + b'],
-      location: 'locationId',
-      methodName: 'evaluate',
-    })
-  ).toEqual(3);
-});
-
-test('_jsonata.evaluate conditional expression', () => {
+test('_jsonata conditional expression', () => {
   expect(
     jsonata({
       params: {
@@ -185,12 +167,11 @@ test('_jsonata.evaluate conditional expression', () => {
         expr: 'temperature > 20 ? "warm" : "cold"',
       },
       location: 'locationId',
-      methodName: 'evaluate',
     })
   ).toEqual('warm');
 });
 
-test('_jsonata.evaluate with $count function', () => {
+test('_jsonata with $count function', () => {
   expect(
     jsonata({
       params: {
@@ -198,12 +179,11 @@ test('_jsonata.evaluate with $count function', () => {
         expr: '$count(items)',
       },
       location: 'locationId',
-      methodName: 'evaluate',
     })
   ).toEqual(4);
 });
 
-test('_jsonata.evaluate complex object construction', () => {
+test('_jsonata complex object construction', () => {
   expect(
     jsonata({
       params: {
@@ -214,7 +194,24 @@ test('_jsonata.evaluate complex object construction', () => {
         expr: '{ "user": user.firstName & " " & user.lastName, "totalSpent": $sum(orders.total) }',
       },
       location: 'locationId',
-      methodName: 'evaluate',
     })
   ).toEqual({ user: 'Jane Smith', totalSpent: 300 });
+});
+
+test('_jsonata array params syntax', () => {
+  expect(
+    jsonata({
+      params: [{ a: 5, b: 3 }, 'a + b'],
+      location: 'locationId',
+    })
+  ).toEqual(8);
+});
+
+test('_jsonata array params with bindings', () => {
+  expect(
+    jsonata({
+      params: [{ price: 100 }, 'price * taxRate', { taxRate: 1.5 }],
+      location: 'locationId',
+    })
+  ).toEqual(150);
 });

--- a/packages/plugins/operators/operators-jsonata/src/operatorsClient.js
+++ b/packages/plugins/operators/operators-jsonata/src/operatorsClient.js
@@ -1,0 +1,17 @@
+/*
+  Copyright 2020-2024 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+export { default as _jsonata } from './operators/shared/jsonata.js';

--- a/packages/plugins/operators/operators-jsonata/src/operatorsServer.js
+++ b/packages/plugins/operators/operators-jsonata/src/operatorsServer.js
@@ -1,0 +1,17 @@
+/*
+  Copyright 2020-2024 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+export { default as _jsonata } from './operators/shared/jsonata.js';

--- a/packages/plugins/operators/operators-jsonata/src/types.js
+++ b/packages/plugins/operators/operators-jsonata/src/types.js
@@ -1,0 +1,24 @@
+/*
+  Copyright 2020-2024 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+import * as client from './operatorsClient.js';
+import * as server from './operatorsServer.js';
+
+export default {
+  operators: {
+    client: Object.keys(client),
+    server: Object.keys(server),
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,7 +77,7 @@ importers:
         version: 0.2.29(@swc/core@1.3.99(@swc/helpers@0.5.2))
       jest:
         specifier: 28.1.3
-        version: 28.1.3(@types/node@20.6.2)
+        version: 28.1.3(@types/node@16.18.101)
 
   packages/build:
     dependencies:
@@ -181,6 +181,9 @@ importers:
       '@lowdefy/operators-diff':
         specifier: 4.4.0
         version: link:../plugins/operators/operators-diff
+      '@lowdefy/operators-jsonata':
+        specifier: 4.4.0
+        version: link:../plugins/operators/operators-jsonata
       '@lowdefy/operators-moment':
         specifier: 4.4.0
         version: link:../plugins/operators/operators-moment
@@ -219,7 +222,7 @@ importers:
         version: 0.2.29(@swc/core@1.3.99(@swc/helpers@0.5.2))
       jest:
         specifier: 28.1.3
-        version: 28.1.3(@types/node@16.18.101)
+        version: 28.1.3(@types/node@20.6.2)
 
   packages/cli:
     dependencies:
@@ -1530,6 +1533,37 @@ importers:
       '@lowdefy/operators':
         specifier: 4.4.0
         version: link:../../../operators
+    devDependencies:
+      '@jest/globals':
+        specifier: 28.1.3
+        version: 28.1.3
+      '@swc/cli':
+        specifier: 0.1.63
+        version: 0.1.63(@swc/core@1.3.99(@swc/helpers@0.5.2))(chokidar@3.5.3)
+      '@swc/core':
+        specifier: 1.3.99
+        version: 1.3.99(@swc/helpers@0.5.2)
+      '@swc/jest':
+        specifier: 0.2.29
+        version: 0.2.29(@swc/core@1.3.99(@swc/helpers@0.5.2))
+      jest:
+        specifier: 28.1.3
+        version: 28.1.3(@types/node@20.6.2)
+      jest-environment-jsdom:
+        specifier: 28.1.3
+        version: 28.1.3
+
+  packages/plugins/operators/operators-jsonata:
+    dependencies:
+      '@lowdefy/helpers':
+        specifier: 4.4.0
+        version: link:../../../utils/helpers
+      '@lowdefy/operators':
+        specifier: 4.4.0
+        version: link:../../../operators
+      jsonata:
+        specifier: 1.8.7
+        version: 1.8.7
     devDependencies:
       '@jest/globals':
         specifier: 28.1.3
@@ -3857,9 +3891,6 @@ packages:
 
   '@types/eslint@8.4.10':
     resolution: {integrity: sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==}
-
-  '@types/estree@1.0.1':
-    resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -6601,6 +6632,10 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonata@1.8.7:
+    resolution: {integrity: sha512-tOW2/hZ+nR2bcQZs+0T62LVe5CHaNa3laFFWb/262r39utN6whJGBF7IR2Wq1QXrDbhftolk5gggW8uUJYlBTQ==}
+    engines: {node: '>= 8'}
 
   jsonc-parser@3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
@@ -11718,11 +11753,8 @@ snapshots:
 
   '@types/eslint@8.4.10':
     dependencies:
-      '@types/estree': 1.0.1
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.11
-    optional: true
-
-  '@types/estree@1.0.1':
     optional: true
 
   '@types/estree@1.0.8': {}
@@ -15156,6 +15188,8 @@ snapshots:
       minimist: 1.2.8
 
   json5@2.2.3: {}
+
+  jsonata@1.8.7: {}
 
   jsonc-parser@3.2.0: {}
 


### PR DESCRIPTION
Closes N/A

### What are the changes and their implications?
Adds a new operator `_jsonata` which provides a query and transformation language for JSON data using the JSONata library.

## Notes
- Uses JSONata 1.8.7 instead of 2.x because version 2.x returns Promises, which are incompatible with Lowdefy's operator system.
- No support for custom function registration (only built-in JSONata functions available).

## Checklist

- [x] Pull request is made to the "develop" branch
- [x] Tests added
- [x] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
