### PR TITLE
refactor(server-dev): Rename logger to lowdefy_server_dev

### DIFF
--- a/packages/servers/server-dev/lib/server/log/createLogger.js
+++ b/packages/servers/server-dev/lib/server/log/createLogger.js
@@ -17,7 +17,7 @@
 import { createNodeLogger } from '@lowdefy/logger/node';
 
 const logger = createNodeLogger({
-  name: 'lowdefy_server',
+  name: 'lowdefy_server_dev',
   level: process.env.LOWDEFY_LOG_LEVEL ?? 'info',
   base: { pid: undefined, hostname: undefined },
 });


### PR DESCRIPTION
## Summary
- Rename dev server logger from `lowdefy_server` to `lowdefy_server_dev` so each server variant has a distinct logger name.
- Follow-up from Sam's review comment on #2017 — e2e server was renamed to `lowdefy_server_e2e` there, this does the same for dev server.

## Test plan
- [ ] Verify dev server starts and logs with the new logger name

🤖 Generated with [Claude Code](https://claude.com/claude-code)