### PR TITLE
fix(lowdefy): Deserialize mock user in `getMockSession`.

### DIFF
--- a/packages/servers/server-dev/lib/server/auth/getMockSession.js
+++ b/packages/servers/server-dev/lib/server/auth/getMockSession.js
@@ -15,6 +15,7 @@
 */
 
 import { createSessionCallback } from '@lowdefy/api';
+import { serializer } from '@lowdefy/helpers';
 
 import authJson from '../../../build/auth.json';
 import callbacks from '../../../build/plugins/auth/callbacks.js';
@@ -37,8 +38,8 @@ async function getMockSession() {
     return undefined;
   }
 
-  // Remove build markers from mock user
-  mockUser = Object.fromEntries(Object.entries(mockUser).filter(([key]) => !key.startsWith('~')));
+  // Deserialize to restore arrays from ~arr markers and remove other build markers
+  mockUser = serializer.deserialize(mockUser);
 
   if (authJson.configured !== true) {
     throw new Error(


### PR DESCRIPTION
## Summary
- Fixes mock user deserialization in `getMockSession` by using `serializer.deserialize` instead of manually filtering build markers

## Test plan
- Test with a mock user config containing arrays (e.g., roles array) to verify arrays are properly restored
- Verify build markers (`~k`, `~r`) are removed from the session object

🤖 Generated with [Claude Code](https://claude.com/claude-code)