### PR TITLE
FileCard visual previews for AgentChat file attachments

### DIFF
--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
@@ -17,10 +17,13 @@
 import React, { useRef, useMemo, useEffect, useState } from 'react';
 import { useChat } from '@ai-sdk/react';
 import { lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai';
-import { Sender } from '@ant-design/x';
-import { Button, Tag, Upload } from 'antd';
+import { FileCard, Sender } from '@ant-design/x';
+import { Button } from 'antd';
 import { PaperClipOutlined } from '@ant-design/icons';
+
 import { type } from '@lowdefy/helpers';
+
+import { getFileCardType, getFileCardIcon } from './fileCardUtils.js';
 
 import ConversationSidebar from './ConversationSidebar.js';
 import DrawerWrapper from './DrawerWrapper.js';
@@ -41,6 +44,7 @@ function AgentChat({ blockId, methods, pageId, properties }) {
     drawer: drawerConfig,
   } = properties;
   const senderRef = useRef(null);
+  const fileInputRef = useRef(null);
   const [attachedFiles, setAttachedFiles] = useState([]);
   const attachmentsConfig = sender?.attachments;
 
@@ -104,7 +108,7 @@ function AgentChat({ blockId, methods, pageId, properties }) {
     return new Promise((resolve) => {
       const reader = new FileReader();
       reader.onload = () => {
-        resolve({ type: 'file', url: reader.result, mediaType: file.type });
+        resolve({ type: 'file', url: reader.result, mediaType: file.type, filename: file.name });
       };
       reader.readAsDataURL(file);
     });
@@ -185,17 +189,46 @@ function AgentChat({ blockId, methods, pageId, properties }) {
         </div>
         <div style={{ padding: '8px 16px 24px' }}>
           {attachmentsConfig?.enabled && attachedFiles.length > 0 && (
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 4 }}>
-              {attachedFiles.map((file, i) => (
-                <Tag
-                  key={i}
-                  closable
-                  onClose={() => setAttachedFiles((prev) => prev.filter((_, j) => j !== i))}
-                >
-                  {file.name}
-                </Tag>
-              ))}
-            </div>
+            <FileCard.List
+              style={{ marginBottom: 4 }}
+              items={attachedFiles.map((file, i) => {
+                const cardType = getFileCardType(file.type);
+                return {
+                  key: `${i}`,
+                  name: file.name,
+                  byte: file.size,
+                  type: cardType,
+                  icon: getFileCardIcon(file.type, file.name),
+                  src: cardType === 'image' ? URL.createObjectURL(file) : undefined,
+                };
+              })}
+              removable
+              onRemove={(item) => {
+                setAttachedFiles((prev) => {
+                  const idx = prev.findIndex((f) => f.name === item.name && f.size === item.byte);
+                  return idx !== -1 ? prev.filter((_, j) => j !== idx) : prev;
+                });
+              }}
+              overflow="wrap"
+              size="small"
+            />
+          )}
+          {attachmentsConfig?.enabled && (
+            <input
+              ref={fileInputRef}
+              type="file"
+              style={{ display: 'none' }}
+              accept={attachmentsConfig.accept}
+              multiple
+              onChange={(e) => {
+                const files = Array.from(e.target.files);
+                const valid = files.filter(
+                  (f) => !(attachmentsConfig.maxSize && f.size > attachmentsConfig.maxSize)
+                );
+                setAttachedFiles((prev) => [...prev, ...valid]);
+                e.target.value = '';
+              }}
+            />
           )}
           <Sender
             ref={senderRef}
@@ -205,20 +238,11 @@ function AgentChat({ blockId, methods, pageId, properties }) {
             loading={isBusy}
             prefix={
               attachmentsConfig?.enabled ? (
-                <Upload
-                  beforeUpload={(file) => {
-                    if (attachmentsConfig.maxSize && file.size > attachmentsConfig.maxSize) {
-                      return false;
-                    }
-                    setAttachedFiles((prev) => [...prev, file]);
-                    return false;
-                  }}
-                  accept={attachmentsConfig.accept}
-                  showUploadList={false}
-                  multiple
-                >
-                  <Button type="text" icon={<PaperClipOutlined />} />
-                </Upload>
+                <Button
+                  type="text"
+                  icon={<PaperClipOutlined />}
+                  onClick={() => fileInputRef.current?.click()}
+                />
               ) : undefined
             }
           />

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js
@@ -16,10 +16,11 @@
 
 import React, { useMemo } from 'react';
 import Markdown from '@ant-design/x-markdown';
-import { CodeHighlighter, Mermaid, ThoughtChain, Think } from '@ant-design/x';
+import { CodeHighlighter, FileCard, Mermaid, ThoughtChain, Think } from '@ant-design/x';
 import { Button } from 'antd';
 import { CopyOutlined, LikeOutlined, DislikeOutlined } from '@ant-design/icons';
 
+import { getFileCardType, getFileCardIcon, getFileName } from './fileCardUtils.js';
 import ToolApproval from './ToolApproval.js';
 
 // Renders a code block as plain text without syntax highlighting or mermaid rendering.
@@ -207,13 +208,15 @@ function MessageBubble({
   if (reasoningDisplay === 'grouped') {
     const reasoning = { category: 'reasoning', parts: [] };
     const tools = { category: 'tool', parts: [] };
+    const files = { category: 'file', parts: [] };
     const text = { category: 'text', parts: [] };
     for (const part of parts) {
       if (part.type === 'reasoning') reasoning.parts.push(part);
       else if (part.type === 'text') text.parts.push(part);
       else if (getToolInfo(part)) tools.parts.push(part);
+      else if (part.type === 'file') files.parts.push(part);
     }
-    segments = [reasoning, tools, text].filter((s) => s.parts.length > 0);
+    segments = [reasoning, tools, files, text].filter((s) => s.parts.length > 0);
   } else {
     segments = [];
     let current = null;
@@ -227,6 +230,8 @@ function MessageBubble({
         category = 'reasoning';
       } else if (getToolInfo(part)) {
         category = 'tool';
+      } else if (part.type === 'file') {
+        category = 'file';
       } else {
         continue;
       }
@@ -314,6 +319,25 @@ function MessageBubble({
             };
           });
           return <ThoughtChain key={`tool-${idx}`} items={items} />;
+        }
+        if (segment.category === 'file') {
+          const fileItems = segment.parts.map((part, i) => {
+            const cardType = getFileCardType(part.mediaType);
+            return {
+              key: `file-${idx}-${i}`,
+              name: getFileName(part),
+              type: cardType,
+              icon: getFileCardIcon(part.mediaType, part.filename),
+              src:
+                cardType === 'image' || cardType === 'video' || cardType === 'audio'
+                  ? part.url
+                  : undefined,
+            };
+          });
+          if (fileItems.length === 1) {
+            return <FileCard key={`file-${idx}`} {...fileItems[0]} />;
+          }
+          return <FileCard.List key={`file-${idx}`} items={fileItems} overflow="wrap" />;
         }
         if (segment.category === 'text') {
           const text = segment.parts.map((p) => p.text).join('');

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageList.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageList.js
@@ -15,10 +15,11 @@
 */
 
 import React from 'react';
-import { Bubble } from '@ant-design/x';
+import { Bubble, FileCard } from '@ant-design/x';
 import { Avatar } from 'antd';
 import { RobotOutlined, UserOutlined } from '@ant-design/icons';
 
+import { getFileCardType, getFileCardIcon, getFileName } from './fileCardUtils.js';
 import MessageBubble from './MessageBubble.js';
 
 function roleAvatar(roleConfig, fallbackIcon) {
@@ -34,13 +35,12 @@ function roleHeader(roleConfig, fallback) {
 }
 
 function MessageList({ messages, isStreaming, config, addToolApprovalResponse, onFeedback }) {
-  // Build a lookup map for assistant message parts.
+  // Build a lookup map for message parts.
   // Bubble.List's contentRender callback only receives (content, info) where info.key is the
   // item key — it does not receive the full message object with its parts array. This map
-  // bridges that gap so MessageBubble can render tool calls, reasoning, etc.
-  const partsMap = new Map(
-    messages.filter((msg) => msg.role === 'assistant').map((msg) => [msg.id, msg.parts])
-  );
+  // bridges that gap so MessageBubble can render tool calls, reasoning, etc. for assistant
+  // messages and FileCard previews for user file attachments.
+  const partsMap = new Map(messages.map((msg) => [msg.id, msg.parts]));
 
   const lastMessage = messages[messages.length - 1];
   const items = messages.map((msg) => {
@@ -80,6 +80,34 @@ function MessageList({ messages, isStreaming, config, addToolApprovalResponse, o
           shape: 'round',
           avatar: roleAvatar(config?.roles?.user, <UserOutlined />),
           header: roleHeader(config?.roles?.user, 'You'),
+          contentRender: (content, info) => {
+            const parts = partsMap.get(info.key);
+            const fileParts = (parts ?? []).filter((p) => p.type === 'file');
+            if (fileParts.length === 0) return content;
+            const fileItems = fileParts.map((part, i) => {
+              const cardType = getFileCardType(part.mediaType);
+              return {
+                key: `file-${i}`,
+                name: getFileName(part),
+                type: cardType,
+                icon: getFileCardIcon(part.mediaType, part.filename),
+                src: cardType === 'image' ? part.url : undefined,
+                size: 'small',
+              };
+            });
+            return (
+              <div>
+                <div style={{ marginBottom: content ? 8 : 0 }}>
+                  {fileItems.length === 1 ? (
+                    <FileCard {...fileItems[0]} />
+                  ) : (
+                    <FileCard.List items={fileItems} overflow="wrap" size="small" />
+                  )}
+                </div>
+                {content && <div>{content}</div>}
+              </div>
+            );
+          },
         },
         ai: {
           placement: 'start',

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/fileCardUtils.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/fileCardUtils.js
@@ -1,0 +1,67 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+function getFileCardType(mediaType) {
+  if (!mediaType) return 'file';
+  if (mediaType.startsWith('image/')) return 'image';
+  if (mediaType.startsWith('audio/')) return 'audio';
+  if (mediaType.startsWith('video/')) return 'video';
+  return 'file';
+}
+
+function getFileCardIcon(mediaType, filename) {
+  if (!mediaType) return 'default';
+  if (mediaType.startsWith('image/')) return 'image';
+  if (mediaType.startsWith('audio/')) return 'audio';
+  if (mediaType.startsWith('video/')) return 'video';
+  if (mediaType === 'application/pdf') return 'pdf';
+  if (mediaType === 'text/markdown' || filename?.endsWith('.md')) return 'markdown';
+  if (mediaType.includes('zip') || mediaType.includes('compressed')) return 'zip';
+  if (
+    mediaType.includes('spreadsheet') ||
+    mediaType.includes('excel') ||
+    filename?.endsWith('.xlsx') ||
+    filename?.endsWith('.xls') ||
+    filename?.endsWith('.csv')
+  ) {
+    return 'excel';
+  }
+  if (mediaType.includes('presentation') || mediaType.includes('powerpoint')) return 'ppt';
+  if (mediaType.includes('wordprocessing') || mediaType.includes('msword')) return 'word';
+  if (mediaType === 'text/javascript' || mediaType === 'application/javascript')
+    return 'javascript';
+  if (mediaType === 'text/x-python' || mediaType === 'application/x-python') return 'python';
+  if (mediaType === 'text/x-java-source') return 'java';
+  return 'default';
+}
+
+function getFileName(part) {
+  if (part.filename) return part.filename;
+  if (part.url && !part.url.startsWith('data:')) {
+    try {
+      const pathname = new URL(part.url).pathname;
+      const segments = pathname.split('/');
+      const last = segments[segments.length - 1];
+      if (last) return decodeURIComponent(last);
+    } catch (e) {
+      // ignore invalid URLs
+    }
+  }
+  const ext = part.mediaType?.split('/')[1]?.split(';')[0] ?? '';
+  return ext ? `file.${ext}` : 'Attachment';
+}
+
+export { getFileCardType, getFileCardIcon, getFileName };

--- a/packages/servers/server-dev/pages/api/agent/[...path].js
+++ b/packages/servers/server-dev/pages/api/agent/[...path].js
@@ -61,4 +61,12 @@ async function handler({ context, req, res }) {
   res.end();
 }
 
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '10mb',
+    },
+  },
+};
+
 export default apiWrapper(handler);

--- a/packages/servers/server/pages/api/agent/[...path].js
+++ b/packages/servers/server/pages/api/agent/[...path].js
@@ -61,4 +61,12 @@ async function handler({ context, req, res }) {
   res.end();
 }
 
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '10mb',
+    },
+  },
+};
+
 export default apiWrapper(handler);


### PR DESCRIPTION
## Summary

File and image content parts from assistant responses were silently dropped by the message renderer, and user-uploaded attachments showed as plain text Tags. This PR adds Ant Design X FileCard previews throughout AgentChat — for pre-send attachment previews, user message history, and assistant file responses.

## Changes

- **@lowdefy/blocks-antd-x**: Add FileCard rendering for file/image parts in MessageBubble (assistant messages) and MessageList (user messages). Replace Tag-based attachment preview with FileCard.List including image thumbnails, file type icons, and remove buttons. Fix multi-file upload by replacing antd Upload with native file input. Add shared MIME-type mapping helpers in fileCardUtils.js.
- **@lowdefy/server, @lowdefy/server-dev**: Increase agent API body parser limit from 1MB to 10MB to accommodate base64-encoded file attachments.

## Key Files

- `AgentChat.js` — Pre-send FileCard.List preview, native file input for multi-file, filename in content parts
- `MessageBubble.js` — New `file` segment category for assistant file/image parts
- `MessageList.js` — User message contentRender with FileCard previews (images above text)
- `fileCardUtils.js` — Shared MIME-to-FileCard type/icon/name mapping helpers

## Notes

- FileCard.List `key: 0` is falsy in JS — the component falls back to a generated string key, breaking removal. Fixed by using string keys and matching by name+size instead.
- antd Upload `beforeUpload` had issues processing multiple files in a batch. Replaced with a plain `<input type="file">` to avoid the quirk entirely.