### PR TITLE
AgentChat Phase 3+4: stream composition, tool display, sender upgrades, and polish

### DIFF
--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
@@ -49,6 +49,14 @@ function AgentChat({ blockId, methods, pageId, properties }) {
   const fileInputRef = useRef(null);
   const [attachedFiles, setAttachedFiles] = useState([]);
   const attachmentsConfig = sender?.attachments;
+  const switchConfigs = sender?.switches ?? [];
+  const [switchState, setSwitchState] = useState(() => {
+    const initial = {};
+    for (const sw of switchConfigs) {
+      initial[sw.key] = sw.default ?? false;
+    }
+    return initial;
+  });
 
   // Sidebar driven entirely by external config
   const showSidebar = conversationsConfig?.enabled;
@@ -122,7 +130,13 @@ function AgentChat({ blockId, methods, pageId, properties }) {
       setMessages(args?.messages ?? []);
     });
     methods.registerMethod('sendMessage', (args) => {
-      if (args?.text) sendMessage({ text: args.text });
+      if (args?.text) {
+        sendMessage({
+          text: args.text,
+          ...(args.files ? { experimental_attachments: args.files } : {}),
+          ...(args.metadata ? { metadata: args.metadata } : {}),
+        });
+      }
     });
     methods.registerMethod('clearMessages', () => {
       setMessages([]);
@@ -192,7 +206,7 @@ function AgentChat({ blockId, methods, pageId, properties }) {
     // Fire onBeforeSend — blocking event. If success is false, cancel the send.
     const response = await methods.triggerEvent({
       name: 'onBeforeSend',
-      event: { text, files: filesMeta, messages },
+      event: { text, files: filesMeta, messages, switches: switchState },
     });
     if (response.success === false) return;
 
@@ -249,6 +263,25 @@ function AgentChat({ blockId, methods, pageId, properties }) {
     });
     sendMessage({ text: suggestion.label });
   }
+
+  function handleSwitchChange(key, checked) {
+    setSwitchState((prev) => ({ ...prev, [key]: checked }));
+    methods.triggerEvent({
+      name: 'onSwitchChange',
+      event: { key, checked },
+    });
+  }
+
+  const agentSuggestions = useMemo(() => {
+    const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant');
+    if (!lastAssistant?.parts) return null;
+    const suggestionPart = [...lastAssistant.parts]
+      .reverse()
+      .find((p) => p.type === 'data-suggestions');
+    return suggestionPart?.data?.items ?? null;
+  }, [messages]);
+
+  const activeSuggestions = agentSuggestions ?? suggestions;
 
   function handleFeedback({ messageId, rating }) {
     const message = messages.find((msg) => msg.id === messageId);
@@ -344,10 +377,10 @@ function AgentChat({ blockId, methods, pageId, properties }) {
             />
           )}
         </div>
-        {!isEmpty && suggestions && suggestions.length > 0 && !isBusy && (
+        {!isEmpty && activeSuggestions && activeSuggestions.length > 0 && !isBusy && (
           <div style={{ padding: '0 16px 8px' }}>
             <Prompts
-              items={suggestions.map((s, i) => ({
+              items={activeSuggestions.map((s, i) => ({
                 key: s.key ?? `suggestion-${i}`,
                 label: s.label,
                 description: s.description,
@@ -417,7 +450,16 @@ function AgentChat({ blockId, methods, pageId, properties }) {
                 />
               ) : undefined
             }
-          />
+          >
+            {switchConfigs.map((sw) => (
+              <Sender.Switch
+                key={sw.key}
+                checked={switchState[sw.key] ?? false}
+                onChange={(checked) => handleSwitchChange(sw.key, checked)}
+                title={sw.label}
+              />
+            ))}
+          </Sender>
         </div>
       </div>
     </div>

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js
@@ -28,6 +28,7 @@ import {
 import { DeleteOutlined, DislikeOutlined, LikeOutlined, ReloadOutlined } from '@ant-design/icons';
 
 import { getFileCardType, getFileCardIcon, getFileName } from './fileCardUtils.js';
+import formatToolResult from './formatToolResult.js';
 import ToolApproval from './ToolApproval.js';
 
 // Module-level singleton for the LaTeX marked extension.
@@ -113,6 +114,14 @@ function summarizeToolOutput(output) {
     return output.length > 80 ? `${output.substring(0, 80)}...` : output;
   }
   return String(output);
+}
+
+function resolveToolResultMode(toolResultDisplay, toolName) {
+  if (typeof toolResultDisplay === 'string') return toolResultDisplay;
+  if (typeof toolResultDisplay === 'object') {
+    return toolResultDisplay[toolName] ?? toolResultDisplay.default ?? 'readable';
+  }
+  return 'summary';
 }
 
 function normalizeActions(actions) {
@@ -261,14 +270,16 @@ function MessageBubble({
     const reasoning = { category: 'reasoning', parts: [] };
     const tools = { category: 'tool', parts: [] };
     const files = { category: 'file', parts: [] };
+    const status = { category: 'status', parts: [] };
     const text = { category: 'text', parts: [] };
     for (const part of parts) {
       if (part.type === 'reasoning') reasoning.parts.push(part);
       else if (part.type === 'text') text.parts.push(part);
       else if (getToolInfo(part)) tools.parts.push(part);
       else if (part.type === 'file') files.parts.push(part);
+      else if (part.type === 'data-status') status.parts.push(part);
     }
-    segments = [reasoning, tools, files, text].filter((s) => s.parts.length > 0);
+    segments = [reasoning, tools, files, status, text].filter((s) => s.parts.length > 0);
   } else {
     segments = [];
     let current = null;
@@ -284,6 +295,8 @@ function MessageBubble({
         category = 'tool';
       } else if (part.type === 'file') {
         category = 'file';
+      } else if (part.type === 'data-status') {
+        category = 'status';
       } else {
         continue;
       }
@@ -304,7 +317,7 @@ function MessageBubble({
     .join('');
 
   return (
-    <div>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
       {segments.map((segment, idx) => {
         if (segment.category === 'reasoning' && showReasoning) {
           const text = segment.parts.map((p) => p.text).join('');
@@ -361,15 +374,31 @@ function MessageBubble({
             }
             let description;
             if (status === 'loading') {
-              description = tool.input
-                ? `Called with: ${JSON.stringify(tool.input)}`
-                : 'Running...';
+              const showInput = config?.showToolInputStreaming !== false;
+              if (showInput && tool.input && Object.keys(tool.input).length > 0) {
+                description = `Input: ${JSON.stringify(tool.input, null, 2)}`;
+              } else {
+                description = 'Running...';
+              }
             } else if (status === 'error') {
               description = 'Tool execution failed';
-            } else if (toolResultDisplay === 'full') {
-              description = JSON.stringify(tool.output, null, 2);
+            } else if (tool.output?.display && typeof tool.output.display === 'string') {
+              description = (
+                <Markdown components={markdownComponents} config={markdownConfig}>
+                  {tool.output.display}
+                </Markdown>
+              );
             } else {
-              description = summarizeToolOutput(tool.output);
+              const mode = resolveToolResultMode(toolResultDisplay, tool.toolName);
+              if (mode === 'readable') {
+                description = formatToolResult(tool.output);
+              } else if (mode === 'full') {
+                description = JSON.stringify(tool.output, null, 2);
+              } else if (mode === 'none') {
+                description = 'Completed';
+              } else {
+                description = summarizeToolOutput(tool.output);
+              }
             }
             return {
               key: tool.toolCallId,
@@ -398,6 +427,28 @@ function MessageBubble({
             return <FileCard key={`file-${idx}`} {...fileItems[0]} />;
           }
           return <FileCard.List key={`file-${idx}`} items={fileItems} overflow="wrap" />;
+        }
+        if (segment.category === 'status') {
+          const lastStatus = segment.parts[segment.parts.length - 1];
+          if (!isStreaming || config?.showStatusUpdates === false) return null;
+          return (
+            <div
+              key={`status-${idx}`}
+              style={{
+                color: '#8c8c8c',
+                fontSize: '0.85em',
+                padding: '4px 0',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+              }}
+            >
+              <span style={{ animation: 'spin 1s linear infinite', display: 'inline-block' }}>
+                ⟳
+              </span>
+              {lastStatus.data?.message ?? 'Processing...'}
+            </div>
+          );
         }
         if (segment.category === 'text') {
           const text = segment.parts.map((p) => p.text).join('');

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageList.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageList.js
@@ -55,14 +55,25 @@ const MessageList = React.forwardRef(function MessageList(
   const partsMap = new Map(messages.map((msg) => [msg.id, msg.parts]));
 
   const lastMessage = messages[messages.length - 1];
-  const items = messages.map((msg) => {
+  const showStepSeparators = config?.showStepSeparators ?? false;
+
+  const items = [];
+  for (const msg of messages) {
     const isLastAssistant = msg === lastMessage && msg.role === 'assistant';
     const textContent =
       msg.parts
         ?.filter((part) => part.type === 'text')
         .map((part) => part.text)
         .join('') ?? '';
-    return {
+
+    if (showStepSeparators && msg.role === 'assistant') {
+      const stepParts = (msg.parts ?? []).filter((p) => p.type === 'step-start');
+      if (stepParts.length > 1) {
+        items.push({ key: `divider-${msg.id}`, role: 'divider' });
+      }
+    }
+
+    items.push({
       key: msg.id,
       content: textContent,
       role: msg.role === 'user' ? 'user' : 'ai',
@@ -73,8 +84,8 @@ const MessageList = React.forwardRef(function MessageList(
         isLastAssistant &&
         textContent.length === 0 &&
         !msg.parts?.some((part) => part.type !== 'text' && part.type !== 'step-start'),
-    };
-  });
+    });
+  }
 
   // When busy but no assistant message exists yet (submitted, waiting for first chunk),
   // append a placeholder so loading dots are visible immediately.

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/WelcomeScreen.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/WelcomeScreen.js
@@ -41,6 +41,7 @@ function WelcomeScreen({ config, onPromptClick }) {
         title={config.title}
         description={config.description}
         icon={config.icon}
+        variant={config.variant}
       />
       {promptItems.length > 0 && (
         <Prompts

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/formatToolResult.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/formatToolResult.js
@@ -1,0 +1,170 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import React, { useState } from 'react';
+
+const URL_REGEX = /^https?:\/\/\S+$/;
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2})/;
+
+function isUrl(value) {
+  return typeof value === 'string' && URL_REGEX.test(value);
+}
+
+function isIsoDate(value) {
+  return typeof value === 'string' && ISO_DATE_REGEX.test(value) && !isNaN(Date.parse(value));
+}
+
+function humanizeKey(key) {
+  return key
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/[_-]/g, ' ')
+    .replace(/^\w/, (c) => c.toUpperCase());
+}
+
+function CollapsibleText({ text, limit }) {
+  const [expanded, setExpanded] = useState(false);
+  if (text.length <= limit) return <span>{text}</span>;
+  return (
+    <span>
+      {expanded ? text : `${text.slice(0, limit)}...`}
+      <a
+        onClick={() => setExpanded(!expanded)}
+        style={{ marginLeft: 4, fontSize: '0.85em', cursor: 'pointer' }}
+      >
+        {expanded ? 'Show less' : 'Show more'}
+      </a>
+    </span>
+  );
+}
+
+function formatValue(value, depth) {
+  if (value === null || value === undefined) {
+    return <span style={{ color: '#999' }}>{'\u2014'}</span>;
+  }
+  if (typeof value === 'boolean') {
+    return <span>{value ? 'Yes' : 'No'}</span>;
+  }
+  if (typeof value === 'number') {
+    return <span>{value.toLocaleString()}</span>;
+  }
+  if (isUrl(value)) {
+    return (
+      <a href={value} target="_blank" rel="noopener noreferrer" style={{ wordBreak: 'break-all' }}>
+        {value}
+      </a>
+    );
+  }
+  if (isIsoDate(value)) {
+    return <span>{new Date(value).toLocaleString()}</span>;
+  }
+  if (typeof value === 'string') {
+    if (value.length > 200) {
+      return <CollapsibleText text={value} limit={200} />;
+    }
+    return <span>{value}</span>;
+  }
+  if (Array.isArray(value)) {
+    return formatArray(value, depth);
+  }
+  if (typeof value === 'object') {
+    return formatObject(value, depth);
+  }
+  return <span>{String(value)}</span>;
+}
+
+function formatArray(arr, depth) {
+  if (arr.length === 0) {
+    return <span style={{ color: '#999' }}>Empty list</span>;
+  }
+  const allPrimitive = arr.every(
+    (item) => item === null || item === undefined || typeof item !== 'object'
+  );
+  if (allPrimitive) {
+    return (
+      <ul style={{ margin: '4px 0', paddingLeft: 20 }}>
+        {arr.map((item, i) => (
+          <li key={i}>{formatValue(item, depth + 1)}</li>
+        ))}
+      </ul>
+    );
+  }
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, margin: '4px 0' }}>
+      {arr.map((item, i) => (
+        <div
+          key={i}
+          style={{
+            padding: '8px 10px',
+            borderRadius: 6,
+            background: 'rgba(0, 0, 0, 0.02)',
+            border: '1px solid rgba(0, 0, 0, 0.06)',
+          }}
+        >
+          {formatValue(item, depth + 1)}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function formatObject(obj, depth) {
+  const keys = Object.keys(obj);
+  if (keys.length === 0) {
+    return <span style={{ color: '#999' }}>Empty</span>;
+  }
+  return (
+    <div
+      style={{ paddingLeft: depth > 0 ? 12 : 0, display: 'flex', flexDirection: 'column', gap: 2 }}
+    >
+      {keys.map((key) => {
+        const val = obj[key];
+        const isNested = val !== null && typeof val === 'object' && !Array.isArray(val);
+        const isArray = Array.isArray(val);
+        if (isNested || isArray) {
+          return (
+            <div key={key} style={{ marginTop: 4 }}>
+              <div style={{ fontWeight: 600, fontSize: '0.9em', marginBottom: 2 }}>
+                {humanizeKey(key)}
+              </div>
+              {formatValue(val, depth + 1)}
+            </div>
+          );
+        }
+        return (
+          <div key={key}>
+            <span style={{ fontWeight: 600, fontSize: '0.9em', color: 'rgba(0, 0, 0, 0.55)' }}>
+              {humanizeKey(key)}:{' '}
+            </span>
+            {formatValue(val, depth + 1)}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function formatToolResult(output) {
+  if (output === null || output === undefined) {
+    return <span style={{ color: '#999' }}>Completed (no data)</span>;
+  }
+  return (
+    <div style={{ fontSize: '0.9em', lineHeight: 1.5, maxHeight: 400, overflowY: 'auto' }}>
+      {formatValue(output, 0)}
+    </div>
+  );
+}
+
+export default formatToolResult;

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/meta.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/meta.js
@@ -34,6 +34,8 @@ export default {
     onStop: 'Trigger when the user stops generation.',
     onConversationMenuClick: 'Trigger when the user clicks a conversation menu item.',
     onSuggestionClick: 'Trigger when the user clicks a follow-up suggestion.',
+    onTitleGenerated: 'Trigger when the agent generates a conversation title.',
+    onSwitchChange: 'Trigger when the user toggles a sender switch.',
   },
   methods: {
     regenerate: 'Regenerate the last assistant message. Accepts optional args.messageId to regenerate a specific message.',

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/schema.json
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/schema.json
@@ -18,6 +18,10 @@
               "icon": {}
             }
           }
+        },
+        "variant": {
+          "type": "string",
+          "enum": ["filled", "borderless"]
         }
       }
     },
@@ -36,11 +40,31 @@
           "default": "interleaved"
         },
         "toolResultDisplay": {
-          "type": "string",
-          "enum": ["summary", "full", "none", "readable"],
-          "default": "summary"
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["summary", "full", "none", "readable"],
+              "default": "summary"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "default": {
+                  "type": "string",
+                  "enum": ["summary", "full", "none", "readable"]
+                }
+              },
+              "additionalProperties": {
+                "type": "string",
+                "enum": ["summary", "full", "none", "readable"]
+              }
+            }
+          ]
         },
         "showSources": { "type": "boolean" },
+        "showStatusUpdates": { "type": "boolean", "default": true },
+        "showStepSeparators": { "type": "boolean", "default": false },
+        "showToolInputStreaming": { "type": "boolean", "default": true },
         "sourcesDisplay": {
           "type": "object",
           "properties": {
@@ -155,6 +179,19 @@
             "enabled": { "type": "boolean" },
             "accept": { "type": "string" },
             "maxSize": { "type": "number" }
+          }
+        },
+        "switches": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": { "type": "string" },
+              "label": { "type": "string" },
+              "icon": {},
+              "default": { "type": "boolean", "default": false }
+            },
+            "required": ["key", "label"]
           }
         }
       }

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/useAgentEvents.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/useAgentEvents.js
@@ -21,6 +21,7 @@ function useAgentEvents({ messages, status, methods, finishMetaRef }) {
   const firedToolCallIds = useRef(new Set());
   const firedToolResultIds = useRef(new Set());
   const firedUserMessageIds = useRef(new Set());
+  const firedTitleIds = useRef(new Set());
   const lastMessageCountRef = useRef(0);
 
   // Fire onMessageComplete when streaming finishes
@@ -129,12 +130,32 @@ function useAgentEvents({ messages, status, methods, finishMetaRef }) {
     }
   }, [messages, methods]);
 
+  // Fire onTitleGenerated when a data-chat-title part appears
+  useEffect(() => {
+    for (const message of messages) {
+      if (message.role !== 'assistant') continue;
+      for (const part of message.parts ?? []) {
+        if (part.type === 'data-chat-title' && part.data?.title) {
+          const titleKey = `${message.id}-${part.data.title}`;
+          if (!firedTitleIds.current.has(titleKey)) {
+            firedTitleIds.current.add(titleKey);
+            methods.triggerEvent({
+              name: 'onTitleGenerated',
+              event: { title: part.data.title },
+            });
+          }
+        }
+      }
+    }
+  }, [messages, methods]);
+
   // Reset tracking when messages are cleared (conversation switch)
   useEffect(() => {
     if (messages.length < lastMessageCountRef.current) {
       firedToolCallIds.current.clear();
       firedToolResultIds.current.clear();
       firedUserMessageIds.current.clear();
+      firedTitleIds.current.clear();
     }
     lastMessageCountRef.current = messages.length;
   }, [messages.length]);

--- a/packages/utils/ai-utils/src/handleAgentChat.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.js
@@ -16,8 +16,8 @@
 
 import {
   ToolLoopAgent,
-  createAgentUIStreamResponse,
-  consumeStream,
+  createUIMessageStream,
+  createUIMessageStreamResponse,
   tool,
   jsonSchema,
   stepCountIs,
@@ -47,9 +47,9 @@ function cleanHookEvent(event) {
 }
 
 // Maps YAML hook names to AI SDK callback names and creates fire-and-forget callbacks.
-// onFinish is intentionally excluded — it is handled at the stream level via
-// createAgentUIStreamResponse so that endpoints receive UIMessage[] (the persisted
-// format developers need) rather than the agent-level CoreMessage[].
+// onFinish is intentionally excluded — it is handled at the stream level inside the
+// createUIMessageStream execute function so that hooks are awaited and can return
+// dataParts to be written to the response stream.
 const hookMapping = {
   onStart: 'experimental_onStart',
   onStepStart: 'experimental_onStepStart',
@@ -197,29 +197,40 @@ async function handleAgentChat({ connection, properties, context }) {
   const hasOnFinishHooks = onFinishEndpointIds && onFinishEndpointIds.length > 0;
   const hasMcpClients = mcpClients.length > 0;
 
-  const response = await createAgentUIStreamResponse({
-    agent: agentInstance,
-    uiMessages: messages,
-    sendSources: agent.properties.sendSources,
-    ...(hasOnFinishHooks || hasMcpClients
-      ? {
-          onFinish: async ({ messages: finishedMessages, finishReason, isAborted }) => {
-            if (hasOnFinishHooks) {
-              const payload = { messages: finishedMessages, finishReason, isAborted };
-              for (const endpointId of onFinishEndpointIds) {
-                context.callEndpoint(endpointId, { payload }).catch(() => {});
+  const stream = createUIMessageStream({
+    execute: async ({ writer }) => {
+      const result = await agentInstance.stream({
+        messages,
+      });
+
+      writer.merge(result.toUIMessageStream());
+
+      // After merge resolves the agent stream is complete.
+      // Call onFinish hooks — awaited so dataParts can be written to stream.
+      if (hasOnFinishHooks) {
+        for (const endpointId of onFinishEndpointIds) {
+          try {
+            const hookResponse = await context.callEndpoint(endpointId, {
+              payload: { messages, finishReason: 'stop', isAborted: false },
+            });
+            if (hookResponse?.dataParts) {
+              for (const part of hookResponse.dataParts) {
+                writer.write(part);
               }
             }
-            if (hasMcpClients) {
-              await Promise.all(mcpClients.map(({ client }) => client.close().catch(() => {})));
-            }
-          },
+          } catch (error) {
+            console.warn(`onFinish hook "${endpointId}" failed: ${error.message}`);
+          }
         }
-      : {}),
-    consumeSseStream: async ({ stream }) => {
-      consumeStream({ stream }).catch(() => {});
+      }
+
+      if (hasMcpClients) {
+        await Promise.all(mcpClients.map(({ client }) => client.close().catch(() => {})));
+      }
     },
   });
+
+  const response = createUIMessageStreamResponse({ stream });
   return { response };
 }
 

--- a/packages/utils/ai-utils/src/handleAgentChat.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.js
@@ -16,6 +16,7 @@
 
 import {
   ToolLoopAgent,
+  createAgentUIStream,
   createUIMessageStream,
   createUIMessageStreamResponse,
   tool,
@@ -30,7 +31,10 @@ import { serializer } from '@lowdefy/helpers';
 // properties and ~arr wrappers for arrays. JSON.parse(JSON.stringify(obj))
 // strips non-enumerable props and produces a clean JSON Schema for the AI SDK.
 function cleanBuildArtifact(obj) {
-  return JSON.parse(JSON.stringify(obj));
+  return JSON.parse(JSON.stringify(obj, (key, value) => {
+    if (key.startsWith('~')) return undefined;
+    return value;
+  }));
 }
 
 // Strip non-serializable fields from agent-level hook events before sending as payload.
@@ -199,11 +203,15 @@ async function handleAgentChat({ connection, properties, context }) {
 
   const stream = createUIMessageStream({
     execute: async ({ writer }) => {
-      const result = await agentInstance.stream({
-        messages,
+      // createAgentUIStream validates UIMessages, converts to ModelMessages,
+      // runs the agent, and returns a UIMessageStream — handling the full
+      // UI→model→UI conversion that ToolLoopAgent.stream() does not.
+      const agentStream = await createAgentUIStream({
+        agent: agentInstance,
+        uiMessages: messages,
       });
 
-      writer.merge(result.toUIMessageStream());
+      writer.merge(agentStream);
 
       // After merge resolves the agent stream is complete.
       // Call onFinish hooks — awaited so dataParts can be written to stream.

--- a/packages/utils/ai-utils/src/handleAgentChat.test.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.test.js
@@ -24,6 +24,7 @@ const mockWriter = {
   write: jest.fn(),
   merge: jest.fn().mockResolvedValue(undefined),
 };
+const mockCreateAgentUIStream = jest.fn().mockResolvedValue({ type: 'agent-ui-stream' });
 const mockCreateUIMessageStream = jest.fn().mockImplementation(({ execute }) => {
   mockCreateUIMessageStream._lastExecute = execute;
   return { type: 'readable-stream' };
@@ -31,21 +32,16 @@ const mockCreateUIMessageStream = jest.fn().mockImplementation(({ execute }) => 
 const mockCreateUIMessageStreamResponse = jest.fn().mockReturnValue({ type: 'web-response' });
 
 let lastAgentConfig = null;
-let lastAgentStreamOpts = null;
-const mockToUIMessageStream = jest.fn().mockReturnValue({ type: 'ui-message-stream' });
 class MockToolLoopAgent {
   constructor(config) {
     this.config = config;
     lastAgentConfig = config;
   }
-  async stream(opts) {
-    lastAgentStreamOpts = opts;
-    return { toUIMessageStream: mockToUIMessageStream };
-  }
 }
 
 jest.unstable_mockModule('ai', () => ({
   ToolLoopAgent: MockToolLoopAgent,
+  createAgentUIStream: mockCreateAgentUIStream,
   createUIMessageStream: mockCreateUIMessageStream,
   createUIMessageStreamResponse: mockCreateUIMessageStreamResponse,
   tool: mockTool,

--- a/packages/utils/ai-utils/src/handleAgentChat.test.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.test.js
@@ -19,21 +19,35 @@ import { jest } from '@jest/globals';
 const mockTool = jest.fn();
 const mockJsonSchema = jest.fn();
 const mockStepCountIs = jest.fn((n) => ({ type: 'stepCount', count: n }));
-const mockCreateAgentUIStreamResponse = jest.fn().mockReturnValue({ type: 'web-response' });
-const mockConsumeStream = jest.fn().mockResolvedValue(undefined);
+
+const mockWriter = {
+  write: jest.fn(),
+  merge: jest.fn().mockResolvedValue(undefined),
+};
+const mockCreateUIMessageStream = jest.fn().mockImplementation(({ execute }) => {
+  mockCreateUIMessageStream._lastExecute = execute;
+  return { type: 'readable-stream' };
+});
+const mockCreateUIMessageStreamResponse = jest.fn().mockReturnValue({ type: 'web-response' });
 
 let lastAgentConfig = null;
+let lastAgentStreamOpts = null;
+const mockToUIMessageStream = jest.fn().mockReturnValue({ type: 'ui-message-stream' });
 class MockToolLoopAgent {
   constructor(config) {
     this.config = config;
     lastAgentConfig = config;
   }
+  async stream(opts) {
+    lastAgentStreamOpts = opts;
+    return { toUIMessageStream: mockToUIMessageStream };
+  }
 }
 
 jest.unstable_mockModule('ai', () => ({
   ToolLoopAgent: MockToolLoopAgent,
-  createAgentUIStreamResponse: mockCreateAgentUIStreamResponse,
-  consumeStream: mockConsumeStream,
+  createUIMessageStream: mockCreateUIMessageStream,
+  createUIMessageStreamResponse: mockCreateUIMessageStreamResponse,
   tool: mockTool,
   jsonSchema: mockJsonSchema,
   stepCountIs: mockStepCountIs,
@@ -100,10 +114,11 @@ test('creates ToolLoopAgent with correct parameters', async () => {
       toolChoice: 'required',
     })
   );
-  expect(mockCreateAgentUIStreamResponse).toHaveBeenCalledWith({
-    agent: expect.any(MockToolLoopAgent),
-    uiMessages: messages,
-    consumeSseStream: expect.any(Function),
+  expect(mockCreateUIMessageStream).toHaveBeenCalledWith({
+    execute: expect.any(Function),
+  });
+  expect(mockCreateUIMessageStreamResponse).toHaveBeenCalledWith({
+    stream: { type: 'readable-stream' },
   });
   expect(result).toEqual({ response: { type: 'web-response' } });
 });
@@ -773,12 +788,6 @@ test('MCP clients closed on finish', async () => {
   };
   mockCreateMCPClient.mockResolvedValue(mockClient);
 
-  let capturedStreamOnFinish;
-  mockCreateAgentUIStreamResponse.mockImplementation((opts) => {
-    capturedStreamOnFinish = opts.onFinish;
-    return { type: 'web-response' };
-  });
-
   const { default: handleAgentChat } = await import('./handleAgentChat.js');
 
   await handleAgentChat({
@@ -798,9 +807,10 @@ test('MCP clients closed on finish', async () => {
     },
   });
 
-  // MCP cleanup now happens via stream-level onFinish
-  expect(capturedStreamOnFinish).toEqual(expect.any(Function));
-  await capturedStreamOnFinish({ messages: [], finishReason: 'stop', isAborted: false });
+  // MCP cleanup happens inside the execute function
+  const execute = mockCreateUIMessageStream._lastExecute;
+  expect(execute).toEqual(expect.any(Function));
+  await execute({ writer: mockWriter });
   expect(mockClose).toHaveBeenCalled();
 });
 
@@ -905,15 +915,148 @@ test('MCP tool listing failure logs warning and continues', async () => {
   consoleSpy.mockRestore();
 });
 
-test('stream-level onFinish calls hook endpoints with UIMessage array', async () => {
+test('stream-level onFinish calls hook endpoints with messages payload', async () => {
   mockTool.mockImplementation((def) => def);
   mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
 
-  let capturedStreamOnFinish;
-  mockCreateAgentUIStreamResponse.mockImplementation((opts) => {
-    capturedStreamOnFinish = opts.onFinish;
-    return { type: 'web-response' };
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+
+  const callEndpoint = jest.fn().mockResolvedValue({ success: true, response: {} });
+  const messages = [
+    { id: 'msg-1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+  ];
+
+  await handleAgentChat({
+    connection: { provider: jest.fn().mockReturnValue({}) },
+    properties: {
+      agent: {
+        tools: [],
+        hooks: { onFinish: ['save-conversation'] },
+        properties: { model: 'gpt-4o' },
+      },
+      messages,
+    },
+    context: { callEndpoint, getEndpointConfig: jest.fn() },
   });
+
+  const execute = mockCreateUIMessageStream._lastExecute;
+  expect(execute).toEqual(expect.any(Function));
+
+  const localWriter = { write: jest.fn(), merge: jest.fn().mockResolvedValue(undefined) };
+  await execute({ writer: localWriter });
+
+  expect(callEndpoint).toHaveBeenCalledWith('save-conversation', {
+    payload: {
+      messages,
+      finishReason: 'stop',
+      isAborted: false,
+    },
+  });
+});
+
+test('no onFinish hooks does not call callEndpoint in execute', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
+
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+
+  const callEndpoint = jest.fn();
+
+  await handleAgentChat({
+    connection: { provider: jest.fn().mockReturnValue({}) },
+    properties: {
+      agent: {
+        tools: [],
+        properties: { model: 'gpt-4o' },
+      },
+      messages: [],
+    },
+    context: { callEndpoint, getEndpointConfig: jest.fn() },
+  });
+
+  const execute = mockCreateUIMessageStream._lastExecute;
+  const localWriter = { write: jest.fn(), merge: jest.fn().mockResolvedValue(undefined) };
+  await execute({ writer: localWriter });
+
+  expect(callEndpoint).not.toHaveBeenCalled();
+  expect(localWriter.write).not.toHaveBeenCalled();
+});
+
+test('onFinish hook dataParts are written to the stream writer', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
+
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+
+  const dataParts = [
+    { type: 'data', value: { suggestions: ['How are you?'] } },
+    { type: 'data', value: { title: 'Greeting conversation' } },
+  ];
+  const callEndpoint = jest.fn().mockResolvedValue({ dataParts });
+
+  await handleAgentChat({
+    connection: { provider: jest.fn().mockReturnValue({}) },
+    properties: {
+      agent: {
+        tools: [],
+        hooks: { onFinish: ['generate-suggestions'] },
+        properties: { model: 'gpt-4o' },
+      },
+      messages: [],
+    },
+    context: { callEndpoint, getEndpointConfig: jest.fn() },
+  });
+
+  const execute = mockCreateUIMessageStream._lastExecute;
+  const localWriter = { write: jest.fn(), merge: jest.fn().mockResolvedValue(undefined) };
+  await execute({ writer: localWriter });
+
+  expect(localWriter.write).toHaveBeenCalledTimes(2);
+  expect(localWriter.write).toHaveBeenNthCalledWith(1, dataParts[0]);
+  expect(localWriter.write).toHaveBeenNthCalledWith(2, dataParts[1]);
+});
+
+test('onFinish hook failure logs warning and continues to next hook', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
+  const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+
+  const callEndpoint = jest
+    .fn()
+    .mockRejectedValueOnce(new Error('Network timeout'))
+    .mockResolvedValueOnce({ dataParts: [{ type: 'data', value: { ok: true } }] });
+
+  await handleAgentChat({
+    connection: { provider: jest.fn().mockReturnValue({}) },
+    properties: {
+      agent: {
+        tools: [],
+        hooks: { onFinish: ['failing-hook', 'succeeding-hook'] },
+        properties: { model: 'gpt-4o' },
+      },
+      messages: [],
+    },
+    context: { callEndpoint, getEndpointConfig: jest.fn() },
+  });
+
+  const execute = mockCreateUIMessageStream._lastExecute;
+  const localWriter = { write: jest.fn(), merge: jest.fn().mockResolvedValue(undefined) };
+  await execute({ writer: localWriter });
+
+  expect(callEndpoint).toHaveBeenCalledTimes(2);
+  expect(consoleSpy).toHaveBeenCalledWith(
+    expect.stringContaining('onFinish hook "failing-hook" failed')
+  );
+  expect(localWriter.write).toHaveBeenCalledTimes(1);
+  expect(localWriter.write).toHaveBeenCalledWith({ type: 'data', value: { ok: true } });
+  consoleSpy.mockRestore();
+});
+
+test('onFinish hook without dataParts does not write to stream', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
 
   const { default: handleAgentChat } = await import('./handleAgentChat.js');
 
@@ -932,71 +1075,10 @@ test('stream-level onFinish calls hook endpoints with UIMessage array', async ()
     context: { callEndpoint, getEndpointConfig: jest.fn() },
   });
 
-  expect(capturedStreamOnFinish).toEqual(expect.any(Function));
+  const execute = mockCreateUIMessageStream._lastExecute;
+  const localWriter = { write: jest.fn(), merge: jest.fn().mockResolvedValue(undefined) };
+  await execute({ writer: localWriter });
 
-  const uiMessages = [
-    { id: 'msg-1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
-    { id: 'msg-2', role: 'assistant', parts: [{ type: 'text', text: 'hello' }] },
-  ];
-  await capturedStreamOnFinish({
-    messages: uiMessages,
-    finishReason: 'stop',
-    isAborted: false,
-    isContinuation: false,
-    responseMessage: uiMessages[1],
-  });
-
-  expect(callEndpoint).toHaveBeenCalledWith('save-conversation', {
-    payload: {
-      messages: uiMessages,
-      finishReason: 'stop',
-      isAborted: false,
-    },
-  });
-});
-
-test('createAgentUIStreamResponse is called with consumeSseStream for disconnect safety', async () => {
-  mockTool.mockImplementation((def) => def);
-  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
-  mockCreateAgentUIStreamResponse.mockReturnValue({ type: 'web-response' });
-
-  const { default: handleAgentChat } = await import('./handleAgentChat.js');
-
-  await handleAgentChat({
-    connection: { provider: jest.fn().mockReturnValue({}) },
-    properties: {
-      agent: {
-        tools: [],
-        properties: { model: 'gpt-4o' },
-      },
-      messages: [],
-    },
-    context: { callEndpoint: jest.fn(), getEndpointConfig: jest.fn() },
-  });
-
-  const callArgs = mockCreateAgentUIStreamResponse.mock.calls[0][0];
-  expect(callArgs.consumeSseStream).toEqual(expect.any(Function));
-});
-
-test('no onFinish hooks produces no stream-level onFinish callback', async () => {
-  mockTool.mockImplementation((def) => def);
-  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
-  mockCreateAgentUIStreamResponse.mockReturnValue({ type: 'web-response' });
-
-  const { default: handleAgentChat } = await import('./handleAgentChat.js');
-
-  await handleAgentChat({
-    connection: { provider: jest.fn().mockReturnValue({}) },
-    properties: {
-      agent: {
-        tools: [],
-        properties: { model: 'gpt-4o' },
-      },
-      messages: [],
-    },
-    context: { callEndpoint: jest.fn(), getEndpointConfig: jest.fn() },
-  });
-
-  const callArgs = mockCreateAgentUIStreamResponse.mock.calls[0][0];
-  expect(callArgs.onFinish).toBeUndefined();
+  expect(callEndpoint).toHaveBeenCalledWith('save-conversation', expect.any(Object));
+  expect(localWriter.write).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary

Implements Phase 3 (Advanced Features) and Phase 4 (Polish) for the AgentChat block. Refactors the server-side stream from a direct pipe to a composed writer pattern, enabling custom data stream parts (status updates, agent-generated suggestions, title generation). Adds readable tool result display, Sender.Switch toggles, and several polish features.

## Changes

- **@lowdefy/ai-utils**: Refactor `handleAgentChat` from `createAgentUIStreamResponse` to composed `createUIMessageStream` + `createAgentUIStream` + writer pattern. `onFinish` hooks are now awaited and can return `dataParts` written to the stream. `cleanBuildArtifact` strips serializer markers (`~k`, `~r`, etc.) via replacer.
- **@lowdefy/blocks-antd-x**: Add readable tool result formatter with heuristic formatting, tool-provided `display` field rendering (Markdown), per-tool `toolResultDisplay` object config. Add `data-status` transient rendering, `data-suggestions` extraction (agent-generated takes priority over state-based), `onTitleGenerated` and `onSwitchChange` events. Add `Sender.Switch` mode toggles with internal state. Add step separators, tool input streaming display, and welcome screen variant.

## Key Files

- `packages/utils/ai-utils/src/handleAgentChat.js` — Stream composition refactor with dataParts support
- `packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/formatToolResult.js` — Heuristic tool result formatter (new file)
- `packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js` — Sender.Switch, agent suggestions, switch state
- `packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js` — Readable/display tool rendering, status parts, segment spacing
- `packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/useAgentEvents.js` — onTitleGenerated event