### PR TITLE
fix: Prevent TypeError when icon name is undefined.

### DIFF
--- a/.changeset/long-zoos-juggle.md
+++ b/.changeset/long-zoos-juggle.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/client': patch
+---
+
+Add guard to prevent TypeError in icon `formatTitle`.

--- a/packages/client/src/createIcon.js
+++ b/packages/client/src/createIcon.js
@@ -41,6 +41,9 @@ const createIcon = (Icons) => {
   const AiOutlineExclamationCircle = Icons['AiOutlineExclamationCircle'];
 
   const formatTitle = (title) => {
+    if (!title || !type.isString(title)) {
+      return '';
+    }
     let spacedTitle = title.replace(/([A-Z])/g, ' $1').trim();
     return spacedTitle.substring(spacedTitle.indexOf(' ') + 1);
   };


### PR DESCRIPTION
Closes N/A

### What are the changes and their implications?
Add guard to prevent TypeError in icon `formatTitle`.

## Checklist

- [x] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
