### PR TITLE
fix(helpers): harden ctorName constructor check (CVE-2019-20149)

### DIFF
--- a/packages/utils/helpers/src/type.js
+++ b/packages/utils/helpers/src/type.js
@@ -24,7 +24,7 @@
 const { toString } = Object.prototype;
 
 function ctorName(val) {
-  return val.constructor ? val.constructor.name : null;
+  return val.constructor && typeof val.constructor === 'function' ? val.constructor.name : null;
 }
 
 function isArray(val) {


### PR DESCRIPTION
## Summary

- Harden `ctorName` in `packages/utils/helpers/src/type.js`: only read `constructor.name` when `constructor` is a function, matching the upstream CVE-2019-20149 fix in `kind-of`.
- Prevents spoofed plain objects (`{ constructor: { name: 'Promise' } }`, etc.) from being misclassified by `kindOf` / `type.typeOf`.
- Single-line change in one application file; no vendored or third-party edits.

## Reproduction (before fix)

`ctorName` used:

```js
return val.constructor ? val.constructor.name : null;
```

Any truthy non-function `constructor` object with a forged `name` could drive the `switch (ctorName(val))` branch in `kindOf` (for example the `'Promise'` case), so `type.typeOf(payload)` incorrectly returned `promise` instead of `object`.

**Minimal PoC (mirrors old vs new `ctorName` logic):**

```bash
node -e "const payload={constructor:{name:'Promise'}}; const oldCtorName=(v)=>v.constructor?v.constructor.name:null; const newCtorName=(v)=>v.constructor&&typeof v.constructor==='function'?v.constructor.name:null; const oldType=(v)=>{switch(oldCtorName(v)){case 'Promise':return 'promise';default:return 'object';}}; const newType=(v)=>{switch(newCtorName(v)){case 'Promise':return 'promise';default:return 'object';}}; console.log(JSON.stringify({before_fix:oldType(payload),after_fix:newType(payload)}));"
```

Observed:

```text
{"before_fix":"promise","after_fix":"object"}
```

## Fix

```js
return val.constructor && typeof val.constructor === 'function' ? val.constructor.name : null;
```

## Verification (after fix)

**1. Lowdefy module (this PR / patched `type.js`)** — from repository root:

```bash
node --input-type=module <<'EOF'
import type from './packages/utils/helpers/src/type.js';
const payload = { constructor: { name: 'Promise' } };
console.log('kindOf(spoofed)=', type.typeOf(payload));
console.log('kindOf(real Promise)=', type.typeOf(Promise.resolve(1)));
EOF
```

Observed:

```text
kindOf(spoofed)= object
kindOf(real Promise)= promise
```

**2. Package tests** (as already run for this change):

```bash
pnpm --filter @lowdefy/errors build
pnpm --filter @lowdefy/helpers test
```

Result: 14/14 test suites passed, 329/329 tests passed.

**3. Patch applies cleanly:** `git apply --check` against current `main`.

## Scope proof

- Only `packages/utils/helpers/src/type.js` changed (one line).
- No vendored dependencies modified; no deprecated paths touched.

## Upstream reference

- [jonschlinkert/kind-of@975c13a](https://github.com/jonschlinkert/kind-of/commit/975c13a)

## Test plan

- [ ] From repo root, run the `node --input-type=module` snippet above; confirm `kindOf(spoofed)=== 'object'` and `kindOf(real Promise)=== 'promise'`.
- [ ] `pnpm --filter @lowdefy/errors build` and `pnpm --filter @lowdefy/helpers test` pass.
- [ ] Optional: on the parent commit, same snippet shows `kindOf(spoofed)=== 'promise'` (incorrect) before this change.

## Exploitability / validation (security)

- Attacker-controlled object shapes can spoof `constructor.name` when `constructor` is not a function; that misclassification is reproducible with the PoC above (`before_fix` vs `after_fix`, and real `type.typeOf` on patched tree).
- Reviewers can confirm necessity without inferring from upstream alone: run the commands and compare outputs.
