### PR TITLE
Add sub-agent support to Lowdefy agents

### DIFF
--- a/packages/api/src/routes/agent/callAgent.js
+++ b/packages/api/src/routes/agent/callAgent.js
@@ -93,6 +93,53 @@ async function callAgent(context, { agentId, pageId, messages }) {
     getEndpointConfig: async ({ endpointId }) => {
       return getEndpointConfig(context, { endpointId });
     },
+    getAgentConfig: async ({ agentId }) => {
+      return getAgentConfig(context, { agentId });
+    },
+    getConnectionForAgent: async ({ agentConfig: subAgentConfig }) => {
+      const subConnectionConfig = await getConnectionConfig(context, {
+        requestConfig: {
+          connectionId: subAgentConfig.connectionId,
+          requestId: subAgentConfig.agentId,
+          '~k': subAgentConfig['~k'],
+        },
+      });
+      const subConnection = getConnection(context, { connectionConfig: subConnectionConfig });
+      const subConnectionProperties = context.evaluateOperators({
+        input: subConnectionConfig.properties || {},
+        location: subConnectionConfig.connectionId,
+        payload: {},
+        steps: {},
+      });
+      return subConnection.create({ connection: subConnectionProperties });
+    },
+    resolveMcpSources: async ({ agentConfig: subAgentConfig }) => {
+      const resolvedMcp = [];
+      for (const mcpSource of subAgentConfig.mcp ?? []) {
+        if (!type.isNone(mcpSource.connectionId)) {
+          const mcpConnConfig = await getConnectionConfig(context, {
+            requestConfig: {
+              connectionId: mcpSource.connectionId,
+              requestId: subAgentConfig.agentId,
+              '~k': subAgentConfig['~k'],
+            },
+          });
+          const mcpConnection = getConnection(context, { connectionConfig: mcpConnConfig });
+          const mcpConnProps = context.evaluateOperators({
+            input: mcpConnConfig.properties || {},
+            location: mcpConnConfig.connectionId,
+            payload: {},
+            steps: {},
+          });
+          const mcpConfig = mcpConnection.create({ connection: mcpConnProps });
+          const { connectionId: _, ...overrides } = mcpSource;
+          resolvedMcp.push({ ...mcpConfig, ...overrides });
+        } else {
+          resolvedMcp.push(mcpSource);
+        }
+      }
+      return resolvedMcp;
+    },
   };
 
   // Resolve MCP connection references to inline config.

--- a/packages/api/src/routes/agent/callAgent.test.js
+++ b/packages/api/src/routes/agent/callAgent.test.js
@@ -580,3 +580,154 @@ test('callAgent resolver context getEndpointConfig throws for missing endpoint',
     capturedResolverContext.getEndpointConfig({ endpointId: 'non-existent' })
   ).rejects.toThrow();
 });
+
+test('callAgent passes getAgentConfig in resolver context', async () => {
+  const mockResolver = jest.fn().mockResolvedValue({ response: {} });
+  const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
+
+  const agentConfig = {
+    agentId: 'my-agent',
+    id: 'agent:my-agent',
+    type: 'ClaudeAgent',
+    connectionId: 'my-anthropic',
+    tools: [],
+    properties: { model: 'claude-3-5-sonnet' },
+  };
+  const subAgentConfig = {
+    agentId: 'sub-agent',
+    id: 'agent:sub-agent',
+    type: 'ClaudeAgent',
+    connectionId: 'my-anthropic',
+    tools: [],
+    properties: { model: 'claude-haiku-4-5-20251001' },
+  };
+  const connectionConfig = {
+    connectionId: 'my-anthropic',
+    id: 'connection:my-anthropic',
+    type: 'Anthropic',
+    properties: { apiKey: 'sk-test' },
+  };
+
+  const readConfigFile = jest.fn((path) => {
+    if (path === 'agents/my-agent.json') return agentConfig;
+    if (path === 'agents/sub-agent.json') return subAgentConfig;
+    if (path === 'connections/my-anthropic.json') return connectionConfig;
+    return null;
+  });
+
+  const context = testContext({
+    logger,
+    readConfigFile,
+    connections: {
+      Anthropic: { create: mockCreate, requests: {} },
+    },
+    session: { user: { id: 'user_1' } },
+  });
+  context.agents = { ClaudeAgent: { resolver: mockResolver, schema: {} } };
+
+  await callAgent(context, { agentId: 'my-agent', pageId: 'page1', messages: [] });
+
+  const resolverContext = mockResolver.mock.calls[0][0].context;
+  expect(resolverContext.getAgentConfig).toBeDefined();
+
+  const loadedConfig = await resolverContext.getAgentConfig({ agentId: 'sub-agent' });
+  expect(loadedConfig.agentId).toBe('sub-agent');
+});
+
+test('callAgent passes getConnectionForAgent in resolver context', async () => {
+  const mockResolver = jest.fn().mockResolvedValue({ response: {} });
+  const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
+
+  const agentConfig = {
+    agentId: 'my-agent',
+    id: 'agent:my-agent',
+    type: 'ClaudeAgent',
+    connectionId: 'my-anthropic',
+    tools: [],
+    properties: { model: 'claude-3-5-sonnet' },
+  };
+  const connectionConfig = {
+    connectionId: 'my-anthropic',
+    id: 'connection:my-anthropic',
+    type: 'Anthropic',
+    properties: { apiKey: 'sk-test' },
+  };
+
+  const readConfigFile = jest.fn((path) => {
+    if (path === 'agents/my-agent.json') return agentConfig;
+    if (path === 'connections/my-anthropic.json') return connectionConfig;
+    return null;
+  });
+
+  const context = testContext({
+    logger,
+    readConfigFile,
+    connections: {
+      Anthropic: { create: mockCreate, requests: {} },
+    },
+    session: { user: { id: 'user_1' } },
+  });
+  context.agents = { ClaudeAgent: { resolver: mockResolver, schema: {} } };
+
+  await callAgent(context, { agentId: 'my-agent', pageId: 'page1', messages: [] });
+
+  const resolverContext = mockResolver.mock.calls[0][0].context;
+  expect(resolverContext.getConnectionForAgent).toBeDefined();
+
+  const connInstance = await resolverContext.getConnectionForAgent({
+    agentConfig: { connectionId: 'my-anthropic', agentId: 'sub-agent', '~k': 'agents.1' },
+  });
+  expect(connInstance).toBeDefined();
+  // mockCreate is called once for the parent agent, then again for getConnectionForAgent
+  expect(mockCreate.mock.calls.length).toBeGreaterThanOrEqual(2);
+});
+
+test('callAgent passes resolveMcpSources in resolver context', async () => {
+  const mockResolver = jest.fn().mockResolvedValue({ response: {} });
+  const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
+  const mockMcpCreate = jest.fn().mockReturnValue({ url: 'http://mcp.test', transport: 'http' });
+
+  const agentConfig = {
+    agentId: 'my-agent',
+    id: 'agent:my-agent',
+    type: 'ClaudeAgent',
+    connectionId: 'my-anthropic',
+    tools: [],
+    properties: { model: 'claude-3-5-sonnet' },
+  };
+  const connectionConfig = {
+    connectionId: 'my-anthropic',
+    id: 'connection:my-anthropic',
+    type: 'Anthropic',
+    properties: { apiKey: 'sk-test' },
+  };
+  const mcpConnectionConfig = {
+    connectionId: 'my-mcp',
+    id: 'connection:my-mcp',
+    type: 'McpServer',
+    properties: { url: 'http://mcp.test' },
+  };
+
+  const readConfigFile = jest.fn((path) => {
+    if (path === 'agents/my-agent.json') return agentConfig;
+    if (path === 'connections/my-anthropic.json') return connectionConfig;
+    if (path === 'connections/my-mcp.json') return mcpConnectionConfig;
+    return null;
+  });
+
+  const context = testContext({
+    logger,
+    readConfigFile,
+    connections: {
+      Anthropic: { create: mockCreate, requests: {} },
+      McpServer: { create: mockMcpCreate, requests: {} },
+    },
+    session: { user: { id: 'user_1' } },
+  });
+  context.agents = { ClaudeAgent: { resolver: mockResolver, schema: {} } };
+
+  await callAgent(context, { agentId: 'my-agent', pageId: 'page1', messages: [] });
+
+  const resolverContext = mockResolver.mock.calls[0][0].context;
+  expect(resolverContext.resolveMcpSources).toBeDefined();
+});

--- a/packages/build/src/build/buildAgents.js
+++ b/packages/build/src/build/buildAgents.js
@@ -162,6 +162,14 @@ function buildAgents({ components, context }) {
       });
     });
 
+    // Normalize sub-agent strings to objects (same pattern as tools/mcp)
+    agent.agents = (agent.agents ?? []).map((ref) => {
+      if (type.isString(ref)) {
+        return { agentId: ref };
+      }
+      return ref;
+    });
+
     // Rename id to internal format
     agent.agentId = agent.id;
     context.agentIds.add(agent.agentId);
@@ -170,6 +178,32 @@ function buildAgents({ components, context }) {
     // Count server operators in properties
     countOperators(agent.properties ?? {}, {
       counter: context.typeCounters.operators.server,
+    });
+  });
+
+  // Second pass: validate sub-agent references (needs all agentIds collected)
+  (components.agents ?? []).forEach((agent) => {
+    const configKey = agent['~k'];
+
+    agent.agents.forEach((subAgentRef) => {
+      // Validate sub-agent reference exists
+      if (!context.agentIds.has(subAgentRef.agentId)) {
+        throw new ConfigError(
+          `Agent "${agent.agentId}" references sub-agent "${subAgentRef.agentId}" which does not exist.`,
+          { configKey }
+        );
+      }
+
+      // Check for name collision with endpoint tools
+      const hasToolCollision = agent.tools.some(
+        (toolConfig) => toolConfig.endpointId === subAgentRef.agentId
+      );
+      if (hasToolCollision) {
+        throw new ConfigError(
+          `Agent "${agent.agentId}" sub-agent "${subAgentRef.agentId}" conflicts with an endpoint tool of the same name.`,
+          { configKey }
+        );
+      }
     });
   });
 

--- a/packages/build/src/build/buildAgents.js
+++ b/packages/build/src/build/buildAgents.js
@@ -21,6 +21,40 @@ import { ConfigError } from '@lowdefy/errors';
 import countOperators from '../utils/countOperators.js';
 import createCheckDuplicateId from '../utils/createCheckDuplicateId.js';
 
+function detectCycles(agents) {
+  const graph = {};
+  for (const agent of agents) {
+    graph[agent.agentId] = (agent.agents ?? []).map((ref) => ref.agentId);
+  }
+
+  const visited = new Set();
+  const inStack = new Set();
+
+  function dfs(id) {
+    if (inStack.has(id)) return id;
+    if (visited.has(id)) return null;
+
+    visited.add(id);
+    inStack.add(id);
+
+    for (const neighbor of graph[id] ?? []) {
+      const cycleNode = dfs(neighbor);
+      if (cycleNode !== null) return cycleNode;
+    }
+
+    inStack.delete(id);
+    return null;
+  }
+
+  for (const id of Object.keys(graph)) {
+    const cycleNode = dfs(id);
+    if (cycleNode !== null) {
+      return cycleNode;
+    }
+  }
+  return null;
+}
+
 function buildAgents({ components, context }) {
   if (type.isNone(components.agents)) {
     return components;
@@ -206,6 +240,15 @@ function buildAgents({ components, context }) {
       }
     });
   });
+
+  // Detect circular sub-agent references
+  const cycleNode = detectCycles(components.agents);
+  if (cycleNode !== null) {
+    const agent = components.agents.find((a) => a.agentId === cycleNode);
+    throw new ConfigError(`Circular sub-agent reference detected involving "${cycleNode}".`, {
+      configKey: agent?.['~k'],
+    });
+  }
 
   return components;
 }

--- a/packages/build/src/build/buildAgents.js
+++ b/packages/build/src/build/buildAgents.js
@@ -17,7 +17,7 @@
 */
 
 import { type } from '@lowdefy/helpers';
-import { ConfigError } from '@lowdefy/errors';
+import { ConfigError, ConfigWarning } from '@lowdefy/errors';
 import countOperators from '../utils/countOperators.js';
 import createCheckDuplicateId from '../utils/createCheckDuplicateId.js';
 
@@ -236,6 +236,18 @@ function buildAgents({ components, context }) {
         throw new ConfigError(
           `Agent "${agent.agentId}" sub-agent "${subAgentRef.agentId}" conflicts with an endpoint tool of the same name.`,
           { configKey }
+        );
+      }
+
+      // Warn if sub-agent has tools with confirm: true (unsupported in sub-agent context)
+      const subAgent = components.agents.find((a) => a.agentId === subAgentRef.agentId);
+      const hasConfirmTools = (subAgent?.tools ?? []).some((t) => t.confirm);
+      if (hasConfirmTools) {
+        context.handleWarning(
+          new ConfigWarning(
+            `Agent "${subAgentRef.agentId}" has tools with confirm: true, but tool approval is not supported in sub-agent context. Tools will auto-execute when called as a sub-agent.`,
+            { configKey }
+          )
         );
       }
     });

--- a/packages/build/src/build/buildAgents.test.js
+++ b/packages/build/src/build/buildAgents.test.js
@@ -79,6 +79,7 @@ test('buildAgents valid agent renames id and adds to agentIds', () => {
       connectionId: 'conn1',
       tools: [{ endpointId: 'tool1' }],
       mcp: [],
+      agents: [],
       properties: {
         model: 'claude-sonnet-4-20250514',
       },
@@ -121,6 +122,7 @@ test('buildAgents multiple valid agents', () => {
       connectionId: 'conn1',
       tools: [],
       mcp: [],
+      agents: [],
       properties: { model: 'test-model' },
     },
     {
@@ -130,6 +132,7 @@ test('buildAgents multiple valid agents', () => {
       connectionId: 'conn1',
       tools: [],
       mcp: [],
+      agents: [],
       properties: { model: 'test-model' },
     },
   ]);
@@ -164,6 +167,7 @@ test('buildAgents agent with no tools works fine', () => {
       connectionId: 'conn1',
       tools: [],
       mcp: [],
+      agents: [],
       properties: { model: 'test-model' },
     },
   ]);
@@ -1046,4 +1050,192 @@ test('buildAgents with no mcp array works fine', () => {
     ],
   };
   expect(() => buildAgents({ components, context })).not.toThrow();
+});
+
+test('buildAgents normalizes string agents to objects with agentId', () => {
+  const context = testContext();
+  const components = {
+    connections: [
+      { id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' },
+    ],
+    agents: [
+      {
+        id: 'researcher',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+      },
+      {
+        id: 'orchestrator',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: ['researcher'],
+      },
+    ],
+  };
+  const res = buildAgents({ components, context });
+  expect(res.agents[1].agents).toEqual([{ agentId: 'researcher' }]);
+});
+
+test('buildAgents passes through object agents with agentId', () => {
+  const context = testContext();
+  const components = {
+    connections: [
+      { id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' },
+    ],
+    agents: [
+      {
+        id: 'researcher',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+      },
+      {
+        id: 'orchestrator',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: [{ agentId: 'researcher', description: 'Research topics' }],
+      },
+    ],
+  };
+  const res = buildAgents({ components, context });
+  expect(res.agents[1].agents).toEqual([
+    { agentId: 'researcher', description: 'Research topics' },
+  ]);
+});
+
+test('buildAgents normalizes mixed agents array', () => {
+  const context = testContext();
+  const components = {
+    connections: [
+      { id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' },
+    ],
+    agents: [
+      {
+        id: 'researcher',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+      },
+      {
+        id: 'analyzer',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+      },
+      {
+        id: 'orchestrator',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: ['researcher', { agentId: 'analyzer', description: 'Analyze data' }],
+      },
+    ],
+  };
+  const res = buildAgents({ components, context });
+  expect(res.agents[2].agents).toEqual([
+    { agentId: 'researcher' },
+    { agentId: 'analyzer', description: 'Analyze data' },
+  ]);
+});
+
+test('buildAgents throws when agents references non-existent agent', () => {
+  const context = testContext();
+  const components = {
+    connections: [
+      { id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' },
+    ],
+    agents: [
+      {
+        id: 'orchestrator',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: ['nonexistent'],
+      },
+    ],
+  };
+  expect(() => buildAgents({ components, context })).toThrow(
+    'Agent "orchestrator" references sub-agent "nonexistent" which does not exist.'
+  );
+});
+
+test('buildAgents throws when agents object references non-existent agent', () => {
+  const context = testContext();
+  const components = {
+    connections: [
+      { id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' },
+    ],
+    agents: [
+      {
+        id: 'orchestrator',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: [{ agentId: 'nonexistent' }],
+      },
+    ],
+  };
+  expect(() => buildAgents({ components, context })).toThrow(
+    'Agent "orchestrator" references sub-agent "nonexistent" which does not exist.'
+  );
+});
+
+test('buildAgents with no agents property works fine', () => {
+  const context = testContext();
+  const components = {
+    connections: [
+      { id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' },
+    ],
+    agents: [
+      {
+        id: 'agent1',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+      },
+    ],
+  };
+  const res = buildAgents({ components, context });
+  expect(res.agents[0].agents).toEqual([]);
+});
+
+test('buildAgents throws when sub-agent tool name collides with endpoint tool', () => {
+  const context = testContext();
+  const components = {
+    connections: [
+      { id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' },
+    ],
+    api: [
+      {
+        id: 'endpoint:researcher',
+        endpointId: 'researcher',
+        type: 'Api',
+        description: 'A tool named researcher',
+        payloadSchema: { type: 'object' },
+        routine: [],
+      },
+    ],
+    agents: [
+      {
+        id: 'researcher',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+      },
+      {
+        id: 'orchestrator',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        tools: ['researcher'],
+        agents: ['researcher'],
+      },
+    ],
+  };
+  expect(() => buildAgents({ components, context })).toThrow(
+    'Agent "orchestrator" sub-agent "researcher" conflicts with an endpoint tool of the same name.'
+  );
 });

--- a/packages/build/src/build/buildAgents.test.js
+++ b/packages/build/src/build/buildAgents.test.js
@@ -1239,3 +1239,156 @@ test('buildAgents throws when sub-agent tool name collides with endpoint tool', 
     'Agent "orchestrator" sub-agent "researcher" conflicts with an endpoint tool of the same name.'
   );
 });
+
+test('buildAgents throws on direct circular reference (A -> B -> A)', () => {
+  const context = testContext();
+  const components = {
+    connections: [
+      { id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' },
+    ],
+    agents: [
+      {
+        id: 'agentA',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: ['agentB'],
+      },
+      {
+        id: 'agentB',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: ['agentA'],
+      },
+    ],
+  };
+  expect(() => buildAgents({ components, context })).toThrow(
+    'Circular sub-agent reference detected involving "agentA".'
+  );
+});
+
+test('buildAgents throws on self-referencing agent', () => {
+  const context = testContext();
+  const components = {
+    connections: [
+      { id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' },
+    ],
+    agents: [
+      {
+        id: 'agentA',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: ['agentA'],
+      },
+    ],
+  };
+  expect(() => buildAgents({ components, context })).toThrow(
+    'Circular sub-agent reference detected involving "agentA".'
+  );
+});
+
+test('buildAgents throws on transitive circular reference (A -> B -> C -> A)', () => {
+  const context = testContext();
+  const components = {
+    connections: [
+      { id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' },
+    ],
+    agents: [
+      {
+        id: 'agentA',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: ['agentB'],
+      },
+      {
+        id: 'agentB',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: ['agentC'],
+      },
+      {
+        id: 'agentC',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: ['agentA'],
+      },
+    ],
+  };
+  expect(() => buildAgents({ components, context })).toThrow(/Circular sub-agent reference/);
+});
+
+test('buildAgents allows valid non-circular sub-agent chains', () => {
+  const context = testContext();
+  const components = {
+    connections: [
+      { id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' },
+    ],
+    agents: [
+      {
+        id: 'worker',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+      },
+      {
+        id: 'supervisor',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: ['worker'],
+      },
+      {
+        id: 'director',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: ['supervisor'],
+      },
+    ],
+  };
+  expect(() => buildAgents({ components, context })).not.toThrow();
+});
+
+test('buildAgents allows diamond-shaped sub-agent graphs (not a cycle)', () => {
+  const context = testContext();
+  const components = {
+    connections: [
+      { id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' },
+    ],
+    agents: [
+      {
+        id: 'worker',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+      },
+      {
+        id: 'teamA',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: ['worker'],
+      },
+      {
+        id: 'teamB',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: ['worker'],
+      },
+      {
+        id: 'director',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: ['teamA', 'teamB'],
+      },
+    ],
+  };
+  expect(() => buildAgents({ components, context })).not.toThrow();
+});

--- a/packages/build/src/build/buildAgents.test.js
+++ b/packages/build/src/build/buildAgents.test.js
@@ -1392,3 +1392,84 @@ test('buildAgents allows diamond-shaped sub-agent graphs (not a cycle)', () => {
   };
   expect(() => buildAgents({ components, context })).not.toThrow();
 });
+
+test('buildAgents warns when sub-agent has tools with confirm: true', () => {
+  const warnings = [];
+  const context = testContext({
+    logger: { warn: (msg) => warnings.push(msg) },
+  });
+  const components = {
+    connections: [
+      { id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' },
+    ],
+    api: [
+      {
+        id: 'endpoint:dangerous-tool',
+        endpointId: 'dangerous-tool',
+        type: 'Api',
+        description: 'A dangerous tool',
+        payloadSchema: { type: 'object' },
+        routine: [],
+      },
+    ],
+    agents: [
+      {
+        id: 'worker',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        tools: [{ endpointId: 'dangerous-tool', confirm: true }],
+      },
+      {
+        id: 'orchestrator',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: ['worker'],
+      },
+    ],
+  };
+  buildAgents({ components, context });
+  expect(warnings.some((w) => w.includes('confirm'))).toBe(true);
+  expect(warnings.some((w) => w.includes('worker'))).toBe(true);
+});
+
+test('buildAgents does not warn when sub-agent has no confirm tools', () => {
+  const warnings = [];
+  const context = testContext({
+    logger: { warn: (msg) => warnings.push(msg) },
+  });
+  const components = {
+    connections: [
+      { id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' },
+    ],
+    api: [
+      {
+        id: 'endpoint:safe-tool',
+        endpointId: 'safe-tool',
+        type: 'Api',
+        description: 'A safe tool',
+        payloadSchema: { type: 'object' },
+        routine: [],
+      },
+    ],
+    agents: [
+      {
+        id: 'worker',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        tools: [{ endpointId: 'safe-tool' }],
+      },
+      {
+        id: 'orchestrator',
+        type: 'ClaudeAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+        agents: ['worker'],
+      },
+    ],
+  };
+  buildAgents({ components, context });
+  expect(warnings.some((w) => w.includes('confirm'))).toBe(false);
+});

--- a/packages/build/src/lowdefySchema.js
+++ b/packages/build/src/lowdefySchema.js
@@ -179,6 +179,27 @@ export default {
             type: 'Agent "hooks" should be an object.',
           },
         },
+        agents: {
+          type: 'array',
+          items: {
+            anyOf: [
+              { type: 'string' },
+              {
+                type: 'object',
+                required: ['agentId'],
+                properties: {
+                  agentId: { type: 'string' },
+                  description: { type: 'string' },
+                  inputSchema: { type: 'object' },
+                },
+                additionalProperties: false,
+              },
+            ],
+          },
+          errorMessage: {
+            type: 'Agent "agents" should be an array.',
+          },
+        },
       },
       errorMessage: {
         type: 'Agent should be an object.',

--- a/packages/build/src/tests/success/01-minimal-config/snapshot.json
+++ b/packages/build/src/tests/success/01-minimal-config/snapshot.json
@@ -120,140 +120,148 @@
       "~k_parent": "12"
     },
     "20": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1s"
     },
     "21": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1s"
     },
     "22": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1s"
     },
     "23": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1s"
     },
     "24": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1s"
     },
     "25": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1s"
     },
     "26": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1s"
     },
     "27": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1s"
     },
     "28": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1s"
     },
     "29": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1s"
     },
     "30": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2u"
     },
     "31": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2u"
     },
     "32": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2u"
     },
     "33": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2u"
     },
     "34": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2u"
     },
     "35": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2u"
     },
     "36": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2u"
     },
     "37": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2u"
     },
     "38": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2u"
     },
     "39": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2u"
     },
     "40": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3f"
     },
     "41": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3f"
     },
     "43": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3f"
     },
     "45": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3f"
     },
     "47": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3f"
     },
     "49": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "4z"
+      "key": "root.imports.requests",
+      "~k_parent": "2k"
     },
     "51": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "50"
+      "key": "root.imports.operators",
+      "~k_parent": "2k"
     },
     "52": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "50"
+      "key": "root.imports.operators.client",
+      "~k_parent": "51"
     },
     "53": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "52"
+    },
+    "54": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "52"
+    },
+    "55": {
       "key": "root.imports.operators.server",
-      "~k_parent": "4z"
+      "~k_parent": "51"
     },
     "a": {
       "key": "root.pages[1:404:Result].style",
@@ -404,374 +412,375 @@
       "~k_parent": "1j"
     },
     "1m": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1i"
     },
     "1n": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1m"
+      "key": "root.types.auth",
+      "~k_parent": "1i"
     },
     "1o": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1m"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1n"
     },
     "1p": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1m"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1n"
     },
     "1q": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1m"
+      "key": "root.types.auth.events",
+      "~k_parent": "1n"
     },
     "1r": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1n"
+    },
+    "1s": {
       "key": "root.types.blocks",
       "~k_parent": "1i"
     },
-    "1s": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1r"
-    },
     "1t": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1s"
     },
     "1u": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1s"
     },
     "1w": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1s"
     },
     "1x": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1s"
     },
     "1y": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1s"
     },
     "1z": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1s"
     },
     "2a": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1s"
     },
     "2b": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1s"
+    },
+    "2c": {
       "key": "root.types.connections",
       "~k_parent": "1i"
     },
-    "2c": {
+    "2d": {
       "key": "root.types.requests",
       "~k_parent": "1i"
     },
-    "2d": {
+    "2e": {
       "key": "root.types.api",
       "~k_parent": "1i"
     },
-    "2e": {
+    "2f": {
       "key": "root.types.operators",
       "~k_parent": "1i"
     },
-    "2f": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2e"
-    },
     "2g": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2f"
     },
     "2h": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2f"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2g"
     },
     "2i": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2e"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2g"
     },
     "2j": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2f"
+    },
+    "2k": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2k": {
-      "key": "root.imports.actions",
-      "~k_parent": "2j"
-    },
     "2l": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2k"
     },
     "2m": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2k"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.imports.auth",
-      "~k_parent": "2j"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2l"
     },
     "2o": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2n"
+      "key": "root.imports.agents",
+      "~k_parent": "2k"
     },
     "2p": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2n"
+      "key": "root.imports.auth",
+      "~k_parent": "2k"
     },
     "2q": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2n"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2p"
     },
     "2r": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2n"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2p"
     },
     "2s": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2j"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2p"
     },
     "2t": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2s"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2p"
     },
     "2u": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks",
+      "~k_parent": "2k"
     },
     "2v": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2u"
     },
     "2y": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2u"
     },
     "2z": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2u"
     },
     "3b": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2u"
     },
     "3c": {
-      "key": "root.imports.connections",
-      "~k_parent": "2j"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2u"
     },
     "3d": {
-      "key": "root.imports.icons",
-      "~k_parent": "2j"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "2u"
     },
     "3e": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3d"
+      "key": "root.imports.connections",
+      "~k_parent": "2k"
     },
     "3f": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3e"
+      "key": "root.imports.icons",
+      "~k_parent": "2k"
     },
     "3g": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3f"
     },
     "3n": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3f"
     },
     "3r": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3f"
     },
     "3t": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3f"
     },
     "3v": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3f"
     },
     "3x": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3f"
     },
     "3z": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3f"
     },
     "4b": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3f"
     },
     "4d": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3f"
     },
     "4f": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3f"
     },
     "4h": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3f"
     },
     "4j": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3f"
     },
     "4l": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3f"
     },
     "4n": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3f"
     },
     "4p": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3f"
     },
     "4r": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3f"
     },
     "4t": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3f"
     },
     "4v": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3f"
     },
     "4x": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.requests",
-      "~k_parent": "2j"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3f"
     },
     "4z": {
-      "key": "root.imports.operators",
-      "~k_parent": "2j"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4y"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "o"
   },
@@ -954,6 +963,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5441,146 +5451,149 @@
       },
       "~k": "1j"
     },
+    "agents": {
+      "~k": "1m"
+    },
     "auth": {
       "adapters": {
-        "~k": "1n"
-      },
-      "callbacks": {
         "~k": "1o"
       },
-      "events": {
+      "callbacks": {
         "~k": "1p"
       },
-      "providers": {
+      "events": {
         "~k": "1q"
       },
-      "~k": "1m"
+      "providers": {
+        "~k": "1r"
+      },
+      "~k": "1n"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1s"
+        "~k": "1t"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1t"
+        "~k": "1u"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1u"
+        "~k": "1v"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1v"
+        "~k": "1w"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1w"
+        "~k": "1x"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
-      "~k": "1r"
+      "~k": "1s"
     },
     "connections": {
-      "~k": "2b"
-    },
-    "requests": {
       "~k": "2c"
     },
-    "api": {
+    "requests": {
       "~k": "2d"
+    },
+    "api": {
+      "~k": "2e"
     },
     "operators": {
       "client": {
@@ -5588,20 +5601,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2g"
+          "~k": "2h"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2h"
+          "~k": "2i"
         },
-        "~k": "2f"
+        "~k": "2g"
       },
       "server": {
-        "~k": "2i"
+        "~k": "2j"
       },
-      "~k": "2e"
+      "~k": "2f"
     },
     "~k": "1i"
   }

--- a/packages/build/src/tests/success/02-minimal-with-name/snapshot.json
+++ b/packages/build/src/tests/success/02-minimal-with-name/snapshot.json
@@ -120,140 +120,148 @@
       "~k_parent": "12"
     },
     "20": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1s"
     },
     "21": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1s"
     },
     "22": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1s"
     },
     "23": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1s"
     },
     "24": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1s"
     },
     "25": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1s"
     },
     "26": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1s"
     },
     "27": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1s"
     },
     "28": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1s"
     },
     "29": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1s"
     },
     "30": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2u"
     },
     "31": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2u"
     },
     "32": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2u"
     },
     "33": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2u"
     },
     "34": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2u"
     },
     "35": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2u"
     },
     "36": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2u"
     },
     "37": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2u"
     },
     "38": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2u"
     },
     "39": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2u"
     },
     "40": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3f"
     },
     "41": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3f"
     },
     "43": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3f"
     },
     "45": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3f"
     },
     "47": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3f"
     },
     "49": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "4z"
+      "key": "root.imports.requests",
+      "~k_parent": "2k"
     },
     "51": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "50"
+      "key": "root.imports.operators",
+      "~k_parent": "2k"
     },
     "52": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "50"
+      "key": "root.imports.operators.client",
+      "~k_parent": "51"
     },
     "53": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "52"
+    },
+    "54": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "52"
+    },
+    "55": {
       "key": "root.imports.operators.server",
-      "~k_parent": "4z"
+      "~k_parent": "51"
     },
     "a": {
       "key": "root.pages[1:404:Result].style",
@@ -404,374 +412,375 @@
       "~k_parent": "1j"
     },
     "1m": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1i"
     },
     "1n": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1m"
+      "key": "root.types.auth",
+      "~k_parent": "1i"
     },
     "1o": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1m"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1n"
     },
     "1p": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1m"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1n"
     },
     "1q": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1m"
+      "key": "root.types.auth.events",
+      "~k_parent": "1n"
     },
     "1r": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1n"
+    },
+    "1s": {
       "key": "root.types.blocks",
       "~k_parent": "1i"
     },
-    "1s": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1r"
-    },
     "1t": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1s"
     },
     "1u": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1s"
     },
     "1w": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1s"
     },
     "1x": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1s"
     },
     "1y": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1s"
     },
     "1z": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1s"
     },
     "2a": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1s"
     },
     "2b": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1s"
+    },
+    "2c": {
       "key": "root.types.connections",
       "~k_parent": "1i"
     },
-    "2c": {
+    "2d": {
       "key": "root.types.requests",
       "~k_parent": "1i"
     },
-    "2d": {
+    "2e": {
       "key": "root.types.api",
       "~k_parent": "1i"
     },
-    "2e": {
+    "2f": {
       "key": "root.types.operators",
       "~k_parent": "1i"
     },
-    "2f": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2e"
-    },
     "2g": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2f"
     },
     "2h": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2f"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2g"
     },
     "2i": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2e"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2g"
     },
     "2j": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2f"
+    },
+    "2k": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2k": {
-      "key": "root.imports.actions",
-      "~k_parent": "2j"
-    },
     "2l": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2k"
     },
     "2m": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2k"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.imports.auth",
-      "~k_parent": "2j"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2l"
     },
     "2o": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2n"
+      "key": "root.imports.agents",
+      "~k_parent": "2k"
     },
     "2p": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2n"
+      "key": "root.imports.auth",
+      "~k_parent": "2k"
     },
     "2q": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2n"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2p"
     },
     "2r": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2n"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2p"
     },
     "2s": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2j"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2p"
     },
     "2t": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2s"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2p"
     },
     "2u": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks",
+      "~k_parent": "2k"
     },
     "2v": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2u"
     },
     "2y": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2u"
     },
     "2z": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2u"
     },
     "3b": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2u"
     },
     "3c": {
-      "key": "root.imports.connections",
-      "~k_parent": "2j"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2u"
     },
     "3d": {
-      "key": "root.imports.icons",
-      "~k_parent": "2j"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "2u"
     },
     "3e": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3d"
+      "key": "root.imports.connections",
+      "~k_parent": "2k"
     },
     "3f": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3e"
+      "key": "root.imports.icons",
+      "~k_parent": "2k"
     },
     "3g": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3f"
     },
     "3n": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3f"
     },
     "3r": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3f"
     },
     "3t": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3f"
     },
     "3v": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3f"
     },
     "3x": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3f"
     },
     "3z": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3f"
     },
     "4b": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3f"
     },
     "4d": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3f"
     },
     "4f": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3f"
     },
     "4h": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3f"
     },
     "4j": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3f"
     },
     "4l": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3f"
     },
     "4n": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3f"
     },
     "4p": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3f"
     },
     "4r": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3f"
     },
     "4t": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3f"
     },
     "4v": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3f"
     },
     "4x": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.requests",
-      "~k_parent": "2j"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3f"
     },
     "4z": {
-      "key": "root.imports.operators",
-      "~k_parent": "2j"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4y"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "o"
   },
@@ -954,6 +963,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5441,146 +5451,149 @@
       },
       "~k": "1j"
     },
+    "agents": {
+      "~k": "1m"
+    },
     "auth": {
       "adapters": {
-        "~k": "1n"
-      },
-      "callbacks": {
         "~k": "1o"
       },
-      "events": {
+      "callbacks": {
         "~k": "1p"
       },
-      "providers": {
+      "events": {
         "~k": "1q"
       },
-      "~k": "1m"
+      "providers": {
+        "~k": "1r"
+      },
+      "~k": "1n"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1s"
+        "~k": "1t"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1t"
+        "~k": "1u"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1u"
+        "~k": "1v"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1v"
+        "~k": "1w"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1w"
+        "~k": "1x"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
-      "~k": "1r"
+      "~k": "1s"
     },
     "connections": {
-      "~k": "2b"
-    },
-    "requests": {
       "~k": "2c"
     },
-    "api": {
+    "requests": {
       "~k": "2d"
+    },
+    "api": {
+      "~k": "2e"
     },
     "operators": {
       "client": {
@@ -5588,20 +5601,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2g"
+          "~k": "2h"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2h"
+          "~k": "2i"
         },
-        "~k": "2f"
+        "~k": "2g"
       },
       "server": {
-        "~k": "2i"
+        "~k": "2j"
       },
-      "~k": "2e"
+      "~k": "2f"
     },
     "~k": "1i"
   }

--- a/packages/build/src/tests/success/03-minimal-with-version/snapshot.json
+++ b/packages/build/src/tests/success/03-minimal-with-version/snapshot.json
@@ -120,140 +120,148 @@
       "~k_parent": "12"
     },
     "20": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1s"
     },
     "21": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1s"
     },
     "22": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1s"
     },
     "23": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1s"
     },
     "24": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1s"
     },
     "25": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1s"
     },
     "26": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1s"
     },
     "27": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1s"
     },
     "28": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1s"
     },
     "29": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1s"
     },
     "30": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2u"
     },
     "31": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2u"
     },
     "32": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2u"
     },
     "33": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2u"
     },
     "34": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2u"
     },
     "35": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2u"
     },
     "36": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2u"
     },
     "37": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2u"
     },
     "38": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2u"
     },
     "39": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2u"
     },
     "40": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3f"
     },
     "41": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3f"
     },
     "43": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3f"
     },
     "45": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3f"
     },
     "47": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3f"
     },
     "49": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "4z"
+      "key": "root.imports.requests",
+      "~k_parent": "2k"
     },
     "51": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "50"
+      "key": "root.imports.operators",
+      "~k_parent": "2k"
     },
     "52": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "50"
+      "key": "root.imports.operators.client",
+      "~k_parent": "51"
     },
     "53": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "52"
+    },
+    "54": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "52"
+    },
+    "55": {
       "key": "root.imports.operators.server",
-      "~k_parent": "4z"
+      "~k_parent": "51"
     },
     "a": {
       "key": "root.pages[1:404:Result].style",
@@ -404,374 +412,375 @@
       "~k_parent": "1j"
     },
     "1m": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1i"
     },
     "1n": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1m"
+      "key": "root.types.auth",
+      "~k_parent": "1i"
     },
     "1o": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1m"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1n"
     },
     "1p": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1m"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1n"
     },
     "1q": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1m"
+      "key": "root.types.auth.events",
+      "~k_parent": "1n"
     },
     "1r": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1n"
+    },
+    "1s": {
       "key": "root.types.blocks",
       "~k_parent": "1i"
     },
-    "1s": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1r"
-    },
     "1t": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1s"
     },
     "1u": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1s"
     },
     "1w": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1s"
     },
     "1x": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1s"
     },
     "1y": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1s"
     },
     "1z": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1s"
     },
     "2a": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1s"
     },
     "2b": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1s"
+    },
+    "2c": {
       "key": "root.types.connections",
       "~k_parent": "1i"
     },
-    "2c": {
+    "2d": {
       "key": "root.types.requests",
       "~k_parent": "1i"
     },
-    "2d": {
+    "2e": {
       "key": "root.types.api",
       "~k_parent": "1i"
     },
-    "2e": {
+    "2f": {
       "key": "root.types.operators",
       "~k_parent": "1i"
     },
-    "2f": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2e"
-    },
     "2g": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2f"
     },
     "2h": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2f"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2g"
     },
     "2i": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2e"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2g"
     },
     "2j": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2f"
+    },
+    "2k": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2k": {
-      "key": "root.imports.actions",
-      "~k_parent": "2j"
-    },
     "2l": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2k"
     },
     "2m": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2k"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.imports.auth",
-      "~k_parent": "2j"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2l"
     },
     "2o": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2n"
+      "key": "root.imports.agents",
+      "~k_parent": "2k"
     },
     "2p": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2n"
+      "key": "root.imports.auth",
+      "~k_parent": "2k"
     },
     "2q": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2n"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2p"
     },
     "2r": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2n"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2p"
     },
     "2s": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2j"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2p"
     },
     "2t": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2s"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2p"
     },
     "2u": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks",
+      "~k_parent": "2k"
     },
     "2v": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2u"
     },
     "2y": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2u"
     },
     "2z": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2u"
     },
     "3b": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2u"
     },
     "3c": {
-      "key": "root.imports.connections",
-      "~k_parent": "2j"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2u"
     },
     "3d": {
-      "key": "root.imports.icons",
-      "~k_parent": "2j"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "2u"
     },
     "3e": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3d"
+      "key": "root.imports.connections",
+      "~k_parent": "2k"
     },
     "3f": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3e"
+      "key": "root.imports.icons",
+      "~k_parent": "2k"
     },
     "3g": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3f"
     },
     "3n": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3f"
     },
     "3r": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3f"
     },
     "3t": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3f"
     },
     "3v": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3f"
     },
     "3x": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3f"
     },
     "3z": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3f"
     },
     "4b": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3f"
     },
     "4d": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3f"
     },
     "4f": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3f"
     },
     "4h": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3f"
     },
     "4j": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3f"
     },
     "4l": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3f"
     },
     "4n": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3f"
     },
     "4p": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3f"
     },
     "4r": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3f"
     },
     "4t": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3f"
     },
     "4v": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3f"
     },
     "4x": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.requests",
-      "~k_parent": "2j"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3f"
     },
     "4z": {
-      "key": "root.imports.operators",
-      "~k_parent": "2j"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4y"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "o"
   },
@@ -954,6 +963,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5441,146 +5451,149 @@
       },
       "~k": "1j"
     },
+    "agents": {
+      "~k": "1m"
+    },
     "auth": {
       "adapters": {
-        "~k": "1n"
-      },
-      "callbacks": {
         "~k": "1o"
       },
-      "events": {
+      "callbacks": {
         "~k": "1p"
       },
-      "providers": {
+      "events": {
         "~k": "1q"
       },
-      "~k": "1m"
+      "providers": {
+        "~k": "1r"
+      },
+      "~k": "1n"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1s"
+        "~k": "1t"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1t"
+        "~k": "1u"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1u"
+        "~k": "1v"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1v"
+        "~k": "1w"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1w"
+        "~k": "1x"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
-      "~k": "1r"
+      "~k": "1s"
     },
     "connections": {
-      "~k": "2b"
-    },
-    "requests": {
       "~k": "2c"
     },
-    "api": {
+    "requests": {
       "~k": "2d"
+    },
+    "api": {
+      "~k": "2e"
     },
     "operators": {
       "client": {
@@ -5588,20 +5601,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2g"
+          "~k": "2h"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2h"
+          "~k": "2i"
         },
-        "~k": "2f"
+        "~k": "2g"
       },
       "server": {
-        "~k": "2i"
+        "~k": "2j"
       },
-      "~k": "2e"
+      "~k": "2f"
     },
     "~k": "1i"
   }

--- a/packages/build/src/tests/success/04-minimal-with-license/snapshot.json
+++ b/packages/build/src/tests/success/04-minimal-with-license/snapshot.json
@@ -120,140 +120,148 @@
       "~k_parent": "12"
     },
     "20": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1s"
     },
     "21": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1s"
     },
     "22": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1s"
     },
     "23": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1s"
     },
     "24": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1s"
     },
     "25": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1s"
     },
     "26": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1s"
     },
     "27": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1s"
     },
     "28": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1s"
     },
     "29": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1s"
     },
     "30": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2u"
     },
     "31": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2u"
     },
     "32": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2u"
     },
     "33": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2u"
     },
     "34": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2u"
     },
     "35": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2u"
     },
     "36": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2u"
     },
     "37": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2u"
     },
     "38": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2u"
     },
     "39": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2u"
     },
     "40": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3f"
     },
     "41": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3f"
     },
     "43": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3f"
     },
     "45": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3f"
     },
     "47": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3f"
     },
     "49": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "4z"
+      "key": "root.imports.requests",
+      "~k_parent": "2k"
     },
     "51": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "50"
+      "key": "root.imports.operators",
+      "~k_parent": "2k"
     },
     "52": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "50"
+      "key": "root.imports.operators.client",
+      "~k_parent": "51"
     },
     "53": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "52"
+    },
+    "54": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "52"
+    },
+    "55": {
       "key": "root.imports.operators.server",
-      "~k_parent": "4z"
+      "~k_parent": "51"
     },
     "a": {
       "key": "root.pages[1:404:Result].style",
@@ -404,374 +412,375 @@
       "~k_parent": "1j"
     },
     "1m": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1i"
     },
     "1n": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1m"
+      "key": "root.types.auth",
+      "~k_parent": "1i"
     },
     "1o": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1m"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1n"
     },
     "1p": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1m"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1n"
     },
     "1q": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1m"
+      "key": "root.types.auth.events",
+      "~k_parent": "1n"
     },
     "1r": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1n"
+    },
+    "1s": {
       "key": "root.types.blocks",
       "~k_parent": "1i"
     },
-    "1s": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1r"
-    },
     "1t": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1s"
     },
     "1u": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1s"
     },
     "1w": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1s"
     },
     "1x": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1s"
     },
     "1y": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1s"
     },
     "1z": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1s"
     },
     "2a": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1s"
     },
     "2b": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1s"
+    },
+    "2c": {
       "key": "root.types.connections",
       "~k_parent": "1i"
     },
-    "2c": {
+    "2d": {
       "key": "root.types.requests",
       "~k_parent": "1i"
     },
-    "2d": {
+    "2e": {
       "key": "root.types.api",
       "~k_parent": "1i"
     },
-    "2e": {
+    "2f": {
       "key": "root.types.operators",
       "~k_parent": "1i"
     },
-    "2f": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2e"
-    },
     "2g": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2f"
     },
     "2h": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2f"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2g"
     },
     "2i": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2e"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2g"
     },
     "2j": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2f"
+    },
+    "2k": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2k": {
-      "key": "root.imports.actions",
-      "~k_parent": "2j"
-    },
     "2l": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2k"
     },
     "2m": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2k"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.imports.auth",
-      "~k_parent": "2j"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2l"
     },
     "2o": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2n"
+      "key": "root.imports.agents",
+      "~k_parent": "2k"
     },
     "2p": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2n"
+      "key": "root.imports.auth",
+      "~k_parent": "2k"
     },
     "2q": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2n"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2p"
     },
     "2r": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2n"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2p"
     },
     "2s": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2j"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2p"
     },
     "2t": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2s"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2p"
     },
     "2u": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks",
+      "~k_parent": "2k"
     },
     "2v": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2u"
     },
     "2y": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2u"
     },
     "2z": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2u"
     },
     "3b": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2u"
     },
     "3c": {
-      "key": "root.imports.connections",
-      "~k_parent": "2j"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2u"
     },
     "3d": {
-      "key": "root.imports.icons",
-      "~k_parent": "2j"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "2u"
     },
     "3e": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3d"
+      "key": "root.imports.connections",
+      "~k_parent": "2k"
     },
     "3f": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3e"
+      "key": "root.imports.icons",
+      "~k_parent": "2k"
     },
     "3g": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3f"
     },
     "3n": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3f"
     },
     "3r": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3f"
     },
     "3t": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3f"
     },
     "3v": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3f"
     },
     "3x": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3f"
     },
     "3z": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3f"
     },
     "4b": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3f"
     },
     "4d": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3f"
     },
     "4f": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3f"
     },
     "4h": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3f"
     },
     "4j": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3f"
     },
     "4l": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3f"
     },
     "4n": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3f"
     },
     "4p": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3f"
     },
     "4r": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3f"
     },
     "4t": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3f"
     },
     "4v": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3f"
     },
     "4x": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.requests",
-      "~k_parent": "2j"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3f"
     },
     "4z": {
-      "key": "root.imports.operators",
-      "~k_parent": "2j"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4y"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "o"
   },
@@ -954,6 +963,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5441,146 +5451,149 @@
       },
       "~k": "1j"
     },
+    "agents": {
+      "~k": "1m"
+    },
     "auth": {
       "adapters": {
-        "~k": "1n"
-      },
-      "callbacks": {
         "~k": "1o"
       },
-      "events": {
+      "callbacks": {
         "~k": "1p"
       },
-      "providers": {
+      "events": {
         "~k": "1q"
       },
-      "~k": "1m"
+      "providers": {
+        "~k": "1r"
+      },
+      "~k": "1n"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1s"
+        "~k": "1t"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1t"
+        "~k": "1u"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1u"
+        "~k": "1v"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1v"
+        "~k": "1w"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1w"
+        "~k": "1x"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
-      "~k": "1r"
+      "~k": "1s"
     },
     "connections": {
-      "~k": "2b"
-    },
-    "requests": {
       "~k": "2c"
     },
-    "api": {
+    "requests": {
       "~k": "2d"
+    },
+    "api": {
+      "~k": "2e"
     },
     "operators": {
       "client": {
@@ -5588,20 +5601,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2g"
+          "~k": "2h"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2h"
+          "~k": "2i"
         },
-        "~k": "2f"
+        "~k": "2g"
       },
       "server": {
-        "~k": "2i"
+        "~k": "2j"
       },
-      "~k": "2e"
+      "~k": "2f"
     },
     "~k": "1i"
   }

--- a/packages/build/src/tests/success/05-empty-pages-array/snapshot.json
+++ b/packages/build/src/tests/success/05-empty-pages-array/snapshot.json
@@ -119,123 +119,123 @@
       "~k_parent": "4"
     },
     "20": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1m"
     },
     "21": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1m"
     },
     "22": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1m"
     },
     "23": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1m"
     },
     "24": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1m"
     },
     "25": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1m"
+    },
+    "26": {
       "key": "root.types.connections",
       "~k_parent": "1c"
     },
-    "26": {
+    "27": {
       "key": "root.types.requests",
       "~k_parent": "1c"
     },
-    "27": {
+    "28": {
       "key": "root.types.api",
       "~k_parent": "1c"
     },
-    "28": {
+    "29": {
       "key": "root.types.operators",
       "~k_parent": "1c"
     },
-    "29": {
-      "key": "root.types.operators.client",
-      "~k_parent": "28"
-    },
     "30": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2o"
     },
     "31": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2o"
     },
     "32": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2o"
     },
     "33": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2o"
     },
     "34": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2o"
     },
     "35": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2o"
     },
     "36": {
-      "key": "root.imports.connections",
-      "~k_parent": "2d"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2o"
     },
     "37": {
-      "key": "root.imports.icons",
-      "~k_parent": "2d"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "2o"
     },
     "38": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "37"
+      "key": "root.imports.connections",
+      "~k_parent": "2e"
     },
     "39": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "38"
+      "key": "root.imports.icons",
+      "~k_parent": "2e"
     },
     "40": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "39"
     },
     "41": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "39"
     },
     "43": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "39"
     },
     "45": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "39"
     },
     "47": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "39"
     },
     "49": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "48"
     },
     "a": {
@@ -363,390 +363,399 @@
       "~k_parent": "1d"
     },
     "1g": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1c"
     },
     "1h": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1g"
+      "key": "root.types.auth",
+      "~k_parent": "1c"
     },
     "1i": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1g"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1h"
     },
     "1j": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1g"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1h"
     },
     "1k": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1g"
+      "key": "root.types.auth.events",
+      "~k_parent": "1h"
     },
     "1l": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1h"
+    },
+    "1m": {
       "key": "root.types.blocks",
       "~k_parent": "1c"
     },
-    "1m": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1l"
-    },
     "1n": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1m"
     },
     "1o": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1m"
     },
     "1p": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1m"
     },
     "1q": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1m"
     },
     "1r": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1m"
     },
     "1s": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1m"
     },
     "1t": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1m"
     },
     "1u": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1m"
     },
     "1v": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1m"
     },
     "1w": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1m"
     },
     "1x": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1m"
     },
     "1y": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1m"
     },
     "1z": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1l"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1m"
     },
     "2a": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "29"
     },
     "2b": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "29"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2a"
     },
     "2c": {
-      "key": "root.types.operators.server",
-      "~k_parent": "28"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2a"
     },
     "2d": {
+      "key": "root.types.operators.server",
+      "~k_parent": "29"
+    },
+    "2e": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2e": {
-      "key": "root.imports.actions",
-      "~k_parent": "2d"
-    },
     "2f": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2e"
     },
     "2g": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2e"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2f"
     },
     "2h": {
-      "key": "root.imports.auth",
-      "~k_parent": "2d"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2f"
     },
     "2i": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2h"
+      "key": "root.imports.agents",
+      "~k_parent": "2e"
     },
     "2j": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2h"
+      "key": "root.imports.auth",
+      "~k_parent": "2e"
     },
     "2k": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2h"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2j"
     },
     "2l": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2h"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2j"
     },
     "2m": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2d"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2j"
     },
     "2n": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2m"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2j"
     },
     "2o": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks",
+      "~k_parent": "2e"
     },
     "2p": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2o"
     },
     "2q": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2o"
     },
     "2r": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2o"
     },
     "2s": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2o"
     },
     "2t": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2o"
     },
     "2u": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2o"
     },
     "2v": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2o"
     },
     "2w": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2o"
     },
     "2x": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2o"
     },
     "2y": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2o"
     },
     "2z": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2m"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2o"
     },
     "3a": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "39"
     },
     "3b": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3a"
     },
     "3c": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "39"
     },
     "3d": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3c"
     },
     "3e": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "39"
     },
     "3f": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "39"
     },
     "3h": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "39"
     },
     "3j": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "39"
     },
     "3l": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "39"
     },
     "3n": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "39"
     },
     "3p": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "39"
     },
     "3r": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "39"
     },
     "3t": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "39"
     },
     "3v": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "39"
     },
     "3x": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "39"
     },
     "3z": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "39"
     },
     "4b": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "39"
     },
     "4d": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "39"
     },
     "4f": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "39"
     },
     "4h": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "39"
     },
     "4j": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "39"
     },
     "4l": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "39"
     },
     "4n": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "39"
     },
     "4p": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "37"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "39"
     },
     "4r": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.requests",
-      "~k_parent": "2d"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "39"
     },
     "4t": {
-      "key": "root.imports.operators",
-      "~k_parent": "2d"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "4t"
+      "key": "root.imports.requests",
+      "~k_parent": "2e"
     },
     "4v": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "4u"
+      "key": "root.imports.operators",
+      "~k_parent": "2e"
     },
     "4w": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "4u"
+      "key": "root.imports.operators.client",
+      "~k_parent": "4v"
     },
     "4x": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "4w"
+    },
+    "4y": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "4w"
+    },
+    "4z": {
       "key": "root.imports.operators.server",
-      "~k_parent": "4t"
+      "~k_parent": "4v"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "n"
   },
@@ -902,6 +911,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5389,146 +5399,149 @@
       },
       "~k": "1d"
     },
+    "agents": {
+      "~k": "1g"
+    },
     "auth": {
       "adapters": {
-        "~k": "1h"
-      },
-      "callbacks": {
         "~k": "1i"
       },
-      "events": {
+      "callbacks": {
         "~k": "1j"
       },
-      "providers": {
+      "events": {
         "~k": "1k"
       },
-      "~k": "1g"
+      "providers": {
+        "~k": "1l"
+      },
+      "~k": "1h"
     },
     "blocks": {
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1m"
+        "~k": "1n"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1n"
+        "~k": "1o"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1o"
+        "~k": "1p"
       },
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1p"
+        "~k": "1q"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1q"
+        "~k": "1r"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1r"
+        "~k": "1s"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1s"
+        "~k": "1t"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1t"
+        "~k": "1u"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1u"
+        "~k": "1v"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1v"
+        "~k": "1w"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1w"
+        "~k": "1x"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
-      "~k": "1l"
+      "~k": "1m"
     },
     "connections": {
-      "~k": "25"
-    },
-    "requests": {
       "~k": "26"
     },
-    "api": {
+    "requests": {
       "~k": "27"
+    },
+    "api": {
+      "~k": "28"
     },
     "operators": {
       "client": {
@@ -5536,20 +5549,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2a"
+          "~k": "2b"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2b"
+          "~k": "2c"
         },
-        "~k": "29"
+        "~k": "2a"
       },
       "server": {
-        "~k": "2c"
+        "~k": "2d"
       },
-      "~k": "28"
+      "~k": "29"
     },
     "~k": "1c"
   }

--- a/packages/build/src/tests/success/06-single-page-minimal/snapshot.json
+++ b/packages/build/src/tests/success/06-single-page-minimal/snapshot.json
@@ -120,140 +120,148 @@
       "~k_parent": "12"
     },
     "20": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1s"
     },
     "21": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1s"
     },
     "22": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1s"
     },
     "23": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1s"
     },
     "24": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1s"
     },
     "25": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1s"
     },
     "26": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1s"
     },
     "27": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1s"
     },
     "28": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1s"
     },
     "29": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1s"
     },
     "30": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2u"
     },
     "31": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2u"
     },
     "32": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2u"
     },
     "33": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2u"
     },
     "34": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2u"
     },
     "35": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2u"
     },
     "36": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2u"
     },
     "37": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2u"
     },
     "38": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2u"
     },
     "39": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2u"
     },
     "40": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3f"
     },
     "41": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3f"
     },
     "43": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3f"
     },
     "45": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3f"
     },
     "47": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3f"
     },
     "49": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "4z"
+      "key": "root.imports.requests",
+      "~k_parent": "2k"
     },
     "51": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "50"
+      "key": "root.imports.operators",
+      "~k_parent": "2k"
     },
     "52": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "50"
+      "key": "root.imports.operators.client",
+      "~k_parent": "51"
     },
     "53": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "52"
+    },
+    "54": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "52"
+    },
+    "55": {
       "key": "root.imports.operators.server",
-      "~k_parent": "4z"
+      "~k_parent": "51"
     },
     "a": {
       "key": "root.pages[1:404:Result].style",
@@ -404,374 +412,375 @@
       "~k_parent": "1j"
     },
     "1m": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1i"
     },
     "1n": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1m"
+      "key": "root.types.auth",
+      "~k_parent": "1i"
     },
     "1o": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1m"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1n"
     },
     "1p": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1m"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1n"
     },
     "1q": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1m"
+      "key": "root.types.auth.events",
+      "~k_parent": "1n"
     },
     "1r": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1n"
+    },
+    "1s": {
       "key": "root.types.blocks",
       "~k_parent": "1i"
     },
-    "1s": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1r"
-    },
     "1t": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1s"
     },
     "1u": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1s"
     },
     "1w": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1s"
     },
     "1x": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1s"
     },
     "1y": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1s"
     },
     "1z": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1s"
     },
     "2a": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1s"
     },
     "2b": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1s"
+    },
+    "2c": {
       "key": "root.types.connections",
       "~k_parent": "1i"
     },
-    "2c": {
+    "2d": {
       "key": "root.types.requests",
       "~k_parent": "1i"
     },
-    "2d": {
+    "2e": {
       "key": "root.types.api",
       "~k_parent": "1i"
     },
-    "2e": {
+    "2f": {
       "key": "root.types.operators",
       "~k_parent": "1i"
     },
-    "2f": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2e"
-    },
     "2g": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2f"
     },
     "2h": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2f"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2g"
     },
     "2i": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2e"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2g"
     },
     "2j": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2f"
+    },
+    "2k": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2k": {
-      "key": "root.imports.actions",
-      "~k_parent": "2j"
-    },
     "2l": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2k"
     },
     "2m": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2k"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.imports.auth",
-      "~k_parent": "2j"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2l"
     },
     "2o": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2n"
+      "key": "root.imports.agents",
+      "~k_parent": "2k"
     },
     "2p": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2n"
+      "key": "root.imports.auth",
+      "~k_parent": "2k"
     },
     "2q": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2n"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2p"
     },
     "2r": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2n"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2p"
     },
     "2s": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2j"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2p"
     },
     "2t": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2s"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2p"
     },
     "2u": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks",
+      "~k_parent": "2k"
     },
     "2v": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2u"
     },
     "2y": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2u"
     },
     "2z": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2u"
     },
     "3b": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2u"
     },
     "3c": {
-      "key": "root.imports.connections",
-      "~k_parent": "2j"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2u"
     },
     "3d": {
-      "key": "root.imports.icons",
-      "~k_parent": "2j"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "2u"
     },
     "3e": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3d"
+      "key": "root.imports.connections",
+      "~k_parent": "2k"
     },
     "3f": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3e"
+      "key": "root.imports.icons",
+      "~k_parent": "2k"
     },
     "3g": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3f"
     },
     "3n": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3f"
     },
     "3r": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3f"
     },
     "3t": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3f"
     },
     "3v": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3f"
     },
     "3x": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3f"
     },
     "3z": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3f"
     },
     "4b": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3f"
     },
     "4d": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3f"
     },
     "4f": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3f"
     },
     "4h": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3f"
     },
     "4j": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3f"
     },
     "4l": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3f"
     },
     "4n": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3f"
     },
     "4p": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3f"
     },
     "4r": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3f"
     },
     "4t": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3f"
     },
     "4v": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3f"
     },
     "4x": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.requests",
-      "~k_parent": "2j"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3f"
     },
     "4z": {
-      "key": "root.imports.operators",
-      "~k_parent": "2j"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4y"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "o"
   },
@@ -954,6 +963,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5441,146 +5451,149 @@
       },
       "~k": "1j"
     },
+    "agents": {
+      "~k": "1m"
+    },
     "auth": {
       "adapters": {
-        "~k": "1n"
-      },
-      "callbacks": {
         "~k": "1o"
       },
-      "events": {
+      "callbacks": {
         "~k": "1p"
       },
-      "providers": {
+      "events": {
         "~k": "1q"
       },
-      "~k": "1m"
+      "providers": {
+        "~k": "1r"
+      },
+      "~k": "1n"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1s"
+        "~k": "1t"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1t"
+        "~k": "1u"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1u"
+        "~k": "1v"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1v"
+        "~k": "1w"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1w"
+        "~k": "1x"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
-      "~k": "1r"
+      "~k": "1s"
     },
     "connections": {
-      "~k": "2b"
-    },
-    "requests": {
       "~k": "2c"
     },
-    "api": {
+    "requests": {
       "~k": "2d"
+    },
+    "api": {
+      "~k": "2e"
     },
     "operators": {
       "client": {
@@ -5588,20 +5601,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2g"
+          "~k": "2h"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2h"
+          "~k": "2i"
         },
-        "~k": "2f"
+        "~k": "2g"
       },
       "server": {
-        "~k": "2i"
+        "~k": "2j"
       },
-      "~k": "2e"
+      "~k": "2f"
     },
     "~k": "1i"
   }

--- a/packages/build/src/tests/success/07-single-page-with-title/snapshot.json
+++ b/packages/build/src/tests/success/07-single-page-with-title/snapshot.json
@@ -121,144 +121,152 @@
       "~k_parent": "13"
     },
     "20": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1t"
     },
     "21": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1t"
     },
     "22": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1t"
     },
     "23": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1t"
     },
     "24": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1t"
     },
     "25": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1t"
     },
     "26": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1t"
     },
     "27": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1t"
     },
     "28": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1t"
     },
     "29": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1t"
     },
     "30": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2v"
     },
     "31": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2v"
     },
     "32": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2v"
     },
     "33": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2v"
     },
     "34": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2v"
     },
     "35": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2v"
     },
     "36": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2v"
     },
     "37": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2v"
     },
     "38": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2v"
     },
     "39": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2v"
     },
     "40": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3g"
     },
     "42": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3g"
     },
     "44": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3g"
     },
     "46": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3g"
     },
     "48": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3g"
     },
     "50": {
-      "key": "root.imports.operators",
-      "~k_parent": "2k"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "50"
+      "key": "root.imports.requests",
+      "~k_parent": "2l"
     },
     "52": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "51"
+      "key": "root.imports.operators",
+      "~k_parent": "2l"
     },
     "53": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "51"
+      "key": "root.imports.operators.client",
+      "~k_parent": "52"
     },
     "54": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "53"
+    },
+    "55": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "53"
+    },
+    "56": {
       "key": "root.imports.operators.server",
-      "~k_parent": "50"
+      "~k_parent": "52"
     },
     "a": {
       "key": "root.pages[1:404:Result]",
@@ -413,370 +421,371 @@
       "~k_parent": "1k"
     },
     "1n": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1j"
     },
     "1o": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1n"
+      "key": "root.types.auth",
+      "~k_parent": "1j"
     },
     "1p": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1n"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1o"
     },
     "1q": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1n"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1o"
     },
     "1r": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1n"
+      "key": "root.types.auth.events",
+      "~k_parent": "1o"
     },
     "1s": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1o"
+    },
+    "1t": {
       "key": "root.types.blocks",
       "~k_parent": "1j"
     },
-    "1t": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1s"
-    },
     "1u": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1t"
     },
     "1v": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1t"
     },
     "1w": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1t"
     },
     "1x": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1t"
     },
     "1y": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1t"
     },
     "1z": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1t"
     },
     "2a": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1t"
     },
     "2b": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1t"
     },
     "2c": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1t"
+    },
+    "2d": {
       "key": "root.types.connections",
       "~k_parent": "1j"
     },
-    "2d": {
+    "2e": {
       "key": "root.types.requests",
       "~k_parent": "1j"
     },
-    "2e": {
+    "2f": {
       "key": "root.types.api",
       "~k_parent": "1j"
     },
-    "2f": {
+    "2g": {
       "key": "root.types.operators",
       "~k_parent": "1j"
     },
-    "2g": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2f"
-    },
     "2h": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2g"
     },
     "2i": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2g"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2h"
     },
     "2j": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2f"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2h"
     },
     "2k": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2g"
+    },
+    "2l": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2l": {
-      "key": "root.imports.actions",
-      "~k_parent": "2k"
-    },
     "2m": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2l"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.imports.auth",
-      "~k_parent": "2k"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2m"
     },
     "2p": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2o"
+      "key": "root.imports.agents",
+      "~k_parent": "2l"
     },
     "2q": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2o"
+      "key": "root.imports.auth",
+      "~k_parent": "2l"
     },
     "2r": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2o"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2o"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2q"
     },
     "2t": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2k"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2q"
     },
     "2u": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2t"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2q"
     },
     "2v": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks",
+      "~k_parent": "2l"
     },
     "2w": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2v"
     },
     "2x": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2v"
     },
     "2y": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2v"
     },
     "2z": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2v"
     },
     "3a": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2v"
     },
     "3b": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2v"
     },
     "3c": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2v"
     },
     "3d": {
-      "key": "root.imports.connections",
-      "~k_parent": "2k"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2v"
     },
     "3e": {
-      "key": "root.imports.icons",
-      "~k_parent": "2k"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "2v"
     },
     "3f": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3e"
+      "key": "root.imports.connections",
+      "~k_parent": "2l"
     },
     "3g": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3f"
+      "key": "root.imports.icons",
+      "~k_parent": "2l"
     },
     "3h": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3g"
     },
     "3k": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3j"
     },
     "3l": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3g"
     },
     "3m": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3l"
     },
     "3n": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3g"
     },
     "3o": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3g"
     },
     "3q": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3g"
     },
     "3s": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3g"
     },
     "3u": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3g"
     },
     "3w": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3g"
     },
     "3y": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3g"
     },
     "4a": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3g"
     },
     "4c": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3g"
     },
     "4e": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3g"
     },
     "4g": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3g"
     },
     "4i": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3g"
     },
     "4k": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3g"
     },
     "4m": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3g"
     },
     "4o": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3g"
     },
     "4q": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3g"
     },
     "4s": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3g"
     },
     "4u": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3g"
     },
     "4w": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3g"
     },
     "4y": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.requests",
-      "~k_parent": "2k"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3g"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "p"
   },
@@ -963,6 +972,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5450,146 +5460,149 @@
       },
       "~k": "1k"
     },
+    "agents": {
+      "~k": "1n"
+    },
     "auth": {
       "adapters": {
-        "~k": "1o"
-      },
-      "callbacks": {
         "~k": "1p"
       },
-      "events": {
+      "callbacks": {
         "~k": "1q"
       },
-      "providers": {
+      "events": {
         "~k": "1r"
       },
-      "~k": "1n"
+      "providers": {
+        "~k": "1s"
+      },
+      "~k": "1o"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1t"
+        "~k": "1u"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1u"
+        "~k": "1v"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1v"
+        "~k": "1w"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1w"
+        "~k": "1x"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
-      "~k": "1s"
+      "~k": "1t"
     },
     "connections": {
-      "~k": "2c"
-    },
-    "requests": {
       "~k": "2d"
     },
-    "api": {
+    "requests": {
       "~k": "2e"
+    },
+    "api": {
+      "~k": "2f"
     },
     "operators": {
       "client": {
@@ -5597,20 +5610,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2h"
+          "~k": "2i"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2i"
+          "~k": "2j"
         },
-        "~k": "2g"
+        "~k": "2h"
       },
       "server": {
-        "~k": "2j"
+        "~k": "2k"
       },
-      "~k": "2f"
+      "~k": "2g"
     },
     "~k": "1j"
   }

--- a/packages/build/src/tests/success/08-page-with-single-block/snapshot.json
+++ b/packages/build/src/tests/success/08-page-with-single-block/snapshot.json
@@ -127,164 +127,164 @@
       "~k_parent": "18"
     },
     "20": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1x"
     },
     "21": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1x"
     },
     "22": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1x"
     },
     "23": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1x"
     },
     "24": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1x"
     },
     "25": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1x"
     },
     "26": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1x"
     },
     "27": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1x"
     },
     "28": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1x"
     },
     "29": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1x"
     },
     "30": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks",
+      "~k_parent": "2q"
     },
     "31": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "30"
     },
     "32": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "30"
     },
     "33": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "30"
     },
     "34": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "30"
     },
     "35": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "30"
     },
     "36": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "30"
     },
     "37": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "30"
     },
     "38": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "30"
     },
     "39": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "30"
     },
     "40": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3m"
     },
     "42": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3m"
     },
     "44": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3m"
     },
     "46": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3m"
     },
     "48": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3m"
     },
     "50": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3m"
     },
     "52": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3m"
     },
     "54": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.requests",
-      "~k_parent": "2p"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3m"
     },
     "56": {
-      "key": "root.imports.operators",
-      "~k_parent": "2p"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "56"
+      "key": "root.imports.requests",
+      "~k_parent": "2q"
     },
     "58": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "57"
+      "key": "root.imports.operators",
+      "~k_parent": "2q"
     },
     "59": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "57"
+      "key": "root.imports.operators.client",
+      "~k_parent": "58"
     },
     "b": {
       "key": "root.pages",
@@ -451,358 +451,367 @@
       "~k_parent": "1o"
     },
     "1r": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1n"
     },
     "1s": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1r"
+      "key": "root.types.auth",
+      "~k_parent": "1n"
     },
     "1t": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1r"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1s"
     },
     "1u": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1r"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1r"
+      "key": "root.types.auth.events",
+      "~k_parent": "1s"
     },
     "1w": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1s"
+    },
+    "1x": {
       "key": "root.types.blocks",
       "~k_parent": "1n"
     },
-    "1x": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1w"
-    },
     "1y": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1x"
     },
     "1z": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "1x"
     },
     "2a": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1x"
     },
     "2b": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1x"
     },
     "2c": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1x"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1x"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1x"
     },
     "2f": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1x"
     },
     "2g": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1x"
     },
     "2h": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1x"
+    },
+    "2i": {
       "key": "root.types.connections",
       "~k_parent": "1n"
     },
-    "2i": {
+    "2j": {
       "key": "root.types.requests",
       "~k_parent": "1n"
     },
-    "2j": {
+    "2k": {
       "key": "root.types.api",
       "~k_parent": "1n"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.operators",
       "~k_parent": "1n"
     },
-    "2l": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2k"
-    },
     "2m": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2l"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2k"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2m"
     },
     "2p": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2l"
+    },
+    "2q": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2q": {
-      "key": "root.imports.actions",
-      "~k_parent": "2p"
-    },
     "2r": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2q"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.imports.auth",
-      "~k_parent": "2p"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2r"
     },
     "2u": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2t"
+      "key": "root.imports.agents",
+      "~k_parent": "2q"
     },
     "2v": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2t"
+      "key": "root.imports.auth",
+      "~k_parent": "2q"
     },
     "2w": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2t"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2v"
     },
     "2x": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2t"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2v"
     },
     "2y": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2p"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2v"
     },
     "2z": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2y"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2v"
     },
     "3a": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "30"
     },
     "3b": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "30"
     },
     "3c": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "30"
     },
     "3d": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "30"
     },
     "3e": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "30"
     },
     "3f": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "30"
     },
     "3g": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "30"
     },
     "3h": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "30"
     },
     "3i": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "30"
     },
     "3j": {
-      "key": "root.imports.connections",
-      "~k_parent": "2p"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "30"
     },
     "3k": {
-      "key": "root.imports.icons",
-      "~k_parent": "2p"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "30"
     },
     "3l": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3k"
+      "key": "root.imports.connections",
+      "~k_parent": "2q"
     },
     "3m": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3l"
+      "key": "root.imports.icons",
+      "~k_parent": "2q"
     },
     "3n": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3m"
     },
     "3u": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3m"
     },
     "3w": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3m"
     },
     "3y": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3m"
     },
     "4a": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3m"
     },
     "4c": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3m"
     },
     "4e": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3m"
     },
     "4g": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3m"
     },
     "4i": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3m"
     },
     "4k": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3m"
     },
     "4m": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3m"
     },
     "4o": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3m"
     },
     "4q": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3m"
     },
     "4s": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3m"
     },
     "4u": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3m"
     },
     "4w": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3m"
     },
     "4y": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3m"
     },
     "5a": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "59"
+    },
+    "5b": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "59"
+    },
+    "5c": {
       "key": "root.imports.operators.server",
-      "~k_parent": "56"
+      "~k_parent": "58"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "r"
   },
@@ -1006,6 +1015,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5493,152 +5503,155 @@
       },
       "~k": "1o"
     },
+    "agents": {
+      "~k": "1r"
+    },
     "auth": {
       "adapters": {
-        "~k": "1s"
-      },
-      "callbacks": {
         "~k": "1t"
       },
-      "events": {
+      "callbacks": {
         "~k": "1u"
       },
-      "providers": {
+      "events": {
         "~k": "1v"
       },
-      "~k": "1r"
+      "providers": {
+        "~k": "1w"
+      },
+      "~k": "1s"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
-      "~k": "1w"
+      "~k": "1x"
     },
     "connections": {
-      "~k": "2h"
-    },
-    "requests": {
       "~k": "2i"
     },
-    "api": {
+    "requests": {
       "~k": "2j"
+    },
+    "api": {
+      "~k": "2k"
     },
     "operators": {
       "client": {
@@ -5646,20 +5659,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2m"
+          "~k": "2n"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2n"
+          "~k": "2o"
         },
-        "~k": "2l"
+        "~k": "2m"
       },
       "server": {
-        "~k": "2o"
+        "~k": "2p"
       },
-      "~k": "2k"
+      "~k": "2l"
     },
     "~k": "1n"
   }

--- a/packages/build/src/tests/success/09-page-with-multiple-blocks/snapshot.json
+++ b/packages/build/src/tests/success/09-page-with-multiple-blocks/snapshot.json
@@ -127,164 +127,164 @@
       "~k_parent": "14"
     },
     "20": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1w"
+    },
+    "21": {
       "key": "root.types.blocks",
       "~k_parent": "1r"
     },
-    "21": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "20"
-    },
     "22": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "21"
     },
     "23": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "21"
     },
     "24": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "21"
     },
     "25": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "21"
     },
     "26": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "21"
     },
     "27": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "21"
     },
     "28": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "20"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "21"
     },
     "29": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "21"
     },
     "30": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2y"
+      "key": "root.imports.auth",
+      "~k_parent": "2v"
     },
     "31": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2y"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "30"
     },
     "32": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2y"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "30"
     },
     "33": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2u"
+      "key": "root.imports.auth.events",
+      "~k_parent": "30"
     },
     "34": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "33"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "30"
     },
     "35": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks",
+      "~k_parent": "2v"
     },
     "36": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "35"
     },
     "37": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "35"
     },
     "38": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "35"
     },
     "39": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "35"
     },
     "40": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3s"
     },
     "42": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3s"
     },
     "44": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3s"
     },
     "46": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3s"
     },
     "48": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3s"
     },
     "50": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3s"
     },
     "52": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3s"
     },
     "54": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3s"
     },
     "56": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3s"
     },
     "58": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3s"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[1:intro:Paragraph]",
@@ -471,366 +471,375 @@
       "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1r"
     },
     "1w": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1v"
+      "key": "root.types.auth",
+      "~k_parent": "1r"
     },
     "1x": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1v"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1w"
     },
     "1y": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1v"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1w"
     },
     "1z": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1v"
+      "key": "root.types.auth.events",
+      "~k_parent": "1w"
     },
     "2a": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "21"
     },
     "2b": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "21"
     },
     "2c": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "20"
+      "key": "root.types.blocks.List",
+      "~k_parent": "21"
     },
     "2d": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "21"
     },
     "2e": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "21"
     },
     "2f": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "20"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "21"
     },
     "2g": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "21"
     },
     "2h": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "21"
     },
     "2i": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "21"
     },
     "2j": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "21"
     },
     "2k": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "21"
     },
     "2l": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "21"
     },
     "2m": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "21"
+    },
+    "2n": {
       "key": "root.types.connections",
       "~k_parent": "1r"
     },
-    "2n": {
+    "2o": {
       "key": "root.types.requests",
       "~k_parent": "1r"
     },
-    "2o": {
+    "2p": {
       "key": "root.types.api",
       "~k_parent": "1r"
     },
-    "2p": {
+    "2q": {
       "key": "root.types.operators",
       "~k_parent": "1r"
     },
-    "2q": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2p"
-    },
     "2r": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2q"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2p"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2r"
     },
     "2u": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2q"
+    },
+    "2v": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2v": {
-      "key": "root.imports.actions",
-      "~k_parent": "2u"
-    },
     "2w": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2v"
     },
     "2x": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2v"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.imports.auth",
-      "~k_parent": "2u"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2w"
     },
     "2z": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2y"
+      "key": "root.imports.agents",
+      "~k_parent": "2v"
     },
     "3a": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "35"
     },
     "3b": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "35"
     },
     "3c": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "35"
     },
     "3d": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "35"
     },
     "3e": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "35"
     },
     "3f": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "35"
     },
     "3g": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "35"
     },
     "3h": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "35"
     },
     "3i": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "35"
     },
     "3j": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "35"
     },
     "3k": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "35"
     },
     "3l": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "35"
     },
     "3m": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "35"
     },
     "3n": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "35"
     },
     "3o": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "35"
     },
     "3p": {
-      "key": "root.imports.connections",
-      "~k_parent": "2u"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "35"
     },
     "3q": {
-      "key": "root.imports.icons",
-      "~k_parent": "2u"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "35"
     },
     "3r": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3q"
+      "key": "root.imports.connections",
+      "~k_parent": "2v"
     },
     "3s": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3r"
+      "key": "root.imports.icons",
+      "~k_parent": "2v"
     },
     "3t": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3s"
     },
     "3w": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3s"
     },
     "3y": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3s"
     },
     "4a": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3s"
     },
     "4c": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3s"
     },
     "4e": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3s"
     },
     "4g": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3s"
     },
     "4i": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3s"
     },
     "4k": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3s"
     },
     "4m": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3s"
     },
     "4o": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3s"
     },
     "4q": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3s"
     },
     "4s": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3s"
     },
     "4u": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3s"
     },
     "4w": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3s"
     },
     "4y": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3s"
     },
     "5a": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.requests",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3s"
     },
     "5c": {
-      "key": "root.imports.operators",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5c"
+      "key": "root.imports.requests",
+      "~k_parent": "2v"
     },
     "5e": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5d"
+      "key": "root.imports.operators",
+      "~k_parent": "2v"
     },
     "5f": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5d"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5e"
     },
     "5g": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5f"
+    },
+    "5h": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5f"
+    },
+    "5i": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5c"
+      "~k_parent": "5e"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "v"
   },
@@ -1054,6 +1063,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5541,158 +5551,161 @@
       },
       "~k": "1s"
     },
+    "agents": {
+      "~k": "1v"
+    },
     "auth": {
       "adapters": {
-        "~k": "1w"
-      },
-      "callbacks": {
         "~k": "1x"
       },
-      "events": {
+      "callbacks": {
         "~k": "1y"
       },
-      "providers": {
+      "events": {
         "~k": "1z"
       },
-      "~k": "1v"
+      "providers": {
+        "~k": "20"
+      },
+      "~k": "1w"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "21"
+        "~k": "22"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "24"
+        "~k": "25"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
-      "~k": "20"
+      "~k": "21"
     },
     "connections": {
-      "~k": "2m"
-    },
-    "requests": {
       "~k": "2n"
     },
-    "api": {
+    "requests": {
       "~k": "2o"
+    },
+    "api": {
+      "~k": "2p"
     },
     "operators": {
       "client": {
@@ -5700,20 +5713,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2r"
+          "~k": "2s"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2s"
+          "~k": "2t"
         },
-        "~k": "2q"
+        "~k": "2r"
       },
       "server": {
-        "~k": "2t"
+        "~k": "2u"
       },
-      "~k": "2p"
+      "~k": "2q"
     },
     "~k": "1r"
   }

--- a/packages/build/src/tests/success/10-page-with-nested-blocks/snapshot.json
+++ b/packages/build/src/tests/success/10-page-with-nested-blocks/snapshot.json
@@ -131,160 +131,160 @@
       "~k_parent": "1y"
     },
     "21": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1x"
     },
     "22": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "21"
+      "key": "root.types.auth",
+      "~k_parent": "1x"
     },
     "23": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "21"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "22"
     },
     "24": {
-      "key": "root.types.auth.events",
-      "~k_parent": "21"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "22"
     },
     "25": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "21"
+      "key": "root.types.auth.events",
+      "~k_parent": "22"
     },
     "26": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "22"
+    },
+    "27": {
       "key": "root.types.blocks",
       "~k_parent": "1x"
     },
-    "27": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "26"
-    },
     "28": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "27"
     },
     "29": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "27"
     },
     "30": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2w"
+    },
+    "31": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "31": {
-      "key": "root.imports.actions",
-      "~k_parent": "30"
-    },
     "32": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "31"
     },
     "33": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "31"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.imports.auth",
-      "~k_parent": "30"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "32"
     },
     "35": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "34"
+      "key": "root.imports.agents",
+      "~k_parent": "31"
     },
     "36": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "34"
+      "key": "root.imports.auth",
+      "~k_parent": "31"
     },
     "37": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "34"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "36"
     },
     "38": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "34"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "36"
     },
     "39": {
-      "key": "root.imports.blocks",
-      "~k_parent": "30"
+      "key": "root.imports.auth.events",
+      "~k_parent": "36"
     },
     "40": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3y"
     },
     "42": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3y"
     },
     "44": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3y"
     },
     "46": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3y"
     },
     "48": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3y"
     },
     "50": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3y"
     },
     "52": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3y"
     },
     "54": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3y"
     },
     "56": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3y"
     },
     "58": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3y"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[0:container:Box].blocks[0:inner1:Title]",
@@ -493,370 +493,379 @@
       "~k_parent": "1y"
     },
     "2a": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "27"
     },
     "2b": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "27"
     },
     "2c": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "27"
     },
     "2d": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "27"
     },
     "2e": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "26"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "27"
     },
     "2f": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "27"
     },
     "2g": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "27"
     },
     "2h": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "27"
     },
     "2i": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "26"
+      "key": "root.types.blocks.List",
+      "~k_parent": "27"
     },
     "2j": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "27"
     },
     "2k": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "27"
     },
     "2l": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "26"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "27"
     },
     "2m": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "27"
     },
     "2n": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "26"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "27"
     },
     "2o": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "26"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "27"
     },
     "2p": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "26"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "27"
     },
     "2q": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "26"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "27"
     },
     "2r": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "27"
     },
     "2s": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "27"
+    },
+    "2t": {
       "key": "root.types.connections",
       "~k_parent": "1x"
     },
-    "2t": {
+    "2u": {
       "key": "root.types.requests",
       "~k_parent": "1x"
     },
-    "2u": {
+    "2v": {
       "key": "root.types.api",
       "~k_parent": "1x"
     },
-    "2v": {
+    "2w": {
       "key": "root.types.operators",
       "~k_parent": "1x"
     },
-    "2w": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2v"
-    },
     "2x": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2w"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2v"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2x"
     },
     "3a": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "39"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "36"
     },
     "3b": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks",
+      "~k_parent": "31"
     },
     "3c": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3b"
     },
     "3e": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3b"
     },
     "3f": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3b"
     },
     "3g": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3b"
     },
     "3h": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3b"
     },
     "3i": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3b"
     },
     "3j": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3b"
     },
     "3k": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3b"
     },
     "3l": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3b"
     },
     "3m": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3b"
     },
     "3n": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3b"
     },
     "3o": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3b"
     },
     "3p": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3b"
     },
     "3q": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3b"
     },
     "3r": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3b"
     },
     "3s": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3b"
     },
     "3t": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3b"
     },
     "3u": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3b"
     },
     "3v": {
-      "key": "root.imports.connections",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3b"
     },
     "3w": {
-      "key": "root.imports.icons",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "3b"
     },
     "3x": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3w"
+      "key": "root.imports.connections",
+      "~k_parent": "31"
     },
     "3y": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3x"
+      "key": "root.imports.icons",
+      "~k_parent": "31"
     },
     "3z": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3y"
     },
     "4c": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3y"
     },
     "4e": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3y"
     },
     "4g": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3y"
     },
     "4i": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3y"
     },
     "4k": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3y"
     },
     "4m": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3y"
     },
     "4o": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3y"
     },
     "4q": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3y"
     },
     "4s": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3y"
     },
     "4u": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3y"
     },
     "4w": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3y"
     },
     "4y": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3y"
     },
     "5a": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3y"
     },
     "5c": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3y"
     },
     "5e": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3y"
     },
     "5g": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.requests",
-      "~k_parent": "30"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3y"
     },
     "5i": {
-      "key": "root.imports.operators",
-      "~k_parent": "30"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5i"
+      "key": "root.imports.requests",
+      "~k_parent": "31"
     },
     "5k": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5j"
+      "key": "root.imports.operators",
+      "~k_parent": "31"
     },
     "5l": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5j"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5k"
     },
     "5m": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5l"
+    },
+    "5n": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5l"
+    },
+    "5o": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5i"
+      "~k_parent": "5k"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "x"
   },
@@ -1104,6 +1113,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5591,158 +5601,161 @@
       },
       "~k": "1y"
     },
+    "agents": {
+      "~k": "21"
+    },
     "auth": {
       "adapters": {
-        "~k": "22"
-      },
-      "callbacks": {
         "~k": "23"
       },
-      "events": {
+      "callbacks": {
         "~k": "24"
       },
-      "providers": {
+      "events": {
         "~k": "25"
       },
-      "~k": "21"
+      "providers": {
+        "~k": "26"
+      },
+      "~k": "22"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "27"
+        "~k": "28"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
-      "~k": "26"
+      "~k": "27"
     },
     "connections": {
-      "~k": "2s"
-    },
-    "requests": {
       "~k": "2t"
     },
-    "api": {
+    "requests": {
       "~k": "2u"
+    },
+    "api": {
+      "~k": "2v"
     },
     "operators": {
       "client": {
@@ -5750,20 +5763,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2x"
+          "~k": "2y"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2y"
+          "~k": "2z"
         },
-        "~k": "2w"
+        "~k": "2x"
       },
       "server": {
-        "~k": "2z"
+        "~k": "30"
       },
-      "~k": "2v"
+      "~k": "2w"
     },
     "~k": "1x"
   }

--- a/packages/build/src/tests/success/11-page-with-areas/snapshot.json
+++ b/packages/build/src/tests/success/11-page-with-areas/snapshot.json
@@ -127,164 +127,164 @@
       "~k_parent": "14"
     },
     "20": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1w"
+    },
+    "21": {
       "key": "root.types.blocks",
       "~k_parent": "1r"
     },
-    "21": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "20"
-    },
     "22": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "21"
     },
     "23": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "21"
     },
     "24": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "21"
     },
     "25": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "21"
     },
     "26": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "21"
     },
     "27": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "21"
     },
     "28": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "21"
     },
     "29": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "20"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "21"
     },
     "30": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2z"
+      "key": "root.imports.agents",
+      "~k_parent": "2w"
     },
     "31": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2z"
+      "key": "root.imports.auth",
+      "~k_parent": "2w"
     },
     "32": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2z"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "31"
     },
     "33": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2z"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "31"
     },
     "34": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2v"
+      "key": "root.imports.auth.events",
+      "~k_parent": "31"
     },
     "35": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "34"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "31"
     },
     "36": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks",
+      "~k_parent": "2w"
     },
     "37": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "36"
     },
     "38": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "36"
     },
     "39": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "36"
     },
     "40": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3u"
     },
     "42": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3u"
     },
     "44": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3u"
     },
     "46": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3u"
     },
     "48": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3u"
     },
     "50": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3u"
     },
     "52": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3u"
     },
     "54": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3u"
     },
     "56": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3u"
     },
     "58": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3u"
     },
     "a": {
       "key": "root.pages[0:home:Card].areas.title.blocks[0:cardTitle:Title]",
@@ -473,374 +473,383 @@
       "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1r"
     },
     "1w": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1v"
+      "key": "root.types.auth",
+      "~k_parent": "1r"
     },
     "1x": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1v"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1w"
     },
     "1y": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1v"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1w"
     },
     "1z": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1v"
+      "key": "root.types.auth.events",
+      "~k_parent": "1w"
     },
     "2a": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "21"
     },
     "2b": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "21"
     },
     "2c": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "21"
     },
     "2d": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "20"
+      "key": "root.types.blocks.List",
+      "~k_parent": "21"
     },
     "2e": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "21"
     },
     "2f": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "21"
     },
     "2g": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "20"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "21"
     },
     "2h": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "21"
     },
     "2i": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "21"
     },
     "2j": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "21"
     },
     "2k": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "21"
     },
     "2l": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "21"
     },
     "2m": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "21"
     },
     "2n": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "21"
+    },
+    "2o": {
       "key": "root.types.connections",
       "~k_parent": "1r"
     },
-    "2o": {
+    "2p": {
       "key": "root.types.requests",
       "~k_parent": "1r"
     },
-    "2p": {
+    "2q": {
       "key": "root.types.api",
       "~k_parent": "1r"
     },
-    "2q": {
+    "2r": {
       "key": "root.types.operators",
       "~k_parent": "1r"
     },
-    "2r": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2r"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2q"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2s"
     },
     "2v": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2r"
+    },
+    "2w": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2w": {
-      "key": "root.imports.actions",
-      "~k_parent": "2v"
-    },
     "2x": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2w"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.auth",
-      "~k_parent": "2v"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2x"
     },
     "3a": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "36"
     },
     "3b": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "36"
     },
     "3c": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "36"
     },
     "3d": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "36"
     },
     "3e": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "36"
     },
     "3f": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "36"
     },
     "3g": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "36"
     },
     "3h": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "36"
     },
     "3i": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "36"
     },
     "3j": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "36"
     },
     "3k": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "36"
     },
     "3l": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "36"
     },
     "3m": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "36"
     },
     "3n": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "36"
     },
     "3o": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "36"
     },
     "3p": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "36"
     },
     "3q": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "36"
     },
     "3r": {
-      "key": "root.imports.connections",
-      "~k_parent": "2v"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "36"
     },
     "3s": {
-      "key": "root.imports.icons",
-      "~k_parent": "2v"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "36"
     },
     "3t": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3s"
+      "key": "root.imports.connections",
+      "~k_parent": "2w"
     },
     "3u": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3t"
+      "key": "root.imports.icons",
+      "~k_parent": "2w"
     },
     "3v": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3u"
     },
     "3y": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3u"
     },
     "4a": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3u"
     },
     "4c": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3u"
     },
     "4e": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3u"
     },
     "4g": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3u"
     },
     "4i": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3u"
     },
     "4k": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3u"
     },
     "4m": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3u"
     },
     "4o": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3u"
     },
     "4q": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3u"
     },
     "4s": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3u"
     },
     "4u": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3u"
     },
     "4w": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3u"
     },
     "4y": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3u"
     },
     "5a": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3u"
     },
     "5c": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.requests",
-      "~k_parent": "2v"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3u"
     },
     "5e": {
-      "key": "root.imports.operators",
-      "~k_parent": "2v"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5e"
+      "key": "root.imports.requests",
+      "~k_parent": "2w"
     },
     "5g": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5f"
+      "key": "root.imports.operators",
+      "~k_parent": "2w"
     },
     "5h": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5f"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5g"
     },
     "5i": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5h"
+    },
+    "5j": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5h"
+    },
+    "5k": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5e"
+      "~k_parent": "5g"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "x"
   },
@@ -1062,6 +1071,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -6039,164 +6049,167 @@
       },
       "~k": "1s"
     },
+    "agents": {
+      "~k": "1v"
+    },
     "auth": {
       "adapters": {
-        "~k": "1w"
-      },
-      "callbacks": {
         "~k": "1x"
       },
-      "events": {
+      "callbacks": {
         "~k": "1y"
       },
-      "providers": {
+      "events": {
         "~k": "1z"
       },
-      "~k": "1v"
+      "providers": {
+        "~k": "20"
+      },
+      "~k": "1w"
     },
     "blocks": {
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
-      "~k": "20"
+      "~k": "21"
     },
     "connections": {
-      "~k": "2n"
-    },
-    "requests": {
       "~k": "2o"
     },
-    "api": {
+    "requests": {
       "~k": "2p"
+    },
+    "api": {
+      "~k": "2q"
     },
     "operators": {
       "client": {
@@ -6204,20 +6217,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2s"
+          "~k": "2t"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2t"
+          "~k": "2u"
         },
-        "~k": "2r"
+        "~k": "2s"
       },
       "server": {
-        "~k": "2u"
+        "~k": "2v"
       },
-      "~k": "2q"
+      "~k": "2r"
     },
     "~k": "1r"
   }

--- a/packages/build/src/tests/success/12-page-with-content-area/snapshot.json
+++ b/packages/build/src/tests/success/12-page-with-content-area/snapshot.json
@@ -127,164 +127,164 @@
       "~k_parent": "18"
     },
     "20": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1x"
     },
     "21": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1x"
     },
     "22": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1x"
     },
     "23": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1x"
     },
     "24": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1x"
     },
     "25": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1x"
     },
     "26": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1x"
     },
     "27": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1x"
     },
     "28": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1x"
     },
     "29": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1x"
     },
     "30": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks",
+      "~k_parent": "2q"
     },
     "31": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "30"
     },
     "32": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "30"
     },
     "33": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "30"
     },
     "34": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "30"
     },
     "35": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "30"
     },
     "36": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "30"
     },
     "37": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "30"
     },
     "38": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "30"
     },
     "39": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "30"
     },
     "40": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3m"
     },
     "42": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3m"
     },
     "44": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3m"
     },
     "46": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3m"
     },
     "48": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3m"
     },
     "50": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3m"
     },
     "52": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3m"
     },
     "54": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.requests",
-      "~k_parent": "2p"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3m"
     },
     "56": {
-      "key": "root.imports.operators",
-      "~k_parent": "2p"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "56"
+      "key": "root.imports.requests",
+      "~k_parent": "2q"
     },
     "58": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "57"
+      "key": "root.imports.operators",
+      "~k_parent": "2q"
     },
     "59": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "57"
+      "key": "root.imports.operators.client",
+      "~k_parent": "58"
     },
     "a": {
       "key": "root.pages[0:home:Box].areas.content.blocks[0:mainContent:Paragraph]",
@@ -453,358 +453,367 @@
       "~k_parent": "1o"
     },
     "1r": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1n"
     },
     "1s": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1r"
+      "key": "root.types.auth",
+      "~k_parent": "1n"
     },
     "1t": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1r"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1s"
     },
     "1u": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1r"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1r"
+      "key": "root.types.auth.events",
+      "~k_parent": "1s"
     },
     "1w": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1s"
+    },
+    "1x": {
       "key": "root.types.blocks",
       "~k_parent": "1n"
     },
-    "1x": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1w"
-    },
     "1y": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1x"
     },
     "1z": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "1x"
     },
     "2a": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1x"
     },
     "2b": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1x"
     },
     "2c": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1x"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1x"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1x"
     },
     "2f": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1x"
     },
     "2g": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1x"
     },
     "2h": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1x"
+    },
+    "2i": {
       "key": "root.types.connections",
       "~k_parent": "1n"
     },
-    "2i": {
+    "2j": {
       "key": "root.types.requests",
       "~k_parent": "1n"
     },
-    "2j": {
+    "2k": {
       "key": "root.types.api",
       "~k_parent": "1n"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.operators",
       "~k_parent": "1n"
     },
-    "2l": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2k"
-    },
     "2m": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2l"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2k"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2m"
     },
     "2p": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2l"
+    },
+    "2q": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2q": {
-      "key": "root.imports.actions",
-      "~k_parent": "2p"
-    },
     "2r": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2q"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.imports.auth",
-      "~k_parent": "2p"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2r"
     },
     "2u": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2t"
+      "key": "root.imports.agents",
+      "~k_parent": "2q"
     },
     "2v": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2t"
+      "key": "root.imports.auth",
+      "~k_parent": "2q"
     },
     "2w": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2t"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2v"
     },
     "2x": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2t"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2v"
     },
     "2y": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2p"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2v"
     },
     "2z": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2y"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2v"
     },
     "3a": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "30"
     },
     "3b": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "30"
     },
     "3c": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "30"
     },
     "3d": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "30"
     },
     "3e": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "30"
     },
     "3f": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "30"
     },
     "3g": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "30"
     },
     "3h": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "30"
     },
     "3i": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "30"
     },
     "3j": {
-      "key": "root.imports.connections",
-      "~k_parent": "2p"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "30"
     },
     "3k": {
-      "key": "root.imports.icons",
-      "~k_parent": "2p"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "30"
     },
     "3l": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3k"
+      "key": "root.imports.connections",
+      "~k_parent": "2q"
     },
     "3m": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3l"
+      "key": "root.imports.icons",
+      "~k_parent": "2q"
     },
     "3n": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3m"
     },
     "3u": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3m"
     },
     "3w": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3m"
     },
     "3y": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3m"
     },
     "4a": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3m"
     },
     "4c": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3m"
     },
     "4e": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3m"
     },
     "4g": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3m"
     },
     "4i": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3m"
     },
     "4k": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3m"
     },
     "4m": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3m"
     },
     "4o": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3m"
     },
     "4q": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3m"
     },
     "4s": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3m"
     },
     "4u": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3m"
     },
     "4w": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3m"
     },
     "4y": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3m"
     },
     "5a": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "59"
+    },
+    "5b": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "59"
+    },
+    "5c": {
       "key": "root.imports.operators.server",
-      "~k_parent": "56"
+      "~k_parent": "58"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "t"
   },
@@ -1008,6 +1017,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5495,152 +5505,155 @@
       },
       "~k": "1o"
     },
+    "agents": {
+      "~k": "1r"
+    },
     "auth": {
       "adapters": {
-        "~k": "1s"
-      },
-      "callbacks": {
         "~k": "1t"
       },
-      "events": {
+      "callbacks": {
         "~k": "1u"
       },
-      "providers": {
+      "events": {
         "~k": "1v"
       },
-      "~k": "1r"
+      "providers": {
+        "~k": "1w"
+      },
+      "~k": "1s"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
-      "~k": "1w"
+      "~k": "1x"
     },
     "connections": {
-      "~k": "2h"
-    },
-    "requests": {
       "~k": "2i"
     },
-    "api": {
+    "requests": {
       "~k": "2j"
+    },
+    "api": {
+      "~k": "2k"
     },
     "operators": {
       "client": {
@@ -5648,20 +5661,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2m"
+          "~k": "2n"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2n"
+          "~k": "2o"
         },
-        "~k": "2l"
+        "~k": "2m"
       },
       "server": {
-        "~k": "2o"
+        "~k": "2p"
       },
-      "~k": "2k"
+      "~k": "2l"
     },
     "~k": "1n"
   }

--- a/packages/build/src/tests/success/13-page-with-multiple-areas/snapshot.json
+++ b/packages/build/src/tests/success/13-page-with-multiple-areas/snapshot.json
@@ -123,164 +123,164 @@
       "~k_parent": "18"
     },
     "20": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1z"
+      "key": "root.types.auth",
+      "~k_parent": "1v"
     },
     "21": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1z"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "20"
     },
     "22": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1z"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "20"
     },
     "23": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1z"
+      "key": "root.types.auth.events",
+      "~k_parent": "20"
     },
     "24": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "20"
+    },
+    "25": {
       "key": "root.types.blocks",
       "~k_parent": "1v"
     },
-    "25": {
-      "key": "root.types.blocks.PageHeaderMenu",
-      "~k_parent": "24"
-    },
     "26": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "24"
+      "key": "root.types.blocks.PageHeaderMenu",
+      "~k_parent": "25"
     },
     "27": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "25"
     },
     "28": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "25"
     },
     "29": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "25"
     },
     "30": {
-      "key": "root.imports.actions",
-      "~k_parent": "2z"
+      "key": "root.imports",
+      "~k_parent": "4"
     },
     "31": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "30"
     },
     "32": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "30"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "31"
     },
     "33": {
-      "key": "root.imports.auth",
-      "~k_parent": "2z"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "31"
     },
     "34": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "33"
+      "key": "root.imports.agents",
+      "~k_parent": "30"
     },
     "35": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "33"
+      "key": "root.imports.auth",
+      "~k_parent": "30"
     },
     "36": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "33"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "35"
     },
     "37": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "33"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "35"
     },
     "38": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2z"
+      "key": "root.imports.auth.events",
+      "~k_parent": "35"
     },
     "39": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "38"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "35"
     },
     "40": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3y"
     },
     "42": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3y"
     },
     "44": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3y"
     },
     "46": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3y"
     },
     "48": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3y"
     },
     "50": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3y"
     },
     "52": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3y"
     },
     "54": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3y"
     },
     "56": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3y"
     },
     "58": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3y"
     },
     "a": {
       "key": "root.pages[0:home:PageHeaderMenu].areas.header.blocks[0:logo:Title]",
@@ -493,374 +493,383 @@
       "~k_parent": "1w"
     },
     "1z": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1v"
     },
     "2a": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "25"
     },
     "2b": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "25"
     },
     "2c": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "25"
     },
     "2d": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "24"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "25"
     },
     "2e": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "25"
     },
     "2f": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "25"
     },
     "2g": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "25"
     },
     "2h": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "24"
+      "key": "root.types.blocks.List",
+      "~k_parent": "25"
     },
     "2i": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "25"
     },
     "2j": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "25"
     },
     "2k": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "24"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "25"
     },
     "2l": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "25"
     },
     "2m": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "24"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "25"
     },
     "2n": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "24"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "25"
     },
     "2o": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "24"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "25"
     },
     "2p": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "24"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "25"
     },
     "2q": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "25"
     },
     "2r": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "25"
+    },
+    "2s": {
       "key": "root.types.connections",
       "~k_parent": "1v"
     },
-    "2s": {
+    "2t": {
       "key": "root.types.requests",
       "~k_parent": "1v"
     },
-    "2t": {
+    "2u": {
       "key": "root.types.api",
       "~k_parent": "1v"
     },
-    "2u": {
+    "2v": {
       "key": "root.types.operators",
       "~k_parent": "1v"
     },
-    "2v": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2u"
-    },
     "2w": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2v"
     },
     "2x": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2v"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2u"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2w"
     },
     "2z": {
-      "key": "root.imports",
-      "~k_parent": "4"
+      "key": "root.types.operators.server",
+      "~k_parent": "2v"
     },
     "3a": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks",
+      "~k_parent": "30"
     },
     "3b": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3a"
     },
     "3c": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3a"
     },
     "3d": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3a"
     },
     "3e": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3a"
     },
     "3f": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3a"
     },
     "3g": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3a"
     },
     "3h": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3a"
     },
     "3i": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3a"
     },
     "3j": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3a"
     },
     "3k": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3a"
     },
     "3l": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3a"
     },
     "3m": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3a"
     },
     "3n": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3a"
     },
     "3o": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3a"
     },
     "3p": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3a"
     },
     "3q": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3a"
     },
     "3r": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3a"
     },
     "3s": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3a"
     },
     "3t": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3a"
     },
     "3u": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3a"
     },
     "3v": {
-      "key": "root.imports.connections",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "3a"
     },
     "3w": {
-      "key": "root.imports.icons",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "3a"
     },
     "3x": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3w"
+      "key": "root.imports.connections",
+      "~k_parent": "30"
     },
     "3y": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3x"
+      "key": "root.imports.icons",
+      "~k_parent": "30"
     },
     "3z": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3y"
     },
     "4c": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3y"
     },
     "4e": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3y"
     },
     "4g": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3y"
     },
     "4i": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3y"
     },
     "4k": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3y"
     },
     "4m": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3y"
     },
     "4o": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3y"
     },
     "4q": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3y"
     },
     "4s": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3y"
     },
     "4u": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3y"
     },
     "4w": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3y"
     },
     "4y": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3y"
     },
     "5a": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3y"
     },
     "5c": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3y"
     },
     "5e": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3y"
     },
     "5g": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.requests",
-      "~k_parent": "2z"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3y"
     },
     "5i": {
-      "key": "root.imports.operators",
-      "~k_parent": "2z"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5i"
+      "key": "root.imports.requests",
+      "~k_parent": "30"
     },
     "5k": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5j"
+      "key": "root.imports.operators",
+      "~k_parent": "30"
     },
     "5l": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5j"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5k"
     },
     "5m": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5l"
+    },
+    "5n": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5l"
+    },
+    "5o": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5i"
+      "~k_parent": "5k"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "11"
   },
@@ -1100,6 +1109,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -6837,164 +6847,167 @@
       },
       "~k": "1w"
     },
+    "agents": {
+      "~k": "1z"
+    },
     "auth": {
       "adapters": {
-        "~k": "20"
-      },
-      "callbacks": {
         "~k": "21"
       },
-      "events": {
+      "callbacks": {
         "~k": "22"
       },
-      "providers": {
+      "events": {
         "~k": "23"
       },
-      "~k": "1z"
+      "providers": {
+        "~k": "24"
+      },
+      "~k": "20"
     },
     "blocks": {
       "PageHeaderMenu": {
         "originalTypeName": "PageHeaderMenu",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "27"
+        "~k": "28"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
-      "~k": "24"
+      "~k": "25"
     },
     "connections": {
-      "~k": "2r"
-    },
-    "requests": {
       "~k": "2s"
     },
-    "api": {
+    "requests": {
       "~k": "2t"
+    },
+    "api": {
+      "~k": "2u"
     },
     "operators": {
       "client": {
@@ -7002,20 +7015,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2w"
+          "~k": "2x"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2x"
+          "~k": "2y"
         },
-        "~k": "2v"
+        "~k": "2w"
       },
       "server": {
-        "~k": "2y"
+        "~k": "2z"
       },
-      "~k": "2u"
+      "~k": "2v"
     },
     "~k": "1v"
   }

--- a/packages/build/src/tests/success/14-page-with-events-onInit/snapshot.json
+++ b/packages/build/src/tests/success/14-page-with-events-onInit/snapshot.json
@@ -127,164 +127,164 @@
       "~k_parent": "18"
     },
     "20": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1z"
     },
     "21": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1z"
     },
     "22": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1z"
     },
     "23": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1z"
     },
     "24": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1z"
     },
     "25": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1z"
     },
     "26": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1z"
     },
     "27": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1z"
     },
     "28": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1z"
     },
     "29": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1z"
     },
     "30": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2q"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2x"
     },
     "31": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "30"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2x"
     },
     "32": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks",
+      "~k_parent": "2r"
     },
     "33": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "32"
     },
     "35": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "32"
     },
     "36": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "32"
     },
     "37": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "32"
     },
     "38": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "32"
     },
     "39": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "32"
     },
     "40": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3n"
     },
     "41": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3n"
     },
     "43": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3n"
     },
     "45": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3n"
     },
     "47": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3n"
     },
     "49": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3n"
     },
     "51": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3n"
     },
     "53": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3n"
     },
     "55": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.requests",
-      "~k_parent": "2q"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3n"
     },
     "57": {
-      "key": "root.imports.operators",
-      "~k_parent": "2q"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "57"
+      "key": "root.imports.requests",
+      "~k_parent": "2r"
     },
     "59": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "58"
+      "key": "root.imports.operators",
+      "~k_parent": "2r"
     },
     "a": {
       "key": "root.pages[0:home:Box].events.onInit[0:initState:SetState].params",
@@ -460,354 +460,363 @@
       "~k_parent": "1p"
     },
     "1t": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1o"
     },
     "1u": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1t"
+      "key": "root.types.auth",
+      "~k_parent": "1o"
     },
     "1v": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1t"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1u"
     },
     "1w": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1t"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1u"
     },
     "1x": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1t"
+      "key": "root.types.auth.events",
+      "~k_parent": "1u"
     },
     "1y": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1u"
+    },
+    "1z": {
       "key": "root.types.blocks",
       "~k_parent": "1o"
     },
-    "1z": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1y"
-    },
     "2a": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1z"
     },
     "2b": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1z"
     },
     "2c": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1z"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1z"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1z"
     },
     "2f": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1z"
     },
     "2g": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1z"
     },
     "2h": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1z"
     },
     "2i": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1z"
+    },
+    "2j": {
       "key": "root.types.connections",
       "~k_parent": "1o"
     },
-    "2j": {
+    "2k": {
       "key": "root.types.requests",
       "~k_parent": "1o"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.api",
       "~k_parent": "1o"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.operators",
       "~k_parent": "1o"
     },
-    "2m": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2l"
-    },
     "2n": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2m"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2l"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2n"
     },
     "2q": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2m"
+    },
+    "2r": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2r": {
-      "key": "root.imports.actions",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2r"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "2r"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2s"
     },
     "2v": {
-      "key": "root.imports.auth",
-      "~k_parent": "2q"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "2s"
     },
     "2w": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2v"
+      "key": "root.imports.agents",
+      "~k_parent": "2r"
     },
     "2x": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2v"
+      "key": "root.imports.auth",
+      "~k_parent": "2r"
     },
     "2y": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2v"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2v"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2x"
     },
     "3a": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "32"
     },
     "3b": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "32"
     },
     "3c": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "32"
     },
     "3d": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "32"
     },
     "3e": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "32"
     },
     "3f": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "32"
     },
     "3g": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "32"
     },
     "3h": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "32"
     },
     "3i": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "32"
     },
     "3j": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "32"
     },
     "3k": {
-      "key": "root.imports.connections",
-      "~k_parent": "2q"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "32"
     },
     "3l": {
-      "key": "root.imports.icons",
-      "~k_parent": "2q"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "32"
     },
     "3m": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3l"
+      "key": "root.imports.connections",
+      "~k_parent": "2r"
     },
     "3n": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3m"
+      "key": "root.imports.icons",
+      "~k_parent": "2r"
     },
     "3o": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3n"
     },
     "3r": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3n"
     },
     "3t": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3n"
     },
     "3v": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3n"
     },
     "3x": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3n"
     },
     "3z": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3n"
     },
     "4b": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3n"
     },
     "4d": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3n"
     },
     "4f": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3n"
     },
     "4h": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3n"
     },
     "4j": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3n"
     },
     "4l": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3n"
     },
     "4n": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3n"
     },
     "4p": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3n"
     },
     "4r": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3n"
     },
     "4t": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3n"
     },
     "4v": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3n"
     },
     "4x": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3n"
     },
     "4z": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "58"
+      "key": "root.imports.operators.client",
+      "~k_parent": "59"
     },
     "5b": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5a"
+    },
+    "5c": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5a"
+    },
+    "5d": {
       "key": "root.imports.operators.server",
-      "~k_parent": "57"
+      "~k_parent": "59"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "s"
   },
@@ -1021,6 +1030,7 @@
     }
   },
   "plugins/actions.js": "import { SetState as SetState } from '@lowdefy/actions-core/actions';\nimport { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  SetState,\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5514,146 +5524,149 @@
       },
       "~k": "1p"
     },
+    "agents": {
+      "~k": "1t"
+    },
     "auth": {
       "adapters": {
-        "~k": "1u"
-      },
-      "callbacks": {
         "~k": "1v"
       },
-      "events": {
+      "callbacks": {
         "~k": "1w"
       },
-      "providers": {
+      "events": {
         "~k": "1x"
       },
-      "~k": "1t"
+      "providers": {
+        "~k": "1y"
+      },
+      "~k": "1u"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1z"
+        "~k": "20"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
-      "~k": "1y"
+      "~k": "1z"
     },
     "connections": {
-      "~k": "2i"
-    },
-    "requests": {
       "~k": "2j"
     },
-    "api": {
+    "requests": {
       "~k": "2k"
+    },
+    "api": {
+      "~k": "2l"
     },
     "operators": {
       "client": {
@@ -5661,20 +5674,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2n"
+          "~k": "2o"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2o"
+          "~k": "2p"
         },
-        "~k": "2m"
+        "~k": "2n"
       },
       "server": {
-        "~k": "2p"
+        "~k": "2q"
       },
-      "~k": "2l"
+      "~k": "2m"
     },
     "~k": "1o"
   }

--- a/packages/build/src/tests/success/15-page-with-events-onMount/snapshot.json
+++ b/packages/build/src/tests/success/15-page-with-events-onMount/snapshot.json
@@ -127,164 +127,164 @@
       "~k_parent": "p"
     },
     "20": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1y"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1z"
     },
     "21": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1y"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1z"
     },
     "22": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1y"
+      "key": "root.types.auth.events",
+      "~k_parent": "1z"
     },
     "23": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1z"
+    },
+    "24": {
       "key": "root.types.blocks",
       "~k_parent": "1t"
     },
-    "24": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "23"
-    },
     "25": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "24"
     },
     "26": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "24"
     },
     "27": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "24"
     },
     "28": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "24"
     },
     "29": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "23"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "24"
     },
     "30": {
-      "key": "root.imports.auth",
-      "~k_parent": "2v"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "2x"
     },
     "31": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "30"
+      "key": "root.imports.agents",
+      "~k_parent": "2w"
     },
     "32": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "30"
+      "key": "root.imports.auth",
+      "~k_parent": "2w"
     },
     "33": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "30"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "30"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "32"
     },
     "35": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2v"
+      "key": "root.imports.auth.events",
+      "~k_parent": "32"
     },
     "36": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "35"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "32"
     },
     "37": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks",
+      "~k_parent": "2w"
     },
     "38": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "37"
     },
     "39": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "37"
     },
     "40": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3s"
     },
     "42": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3s"
     },
     "44": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3s"
     },
     "46": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3s"
     },
     "48": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3s"
     },
     "50": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3s"
     },
     "52": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3s"
     },
     "54": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3s"
     },
     "56": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3s"
     },
     "58": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3s"
     },
     "a": {
       "key": "root.pages[0:home:Box].events.onMount[0:mountAction:SetState].params",
@@ -483,354 +483,363 @@
       "~k_parent": "1u"
     },
     "1y": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1t"
     },
     "1z": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1y"
+      "key": "root.types.auth",
+      "~k_parent": "1t"
     },
     "2a": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "24"
     },
     "2b": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "24"
     },
     "2c": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "24"
     },
     "2d": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "23"
+      "key": "root.types.blocks.List",
+      "~k_parent": "24"
     },
     "2e": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "24"
     },
     "2f": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "24"
     },
     "2g": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "23"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "24"
     },
     "2h": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "24"
     },
     "2i": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "23"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "24"
     },
     "2j": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "23"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "24"
     },
     "2k": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "23"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "24"
     },
     "2l": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "23"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "24"
     },
     "2m": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "24"
     },
     "2n": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "24"
+    },
+    "2o": {
       "key": "root.types.connections",
       "~k_parent": "1t"
     },
-    "2o": {
+    "2p": {
       "key": "root.types.requests",
       "~k_parent": "1t"
     },
-    "2p": {
+    "2q": {
       "key": "root.types.api",
       "~k_parent": "1t"
     },
-    "2q": {
+    "2r": {
       "key": "root.types.operators",
       "~k_parent": "1t"
     },
-    "2r": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2r"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2q"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2s"
     },
     "2v": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2r"
+    },
+    "2w": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2w": {
-      "key": "root.imports.actions",
-      "~k_parent": "2v"
-    },
     "2x": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2w"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "2w"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2x"
     },
     "3a": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "37"
     },
     "3b": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "37"
     },
     "3c": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "37"
     },
     "3d": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "37"
     },
     "3e": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "37"
     },
     "3f": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "37"
     },
     "3g": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "37"
     },
     "3h": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "37"
     },
     "3i": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "37"
     },
     "3j": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "37"
     },
     "3k": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "37"
     },
     "3l": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "37"
     },
     "3m": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "37"
     },
     "3n": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "37"
     },
     "3o": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "37"
     },
     "3p": {
-      "key": "root.imports.connections",
-      "~k_parent": "2v"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "37"
     },
     "3q": {
-      "key": "root.imports.icons",
-      "~k_parent": "2v"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "37"
     },
     "3r": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3q"
+      "key": "root.imports.connections",
+      "~k_parent": "2w"
     },
     "3s": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3r"
+      "key": "root.imports.icons",
+      "~k_parent": "2w"
     },
     "3t": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3s"
     },
     "3w": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3s"
     },
     "3y": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3s"
     },
     "4a": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3s"
     },
     "4c": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3s"
     },
     "4e": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3s"
     },
     "4g": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3s"
     },
     "4i": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3s"
     },
     "4k": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3s"
     },
     "4m": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3s"
     },
     "4o": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3s"
     },
     "4q": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3s"
     },
     "4s": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3s"
     },
     "4u": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3s"
     },
     "4w": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3s"
     },
     "4y": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3s"
     },
     "5a": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.requests",
-      "~k_parent": "2v"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3s"
     },
     "5c": {
-      "key": "root.imports.operators",
-      "~k_parent": "2v"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5c"
+      "key": "root.imports.requests",
+      "~k_parent": "2w"
     },
     "5e": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5d"
+      "key": "root.imports.operators",
+      "~k_parent": "2w"
     },
     "5f": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5d"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5e"
     },
     "5g": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5f"
+    },
+    "5h": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5f"
+    },
+    "5i": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5c"
+      "~k_parent": "5e"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "v"
   },
@@ -1065,6 +1074,7 @@
     }
   },
   "plugins/actions.js": "import { SetState as SetState } from '@lowdefy/actions-core/actions';\nimport { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  SetState,\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5558,146 +5568,149 @@
       },
       "~k": "1u"
     },
+    "agents": {
+      "~k": "1y"
+    },
     "auth": {
       "adapters": {
-        "~k": "1z"
-      },
-      "callbacks": {
         "~k": "20"
       },
-      "events": {
+      "callbacks": {
         "~k": "21"
       },
-      "providers": {
+      "events": {
         "~k": "22"
       },
-      "~k": "1y"
+      "providers": {
+        "~k": "23"
+      },
+      "~k": "1z"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "24"
+        "~k": "25"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
-      "~k": "23"
+      "~k": "24"
     },
     "connections": {
-      "~k": "2n"
-    },
-    "requests": {
       "~k": "2o"
     },
-    "api": {
+    "requests": {
       "~k": "2p"
+    },
+    "api": {
+      "~k": "2q"
     },
     "operators": {
       "client": {
@@ -5705,20 +5718,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2s"
+          "~k": "2t"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2t"
+          "~k": "2u"
         },
-        "~k": "2r"
+        "~k": "2s"
       },
       "server": {
-        "~k": "2u"
+        "~k": "2v"
       },
-      "~k": "2q"
+      "~k": "2r"
     },
     "~k": "1t"
   }

--- a/packages/build/src/tests/success/16-page-with-layout-span/snapshot.json
+++ b/packages/build/src/tests/success/16-page-with-layout-span/snapshot.json
@@ -127,164 +127,164 @@
       "~k_parent": "4"
     },
     "20": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1z"
     },
     "21": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1z"
     },
     "22": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1z"
     },
     "23": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1z"
     },
     "24": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1z"
     },
     "25": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1z"
     },
     "26": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1z"
     },
     "27": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1z"
     },
     "28": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1z"
     },
     "29": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1z"
     },
     "30": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2z"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2w"
     },
     "31": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks",
+      "~k_parent": "2r"
     },
     "32": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "31"
     },
     "33": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "31"
     },
     "34": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "31"
     },
     "35": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "31"
     },
     "36": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "31"
     },
     "37": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "31"
     },
     "38": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "31"
     },
     "39": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "31"
     },
     "40": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3m"
     },
     "42": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3m"
     },
     "44": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3m"
     },
     "46": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3m"
     },
     "48": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3m"
     },
     "50": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3m"
     },
     "52": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3m"
     },
     "54": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.requests",
-      "~k_parent": "2q"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3m"
     },
     "56": {
-      "key": "root.imports.operators",
-      "~k_parent": "2q"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "56"
+      "key": "root.imports.requests",
+      "~k_parent": "2r"
     },
     "58": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "57"
+      "key": "root.imports.operators",
+      "~k_parent": "2r"
     },
     "59": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "57"
+      "key": "root.imports.operators.client",
+      "~k_parent": "58"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[1:col2:Box]",
@@ -461,350 +461,359 @@
       "~k_parent": "1q"
     },
     "1t": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1p"
     },
     "1u": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1t"
+      "key": "root.types.auth",
+      "~k_parent": "1p"
     },
     "1v": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1t"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1u"
     },
     "1w": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1t"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1u"
     },
     "1x": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1t"
+      "key": "root.types.auth.events",
+      "~k_parent": "1u"
     },
     "1y": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1u"
+    },
+    "1z": {
       "key": "root.types.blocks",
       "~k_parent": "1p"
     },
-    "1z": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1y"
-    },
     "2a": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1z"
     },
     "2b": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1z"
     },
     "2c": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1z"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1z"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1z"
     },
     "2f": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1z"
     },
     "2g": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1z"
     },
     "2h": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1z"
     },
     "2i": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1z"
+    },
+    "2j": {
       "key": "root.types.connections",
       "~k_parent": "1p"
     },
-    "2j": {
+    "2k": {
       "key": "root.types.requests",
       "~k_parent": "1p"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.api",
       "~k_parent": "1p"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.operators",
       "~k_parent": "1p"
     },
-    "2m": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2l"
-    },
     "2n": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2m"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2l"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2n"
     },
     "2q": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2m"
+    },
+    "2r": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2r": {
-      "key": "root.imports.actions",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2r"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.imports.auth",
-      "~k_parent": "2q"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2s"
     },
     "2v": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2u"
+      "key": "root.imports.agents",
+      "~k_parent": "2r"
     },
     "2w": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2u"
+      "key": "root.imports.auth",
+      "~k_parent": "2r"
     },
     "2x": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2u"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2u"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2w"
     },
     "2z": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2q"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2w"
     },
     "3a": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "31"
     },
     "3b": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "31"
     },
     "3c": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "31"
     },
     "3d": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "31"
     },
     "3e": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "31"
     },
     "3f": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "31"
     },
     "3g": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "31"
     },
     "3h": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "31"
     },
     "3i": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "31"
     },
     "3j": {
-      "key": "root.imports.connections",
-      "~k_parent": "2q"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "31"
     },
     "3k": {
-      "key": "root.imports.icons",
-      "~k_parent": "2q"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "31"
     },
     "3l": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3k"
+      "key": "root.imports.connections",
+      "~k_parent": "2r"
     },
     "3m": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3l"
+      "key": "root.imports.icons",
+      "~k_parent": "2r"
     },
     "3n": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3m"
     },
     "3u": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3m"
     },
     "3w": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3m"
     },
     "3y": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3m"
     },
     "4a": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3m"
     },
     "4c": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3m"
     },
     "4e": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3m"
     },
     "4g": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3m"
     },
     "4i": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3m"
     },
     "4k": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3m"
     },
     "4m": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3m"
     },
     "4o": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3m"
     },
     "4q": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3m"
     },
     "4s": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3m"
     },
     "4u": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3m"
     },
     "4w": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3m"
     },
     "4y": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3m"
     },
     "5a": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "59"
+    },
+    "5b": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "59"
+    },
+    "5c": {
       "key": "root.imports.operators.server",
-      "~k_parent": "56"
+      "~k_parent": "58"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "t"
   },
@@ -1018,6 +1027,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5505,146 +5515,149 @@
       },
       "~k": "1q"
     },
+    "agents": {
+      "~k": "1t"
+    },
     "auth": {
       "adapters": {
-        "~k": "1u"
-      },
-      "callbacks": {
         "~k": "1v"
       },
-      "events": {
+      "callbacks": {
         "~k": "1w"
       },
-      "providers": {
+      "events": {
         "~k": "1x"
       },
-      "~k": "1t"
+      "providers": {
+        "~k": "1y"
+      },
+      "~k": "1u"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "1z"
+        "~k": "20"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
-      "~k": "1y"
+      "~k": "1z"
     },
     "connections": {
-      "~k": "2i"
-    },
-    "requests": {
       "~k": "2j"
     },
-    "api": {
+    "requests": {
       "~k": "2k"
+    },
+    "api": {
+      "~k": "2l"
     },
     "operators": {
       "client": {
@@ -5652,20 +5665,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2n"
+          "~k": "2o"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2o"
+          "~k": "2p"
         },
-        "~k": "2m"
+        "~k": "2n"
       },
       "server": {
-        "~k": "2p"
+        "~k": "2q"
       },
-      "~k": "2l"
+      "~k": "2m"
     },
     "~k": "1p"
   }

--- a/packages/build/src/tests/success/17-page-with-layout-responsive/snapshot.json
+++ b/packages/build/src/tests/success/17-page-with-layout-responsive/snapshot.json
@@ -127,164 +127,164 @@
       "~k_parent": "14"
     },
     "20": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1w"
+    },
+    "21": {
       "key": "root.types.blocks",
       "~k_parent": "1r"
     },
-    "21": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "20"
-    },
     "22": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "21"
     },
     "23": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "21"
     },
     "24": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "21"
     },
     "25": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "21"
     },
     "26": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "20"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "21"
     },
     "27": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "21"
     },
     "28": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "21"
     },
     "29": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "21"
     },
     "30": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2w"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2y"
     },
     "31": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2s"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2y"
     },
     "32": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "31"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2y"
     },
     "33": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks",
+      "~k_parent": "2t"
     },
     "34": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "33"
     },
     "35": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "33"
     },
     "36": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "33"
     },
     "37": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "33"
     },
     "38": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "33"
     },
     "39": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "33"
     },
     "40": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3o"
     },
     "42": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3o"
     },
     "44": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3o"
     },
     "46": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3o"
     },
     "48": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3o"
     },
     "50": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3o"
     },
     "52": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3o"
     },
     "54": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3o"
     },
     "56": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.requests",
-      "~k_parent": "2s"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3o"
     },
     "58": {
-      "key": "root.imports.operators",
-      "~k_parent": "2s"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "58"
+      "key": "root.imports.requests",
+      "~k_parent": "2t"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[0:responsive:Box].layout.sm",
@@ -471,350 +471,359 @@
       "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1r"
     },
     "1w": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1v"
+      "key": "root.types.auth",
+      "~k_parent": "1r"
     },
     "1x": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1v"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1w"
     },
     "1y": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1v"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1w"
     },
     "1z": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1v"
+      "key": "root.types.auth.events",
+      "~k_parent": "1w"
     },
     "2a": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "20"
+      "key": "root.types.blocks.List",
+      "~k_parent": "21"
     },
     "2b": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "21"
     },
     "2c": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "21"
     },
     "2d": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "20"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "21"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "21"
     },
     "2f": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "21"
     },
     "2g": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "21"
     },
     "2h": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "21"
     },
     "2i": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "21"
     },
     "2j": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "21"
     },
     "2k": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "21"
+    },
+    "2l": {
       "key": "root.types.connections",
       "~k_parent": "1r"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.requests",
       "~k_parent": "1r"
     },
-    "2m": {
+    "2n": {
       "key": "root.types.api",
       "~k_parent": "1r"
     },
-    "2n": {
+    "2o": {
       "key": "root.types.operators",
       "~k_parent": "1r"
     },
-    "2o": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2n"
-    },
     "2p": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2o"
     },
     "2q": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2o"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2p"
     },
     "2r": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2n"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2p"
     },
     "2s": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2o"
+    },
+    "2t": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2t": {
-      "key": "root.imports.actions",
-      "~k_parent": "2s"
-    },
     "2u": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2t"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.imports.auth",
-      "~k_parent": "2s"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2w"
+      "key": "root.imports.agents",
+      "~k_parent": "2t"
     },
     "2y": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2w"
+      "key": "root.imports.auth",
+      "~k_parent": "2t"
     },
     "2z": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2w"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "33"
     },
     "3b": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "33"
     },
     "3c": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "33"
     },
     "3d": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "33"
     },
     "3e": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "33"
     },
     "3f": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "33"
     },
     "3g": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "33"
     },
     "3h": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "33"
     },
     "3i": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "33"
     },
     "3j": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "33"
     },
     "3k": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "33"
     },
     "3l": {
-      "key": "root.imports.connections",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "33"
     },
     "3m": {
-      "key": "root.imports.icons",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "33"
     },
     "3n": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3m"
+      "key": "root.imports.connections",
+      "~k_parent": "2t"
     },
     "3o": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3n"
+      "key": "root.imports.icons",
+      "~k_parent": "2t"
     },
     "3p": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3o"
     },
     "3s": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3o"
     },
     "3u": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3o"
     },
     "3w": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3o"
     },
     "3y": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3o"
     },
     "4a": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3o"
     },
     "4c": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3o"
     },
     "4e": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3o"
     },
     "4g": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3o"
     },
     "4i": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3o"
     },
     "4k": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3o"
     },
     "4m": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3o"
     },
     "4o": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3o"
     },
     "4q": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3o"
     },
     "4s": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3o"
     },
     "4u": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3o"
     },
     "4w": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3o"
     },
     "4y": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3o"
     },
     "5a": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "59"
+      "key": "root.imports.operators",
+      "~k_parent": "2t"
     },
     "5b": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "59"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5a"
     },
     "5c": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5b"
+    },
+    "5d": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5b"
+    },
+    "5e": {
       "key": "root.imports.operators.server",
-      "~k_parent": "58"
+      "~k_parent": "5a"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "v"
   },
@@ -1034,6 +1043,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5521,146 +5531,149 @@
       },
       "~k": "1s"
     },
+    "agents": {
+      "~k": "1v"
+    },
     "auth": {
       "adapters": {
-        "~k": "1w"
-      },
-      "callbacks": {
         "~k": "1x"
       },
-      "events": {
+      "callbacks": {
         "~k": "1y"
       },
-      "providers": {
+      "events": {
         "~k": "1z"
       },
-      "~k": "1v"
+      "providers": {
+        "~k": "20"
+      },
+      "~k": "1w"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "21"
+        "~k": "22"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
-      "~k": "20"
+      "~k": "21"
     },
     "connections": {
-      "~k": "2k"
-    },
-    "requests": {
       "~k": "2l"
     },
-    "api": {
+    "requests": {
       "~k": "2m"
+    },
+    "api": {
+      "~k": "2n"
     },
     "operators": {
       "client": {
@@ -5668,20 +5681,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2p"
+          "~k": "2q"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2q"
+          "~k": "2r"
         },
-        "~k": "2o"
+        "~k": "2p"
       },
       "server": {
-        "~k": "2r"
+        "~k": "2s"
       },
-      "~k": "2n"
+      "~k": "2o"
     },
     "~k": "1r"
   }

--- a/packages/build/src/tests/success/18-page-with-style/snapshot.json
+++ b/packages/build/src/tests/success/18-page-with-style/snapshot.json
@@ -127,164 +127,164 @@
       "~k_parent": "n"
     },
     "20": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1x"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1y"
     },
     "21": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1x"
+      "key": "root.types.auth.events",
+      "~k_parent": "1y"
     },
     "22": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1y"
+    },
+    "23": {
       "key": "root.types.blocks",
       "~k_parent": "1t"
     },
-    "23": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "22"
-    },
     "24": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "23"
     },
     "25": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "23"
     },
     "26": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "23"
     },
     "27": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "23"
     },
     "28": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "23"
     },
     "29": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "22"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "23"
     },
     "30": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2z"
+      "key": "root.imports.agents",
+      "~k_parent": "2w"
     },
     "31": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2z"
+      "key": "root.imports.auth",
+      "~k_parent": "2w"
     },
     "32": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2z"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "31"
     },
     "33": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2z"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "31"
     },
     "34": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2v"
+      "key": "root.imports.auth.events",
+      "~k_parent": "31"
     },
     "35": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "34"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "31"
     },
     "36": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks",
+      "~k_parent": "2w"
     },
     "37": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "36"
     },
     "38": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "36"
     },
     "39": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "36"
     },
     "40": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3s"
     },
     "42": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3s"
     },
     "44": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3s"
     },
     "46": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3s"
     },
     "48": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3s"
     },
     "50": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3s"
     },
     "52": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3s"
     },
     "54": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3s"
     },
     "56": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3s"
     },
     "58": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3s"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[0:styled:Title].style",
@@ -477,358 +477,367 @@
       "~k_parent": "1u"
     },
     "1x": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1t"
     },
     "1y": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1x"
+      "key": "root.types.auth",
+      "~k_parent": "1t"
     },
     "1z": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1x"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1y"
     },
     "2a": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "23"
     },
     "2b": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "23"
     },
     "2c": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "23"
     },
     "2d": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "22"
+      "key": "root.types.blocks.List",
+      "~k_parent": "23"
     },
     "2e": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "23"
     },
     "2f": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "23"
     },
     "2g": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "22"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "23"
     },
     "2h": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "23"
     },
     "2i": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "22"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "23"
     },
     "2j": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "22"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "23"
     },
     "2k": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "22"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "23"
     },
     "2l": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "22"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "23"
     },
     "2m": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "23"
     },
     "2n": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "23"
+    },
+    "2o": {
       "key": "root.types.connections",
       "~k_parent": "1t"
     },
-    "2o": {
+    "2p": {
       "key": "root.types.requests",
       "~k_parent": "1t"
     },
-    "2p": {
+    "2q": {
       "key": "root.types.api",
       "~k_parent": "1t"
     },
-    "2q": {
+    "2r": {
       "key": "root.types.operators",
       "~k_parent": "1t"
     },
-    "2r": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2r"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2q"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2s"
     },
     "2v": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2r"
+    },
+    "2w": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2w": {
-      "key": "root.imports.actions",
-      "~k_parent": "2v"
-    },
     "2x": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2w"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.auth",
-      "~k_parent": "2v"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2x"
     },
     "3a": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "36"
     },
     "3b": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "36"
     },
     "3c": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "36"
     },
     "3d": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "36"
     },
     "3e": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "36"
     },
     "3f": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "36"
     },
     "3g": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "36"
     },
     "3h": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "36"
     },
     "3i": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "36"
     },
     "3j": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "36"
     },
     "3k": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "36"
     },
     "3l": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "36"
     },
     "3m": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "36"
     },
     "3n": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "36"
     },
     "3o": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "36"
     },
     "3p": {
-      "key": "root.imports.connections",
-      "~k_parent": "2v"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "36"
     },
     "3q": {
-      "key": "root.imports.icons",
-      "~k_parent": "2v"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "36"
     },
     "3r": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3q"
+      "key": "root.imports.connections",
+      "~k_parent": "2w"
     },
     "3s": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3r"
+      "key": "root.imports.icons",
+      "~k_parent": "2w"
     },
     "3t": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3s"
     },
     "3w": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3s"
     },
     "3y": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3s"
     },
     "4a": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3s"
     },
     "4c": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3s"
     },
     "4e": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3s"
     },
     "4g": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3s"
     },
     "4i": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3s"
     },
     "4k": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3s"
     },
     "4m": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3s"
     },
     "4o": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3s"
     },
     "4q": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3s"
     },
     "4s": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3s"
     },
     "4u": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3s"
     },
     "4w": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3s"
     },
     "4y": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3s"
     },
     "5a": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.requests",
-      "~k_parent": "2v"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3s"
     },
     "5c": {
-      "key": "root.imports.operators",
-      "~k_parent": "2v"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5c"
+      "key": "root.imports.requests",
+      "~k_parent": "2w"
     },
     "5e": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5d"
+      "key": "root.imports.operators",
+      "~k_parent": "2w"
     },
     "5f": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5d"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5e"
     },
     "5g": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5f"
+    },
+    "5h": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5f"
+    },
+    "5i": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5c"
+      "~k_parent": "5e"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "t"
   },
@@ -1049,6 +1058,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5536,152 +5546,155 @@
       },
       "~k": "1u"
     },
+    "agents": {
+      "~k": "1x"
+    },
     "auth": {
       "adapters": {
-        "~k": "1y"
-      },
-      "callbacks": {
         "~k": "1z"
       },
-      "events": {
+      "callbacks": {
         "~k": "20"
       },
-      "providers": {
+      "events": {
         "~k": "21"
       },
-      "~k": "1x"
+      "providers": {
+        "~k": "22"
+      },
+      "~k": "1y"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "23"
+        "~k": "24"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
-      "~k": "22"
+      "~k": "23"
     },
     "connections": {
-      "~k": "2n"
-    },
-    "requests": {
       "~k": "2o"
     },
-    "api": {
+    "requests": {
       "~k": "2p"
+    },
+    "api": {
+      "~k": "2q"
     },
     "operators": {
       "client": {
@@ -5689,20 +5702,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2s"
+          "~k": "2t"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2t"
+          "~k": "2u"
         },
-        "~k": "2r"
+        "~k": "2s"
       },
       "server": {
-        "~k": "2u"
+        "~k": "2v"
       },
-      "~k": "2q"
+      "~k": "2r"
     },
     "~k": "1t"
   }

--- a/packages/build/src/tests/success/19-page-with-visible/snapshot.json
+++ b/packages/build/src/tests/success/19-page-with-visible/snapshot.json
@@ -127,164 +127,164 @@
       "~k_parent": "4"
     },
     "20": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1z"
     },
     "21": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "1z"
     },
     "22": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1z"
     },
     "23": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1z"
     },
     "24": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1z"
     },
     "25": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1z"
     },
     "26": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1z"
     },
     "27": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1z"
     },
     "28": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1z"
     },
     "29": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1z"
     },
     "30": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2r"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2x"
     },
     "31": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "30"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2x"
     },
     "32": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks",
+      "~k_parent": "2s"
     },
     "33": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "32"
     },
     "35": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "32"
     },
     "36": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "32"
     },
     "37": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "32"
     },
     "38": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "32"
     },
     "39": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "32"
     },
     "40": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3o"
     },
     "42": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3o"
     },
     "44": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3o"
     },
     "46": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3o"
     },
     "48": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3o"
     },
     "50": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3o"
     },
     "52": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3o"
     },
     "54": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3o"
     },
     "56": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.requests",
-      "~k_parent": "2r"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3o"
     },
     "58": {
-      "key": "root.imports.operators",
-      "~k_parent": "2r"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "58"
+      "key": "root.imports.requests",
+      "~k_parent": "2s"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[1:hidden:Paragraph]",
@@ -461,358 +461,367 @@
       "~k_parent": "1q"
     },
     "1t": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1p"
     },
     "1u": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1t"
+      "key": "root.types.auth",
+      "~k_parent": "1p"
     },
     "1v": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1t"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1u"
     },
     "1w": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1t"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1u"
     },
     "1x": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1t"
+      "key": "root.types.auth.events",
+      "~k_parent": "1u"
     },
     "1y": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1u"
+    },
+    "1z": {
       "key": "root.types.blocks",
       "~k_parent": "1p"
     },
-    "1z": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1y"
-    },
     "2a": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1z"
     },
     "2b": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1z"
     },
     "2c": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1z"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1z"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1z"
     },
     "2f": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1z"
     },
     "2g": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1z"
     },
     "2h": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1z"
     },
     "2i": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1z"
     },
     "2j": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1z"
+    },
+    "2k": {
       "key": "root.types.connections",
       "~k_parent": "1p"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.requests",
       "~k_parent": "1p"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.api",
       "~k_parent": "1p"
     },
-    "2m": {
+    "2n": {
       "key": "root.types.operators",
       "~k_parent": "1p"
     },
-    "2n": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2m"
-    },
     "2o": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2n"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2o"
     },
     "2q": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2m"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2o"
     },
     "2r": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2n"
+    },
+    "2s": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2s": {
-      "key": "root.imports.actions",
-      "~k_parent": "2r"
-    },
     "2t": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.imports.auth",
-      "~k_parent": "2r"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2t"
     },
     "2w": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2v"
+      "key": "root.imports.agents",
+      "~k_parent": "2s"
     },
     "2x": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2v"
+      "key": "root.imports.auth",
+      "~k_parent": "2s"
     },
     "2y": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2v"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2v"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2x"
     },
     "3a": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "32"
     },
     "3b": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "32"
     },
     "3c": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "32"
     },
     "3d": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "32"
     },
     "3e": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "32"
     },
     "3f": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "32"
     },
     "3g": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "32"
     },
     "3h": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "32"
     },
     "3i": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "32"
     },
     "3j": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "32"
     },
     "3k": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "32"
     },
     "3l": {
-      "key": "root.imports.connections",
-      "~k_parent": "2r"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "32"
     },
     "3m": {
-      "key": "root.imports.icons",
-      "~k_parent": "2r"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "32"
     },
     "3n": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3m"
+      "key": "root.imports.connections",
+      "~k_parent": "2s"
     },
     "3o": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3n"
+      "key": "root.imports.icons",
+      "~k_parent": "2s"
     },
     "3p": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3o"
     },
     "3s": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3o"
     },
     "3u": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3o"
     },
     "3w": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3o"
     },
     "3y": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3o"
     },
     "4a": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3o"
     },
     "4c": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3o"
     },
     "4e": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3o"
     },
     "4g": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3o"
     },
     "4i": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3o"
     },
     "4k": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3o"
     },
     "4m": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3o"
     },
     "4o": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3o"
     },
     "4q": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3o"
     },
     "4s": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3o"
     },
     "4u": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3o"
     },
     "4w": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3o"
     },
     "4y": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3o"
     },
     "5a": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "59"
+      "key": "root.imports.operators",
+      "~k_parent": "2s"
     },
     "5b": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "59"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5a"
     },
     "5c": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5b"
+    },
+    "5d": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5b"
+    },
+    "5e": {
       "key": "root.imports.operators.server",
-      "~k_parent": "58"
+      "~k_parent": "5a"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "t"
   },
@@ -1028,6 +1037,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5515,152 +5525,155 @@
       },
       "~k": "1q"
     },
+    "agents": {
+      "~k": "1t"
+    },
     "auth": {
       "adapters": {
-        "~k": "1u"
-      },
-      "callbacks": {
         "~k": "1v"
       },
-      "events": {
+      "callbacks": {
         "~k": "1w"
       },
-      "providers": {
+      "events": {
         "~k": "1x"
       },
-      "~k": "1t"
+      "providers": {
+        "~k": "1y"
+      },
+      "~k": "1u"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1z"
+        "~k": "20"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "20"
+        "~k": "21"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
-      "~k": "1y"
+      "~k": "1z"
     },
     "connections": {
-      "~k": "2j"
-    },
-    "requests": {
       "~k": "2k"
     },
-    "api": {
+    "requests": {
       "~k": "2l"
+    },
+    "api": {
+      "~k": "2m"
     },
     "operators": {
       "client": {
@@ -5668,20 +5681,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2o"
+          "~k": "2p"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2p"
+          "~k": "2q"
         },
-        "~k": "2n"
+        "~k": "2o"
       },
       "server": {
-        "~k": "2q"
+        "~k": "2r"
       },
-      "~k": "2m"
+      "~k": "2n"
     },
     "~k": "1p"
   }

--- a/packages/build/src/tests/success/20-page-with-properties/snapshot.json
+++ b/packages/build/src/tests/success/20-page-with-properties/snapshot.json
@@ -127,164 +127,164 @@
       "~k_parent": "18"
     },
     "20": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1y"
     },
     "21": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1y"
     },
     "22": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1y"
     },
     "23": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1y"
     },
     "24": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1y"
     },
     "25": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1y"
     },
     "26": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1y"
     },
     "27": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1y"
     },
     "28": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1y"
     },
     "29": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1y"
     },
     "30": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks",
+      "~k_parent": "2q"
     },
     "31": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "30"
     },
     "32": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "30"
     },
     "33": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "30"
     },
     "34": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "30"
     },
     "35": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "30"
     },
     "36": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "30"
     },
     "37": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "30"
     },
     "38": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "30"
     },
     "39": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "30"
     },
     "40": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3l"
     },
     "41": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3l"
     },
     "43": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3l"
     },
     "45": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3l"
     },
     "47": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3l"
     },
     "49": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3l"
     },
     "51": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3l"
     },
     "53": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.requests",
-      "~k_parent": "2p"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3l"
     },
     "55": {
-      "key": "root.imports.operators",
-      "~k_parent": "2p"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "55"
+      "key": "root.imports.requests",
+      "~k_parent": "2q"
     },
     "57": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "56"
+      "key": "root.imports.operators",
+      "~k_parent": "2q"
     },
     "58": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "56"
+      "key": "root.imports.operators.client",
+      "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "55"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "58"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[0:button:Button].properties",
@@ -456,350 +456,359 @@
       "~k_parent": "1p"
     },
     "1s": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1o"
     },
     "1t": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1s"
+      "key": "root.types.auth",
+      "~k_parent": "1o"
     },
     "1u": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1s"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1t"
     },
     "1v": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1s"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1t"
     },
     "1w": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1s"
+      "key": "root.types.auth.events",
+      "~k_parent": "1t"
     },
     "1x": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1t"
+    },
+    "1y": {
       "key": "root.types.blocks",
       "~k_parent": "1o"
     },
-    "1y": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1x"
-    },
     "1z": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1y"
     },
     "2a": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1y"
     },
     "2b": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1y"
     },
     "2c": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1y"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1y"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1y"
     },
     "2f": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1y"
     },
     "2g": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1y"
     },
     "2h": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1y"
+    },
+    "2i": {
       "key": "root.types.connections",
       "~k_parent": "1o"
     },
-    "2i": {
+    "2j": {
       "key": "root.types.requests",
       "~k_parent": "1o"
     },
-    "2j": {
+    "2k": {
       "key": "root.types.api",
       "~k_parent": "1o"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.operators",
       "~k_parent": "1o"
     },
-    "2l": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2k"
-    },
     "2m": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2l"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2k"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2m"
     },
     "2p": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2l"
+    },
+    "2q": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2q": {
-      "key": "root.imports.actions",
-      "~k_parent": "2p"
-    },
     "2r": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2q"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.imports.auth",
-      "~k_parent": "2p"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2r"
     },
     "2u": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2t"
+      "key": "root.imports.agents",
+      "~k_parent": "2q"
     },
     "2v": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2t"
+      "key": "root.imports.auth",
+      "~k_parent": "2q"
     },
     "2w": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2t"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2v"
     },
     "2x": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2t"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2v"
     },
     "2y": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2p"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2v"
     },
     "2z": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2y"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2v"
     },
     "3a": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "30"
     },
     "3b": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "30"
     },
     "3c": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "30"
     },
     "3d": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "30"
     },
     "3e": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "30"
     },
     "3f": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "30"
     },
     "3g": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "30"
     },
     "3h": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "30"
     },
     "3i": {
-      "key": "root.imports.connections",
-      "~k_parent": "2p"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "30"
     },
     "3j": {
-      "key": "root.imports.icons",
-      "~k_parent": "2p"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "30"
     },
     "3k": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3j"
+      "key": "root.imports.connections",
+      "~k_parent": "2q"
     },
     "3l": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3k"
+      "key": "root.imports.icons",
+      "~k_parent": "2q"
     },
     "3m": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3l"
     },
     "3n": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3l"
     },
     "3p": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3l"
     },
     "3r": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3l"
     },
     "3t": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3l"
     },
     "3v": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3l"
     },
     "3x": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3l"
     },
     "3z": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3l"
     },
     "4b": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3l"
     },
     "4d": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3l"
     },
     "4f": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3l"
     },
     "4h": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3l"
     },
     "4j": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3l"
     },
     "4l": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3l"
     },
     "4n": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3l"
     },
     "4p": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3l"
     },
     "4r": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3l"
     },
     "4t": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3l"
     },
     "4v": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3l"
     },
     "4x": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3l"
     },
     "4z": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4y"
+    },
+    "5a": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "58"
+    },
+    "5b": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "57"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "s"
   },
@@ -1012,6 +1021,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5499,146 +5509,149 @@
       },
       "~k": "1p"
     },
+    "agents": {
+      "~k": "1s"
+    },
     "auth": {
       "adapters": {
-        "~k": "1t"
-      },
-      "callbacks": {
         "~k": "1u"
       },
-      "events": {
+      "callbacks": {
         "~k": "1v"
       },
-      "providers": {
+      "events": {
         "~k": "1w"
       },
-      "~k": "1s"
+      "providers": {
+        "~k": "1x"
+      },
+      "~k": "1t"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1z"
+        "~k": "20"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
-      "~k": "1x"
+      "~k": "1y"
     },
     "connections": {
-      "~k": "2h"
-    },
-    "requests": {
       "~k": "2i"
     },
-    "api": {
+    "requests": {
       "~k": "2j"
+    },
+    "api": {
+      "~k": "2k"
     },
     "operators": {
       "client": {
@@ -5646,20 +5659,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2m"
+          "~k": "2n"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2n"
+          "~k": "2o"
         },
-        "~k": "2l"
+        "~k": "2m"
       },
       "server": {
-        "~k": "2o"
+        "~k": "2p"
       },
-      "~k": "2k"
+      "~k": "2l"
     },
     "~k": "1o"
   }

--- a/packages/build/src/tests/success/21-multiple-pages/snapshot.json
+++ b/packages/build/src/tests/success/21-multiple-pages/snapshot.json
@@ -167,124 +167,124 @@
       "~k_parent": "20"
     },
     "30": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2l"
     },
     "31": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2l"
     },
     "32": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2l"
     },
     "33": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2l"
     },
     "34": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2l"
+    },
+    "35": {
       "key": "root.types.connections",
       "~k_parent": "2b"
     },
-    "35": {
+    "36": {
       "key": "root.types.requests",
       "~k_parent": "2b"
     },
-    "36": {
+    "37": {
       "key": "root.types.api",
       "~k_parent": "2b"
     },
-    "37": {
+    "38": {
       "key": "root.types.operators",
       "~k_parent": "2b"
     },
-    "38": {
-      "key": "root.types.operators.client",
-      "~k_parent": "37"
-    },
     "39": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "38"
     },
     "40": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3n"
     },
     "41": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3n"
     },
     "42": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3n"
     },
     "43": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3n"
     },
     "44": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3n"
     },
     "45": {
-      "key": "root.imports.connections",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3n"
     },
     "46": {
-      "key": "root.imports.icons",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3n"
     },
     "47": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "46"
+      "key": "root.imports.connections",
+      "~k_parent": "3d"
     },
     "48": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "47"
+      "key": "root.imports.icons",
+      "~k_parent": "3d"
     },
     "49": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "48"
     },
     "52": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "48"
     },
     "54": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "48"
     },
     "56": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "48"
     },
     "58": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "48"
     },
     "a": {
       "key": "root.pages[2:contact:Box]",
@@ -513,390 +513,399 @@
       "~k_parent": "2c"
     },
     "2f": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "2b"
     },
     "2g": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2f"
+      "key": "root.types.auth",
+      "~k_parent": "2b"
     },
     "2h": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2f"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2g"
     },
     "2i": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2f"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2g"
     },
     "2j": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2f"
+      "key": "root.types.auth.events",
+      "~k_parent": "2g"
     },
     "2k": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2g"
+    },
+    "2l": {
       "key": "root.types.blocks",
       "~k_parent": "2b"
     },
-    "2l": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2k"
-    },
     "2m": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2l"
     },
     "2o": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2l"
     },
     "2p": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2l"
     },
     "2q": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2l"
     },
     "2r": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2l"
     },
     "2s": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2l"
     },
     "2t": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2l"
     },
     "2u": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2l"
     },
     "2v": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2l"
     },
     "2w": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2l"
     },
     "2x": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2l"
     },
     "2y": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2l"
     },
     "2z": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2l"
     },
     "3a": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "38"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "39"
     },
     "3b": {
-      "key": "root.types.operators.server",
-      "~k_parent": "37"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "39"
     },
     "3c": {
+      "key": "root.types.operators.server",
+      "~k_parent": "38"
+    },
+    "3d": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "3d": {
-      "key": "root.imports.actions",
-      "~k_parent": "3c"
-    },
     "3e": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3d"
     },
     "3f": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3d"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.imports.auth",
-      "~k_parent": "3c"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3e"
     },
     "3h": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3g"
+      "key": "root.imports.agents",
+      "~k_parent": "3d"
     },
     "3i": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3g"
+      "key": "root.imports.auth",
+      "~k_parent": "3d"
     },
     "3j": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3g"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3g"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3i"
     },
     "3l": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3c"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3i"
     },
     "3m": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3l"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3i"
     },
     "3n": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks",
+      "~k_parent": "3d"
     },
     "3o": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3n"
     },
     "3q": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3n"
     },
     "3r": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3n"
     },
     "3s": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3n"
     },
     "3t": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3n"
     },
     "3u": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3n"
     },
     "3v": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3n"
     },
     "3w": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3n"
     },
     "3x": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3n"
     },
     "3y": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3n"
     },
     "3z": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3n"
     },
     "4a": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "48"
     },
     "4c": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "48"
     },
     "4e": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "48"
     },
     "4g": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "48"
     },
     "4i": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "48"
     },
     "4k": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "48"
     },
     "4m": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "48"
     },
     "4o": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "48"
     },
     "4q": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "48"
     },
     "4s": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "48"
     },
     "4u": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "48"
     },
     "4w": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "48"
     },
     "4y": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "48"
     },
     "5a": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "48"
     },
     "5c": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "48"
     },
     "5e": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "48"
     },
     "5g": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "48"
     },
     "5i": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "48"
     },
     "5k": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "48"
     },
     "5m": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "48"
     },
     "5o": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "48"
     },
     "5q": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.requests",
-      "~k_parent": "3c"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "48"
     },
     "5s": {
-      "key": "root.imports.operators",
-      "~k_parent": "3c"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5s"
+      "key": "root.imports.requests",
+      "~k_parent": "3d"
     },
     "5u": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5t"
+      "key": "root.imports.operators",
+      "~k_parent": "3d"
     },
     "5v": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5t"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5u"
     },
     "5w": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5v"
+    },
+    "5x": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5v"
+    },
+    "5y": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5s"
+      "~k_parent": "5u"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "x"
   },
@@ -1203,6 +1212,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5690,146 +5700,149 @@
       },
       "~k": "2c"
     },
+    "agents": {
+      "~k": "2f"
+    },
     "auth": {
       "adapters": {
-        "~k": "2g"
-      },
-      "callbacks": {
         "~k": "2h"
       },
-      "events": {
+      "callbacks": {
         "~k": "2i"
       },
-      "providers": {
+      "events": {
         "~k": "2j"
       },
-      "~k": "2f"
+      "providers": {
+        "~k": "2k"
+      },
+      "~k": "2g"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 6,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
-      "~k": "2k"
+      "~k": "2l"
     },
     "connections": {
-      "~k": "34"
-    },
-    "requests": {
       "~k": "35"
     },
-    "api": {
+    "requests": {
       "~k": "36"
+    },
+    "api": {
+      "~k": "37"
     },
     "operators": {
       "client": {
@@ -5837,20 +5850,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "39"
+          "~k": "3a"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3a"
+          "~k": "3b"
         },
-        "~k": "38"
+        "~k": "39"
       },
       "server": {
-        "~k": "3b"
+        "~k": "3c"
       },
-      "~k": "37"
+      "~k": "38"
     },
     "~k": "2b"
   }

--- a/packages/build/src/tests/success/22-page-404-auto-generated/snapshot.json
+++ b/packages/build/src/tests/success/22-page-404-auto-generated/snapshot.json
@@ -120,140 +120,148 @@
       "~k_parent": "12"
     },
     "20": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1s"
     },
     "21": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1s"
     },
     "22": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1s"
     },
     "23": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1s"
     },
     "24": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1s"
     },
     "25": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1s"
     },
     "26": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1s"
     },
     "27": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1s"
     },
     "28": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1s"
     },
     "29": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1s"
     },
     "30": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2u"
     },
     "31": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2u"
     },
     "32": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2u"
     },
     "33": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2u"
     },
     "34": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2u"
     },
     "35": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2u"
     },
     "36": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2u"
     },
     "37": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2u"
     },
     "38": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2u"
     },
     "39": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2u"
     },
     "40": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3f"
     },
     "41": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3f"
     },
     "43": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3f"
     },
     "45": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3f"
     },
     "47": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3f"
     },
     "49": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "4z"
+      "key": "root.imports.requests",
+      "~k_parent": "2k"
     },
     "51": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "50"
+      "key": "root.imports.operators",
+      "~k_parent": "2k"
     },
     "52": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "50"
+      "key": "root.imports.operators.client",
+      "~k_parent": "51"
     },
     "53": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "52"
+    },
+    "54": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "52"
+    },
+    "55": {
       "key": "root.imports.operators.server",
-      "~k_parent": "4z"
+      "~k_parent": "51"
     },
     "a": {
       "key": "root.pages[1:404:Result].style",
@@ -404,374 +412,375 @@
       "~k_parent": "1j"
     },
     "1m": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1i"
     },
     "1n": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1m"
+      "key": "root.types.auth",
+      "~k_parent": "1i"
     },
     "1o": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1m"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1n"
     },
     "1p": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1m"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1n"
     },
     "1q": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1m"
+      "key": "root.types.auth.events",
+      "~k_parent": "1n"
     },
     "1r": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1n"
+    },
+    "1s": {
       "key": "root.types.blocks",
       "~k_parent": "1i"
     },
-    "1s": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1r"
-    },
     "1t": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1s"
     },
     "1u": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1s"
     },
     "1w": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1s"
     },
     "1x": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1s"
     },
     "1y": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1s"
     },
     "1z": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1s"
     },
     "2a": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1s"
     },
     "2b": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1s"
+    },
+    "2c": {
       "key": "root.types.connections",
       "~k_parent": "1i"
     },
-    "2c": {
+    "2d": {
       "key": "root.types.requests",
       "~k_parent": "1i"
     },
-    "2d": {
+    "2e": {
       "key": "root.types.api",
       "~k_parent": "1i"
     },
-    "2e": {
+    "2f": {
       "key": "root.types.operators",
       "~k_parent": "1i"
     },
-    "2f": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2e"
-    },
     "2g": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2f"
     },
     "2h": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2f"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2g"
     },
     "2i": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2e"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2g"
     },
     "2j": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2f"
+    },
+    "2k": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2k": {
-      "key": "root.imports.actions",
-      "~k_parent": "2j"
-    },
     "2l": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2k"
     },
     "2m": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2k"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.imports.auth",
-      "~k_parent": "2j"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2l"
     },
     "2o": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2n"
+      "key": "root.imports.agents",
+      "~k_parent": "2k"
     },
     "2p": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2n"
+      "key": "root.imports.auth",
+      "~k_parent": "2k"
     },
     "2q": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2n"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2p"
     },
     "2r": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2n"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2p"
     },
     "2s": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2j"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2p"
     },
     "2t": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2s"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2p"
     },
     "2u": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks",
+      "~k_parent": "2k"
     },
     "2v": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2u"
     },
     "2y": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2u"
     },
     "2z": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2u"
     },
     "3b": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2u"
     },
     "3c": {
-      "key": "root.imports.connections",
-      "~k_parent": "2j"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2u"
     },
     "3d": {
-      "key": "root.imports.icons",
-      "~k_parent": "2j"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "2u"
     },
     "3e": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3d"
+      "key": "root.imports.connections",
+      "~k_parent": "2k"
     },
     "3f": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3e"
+      "key": "root.imports.icons",
+      "~k_parent": "2k"
     },
     "3g": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3f"
     },
     "3n": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3f"
     },
     "3r": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3f"
     },
     "3t": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3f"
     },
     "3v": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3f"
     },
     "3x": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3f"
     },
     "3z": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3f"
     },
     "4b": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3f"
     },
     "4d": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3f"
     },
     "4f": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3f"
     },
     "4h": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3f"
     },
     "4j": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3f"
     },
     "4l": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3f"
     },
     "4n": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3f"
     },
     "4p": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3f"
     },
     "4r": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3f"
     },
     "4t": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3f"
     },
     "4v": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3f"
     },
     "4x": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.requests",
-      "~k_parent": "2j"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3f"
     },
     "4z": {
-      "key": "root.imports.operators",
-      "~k_parent": "2j"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4y"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "o"
   },
@@ -954,6 +963,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5441,146 +5451,149 @@
       },
       "~k": "1j"
     },
+    "agents": {
+      "~k": "1m"
+    },
     "auth": {
       "adapters": {
-        "~k": "1n"
-      },
-      "callbacks": {
         "~k": "1o"
       },
-      "events": {
+      "callbacks": {
         "~k": "1p"
       },
-      "providers": {
+      "events": {
         "~k": "1q"
       },
-      "~k": "1m"
+      "providers": {
+        "~k": "1r"
+      },
+      "~k": "1n"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1s"
+        "~k": "1t"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1t"
+        "~k": "1u"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1u"
+        "~k": "1v"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1v"
+        "~k": "1w"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1w"
+        "~k": "1x"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
-      "~k": "1r"
+      "~k": "1s"
     },
     "connections": {
-      "~k": "2b"
-    },
-    "requests": {
       "~k": "2c"
     },
-    "api": {
+    "requests": {
       "~k": "2d"
+    },
+    "api": {
+      "~k": "2e"
     },
     "operators": {
       "client": {
@@ -5588,20 +5601,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2g"
+          "~k": "2h"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2h"
+          "~k": "2i"
         },
-        "~k": "2f"
+        "~k": "2g"
       },
       "server": {
-        "~k": "2i"
+        "~k": "2j"
       },
-      "~k": "2e"
+      "~k": "2f"
     },
     "~k": "1i"
   }

--- a/packages/build/src/tests/success/23-page-404-custom/snapshot.json
+++ b/packages/build/src/tests/success/23-page-404-custom/snapshot.json
@@ -106,140 +106,140 @@
       "~k_parent": "14"
     },
     "16": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "13"
     },
     "17": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "16"
+      "key": "root.types.auth",
+      "~k_parent": "13"
     },
     "18": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "16"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "17"
     },
     "19": {
-      "key": "root.types.auth.events",
-      "~k_parent": "16"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "17"
     },
     "20": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "1y"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "1z"
     },
     "21": {
-      "key": "root.types.operators.server",
-      "~k_parent": "1x"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "1z"
     },
     "22": {
+      "key": "root.types.operators.server",
+      "~k_parent": "1y"
+    },
+    "23": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "23": {
-      "key": "root.imports.actions",
-      "~k_parent": "22"
-    },
     "24": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "23"
     },
     "25": {
-      "key": "root.imports.auth",
-      "~k_parent": "22"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "24"
     },
     "26": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "25"
+      "key": "root.imports.agents",
+      "~k_parent": "23"
     },
     "27": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "25"
+      "key": "root.imports.auth",
+      "~k_parent": "23"
     },
     "28": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "25"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "27"
     },
     "29": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "25"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "27"
     },
     "30": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "2z"
     },
     "31": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "2w"
     },
     "32": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "31"
     },
     "33": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "2w"
     },
     "34": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "33"
     },
     "35": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "2w"
     },
     "36": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "35"
     },
     "37": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "2w"
     },
     "38": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "37"
     },
     "39": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "2w"
     },
     "40": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "2w"
     },
     "42": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "2w"
     },
     "44": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "2w"
     },
     "46": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "2w"
     },
     "48": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "2w"
     },
     "a": {
       "key": "root.pages",
@@ -342,362 +342,371 @@
       "~k_parent": "y"
     },
     "1a": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "16"
+      "key": "root.types.auth.events",
+      "~k_parent": "17"
     },
     "1b": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "17"
+    },
+    "1c": {
       "key": "root.types.blocks",
       "~k_parent": "13"
     },
-    "1c": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1b"
-    },
     "1d": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1c"
     },
     "1e": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1c"
     },
     "1f": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1c"
     },
     "1g": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1c"
     },
     "1h": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1c"
     },
     "1i": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1c"
     },
     "1j": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1c"
     },
     "1k": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1c"
     },
     "1l": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1c"
     },
     "1m": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1c"
     },
     "1n": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1c"
     },
     "1o": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1c"
     },
     "1p": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1c"
     },
     "1q": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1c"
     },
     "1r": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1c"
     },
     "1s": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1c"
     },
     "1t": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1c"
     },
     "1u": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1c"
+    },
+    "1v": {
       "key": "root.types.connections",
       "~k_parent": "13"
     },
-    "1v": {
+    "1w": {
       "key": "root.types.requests",
       "~k_parent": "13"
     },
-    "1w": {
+    "1x": {
       "key": "root.types.api",
       "~k_parent": "13"
     },
-    "1x": {
+    "1y": {
       "key": "root.types.operators",
       "~k_parent": "13"
     },
-    "1y": {
-      "key": "root.types.operators.client",
-      "~k_parent": "1x"
-    },
     "1z": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "1y"
     },
     "2a": {
-      "key": "root.imports.blocks",
-      "~k_parent": "22"
+      "key": "root.imports.auth.events",
+      "~k_parent": "27"
     },
     "2b": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2a"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "27"
     },
     "2c": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks",
+      "~k_parent": "23"
     },
     "2d": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2c"
     },
     "2e": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2c"
     },
     "2f": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2c"
     },
     "2g": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2c"
     },
     "2h": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2c"
     },
     "2i": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2c"
     },
     "2j": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2c"
     },
     "2k": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2c"
     },
     "2l": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2c"
     },
     "2m": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2c"
     },
     "2n": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2c"
     },
     "2o": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2c"
     },
     "2p": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2c"
     },
     "2q": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2c"
     },
     "2r": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2c"
     },
     "2s": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2c"
     },
     "2t": {
-      "key": "root.imports.connections",
-      "~k_parent": "22"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2c"
     },
     "2u": {
-      "key": "root.imports.icons",
-      "~k_parent": "22"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2c"
     },
     "2v": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "2u"
+      "key": "root.imports.connections",
+      "~k_parent": "23"
     },
     "2w": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "2v"
+      "key": "root.imports.icons",
+      "~k_parent": "23"
     },
     "2x": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "2w"
     },
     "3a": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "39"
     },
     "3b": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "2w"
     },
     "3c": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "2w"
     },
     "3e": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3d"
     },
     "3f": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "2w"
     },
     "3g": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "2w"
     },
     "3i": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "2w"
     },
     "3k": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "3j"
     },
     "3l": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "2w"
     },
     "3m": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "3l"
     },
     "3n": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "2w"
     },
     "3o": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "2w"
     },
     "3q": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "2w"
     },
     "3s": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "2w"
     },
     "3u": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "2w"
     },
     "3w": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "2w"
     },
     "3y": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "2w"
     },
     "4a": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "2w"
     },
     "4c": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "2w"
     },
     "4e": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.requests",
-      "~k_parent": "22"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "2w"
     },
     "4g": {
-      "key": "root.imports.operators",
-      "~k_parent": "22"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "4g"
+      "key": "root.imports.requests",
+      "~k_parent": "23"
     },
     "4i": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "4h"
+      "key": "root.imports.operators",
+      "~k_parent": "23"
     },
     "4j": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "4h"
+      "key": "root.imports.operators.client",
+      "~k_parent": "4i"
     },
     "4k": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "4j"
+    },
+    "4l": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "4j"
+    },
+    "4m": {
       "key": "root.imports.operators.server",
-      "~k_parent": "4g"
+      "~k_parent": "4i"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "d"
   },
@@ -784,6 +793,7 @@
     }
   },
   "plugins/actions.js": "import { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5265,140 +5275,143 @@
       },
       "~k": "14"
     },
+    "agents": {
+      "~k": "16"
+    },
     "auth": {
       "adapters": {
-        "~k": "17"
-      },
-      "callbacks": {
         "~k": "18"
       },
-      "events": {
+      "callbacks": {
         "~k": "19"
       },
-      "providers": {
+      "events": {
         "~k": "1a"
       },
-      "~k": "16"
+      "providers": {
+        "~k": "1b"
+      },
+      "~k": "17"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1c"
+        "~k": "1d"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1d"
+        "~k": "1e"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1e"
+        "~k": "1f"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1f"
+        "~k": "1g"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1g"
+        "~k": "1h"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1h"
+        "~k": "1i"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1i"
+        "~k": "1j"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1j"
+        "~k": "1k"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1k"
+        "~k": "1l"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1l"
+        "~k": "1m"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1m"
+        "~k": "1n"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1n"
+        "~k": "1o"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1o"
+        "~k": "1p"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1p"
+        "~k": "1q"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1q"
+        "~k": "1r"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1r"
+        "~k": "1s"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1s"
+        "~k": "1t"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1t"
+        "~k": "1u"
       },
-      "~k": "1b"
+      "~k": "1c"
     },
     "connections": {
-      "~k": "1u"
-    },
-    "requests": {
       "~k": "1v"
     },
-    "api": {
+    "requests": {
       "~k": "1w"
+    },
+    "api": {
+      "~k": "1x"
     },
     "operators": {
       "client": {
@@ -5406,20 +5419,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "1z"
+          "~k": "20"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "20"
+          "~k": "21"
         },
-        "~k": "1y"
+        "~k": "1z"
       },
       "server": {
-        "~k": "21"
+        "~k": "22"
       },
-      "~k": "1x"
+      "~k": "1y"
     },
     "~k": "13"
   }

--- a/packages/build/src/tests/success/24-page-with-skeleton/snapshot.json
+++ b/packages/build/src/tests/success/24-page-with-skeleton/snapshot.json
@@ -127,164 +127,164 @@
       "~k_parent": "4"
     },
     "20": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1z"
     },
     "21": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "1z"
     },
     "22": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1z"
     },
     "23": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1z"
     },
     "24": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1z"
     },
     "25": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1z"
     },
     "26": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1z"
     },
     "27": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1z"
     },
     "28": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1z"
     },
     "29": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1z"
     },
     "30": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2r"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2x"
     },
     "31": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "30"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2x"
     },
     "32": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks",
+      "~k_parent": "2s"
     },
     "33": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "32"
     },
     "35": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "32"
     },
     "36": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "32"
     },
     "37": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "32"
     },
     "38": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "32"
     },
     "39": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "32"
     },
     "40": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3o"
     },
     "42": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3o"
     },
     "44": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3o"
     },
     "46": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3o"
     },
     "48": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3o"
     },
     "50": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3o"
     },
     "52": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3o"
     },
     "54": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3o"
     },
     "56": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.requests",
-      "~k_parent": "2r"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3o"
     },
     "58": {
-      "key": "root.imports.operators",
-      "~k_parent": "2r"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "58"
+      "key": "root.imports.requests",
+      "~k_parent": "2s"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[0:content:Paragraph]",
@@ -461,358 +461,367 @@
       "~k_parent": "1q"
     },
     "1t": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1p"
     },
     "1u": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1t"
+      "key": "root.types.auth",
+      "~k_parent": "1p"
     },
     "1v": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1t"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1u"
     },
     "1w": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1t"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1u"
     },
     "1x": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1t"
+      "key": "root.types.auth.events",
+      "~k_parent": "1u"
     },
     "1y": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1u"
+    },
+    "1z": {
       "key": "root.types.blocks",
       "~k_parent": "1p"
     },
-    "1z": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1y"
-    },
     "2a": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1z"
     },
     "2b": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1z"
     },
     "2c": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1z"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1z"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1z"
     },
     "2f": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1z"
     },
     "2g": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1z"
     },
     "2h": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1z"
     },
     "2i": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1z"
     },
     "2j": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1z"
+    },
+    "2k": {
       "key": "root.types.connections",
       "~k_parent": "1p"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.requests",
       "~k_parent": "1p"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.api",
       "~k_parent": "1p"
     },
-    "2m": {
+    "2n": {
       "key": "root.types.operators",
       "~k_parent": "1p"
     },
-    "2n": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2m"
-    },
     "2o": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2n"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2o"
     },
     "2q": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2m"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2o"
     },
     "2r": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2n"
+    },
+    "2s": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2s": {
-      "key": "root.imports.actions",
-      "~k_parent": "2r"
-    },
     "2t": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.imports.auth",
-      "~k_parent": "2r"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2t"
     },
     "2w": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2v"
+      "key": "root.imports.agents",
+      "~k_parent": "2s"
     },
     "2x": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2v"
+      "key": "root.imports.auth",
+      "~k_parent": "2s"
     },
     "2y": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2v"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2v"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2x"
     },
     "3a": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "32"
     },
     "3b": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "32"
     },
     "3c": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "32"
     },
     "3d": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "32"
     },
     "3e": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "32"
     },
     "3f": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "32"
     },
     "3g": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "32"
     },
     "3h": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "32"
     },
     "3i": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "32"
     },
     "3j": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "32"
     },
     "3k": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "32"
     },
     "3l": {
-      "key": "root.imports.connections",
-      "~k_parent": "2r"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "32"
     },
     "3m": {
-      "key": "root.imports.icons",
-      "~k_parent": "2r"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "32"
     },
     "3n": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3m"
+      "key": "root.imports.connections",
+      "~k_parent": "2s"
     },
     "3o": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3n"
+      "key": "root.imports.icons",
+      "~k_parent": "2s"
     },
     "3p": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3o"
     },
     "3s": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3o"
     },
     "3u": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3o"
     },
     "3w": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3o"
     },
     "3y": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3o"
     },
     "4a": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3o"
     },
     "4c": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3o"
     },
     "4e": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3o"
     },
     "4g": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3o"
     },
     "4i": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3o"
     },
     "4k": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3o"
     },
     "4m": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3o"
     },
     "4o": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3o"
     },
     "4q": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3o"
     },
     "4s": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3o"
     },
     "4u": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3o"
     },
     "4w": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3o"
     },
     "4y": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3o"
     },
     "5a": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "59"
+      "key": "root.imports.operators",
+      "~k_parent": "2s"
     },
     "5b": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "59"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5a"
     },
     "5c": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5b"
+    },
+    "5d": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5b"
+    },
+    "5e": {
       "key": "root.imports.operators.server",
-      "~k_parent": "58"
+      "~k_parent": "5a"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "t"
   },
@@ -1024,6 +1033,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5511,152 +5521,155 @@
       },
       "~k": "1q"
     },
+    "agents": {
+      "~k": "1t"
+    },
     "auth": {
       "adapters": {
-        "~k": "1u"
-      },
-      "callbacks": {
         "~k": "1v"
       },
-      "events": {
+      "callbacks": {
         "~k": "1w"
       },
-      "providers": {
+      "events": {
         "~k": "1x"
       },
-      "~k": "1t"
+      "providers": {
+        "~k": "1y"
+      },
+      "~k": "1u"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1z"
+        "~k": "20"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
-      "~k": "1y"
+      "~k": "1z"
     },
     "connections": {
-      "~k": "2j"
-    },
-    "requests": {
       "~k": "2k"
     },
-    "api": {
+    "requests": {
       "~k": "2l"
+    },
+    "api": {
+      "~k": "2m"
     },
     "operators": {
       "client": {
@@ -5664,20 +5677,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2o"
+          "~k": "2p"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2p"
+          "~k": "2q"
         },
-        "~k": "2n"
+        "~k": "2o"
       },
       "server": {
-        "~k": "2q"
+        "~k": "2r"
       },
-      "~k": "2m"
+      "~k": "2n"
     },
     "~k": "1p"
   }

--- a/packages/build/src/tests/success/25-page-with-loading/snapshot.json
+++ b/packages/build/src/tests/success/25-page-with-loading/snapshot.json
@@ -127,164 +127,164 @@
       "~k_parent": "18"
     },
     "20": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1y"
     },
     "21": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "1y"
     },
     "22": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1y"
     },
     "23": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1y"
     },
     "24": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1y"
     },
     "25": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1y"
     },
     "26": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1y"
     },
     "27": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1y"
     },
     "28": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1y"
     },
     "29": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1y"
     },
     "30": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2z"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2w"
     },
     "31": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks",
+      "~k_parent": "2r"
     },
     "32": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "31"
     },
     "33": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "31"
     },
     "34": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "31"
     },
     "35": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "31"
     },
     "36": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "31"
     },
     "37": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "31"
     },
     "38": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "31"
     },
     "39": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "31"
     },
     "40": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3n"
     },
     "41": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3n"
     },
     "43": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3n"
     },
     "45": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3n"
     },
     "47": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3n"
     },
     "49": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3n"
     },
     "51": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3n"
     },
     "53": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3n"
     },
     "55": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.requests",
-      "~k_parent": "2q"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3n"
     },
     "57": {
-      "key": "root.imports.operators",
-      "~k_parent": "2q"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "57"
+      "key": "root.imports.requests",
+      "~k_parent": "2r"
     },
     "59": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "58"
+      "key": "root.imports.operators",
+      "~k_parent": "2r"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[1:content:Paragraph].properties",
@@ -456,358 +456,367 @@
       "~k_parent": "1p"
     },
     "1s": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1o"
     },
     "1t": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1s"
+      "key": "root.types.auth",
+      "~k_parent": "1o"
     },
     "1u": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1s"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1t"
     },
     "1v": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1s"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1t"
     },
     "1w": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1s"
+      "key": "root.types.auth.events",
+      "~k_parent": "1t"
     },
     "1x": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1t"
+    },
+    "1y": {
       "key": "root.types.blocks",
       "~k_parent": "1o"
     },
-    "1y": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1x"
-    },
     "1z": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1y"
     },
     "2a": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1y"
     },
     "2b": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1y"
     },
     "2c": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1y"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1y"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1y"
     },
     "2f": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1y"
     },
     "2g": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1y"
     },
     "2h": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1y"
     },
     "2i": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1y"
+    },
+    "2j": {
       "key": "root.types.connections",
       "~k_parent": "1o"
     },
-    "2j": {
+    "2k": {
       "key": "root.types.requests",
       "~k_parent": "1o"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.api",
       "~k_parent": "1o"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.operators",
       "~k_parent": "1o"
     },
-    "2m": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2l"
-    },
     "2n": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2m"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2l"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2n"
     },
     "2q": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2m"
+    },
+    "2r": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2r": {
-      "key": "root.imports.actions",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2r"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.imports.auth",
-      "~k_parent": "2q"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2s"
     },
     "2v": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2u"
+      "key": "root.imports.agents",
+      "~k_parent": "2r"
     },
     "2w": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2u"
+      "key": "root.imports.auth",
+      "~k_parent": "2r"
     },
     "2x": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2u"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2u"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2w"
     },
     "2z": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2q"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2w"
     },
     "3a": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "31"
     },
     "3b": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "31"
     },
     "3c": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "31"
     },
     "3d": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "31"
     },
     "3e": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "31"
     },
     "3f": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "31"
     },
     "3g": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "31"
     },
     "3h": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "31"
     },
     "3i": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "31"
     },
     "3j": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "31"
     },
     "3k": {
-      "key": "root.imports.connections",
-      "~k_parent": "2q"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "31"
     },
     "3l": {
-      "key": "root.imports.icons",
-      "~k_parent": "2q"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "31"
     },
     "3m": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3l"
+      "key": "root.imports.connections",
+      "~k_parent": "2r"
     },
     "3n": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3m"
+      "key": "root.imports.icons",
+      "~k_parent": "2r"
     },
     "3o": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3n"
     },
     "3r": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3n"
     },
     "3t": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3n"
     },
     "3v": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3n"
     },
     "3x": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3n"
     },
     "3z": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3n"
     },
     "4b": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3n"
     },
     "4d": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3n"
     },
     "4f": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3n"
     },
     "4h": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3n"
     },
     "4j": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3n"
     },
     "4l": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3n"
     },
     "4n": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3n"
     },
     "4p": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3n"
     },
     "4r": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3n"
     },
     "4t": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3n"
     },
     "4v": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3n"
     },
     "4x": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3n"
     },
     "4z": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "58"
+      "key": "root.imports.operators.client",
+      "~k_parent": "59"
     },
     "5b": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5a"
+    },
+    "5c": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5a"
+    },
+    "5d": {
       "key": "root.imports.operators.server",
-      "~k_parent": "57"
+      "~k_parent": "59"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "s"
   },
@@ -1020,6 +1029,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5507,152 +5517,155 @@
       },
       "~k": "1p"
     },
+    "agents": {
+      "~k": "1s"
+    },
     "auth": {
       "adapters": {
-        "~k": "1t"
-      },
-      "callbacks": {
         "~k": "1u"
       },
-      "events": {
+      "callbacks": {
         "~k": "1v"
       },
-      "providers": {
+      "events": {
         "~k": "1w"
       },
-      "~k": "1s"
+      "providers": {
+        "~k": "1x"
+      },
+      "~k": "1t"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 2,
-        "~k": "1z"
+        "~k": "20"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
-      "~k": "1x"
+      "~k": "1y"
     },
     "connections": {
-      "~k": "2i"
-    },
-    "requests": {
       "~k": "2j"
     },
-    "api": {
+    "requests": {
       "~k": "2k"
+    },
+    "api": {
+      "~k": "2l"
     },
     "operators": {
       "client": {
@@ -5660,20 +5673,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2n"
+          "~k": "2o"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2o"
+          "~k": "2p"
         },
-        "~k": "2m"
+        "~k": "2n"
       },
       "server": {
-        "~k": "2p"
+        "~k": "2q"
       },
-      "~k": "2l"
+      "~k": "2m"
     },
     "~k": "1o"
   }

--- a/packages/build/src/tests/success/30-multifile-pages-ref/snapshot.json
+++ b/packages/build/src/tests/success/30-multifile-pages-ref/snapshot.json
@@ -171,163 +171,163 @@
       "~k_parent": "22"
     },
     "30": {
-      "key": "root.types.blocks.TextArea",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "2w"
     },
     "31": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.TextArea",
+      "~k_parent": "2w"
     },
     "32": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2w"
     },
     "33": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2w"
     },
     "34": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2w"
     },
     "35": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2w"
     },
     "36": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2w"
     },
     "37": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2w"
     },
     "38": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2w"
     },
     "39": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2w"
     },
     "40": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3r"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3x"
     },
     "41": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "40"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3x"
     },
     "42": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks",
+      "~k_parent": "3s"
     },
     "43": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "42"
     },
     "45": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "42"
     },
     "46": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "42"
     },
     "47": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "42"
     },
     "48": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "42"
     },
     "49": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "42"
     },
     "50": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4r"
     },
     "51": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4r"
     },
     "53": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4r"
     },
     "55": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4r"
     },
     "57": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4r"
     },
     "59": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4r"
     },
     "61": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4r"
     },
     "63": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4r"
     },
     "65": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4r"
     },
     "67": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4r"
     },
     "69": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "68"
     },
     "a": {
@@ -637,382 +637,391 @@
       "~k_parent": "2n"
     },
     "2q": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "2m"
     },
     "2r": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2q"
+      "key": "root.types.auth",
+      "~k_parent": "2m"
     },
     "2s": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2q"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2q"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2r"
     },
     "2u": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2q"
+      "key": "root.types.auth.events",
+      "~k_parent": "2r"
     },
     "2v": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2r"
+    },
+    "2w": {
       "key": "root.types.blocks",
       "~k_parent": "2m"
     },
-    "2w": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2v"
-    },
     "2x": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2w"
     },
     "2z": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "2w"
     },
     "3a": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2w"
     },
     "3b": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2w"
     },
     "3c": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2w"
     },
     "3d": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2w"
     },
     "3e": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2w"
     },
     "3f": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2w"
     },
     "3g": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2w"
     },
     "3h": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2w"
     },
     "3i": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2w"
     },
     "3j": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2w"
+    },
+    "3k": {
       "key": "root.types.connections",
       "~k_parent": "2m"
     },
-    "3k": {
+    "3l": {
       "key": "root.types.requests",
       "~k_parent": "2m"
     },
-    "3l": {
+    "3m": {
       "key": "root.types.api",
       "~k_parent": "2m"
     },
-    "3m": {
+    "3n": {
       "key": "root.types.operators",
       "~k_parent": "2m"
     },
-    "3n": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3m"
-    },
     "3o": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3n"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3m"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3o"
     },
     "3r": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3n"
+    },
+    "3s": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "3s": {
-      "key": "root.imports.actions",
-      "~k_parent": "3r"
-    },
     "3t": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3s"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.auth",
-      "~k_parent": "3r"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3t"
     },
     "3w": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3v"
+      "key": "root.imports.agents",
+      "~k_parent": "3s"
     },
     "3x": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3v"
+      "key": "root.imports.auth",
+      "~k_parent": "3s"
     },
     "3y": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3v"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3v"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3x"
     },
     "4a": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "42"
     },
     "4b": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "42"
     },
     "4c": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "42"
     },
     "4d": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "42"
     },
     "4e": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "42"
     },
     "4f": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "42"
     },
     "4g": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "42"
     },
     "4h": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "42"
     },
     "4i": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "42"
     },
     "4j": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "42"
     },
     "4k": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "42"
     },
     "4l": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "42"
     },
     "4m": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "42"
     },
     "4n": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "42"
     },
     "4o": {
-      "key": "root.imports.connections",
-      "~k_parent": "3r"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "42"
     },
     "4p": {
-      "key": "root.imports.icons",
-      "~k_parent": "3r"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "42"
     },
     "4q": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4p"
+      "key": "root.imports.connections",
+      "~k_parent": "3s"
     },
     "4r": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4q"
+      "key": "root.imports.icons",
+      "~k_parent": "3s"
     },
     "4s": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4r"
     },
     "4v": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4r"
     },
     "4x": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4r"
     },
     "4z": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4r"
     },
     "5b": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4r"
     },
     "5d": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4r"
     },
     "5f": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4r"
     },
     "5h": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4r"
     },
     "5j": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4r"
     },
     "5l": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4r"
     },
     "5n": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4r"
     },
     "5p": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4r"
     },
     "5r": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4r"
     },
     "5t": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4r"
     },
     "5v": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4r"
     },
     "5x": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4r"
     },
     "5z": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.imports.requests",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4r"
     },
     "6b": {
-      "key": "root.imports.operators",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6b"
+      "key": "root.imports.requests",
+      "~k_parent": "3s"
     },
     "6d": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6c"
+      "key": "root.imports.operators",
+      "~k_parent": "3s"
     },
     "6e": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6c"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6d"
     },
     "6f": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6e"
+    },
+    "6g": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6e"
+    },
+    "6h": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6b"
+      "~k_parent": "6d"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "1c"
   },
@@ -1372,6 +1381,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -7255,170 +7265,173 @@
       },
       "~k": "2n"
     },
+    "agents": {
+      "~k": "2q"
+    },
     "auth": {
       "adapters": {
-        "~k": "2r"
-      },
-      "callbacks": {
         "~k": "2s"
       },
-      "events": {
+      "callbacks": {
         "~k": "2t"
       },
-      "providers": {
+      "events": {
         "~k": "2u"
       },
-      "~k": "2q"
+      "providers": {
+        "~k": "2v"
+      },
+      "~k": "2r"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2y"
+        "~k": "2z"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "TextArea": {
         "originalTypeName": "TextArea",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "31"
+        "~k": "32"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3f"
+        "~k": "3g"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3h"
+        "~k": "3i"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3i"
+        "~k": "3j"
       },
-      "~k": "2v"
+      "~k": "2w"
     },
     "connections": {
-      "~k": "3j"
-    },
-    "requests": {
       "~k": "3k"
     },
-    "api": {
+    "requests": {
       "~k": "3l"
+    },
+    "api": {
+      "~k": "3m"
     },
     "operators": {
       "client": {
@@ -7426,20 +7439,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3o"
+          "~k": "3p"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3p"
+          "~k": "3q"
         },
-        "~k": "3n"
+        "~k": "3o"
       },
       "server": {
-        "~k": "3q"
+        "~k": "3r"
       },
-      "~k": "3m"
+      "~k": "3n"
     },
     "~k": "2m"
   }

--- a/packages/build/src/tests/success/31-multifile-blocks-ref/snapshot.json
+++ b/packages/build/src/tests/success/31-multifile-blocks-ref/snapshot.json
@@ -197,131 +197,131 @@
       "~k_parent": "35"
     },
     "38": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "34"
     },
     "39": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "38"
+      "key": "root.types.auth",
+      "~k_parent": "34"
     },
     "40": {
-      "key": "root.types.requests",
+      "key": "root.types.connections",
       "~k_parent": "34"
     },
     "41": {
-      "key": "root.types.api",
+      "key": "root.types.requests",
       "~k_parent": "34"
     },
     "42": {
-      "key": "root.types.operators",
+      "key": "root.types.api",
       "~k_parent": "34"
     },
     "43": {
-      "key": "root.types.operators.client",
-      "~k_parent": "42"
+      "key": "root.types.operators",
+      "~k_parent": "34"
     },
     "44": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "43"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "44"
     },
     "46": {
-      "key": "root.types.operators.server",
-      "~k_parent": "42"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "44"
     },
     "47": {
+      "key": "root.types.operators.server",
+      "~k_parent": "43"
+    },
+    "48": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "48": {
-      "key": "root.imports.actions",
-      "~k_parent": "47"
-    },
     "49": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "4i"
     },
     "51": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "4i"
     },
     "52": {
-      "key": "root.imports.connections",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "4i"
     },
     "53": {
-      "key": "root.imports.icons",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "4i"
     },
     "54": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "53"
+      "key": "root.imports.connections",
+      "~k_parent": "48"
     },
     "55": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "54"
+      "key": "root.imports.icons",
+      "~k_parent": "48"
     },
     "56": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "55"
     },
     "59": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "55"
     },
     "61": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "55"
     },
     "63": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "55"
     },
     "65": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "55"
     },
     "67": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "55"
     },
     "69": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "68"
     },
     "a": {
@@ -679,398 +679,407 @@
       "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "38"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "39"
     },
     "3b": {
-      "key": "root.types.auth.events",
-      "~k_parent": "38"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "39"
     },
     "3c": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "38"
+      "key": "root.types.auth.events",
+      "~k_parent": "39"
     },
     "3d": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "39"
+    },
+    "3e": {
       "key": "root.types.blocks",
       "~k_parent": "34"
     },
-    "3e": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "3d"
-    },
     "3f": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "3e"
     },
     "3h": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "3e"
     },
     "3i": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3e"
     },
     "3j": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3e"
     },
     "3k": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3e"
     },
     "3l": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3e"
     },
     "3m": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3e"
     },
     "3n": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3e"
     },
     "3o": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3e"
     },
     "3p": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3e"
     },
     "3q": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3e"
     },
     "3r": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3e"
     },
     "3s": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3e"
     },
     "3t": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3e"
     },
     "3u": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3e"
     },
     "3v": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3e"
     },
     "3w": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3e"
     },
     "3x": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3e"
     },
     "3y": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "3d"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3e"
     },
     "3z": {
-      "key": "root.types.connections",
-      "~k_parent": "34"
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3e"
     },
     "4a": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "48"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.auth",
-      "~k_parent": "47"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "49"
     },
     "4c": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "4b"
+      "key": "root.imports.agents",
+      "~k_parent": "48"
     },
     "4d": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "4b"
+      "key": "root.imports.auth",
+      "~k_parent": "48"
     },
     "4e": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "4b"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "4b"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "4d"
     },
     "4g": {
-      "key": "root.imports.blocks",
-      "~k_parent": "47"
+      "key": "root.imports.auth.events",
+      "~k_parent": "4d"
     },
     "4h": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "4g"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "4d"
     },
     "4i": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks",
+      "~k_parent": "48"
     },
     "4j": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "4i"
     },
     "4l": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "4i"
     },
     "4m": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "4i"
     },
     "4n": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "4i"
     },
     "4o": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "4i"
     },
     "4p": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "4i"
     },
     "4q": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "4i"
     },
     "4r": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "4i"
     },
     "4s": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "4i"
     },
     "4t": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "4i"
     },
     "4u": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "4i"
     },
     "4v": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "4i"
     },
     "4w": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "4i"
     },
     "4x": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "4i"
     },
     "4y": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "4i"
     },
     "4z": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "4i"
     },
     "5a": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "55"
     },
     "5b": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "55"
     },
     "5d": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "55"
     },
     "5f": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "55"
     },
     "5h": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "55"
     },
     "5j": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "55"
     },
     "5l": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "55"
     },
     "5n": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "55"
     },
     "5p": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "55"
     },
     "5r": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "55"
     },
     "5t": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "55"
     },
     "5v": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "55"
     },
     "5x": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "55"
     },
     "5z": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "55"
     },
     "6b": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "55"
     },
     "6d": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "55"
     },
     "6f": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "6e"
     },
     "6g": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "55"
     },
     "6h": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "6g"
     },
     "6i": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "55"
     },
     "6j": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "6i"
     },
     "6k": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "55"
     },
     "6l": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "6k"
     },
     "6m": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "53"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "55"
     },
     "6n": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6m"
     },
     "6o": {
-      "key": "root.imports.requests",
-      "~k_parent": "47"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "55"
     },
     "6p": {
-      "key": "root.imports.operators",
-      "~k_parent": "47"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6o"
     },
     "6q": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6p"
+      "key": "root.imports.requests",
+      "~k_parent": "48"
     },
     "6r": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6q"
+      "key": "root.imports.operators",
+      "~k_parent": "48"
     },
     "6s": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6q"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6r"
     },
     "6t": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6s"
+    },
+    "6u": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6s"
+    },
+    "6v": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6p"
+      "~k_parent": "6r"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "1h"
   },
@@ -1479,6 +1488,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5986,158 +5996,161 @@
       },
       "~k": "35"
     },
+    "agents": {
+      "~k": "38"
+    },
     "auth": {
       "adapters": {
-        "~k": "39"
-      },
-      "callbacks": {
         "~k": "3a"
       },
-      "events": {
+      "callbacks": {
         "~k": "3b"
       },
-      "providers": {
+      "events": {
         "~k": "3c"
       },
-      "~k": "38"
+      "providers": {
+        "~k": "3d"
+      },
+      "~k": "39"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "3e"
+        "~k": "3f"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "3f"
+        "~k": "3g"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "3g"
+        "~k": "3h"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3h"
+        "~k": "3i"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3i"
+        "~k": "3j"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3j"
+        "~k": "3k"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3k"
+        "~k": "3l"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3l"
+        "~k": "3m"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3m"
+        "~k": "3n"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3n"
+        "~k": "3o"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3o"
+        "~k": "3p"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3p"
+        "~k": "3q"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3q"
+        "~k": "3r"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3r"
+        "~k": "3s"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3s"
+        "~k": "3t"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3t"
+        "~k": "3u"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3u"
+        "~k": "3v"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3v"
+        "~k": "3w"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3w"
+        "~k": "3x"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3x"
+        "~k": "3y"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3y"
+        "~k": "3z"
       },
-      "~k": "3d"
+      "~k": "3e"
     },
     "connections": {
-      "~k": "3z"
-    },
-    "requests": {
       "~k": "40"
     },
-    "api": {
+    "requests": {
       "~k": "41"
+    },
+    "api": {
+      "~k": "42"
     },
     "operators": {
       "client": {
@@ -6145,20 +6158,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "44"
+          "~k": "45"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "45"
+          "~k": "46"
         },
-        "~k": "43"
+        "~k": "44"
       },
       "server": {
-        "~k": "46"
+        "~k": "47"
       },
-      "~k": "42"
+      "~k": "43"
     },
     "~k": "34"
   }

--- a/packages/build/src/tests/success/32-multifile-connections-ref/snapshot.json
+++ b/packages/build/src/tests/success/32-multifile-connections-ref/snapshot.json
@@ -161,156 +161,156 @@
       "~k_parent": "1z"
     },
     "22": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1y"
     },
     "23": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "22"
+      "key": "root.types.auth",
+      "~k_parent": "1y"
     },
     "24": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "22"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "23"
     },
     "25": {
-      "key": "root.types.auth.events",
-      "~k_parent": "22"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "23"
     },
     "26": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "22"
+      "key": "root.types.auth.events",
+      "~k_parent": "23"
     },
     "27": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "23"
+    },
+    "28": {
       "key": "root.types.blocks",
       "~k_parent": "1y"
     },
-    "28": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "27"
-    },
     "29": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2z"
     },
     "31": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2z"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "30"
     },
     "32": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2y"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "30"
     },
     "33": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2z"
+    },
+    "34": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "34": {
-      "key": "root.imports.actions",
-      "~k_parent": "33"
-    },
     "35": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "34"
     },
     "36": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "34"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "35"
     },
     "37": {
-      "key": "root.imports.auth",
-      "~k_parent": "33"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "35"
     },
     "38": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "37"
+      "key": "root.imports.agents",
+      "~k_parent": "34"
     },
     "39": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "37"
+      "key": "root.imports.auth",
+      "~k_parent": "34"
     },
     "40": {
-      "key": "root.imports.icons",
-      "~k_parent": "33"
+      "key": "root.imports.connections[0]",
+      "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "40"
+      "key": "root.imports.connections[1]",
+      "~k_parent": "3z"
     },
     "42": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "41"
+      "key": "root.imports.icons",
+      "~k_parent": "34"
     },
     "43": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "42"
     },
     "46": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "42"
     },
     "48": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "42"
     },
     "50": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "42"
     },
     "52": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "42"
     },
     "54": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "42"
     },
     "56": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "42"
     },
     "58": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "42"
     },
     "a": {
       "key": "root.connections[1:db:MongoDBCollection].properties",
@@ -527,390 +527,399 @@
       "~k_parent": "1y"
     },
     "2a": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "28"
     },
     "2b": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "28"
     },
     "2c": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "28"
     },
     "2d": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "28"
     },
     "2e": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "27"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "28"
     },
     "2f": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "28"
     },
     "2g": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "28"
     },
     "2h": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "28"
     },
     "2i": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "27"
+      "key": "root.types.blocks.List",
+      "~k_parent": "28"
     },
     "2j": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "28"
     },
     "2k": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "28"
     },
     "2l": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "27"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "28"
     },
     "2m": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "28"
     },
     "2n": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "28"
     },
     "2o": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "28"
     },
     "2p": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "28"
     },
     "2q": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "28"
     },
     "2r": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "28"
     },
     "2s": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "28"
+    },
+    "2t": {
       "key": "root.types.connections",
       "~k_parent": "1y"
     },
-    "2t": {
-      "key": "root.types.connections.AxiosHttp",
-      "~k_parent": "2s"
-    },
     "2u": {
-      "key": "root.types.connections.MongoDBCollection",
-      "~k_parent": "2s"
+      "key": "root.types.connections.AxiosHttp",
+      "~k_parent": "2t"
     },
     "2v": {
+      "key": "root.types.connections.MongoDBCollection",
+      "~k_parent": "2t"
+    },
+    "2w": {
       "key": "root.types.requests",
       "~k_parent": "1y"
     },
-    "2w": {
-      "key": "root.types.requests.AxiosHttp",
-      "~k_parent": "2v"
-    },
     "2x": {
+      "key": "root.types.requests.AxiosHttp",
+      "~k_parent": "2w"
+    },
+    "2y": {
       "key": "root.types.api",
       "~k_parent": "1y"
     },
-    "2y": {
+    "2z": {
       "key": "root.types.operators",
       "~k_parent": "1y"
     },
-    "2z": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2y"
-    },
     "3a": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "37"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "39"
     },
     "3b": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "37"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "39"
     },
     "3c": {
-      "key": "root.imports.blocks",
-      "~k_parent": "33"
+      "key": "root.imports.auth.events",
+      "~k_parent": "39"
     },
     "3d": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3c"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "39"
     },
     "3e": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks",
+      "~k_parent": "34"
     },
     "3f": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3e"
     },
     "3h": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3e"
     },
     "3i": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3e"
     },
     "3j": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3e"
     },
     "3k": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3e"
     },
     "3l": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3e"
     },
     "3m": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3e"
     },
     "3n": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3e"
     },
     "3o": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3e"
     },
     "3p": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3e"
     },
     "3q": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3e"
     },
     "3r": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3e"
     },
     "3s": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3e"
     },
     "3t": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3e"
     },
     "3u": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3e"
     },
     "3v": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3e"
     },
     "3w": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3e"
     },
     "3x": {
-      "key": "root.imports.connections",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3e"
     },
     "3y": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3e"
     },
     "3z": {
-      "key": "root.imports.connections[1]",
-      "~k_parent": "3x"
+      "key": "root.imports.connections",
+      "~k_parent": "34"
     },
     "4a": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "42"
     },
     "4c": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "42"
     },
     "4e": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "42"
     },
     "4g": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "42"
     },
     "4i": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "42"
     },
     "4k": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "42"
     },
     "4m": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "42"
     },
     "4o": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "42"
     },
     "4q": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "42"
     },
     "4s": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "42"
     },
     "4u": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "42"
     },
     "4w": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "42"
     },
     "4y": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "42"
     },
     "5a": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "42"
     },
     "5c": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "42"
     },
     "5e": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "42"
     },
     "5g": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "42"
     },
     "5i": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "42"
     },
     "5k": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.requests",
-      "~k_parent": "33"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "42"
     },
     "5m": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.operators",
-      "~k_parent": "33"
+      "key": "root.imports.requests",
+      "~k_parent": "34"
     },
     "5o": {
-      "key": "root.imports.operators.client",
+      "key": "root.imports.requests[0]",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5o"
+      "key": "root.imports.operators",
+      "~k_parent": "34"
     },
     "5q": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5o"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5p"
     },
     "5r": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5q"
+    },
+    "5s": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5q"
+    },
+    "5t": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5n"
+      "~k_parent": "5p"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "10"
   },
@@ -1143,6 +1152,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5635,170 +5645,173 @@
       },
       "~k": "1z"
     },
+    "agents": {
+      "~k": "22"
+    },
     "auth": {
       "adapters": {
-        "~k": "23"
-      },
-      "callbacks": {
         "~k": "24"
       },
-      "events": {
+      "callbacks": {
         "~k": "25"
       },
-      "providers": {
+      "events": {
         "~k": "26"
       },
-      "~k": "22"
+      "providers": {
+        "~k": "27"
+      },
+      "~k": "23"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "28"
+        "~k": "29"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
-      "~k": "27"
+      "~k": "28"
     },
     "connections": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "MongoDBCollection": {
         "originalTypeName": "MongoDBCollection",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
-      "~k": "2s"
+      "~k": "2t"
     },
     "requests": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
-      "~k": "2v"
+      "~k": "2w"
     },
     "api": {
-      "~k": "2x"
+      "~k": "2y"
     },
     "operators": {
       "client": {
@@ -5806,20 +5819,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "30"
+          "~k": "31"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "31"
+          "~k": "32"
         },
-        "~k": "2z"
+        "~k": "30"
       },
       "server": {
-        "~k": "32"
+        "~k": "33"
       },
-      "~k": "2y"
+      "~k": "2z"
     },
     "~k": "1y"
   }

--- a/packages/build/src/tests/success/33-multifile-nested-refs/snapshot.json
+++ b/packages/build/src/tests/success/33-multifile-nested-refs/snapshot.json
@@ -229,164 +229,164 @@
       "~k_parent": "38"
     },
     "40": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "3y"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "3z"
     },
     "41": {
-      "key": "root.types.auth.events",
-      "~k_parent": "3y"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "3z"
     },
     "42": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "3y"
+      "key": "root.types.auth.events",
+      "~k_parent": "3z"
     },
     "43": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "3z"
+    },
+    "44": {
       "key": "root.types.blocks",
       "~k_parent": "3u"
     },
-    "44": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "43"
-    },
     "45": {
-      "key": "root.types.blocks.Breadcrumb",
-      "~k_parent": "43"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "44"
     },
     "46": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "43"
+      "key": "root.types.blocks.Breadcrumb",
+      "~k_parent": "44"
     },
     "47": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "43"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "44"
     },
     "48": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "43"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "44"
     },
     "49": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "43"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "44"
     },
     "50": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "4x"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "4y"
     },
     "51": {
-      "key": "root.types.operators.server",
-      "~k_parent": "4w"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "4y"
     },
     "52": {
+      "key": "root.types.operators.server",
+      "~k_parent": "4x"
+    },
+    "53": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "53": {
-      "key": "root.imports.actions",
-      "~k_parent": "52"
-    },
     "54": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "53"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.auth",
-      "~k_parent": "52"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "54"
     },
     "57": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "56"
+      "key": "root.imports.agents",
+      "~k_parent": "53"
     },
     "58": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "56"
+      "key": "root.imports.auth",
+      "~k_parent": "53"
     },
     "59": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "56"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.blocks[24]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "5d"
     },
     "61": {
-      "key": "root.imports.connections",
-      "~k_parent": "52"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "5d"
     },
     "62": {
-      "key": "root.imports.icons",
-      "~k_parent": "52"
+      "key": "root.imports.blocks[24]",
+      "~k_parent": "5d"
     },
     "63": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "62"
+      "key": "root.imports.connections",
+      "~k_parent": "53"
     },
     "64": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "63"
+      "key": "root.imports.icons",
+      "~k_parent": "53"
     },
     "65": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "64"
     },
     "68": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "64"
     },
     "70": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "6z"
     },
     "71": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "64"
     },
     "72": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "71"
     },
     "73": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "64"
     },
     "74": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "73"
     },
     "75": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "64"
     },
     "76": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "75"
     },
     "77": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "64"
     },
     "78": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "77"
     },
     "79": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "64"
     },
     "a": {
       "key": "root.pages[0:dashboard:Box].blocks",
@@ -871,406 +871,415 @@
       "~k_parent": "3v"
     },
     "3y": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "3u"
     },
     "3z": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "3y"
+      "key": "root.types.auth",
+      "~k_parent": "3u"
     },
     "4a": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "43"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "44"
     },
     "4b": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "43"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "44"
     },
     "4c": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "43"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "44"
     },
     "4d": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "43"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "44"
     },
     "4e": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "43"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "44"
     },
     "4f": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "43"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "44"
     },
     "4g": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "43"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "44"
     },
     "4h": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "43"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "44"
     },
     "4i": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "43"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "44"
     },
     "4j": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "43"
+      "key": "root.types.blocks.List",
+      "~k_parent": "44"
     },
     "4k": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "43"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "44"
     },
     "4l": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "43"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "44"
     },
     "4m": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "43"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "44"
     },
     "4n": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "43"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "44"
     },
     "4o": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "43"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "44"
     },
     "4p": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "43"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "44"
     },
     "4q": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "43"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "44"
     },
     "4r": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "43"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "44"
     },
     "4s": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "43"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "44"
     },
     "4t": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "44"
+    },
+    "4u": {
       "key": "root.types.connections",
       "~k_parent": "3u"
     },
-    "4u": {
+    "4v": {
       "key": "root.types.requests",
       "~k_parent": "3u"
     },
-    "4v": {
+    "4w": {
       "key": "root.types.api",
       "~k_parent": "3u"
     },
-    "4w": {
+    "4x": {
       "key": "root.types.operators",
       "~k_parent": "3u"
     },
-    "4x": {
-      "key": "root.types.operators.client",
-      "~k_parent": "4w"
-    },
     "4y": {
-      "key": "root.types.operators.client._global",
+      "key": "root.types.operators.client",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "4x"
+      "key": "root.types.operators.client._global",
+      "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "56"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "58"
     },
     "5b": {
-      "key": "root.imports.blocks",
-      "~k_parent": "52"
+      "key": "root.imports.auth.events",
+      "~k_parent": "58"
     },
     "5c": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "5b"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "58"
     },
     "5d": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks",
+      "~k_parent": "53"
     },
     "5e": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "5d"
     },
     "5g": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "5d"
     },
     "5h": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "5d"
     },
     "5i": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "5d"
     },
     "5j": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "5d"
     },
     "5k": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "5d"
     },
     "5l": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "5d"
     },
     "5m": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "5d"
     },
     "5n": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "5d"
     },
     "5o": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "5d"
     },
     "5p": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "5d"
     },
     "5q": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "5d"
     },
     "5r": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "5d"
     },
     "5s": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "5d"
     },
     "5t": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "5d"
     },
     "5u": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "5d"
     },
     "5v": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "5d"
     },
     "5w": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "5d"
     },
     "5x": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "5d"
     },
     "5y": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "5d"
     },
     "5z": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "5d"
     },
     "6a": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "64"
     },
     "6c": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "64"
     },
     "6e": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "64"
     },
     "6g": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "6f"
     },
     "6h": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "64"
     },
     "6i": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "64"
     },
     "6k": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "6j"
     },
     "6l": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "64"
     },
     "6m": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "6l"
     },
     "6n": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "64"
     },
     "6o": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "6n"
     },
     "6p": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "64"
     },
     "6q": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "64"
     },
     "6s": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "6r"
     },
     "6t": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "64"
     },
     "6u": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "64"
     },
     "6w": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "6v"
     },
     "6x": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "64"
     },
     "6y": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "64"
     },
     "7a": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "79"
     },
     "7b": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "64"
     },
     "7c": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "7b"
     },
     "7d": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "64"
     },
     "7e": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "7d"
     },
     "7f": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "64"
     },
     "7g": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "7f"
     },
     "7h": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "64"
     },
     "7i": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "7h"
     },
     "7j": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "64"
     },
     "7k": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "7j"
     },
     "7l": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "64"
     },
     "7m": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "7l"
     },
     "7n": {
-      "key": "root.imports.requests",
-      "~k_parent": "52"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "64"
     },
     "7o": {
-      "key": "root.imports.operators",
-      "~k_parent": "52"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "7n"
     },
     "7p": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "7o"
+      "key": "root.imports.requests",
+      "~k_parent": "53"
     },
     "7q": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "7p"
+      "key": "root.imports.operators",
+      "~k_parent": "53"
     },
     "7r": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "7p"
+      "key": "root.imports.operators.client",
+      "~k_parent": "7q"
     },
     "7s": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "7p"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "7r"
     },
     "7t": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "7r"
+    },
+    "7u": {
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "7r"
+    },
+    "7v": {
       "key": "root.imports.operators.server",
-      "~k_parent": "7o"
+      "~k_parent": "7q"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "24"
   },
@@ -1797,6 +1806,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -8279,26 +8289,6 @@
       "lineNumber": 13,
       "path": "pages/settings.yaml"
     },
-    "pages.0.blocks.0": {
-      "parent": "pages.0",
-      "lineNumber": 6,
-      "path": "blocks/page-header.yaml"
-    },
-    "pages.0.blocks.1.blocks.0": {
-      "parent": "pages.0",
-      "lineNumber": 10,
-      "path": "components/metric-card.yaml"
-    },
-    "pages.0.blocks.1.blocks.1": {
-      "parent": "pages.0",
-      "lineNumber": 15,
-      "path": "components/metric-card.yaml"
-    },
-    "pages.0.blocks.2": {
-      "parent": "pages.0",
-      "lineNumber": 20,
-      "path": "blocks/page-footer.yaml"
-    },
     "pages.1.blocks.0": {
       "parent": "pages.1",
       "lineNumber": 6,
@@ -8317,6 +8307,26 @@
     "pages.1.blocks.2": {
       "parent": "pages.1",
       "lineNumber": 22,
+      "path": "blocks/page-footer.yaml"
+    },
+    "pages.0.blocks.0": {
+      "parent": "pages.0",
+      "lineNumber": 6,
+      "path": "blocks/page-header.yaml"
+    },
+    "pages.0.blocks.1.blocks.0": {
+      "parent": "pages.0",
+      "lineNumber": 10,
+      "path": "components/metric-card.yaml"
+    },
+    "pages.0.blocks.1.blocks.1": {
+      "parent": "pages.0",
+      "lineNumber": 15,
+      "path": "components/metric-card.yaml"
+    },
+    "pages.0.blocks.2": {
+      "parent": "pages.0",
+      "lineNumber": 20,
       "path": "blocks/page-footer.yaml"
     }
   },
@@ -8340,182 +8350,185 @@
       },
       "~k": "3v"
     },
+    "agents": {
+      "~k": "3y"
+    },
     "auth": {
       "adapters": {
-        "~k": "3z"
-      },
-      "callbacks": {
         "~k": "40"
       },
-      "events": {
+      "callbacks": {
         "~k": "41"
       },
-      "providers": {
+      "events": {
         "~k": "42"
       },
-      "~k": "3y"
+      "providers": {
+        "~k": "43"
+      },
+      "~k": "3z"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 8,
-        "~k": "44"
+        "~k": "45"
       },
       "Breadcrumb": {
         "originalTypeName": "Breadcrumb",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "45"
+        "~k": "46"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "46"
+        "~k": "47"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "47"
+        "~k": "48"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "48"
+        "~k": "49"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "49"
+        "~k": "4a"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "4a"
+        "~k": "4b"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4b"
+        "~k": "4c"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4c"
+        "~k": "4d"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4d"
+        "~k": "4e"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4e"
+        "~k": "4f"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4f"
+        "~k": "4g"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4g"
+        "~k": "4h"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4h"
+        "~k": "4i"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4i"
+        "~k": "4j"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4j"
+        "~k": "4k"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4k"
+        "~k": "4l"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4l"
+        "~k": "4m"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4m"
+        "~k": "4n"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4n"
+        "~k": "4o"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4o"
+        "~k": "4p"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4p"
+        "~k": "4q"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4q"
+        "~k": "4r"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4r"
+        "~k": "4s"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4s"
+        "~k": "4t"
       },
-      "~k": "43"
+      "~k": "44"
     },
     "connections": {
-      "~k": "4t"
-    },
-    "requests": {
       "~k": "4u"
     },
-    "api": {
+    "requests": {
       "~k": "4v"
+    },
+    "api": {
+      "~k": "4w"
     },
     "operators": {
       "client": {
@@ -8523,26 +8536,26 @@
           "originalTypeName": "_global",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "4y"
+          "~k": "4z"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4z"
+          "~k": "50"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "50"
+          "~k": "51"
         },
-        "~k": "4x"
+        "~k": "4y"
       },
       "server": {
-        "~k": "51"
+        "~k": "52"
       },
-      "~k": "4w"
+      "~k": "4x"
     },
     "~k": "3u"
   }

--- a/packages/build/src/tests/success/34-crud-app-complete/snapshot.json
+++ b/packages/build/src/tests/success/34-crud-app-complete/snapshot.json
@@ -417,120 +417,120 @@
       "~k_parent": "6v"
     },
     "71": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "6u"
     },
     "72": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "71"
+      "key": "root.types.auth",
+      "~k_parent": "6u"
     },
     "73": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "71"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "72"
     },
     "74": {
-      "key": "root.types.auth.events",
-      "~k_parent": "71"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "72"
     },
     "75": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "71"
+      "key": "root.types.auth.events",
+      "~k_parent": "72"
     },
     "76": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "72"
+    },
+    "77": {
       "key": "root.types.blocks",
       "~k_parent": "6u"
     },
-    "77": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "76"
-    },
     "78": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "76"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "77"
     },
     "79": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "76"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "77"
     },
     "80": {
-      "key": "root.types.requests.MongoDBFindOne",
-      "~k_parent": "7w"
+      "key": "root.types.requests.MongoDBInsertOne",
+      "~k_parent": "7x"
     },
     "81": {
-      "key": "root.types.requests.MongoDBUpdateOne",
-      "~k_parent": "7w"
+      "key": "root.types.requests.MongoDBFindOne",
+      "~k_parent": "7x"
     },
     "82": {
+      "key": "root.types.requests.MongoDBUpdateOne",
+      "~k_parent": "7x"
+    },
+    "83": {
       "key": "root.types.api",
       "~k_parent": "6u"
     },
-    "83": {
+    "84": {
       "key": "root.types.operators",
       "~k_parent": "6u"
     },
-    "84": {
-      "key": "root.types.operators.client",
-      "~k_parent": "83"
-    },
     "85": {
-      "key": "root.types.operators.client._state",
+      "key": "root.types.operators.client",
       "~k_parent": "84"
     },
     "86": {
-      "key": "root.types.operators.client._request",
-      "~k_parent": "84"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "85"
     },
     "87": {
-      "key": "root.types.operators.client._url_query",
-      "~k_parent": "84"
+      "key": "root.types.operators.client._request",
+      "~k_parent": "85"
     },
     "88": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "84"
+      "key": "root.types.operators.client._url_query",
+      "~k_parent": "85"
     },
     "89": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "84"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "85"
     },
     "90": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "8r"
     },
     "91": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "8r"
     },
     "92": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "8r"
     },
     "93": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "8r"
     },
     "94": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "8r"
     },
     "95": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "8r"
     },
     "96": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "8r"
     },
     "97": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "8r"
     },
     "98": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "8r"
     },
     "99": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "8r"
     },
     "a": {
       "key": "root.menus[0:default].links",
@@ -1459,526 +1459,535 @@
       "~k_parent": "6v"
     },
     "7a": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "76"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "77"
     },
     "7b": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "76"
+      "key": "root.types.blocks.List",
+      "~k_parent": "77"
     },
     "7c": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "76"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "77"
     },
     "7d": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "76"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "77"
     },
     "7e": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "76"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "77"
     },
     "7f": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "76"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "77"
     },
     "7g": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "76"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "77"
     },
     "7h": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "76"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "77"
     },
     "7i": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "76"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "77"
     },
     "7j": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "76"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "77"
     },
     "7k": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "76"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "77"
     },
     "7l": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "76"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "77"
     },
     "7m": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "76"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "77"
     },
     "7n": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "76"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "77"
     },
     "7o": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "76"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "77"
     },
     "7p": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "76"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "77"
     },
     "7q": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "76"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "77"
     },
     "7r": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "76"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "77"
     },
     "7s": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "76"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "77"
     },
     "7t": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "76"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "77"
     },
     "7u": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "77"
+    },
+    "7v": {
       "key": "root.types.connections",
       "~k_parent": "6u"
     },
-    "7v": {
-      "key": "root.types.connections.MongoDBCollection",
-      "~k_parent": "7u"
-    },
     "7w": {
+      "key": "root.types.connections.MongoDBCollection",
+      "~k_parent": "7v"
+    },
+    "7x": {
       "key": "root.types.requests",
       "~k_parent": "6u"
     },
-    "7x": {
-      "key": "root.types.requests.MongoDBFind",
-      "~k_parent": "7w"
-    },
     "7y": {
-      "key": "root.types.requests.MongoDBDeleteOne",
-      "~k_parent": "7w"
+      "key": "root.types.requests.MongoDBFind",
+      "~k_parent": "7x"
     },
     "7z": {
-      "key": "root.types.requests.MongoDBInsertOne",
-      "~k_parent": "7w"
+      "key": "root.types.requests.MongoDBDeleteOne",
+      "~k_parent": "7x"
     },
     "8a": {
-      "key": "root.types.operators.server",
-      "~k_parent": "83"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "85"
     },
     "8b": {
-      "key": "root.types.operators.server._payload",
-      "~k_parent": "8a"
+      "key": "root.types.operators.server",
+      "~k_parent": "84"
     },
     "8c": {
-      "key": "root.types.operators.server._date",
-      "~k_parent": "8a"
+      "key": "root.types.operators.server._payload",
+      "~k_parent": "8b"
     },
     "8d": {
+      "key": "root.types.operators.server._date",
+      "~k_parent": "8b"
+    },
+    "8e": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "8e": {
-      "key": "root.imports.actions",
-      "~k_parent": "8d"
-    },
     "8f": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "8e"
     },
     "8g": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "8e"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "8f"
     },
     "8h": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "8e"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "8f"
     },
     "8i": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "8e"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "8f"
     },
     "8j": {
-      "key": "root.imports.actions[4]",
-      "~k_parent": "8e"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "8f"
     },
     "8k": {
-      "key": "root.imports.auth",
-      "~k_parent": "8d"
+      "key": "root.imports.actions[4]",
+      "~k_parent": "8f"
     },
     "8l": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "8k"
+      "key": "root.imports.agents",
+      "~k_parent": "8e"
     },
     "8m": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "8k"
+      "key": "root.imports.auth",
+      "~k_parent": "8e"
     },
     "8n": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "8k"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "8m"
     },
     "8o": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "8k"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "8m"
     },
     "8p": {
-      "key": "root.imports.blocks",
-      "~k_parent": "8d"
+      "key": "root.imports.auth.events",
+      "~k_parent": "8m"
     },
     "8q": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "8p"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "8m"
     },
     "8r": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks",
+      "~k_parent": "8e"
     },
     "8s": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "8r"
     },
     "8t": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "8r"
     },
     "8u": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "8r"
     },
     "8v": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "8r"
     },
     "8w": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "8r"
     },
     "8x": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "8r"
     },
     "8y": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "8r"
     },
     "8z": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "8r"
     },
     "9a": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "8r"
     },
     "9b": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "8r"
     },
     "9c": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "8p"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "8r"
     },
     "9d": {
-      "key": "root.imports.connections",
-      "~k_parent": "8d"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "8r"
     },
     "9e": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "9d"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "8r"
     },
     "9f": {
-      "key": "root.imports.icons",
-      "~k_parent": "8d"
+      "key": "root.imports.connections",
+      "~k_parent": "8e"
     },
     "9g": {
-      "key": "root.imports.icons[0]",
+      "key": "root.imports.connections[0]",
       "~k_parent": "9f"
     },
     "9h": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "9g"
+      "key": "root.imports.icons",
+      "~k_parent": "8e"
     },
     "9i": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "9h"
     },
     "9j": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "9i"
     },
     "9k": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "9h"
     },
     "9l": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "9k"
     },
     "9m": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "9h"
     },
     "9n": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "9m"
     },
     "9o": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "9h"
     },
     "9p": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "9o"
     },
     "9q": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "9h"
     },
     "9r": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "9q"
     },
     "9s": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "9h"
     },
     "9t": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "9s"
     },
     "9u": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "9h"
     },
     "9v": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "9u"
     },
     "9w": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "9h"
     },
     "9x": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "9w"
     },
     "9y": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "9h"
     },
     "9z": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "9y"
     },
     "a0": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "9h"
     },
     "a1": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "a0"
     },
     "a2": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "9h"
     },
     "a3": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "a2"
     },
     "a4": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "9h"
     },
     "a5": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "a4"
     },
     "a6": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "9h"
     },
     "a7": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "a6"
     },
     "a8": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "9h"
     },
     "a9": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "a8"
     },
     "aa": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "9h"
     },
     "ab": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "aa"
     },
     "ac": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "9h"
     },
     "ad": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "ac"
     },
     "ae": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "9h"
     },
     "af": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "ae"
     },
     "ag": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "9h"
     },
     "ah": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "ag"
     },
     "ai": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "9h"
     },
     "aj": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "ai"
     },
     "ak": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "9h"
     },
     "al": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "ak"
     },
     "am": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "9h"
     },
     "an": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "am"
     },
     "ao": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "9h"
     },
     "ap": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "ao"
     },
     "aq": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "9h"
     },
     "ar": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "aq"
     },
     "as": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "9h"
     },
     "at": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "as"
     },
     "au": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "9h"
     },
     "av": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "au"
     },
     "aw": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "9h"
     },
     "ax": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "aw"
     },
     "ay": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "9f"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "9h"
     },
     "az": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "ay"
     },
     "b0": {
-      "key": "root.imports.requests",
-      "~k_parent": "8d"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "9h"
     },
     "b1": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "b0"
     },
     "b2": {
-      "key": "root.imports.requests[1]",
-      "~k_parent": "b0"
+      "key": "root.imports.requests",
+      "~k_parent": "8e"
     },
     "b3": {
-      "key": "root.imports.requests[2]",
-      "~k_parent": "b0"
+      "key": "root.imports.requests[0]",
+      "~k_parent": "b2"
     },
     "b4": {
-      "key": "root.imports.requests[3]",
-      "~k_parent": "b0"
+      "key": "root.imports.requests[1]",
+      "~k_parent": "b2"
     },
     "b5": {
-      "key": "root.imports.requests[4]",
-      "~k_parent": "b0"
+      "key": "root.imports.requests[2]",
+      "~k_parent": "b2"
     },
     "b6": {
-      "key": "root.imports.operators",
-      "~k_parent": "8d"
+      "key": "root.imports.requests[3]",
+      "~k_parent": "b2"
     },
     "b7": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "b6"
+      "key": "root.imports.requests[4]",
+      "~k_parent": "b2"
     },
     "b8": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "b7"
+      "key": "root.imports.operators",
+      "~k_parent": "8e"
     },
     "b9": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "b7"
+      "key": "root.imports.operators.client",
+      "~k_parent": "b8"
     },
     "ba": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "b7"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "b9"
     },
     "bb": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "b7"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "b9"
     },
     "bc": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "b7"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "b9"
     },
     "bd": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "b6"
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "b9"
     },
     "be": {
-      "key": "root.imports.operators.server[0]",
-      "~k_parent": "bd"
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "b9"
     },
     "bf": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "b8"
+    },
+    "bg": {
+      "key": "root.imports.operators.server[0]",
+      "~k_parent": "bf"
+    },
+    "bh": {
       "key": "root.imports.operators.server[1]",
-      "~k_parent": "bd"
+      "~k_parent": "bf"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "4q"
   },
@@ -3074,6 +3083,7 @@
     }
   },
   "plugins/actions.js": "import { Request as Request } from '@lowdefy/actions-core/actions';\nimport { Link as Link } from '@lowdefy/actions-core/actions';\nimport { Validate as Validate } from '@lowdefy/actions-core/actions';\nimport { SetState as SetState } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Request,\n  Link,\n  Validate,\n  SetState,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -8975,206 +8985,209 @@
       },
       "~k": "6v"
     },
+    "agents": {
+      "~k": "71"
+    },
     "auth": {
       "adapters": {
-        "~k": "72"
-      },
-      "callbacks": {
         "~k": "73"
       },
-      "events": {
+      "callbacks": {
         "~k": "74"
       },
-      "providers": {
+      "events": {
         "~k": "75"
       },
-      "~k": "71"
+      "providers": {
+        "~k": "76"
+      },
+      "~k": "72"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "77"
+        "~k": "78"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "78"
+        "~k": "79"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "79"
+        "~k": "7a"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "7a"
+        "~k": "7b"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "7b"
+        "~k": "7c"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7c"
+        "~k": "7d"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 4,
-        "~k": "7d"
+        "~k": "7e"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "7e"
+        "~k": "7f"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7f"
+        "~k": "7g"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7g"
+        "~k": "7h"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7h"
+        "~k": "7i"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7i"
+        "~k": "7j"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7j"
+        "~k": "7k"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7k"
+        "~k": "7l"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7l"
+        "~k": "7m"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7m"
+        "~k": "7n"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7n"
+        "~k": "7o"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7o"
+        "~k": "7p"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7p"
+        "~k": "7q"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7q"
+        "~k": "7r"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7r"
+        "~k": "7s"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7s"
+        "~k": "7t"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "7t"
+        "~k": "7u"
       },
-      "~k": "76"
+      "~k": "77"
     },
     "connections": {
       "MongoDBCollection": {
         "originalTypeName": "MongoDBCollection",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "7v"
+        "~k": "7w"
       },
-      "~k": "7u"
+      "~k": "7v"
     },
     "requests": {
       "MongoDBFind": {
         "originalTypeName": "MongoDBFind",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "7x"
+        "~k": "7y"
       },
       "MongoDBDeleteOne": {
         "originalTypeName": "MongoDBDeleteOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "7y"
+        "~k": "7z"
       },
       "MongoDBInsertOne": {
         "originalTypeName": "MongoDBInsertOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "7z"
+        "~k": "80"
       },
       "MongoDBFindOne": {
         "originalTypeName": "MongoDBFindOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "80"
+        "~k": "81"
       },
       "MongoDBUpdateOne": {
         "originalTypeName": "MongoDBUpdateOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "81"
+        "~k": "82"
       },
-      "~k": "7w"
+      "~k": "7x"
     },
     "api": {
-      "~k": "82"
+      "~k": "83"
     },
     "operators": {
       "client": {
@@ -9182,50 +9195,50 @@
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 8,
-          "~k": "85"
+          "~k": "86"
         },
         "_request": {
           "originalTypeName": "_request",
           "package": "@lowdefy/operators-js",
           "count": 3,
-          "~k": "86"
+          "~k": "87"
         },
         "_url_query": {
           "originalTypeName": "_url_query",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "87"
+          "~k": "88"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "88"
+          "~k": "89"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "89"
+          "~k": "8a"
         },
-        "~k": "84"
+        "~k": "85"
       },
       "server": {
         "_payload": {
           "originalTypeName": "_payload",
           "package": "@lowdefy/operators-js",
           "count": 7,
-          "~k": "8b"
+          "~k": "8c"
         },
         "_date": {
           "originalTypeName": "_date",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "8c"
+          "~k": "8d"
         },
-        "~k": "8a"
+        "~k": "8b"
       },
-      "~k": "83"
+      "~k": "84"
     },
     "~k": "6u"
   }

--- a/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
+++ b/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
@@ -322,164 +322,164 @@
       "~k_parent": "4"
     },
     "50": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "4m"
     },
     "51": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.List",
+      "~k_parent": "4m"
     },
     "52": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "4m"
     },
     "53": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "4m"
     },
     "54": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "4m"
     },
     "55": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "4m"
     },
     "56": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "4m"
     },
     "57": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "4m"
     },
     "58": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "4m"
     },
     "59": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "4m"
     },
     "60": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "5y"
     },
     "61": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "5y"
     },
     "62": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "5y"
     },
     "63": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "5y"
     },
     "64": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "5y"
     },
     "65": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "5y"
     },
     "66": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "5y"
     },
     "67": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "5y"
     },
     "68": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "5y"
     },
     "69": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "5y"
     },
     "70": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "6p"
     },
     "71": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "70"
     },
     "72": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "6p"
     },
     "73": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "72"
     },
     "74": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "6p"
     },
     "75": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "74"
     },
     "76": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "6p"
     },
     "77": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "76"
     },
     "78": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "6p"
     },
     "79": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "78"
     },
     "80": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "6p"
     },
     "81": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "80"
     },
     "82": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "6p"
     },
     "83": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "82"
     },
     "84": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "6p"
     },
     "85": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "84"
     },
     "86": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "6p"
     },
     "87": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "86"
     },
     "88": {
-      "key": "root.imports.requests",
-      "~k_parent": "5k"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "6p"
     },
     "89": {
-      "key": "root.imports.operators",
-      "~k_parent": "5k"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "88"
     },
     "a": {
       "key": "root.auth.providers[0:google:GoogleProvider].properties.clientSecret",
@@ -1006,422 +1006,431 @@
       "~k_parent": "4a"
     },
     "4f": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "49"
     },
     "4g": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "4f"
+      "key": "root.types.auth",
+      "~k_parent": "49"
     },
     "4h": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "4f"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.types.auth.events",
-      "~k_parent": "4f"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "4g"
     },
     "4j": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "4f"
+      "key": "root.types.auth.events",
+      "~k_parent": "4g"
     },
     "4k": {
-      "key": "root.types.auth.providers.GoogleProvider",
-      "~k_parent": "4j"
+      "key": "root.types.auth.providers",
+      "~k_parent": "4g"
     },
     "4l": {
+      "key": "root.types.auth.providers.GoogleProvider",
+      "~k_parent": "4k"
+    },
+    "4m": {
       "key": "root.types.blocks",
       "~k_parent": "49"
     },
-    "4m": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "4l"
-    },
     "4n": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "4m"
     },
     "4p": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "4m"
     },
     "4q": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "4m"
     },
     "4r": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "4m"
     },
     "4s": {
-      "key": "root.types.blocks.Avatar",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "4m"
     },
     "4t": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Avatar",
+      "~k_parent": "4m"
     },
     "4u": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "4m"
     },
     "4v": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "4m"
     },
     "4w": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "4m"
     },
     "4x": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "4m"
     },
     "4y": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "4m"
     },
     "4z": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "4m"
     },
     "5a": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "4m"
     },
     "5b": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "4m"
+    },
+    "5c": {
       "key": "root.types.connections",
       "~k_parent": "49"
     },
-    "5c": {
+    "5d": {
       "key": "root.types.requests",
       "~k_parent": "49"
     },
-    "5d": {
+    "5e": {
       "key": "root.types.api",
       "~k_parent": "49"
     },
-    "5e": {
+    "5f": {
       "key": "root.types.operators",
       "~k_parent": "49"
     },
-    "5f": {
-      "key": "root.types.operators.client",
-      "~k_parent": "5e"
-    },
     "5g": {
-      "key": "root.types.operators.client._user",
+      "key": "root.types.operators.client",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "5f"
+      "key": "root.types.operators.client._user",
+      "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "5f"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "5g"
     },
     "5j": {
-      "key": "root.types.operators.server",
-      "~k_parent": "5e"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "5g"
     },
     "5k": {
+      "key": "root.types.operators.server",
+      "~k_parent": "5f"
+    },
+    "5l": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "5l": {
-      "key": "root.imports.actions",
-      "~k_parent": "5k"
-    },
     "5m": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "5l"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "5l"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "5m"
     },
     "5p": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "5l"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "5m"
     },
     "5q": {
-      "key": "root.imports.auth",
-      "~k_parent": "5k"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "5m"
     },
     "5r": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "5q"
+      "key": "root.imports.agents",
+      "~k_parent": "5l"
     },
     "5s": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "5q"
+      "key": "root.imports.auth",
+      "~k_parent": "5l"
     },
     "5t": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "5q"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "5q"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "5s"
     },
     "5v": {
-      "key": "root.imports.auth.providers[0]",
-      "~k_parent": "5u"
+      "key": "root.imports.auth.events",
+      "~k_parent": "5s"
     },
     "5w": {
-      "key": "root.imports.blocks",
-      "~k_parent": "5k"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "5s"
     },
     "5x": {
-      "key": "root.imports.blocks[0]",
+      "key": "root.imports.auth.providers[0]",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks",
+      "~k_parent": "5l"
     },
     "5z": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "5y"
     },
     "6b": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "5y"
     },
     "6c": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "5y"
     },
     "6d": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "5y"
     },
     "6e": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "5y"
     },
     "6f": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "5y"
     },
     "6g": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "5y"
     },
     "6h": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "5y"
     },
     "6i": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "5y"
     },
     "6j": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "5y"
     },
     "6k": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "5y"
     },
     "6l": {
-      "key": "root.imports.blocks[24]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "5y"
     },
     "6m": {
-      "key": "root.imports.connections",
-      "~k_parent": "5k"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "5y"
     },
     "6n": {
-      "key": "root.imports.icons",
-      "~k_parent": "5k"
+      "key": "root.imports.blocks[24]",
+      "~k_parent": "5y"
     },
     "6o": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "6n"
+      "key": "root.imports.connections",
+      "~k_parent": "5l"
     },
     "6p": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "6o"
+      "key": "root.imports.icons",
+      "~k_parent": "5l"
     },
     "6q": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "6q"
     },
     "6s": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "6p"
     },
     "6t": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "6s"
     },
     "6u": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "6p"
     },
     "6v": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "6u"
     },
     "6w": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "6p"
     },
     "6x": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "6w"
     },
     "6y": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "6p"
     },
     "6z": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "6y"
     },
     "7a": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "6p"
     },
     "7b": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "7a"
     },
     "7c": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "6p"
     },
     "7d": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "7c"
     },
     "7e": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "6p"
     },
     "7f": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "7e"
     },
     "7g": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "6p"
     },
     "7h": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "7g"
     },
     "7i": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "6p"
     },
     "7j": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "7i"
     },
     "7k": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "6p"
     },
     "7l": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "7k"
     },
     "7m": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "6p"
     },
     "7n": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "7m"
     },
     "7o": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "6p"
     },
     "7p": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "7o"
     },
     "7q": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "6p"
     },
     "7r": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "7q"
     },
     "7s": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "6p"
     },
     "7t": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "7s"
     },
     "7u": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "6p"
     },
     "7v": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "7u"
     },
     "7w": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "6p"
     },
     "7x": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "7w"
     },
     "7y": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "6p"
     },
     "7z": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "7y"
     },
     "8a": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "89"
+      "key": "root.imports.requests",
+      "~k_parent": "5l"
     },
     "8b": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "8a"
+      "key": "root.imports.operators",
+      "~k_parent": "5l"
     },
     "8c": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "8a"
+      "key": "root.imports.operators.client",
+      "~k_parent": "8b"
     },
     "8d": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "8a"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "8c"
     },
     "8e": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "8c"
+    },
+    "8f": {
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "8c"
+    },
+    "8g": {
       "key": "root.imports.operators.server",
-      "~k_parent": "89"
+      "~k_parent": "8b"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "2v"
   },
@@ -2031,6 +2040,7 @@
     }
   },
   "plugins/actions.js": "import { Login as Login } from '@lowdefy/actions-core/actions';\nimport { Logout as Logout } from '@lowdefy/actions-core/actions';\nimport { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Login,\n  Logout,\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -8924,188 +8934,191 @@
       },
       "~k": "4a"
     },
+    "agents": {
+      "~k": "4f"
+    },
     "auth": {
       "adapters": {
-        "~k": "4g"
-      },
-      "callbacks": {
         "~k": "4h"
       },
-      "events": {
+      "callbacks": {
         "~k": "4i"
+      },
+      "events": {
+        "~k": "4j"
       },
       "providers": {
         "GoogleProvider": {
           "originalTypeName": "GoogleProvider",
           "package": "next-auth",
           "count": 1,
-          "~k": "4k"
+          "~k": "4l"
         },
-        "~k": "4j"
+        "~k": "4k"
       },
-      "~k": "4f"
+      "~k": "4g"
     },
     "blocks": {
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "4m"
+        "~k": "4n"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "4n"
+        "~k": "4o"
       },
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 6,
-        "~k": "4o"
+        "~k": "4p"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "4p"
+        "~k": "4q"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "4q"
+        "~k": "4r"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "4r"
+        "~k": "4s"
       },
       "Avatar": {
         "originalTypeName": "Avatar",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4s"
+        "~k": "4t"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4t"
+        "~k": "4u"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4u"
+        "~k": "4v"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4v"
+        "~k": "4w"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4w"
+        "~k": "4x"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4x"
+        "~k": "4y"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4y"
+        "~k": "4z"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4z"
+        "~k": "50"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "50"
+        "~k": "51"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "51"
+        "~k": "52"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "52"
+        "~k": "53"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "53"
+        "~k": "54"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "54"
+        "~k": "55"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "55"
+        "~k": "56"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "56"
+        "~k": "57"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "57"
+        "~k": "58"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "58"
+        "~k": "59"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "59"
+        "~k": "5a"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "5a"
+        "~k": "5b"
       },
-      "~k": "4l"
+      "~k": "4m"
     },
     "connections": {
-      "~k": "5b"
-    },
-    "requests": {
       "~k": "5c"
     },
-    "api": {
+    "requests": {
       "~k": "5d"
+    },
+    "api": {
+      "~k": "5e"
     },
     "operators": {
       "client": {
@@ -9113,26 +9126,26 @@
           "originalTypeName": "_user",
           "package": "@lowdefy/operators-js",
           "count": 4,
-          "~k": "5g"
+          "~k": "5h"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5h"
+          "~k": "5i"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5i"
+          "~k": "5j"
         },
-        "~k": "5f"
+        "~k": "5g"
       },
       "server": {
-        "~k": "5j"
+        "~k": "5k"
       },
-      "~k": "5e"
+      "~k": "5f"
     },
     "~k": "49"
   }

--- a/packages/build/src/tests/success/36-auth-roles-app/snapshot.json
+++ b/packages/build/src/tests/success/36-auth-roles-app/snapshot.json
@@ -315,164 +315,164 @@
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "4u"
     },
     "51": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "4u"
     },
     "52": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "4u"
     },
     "53": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "4u"
     },
     "54": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.List",
+      "~k_parent": "4u"
     },
     "55": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "4u"
     },
     "56": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "4u"
     },
     "57": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "4u"
     },
     "58": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "4u"
     },
     "59": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "4u"
     },
     "60": {
-      "key": "root.imports.blocks[0]",
+      "key": "root.imports.auth.providers[0]",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks",
+      "~k_parent": "5n"
     },
     "62": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "61"
     },
     "64": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "61"
     },
     "65": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "61"
     },
     "66": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "61"
     },
     "67": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "61"
     },
     "68": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "61"
     },
     "69": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "61"
     },
     "70": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "6n"
     },
     "71": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "70"
     },
     "72": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "6n"
     },
     "73": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "72"
     },
     "74": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "6n"
     },
     "75": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "74"
     },
     "76": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "6n"
     },
     "77": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "76"
     },
     "78": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "6n"
     },
     "79": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "78"
     },
     "80": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "6n"
     },
     "81": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "80"
     },
     "82": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "6n"
     },
     "83": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "82"
     },
     "84": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "6n"
     },
     "85": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "84"
     },
     "86": {
-      "key": "root.imports.requests",
-      "~k_parent": "5m"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "6n"
     },
     "87": {
-      "key": "root.imports.operators",
-      "~k_parent": "5m"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "86"
     },
     "88": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "87"
+      "key": "root.imports.requests",
+      "~k_parent": "5n"
     },
     "89": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "88"
+      "key": "root.imports.operators",
+      "~k_parent": "5n"
     },
     "a": {
       "key": "root.auth.providers[0:credentials:CredentialsProvider].properties.credentials.email",
@@ -973,386 +973,395 @@
       "~k_parent": "4h"
     },
     "4l": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "4g"
     },
     "4m": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "4l"
+      "key": "root.types.auth",
+      "~k_parent": "4g"
     },
     "4n": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "4l"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.types.auth.callbacks.JwtCallback",
-      "~k_parent": "4n"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "4m"
     },
     "4p": {
-      "key": "root.types.auth.callbacks.SessionCallback",
-      "~k_parent": "4n"
+      "key": "root.types.auth.callbacks.JwtCallback",
+      "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.types.auth.events",
-      "~k_parent": "4l"
+      "key": "root.types.auth.callbacks.SessionCallback",
+      "~k_parent": "4o"
     },
     "4r": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "4l"
+      "key": "root.types.auth.events",
+      "~k_parent": "4m"
     },
     "4s": {
-      "key": "root.types.auth.providers.CredentialsProvider",
-      "~k_parent": "4r"
+      "key": "root.types.auth.providers",
+      "~k_parent": "4m"
     },
     "4t": {
+      "key": "root.types.auth.providers.CredentialsProvider",
+      "~k_parent": "4s"
+    },
+    "4u": {
       "key": "root.types.blocks",
       "~k_parent": "4g"
     },
-    "4u": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "4t"
-    },
     "4v": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "4u"
     },
     "4x": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "4u"
     },
     "4y": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "4u"
     },
     "4z": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "4u"
     },
     "5a": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "4u"
     },
     "5b": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "4u"
     },
     "5c": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "4u"
     },
     "5d": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "4t"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "4u"
     },
     "5e": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "4u"
+    },
+    "5f": {
       "key": "root.types.connections",
       "~k_parent": "4g"
     },
-    "5f": {
+    "5g": {
       "key": "root.types.requests",
       "~k_parent": "4g"
     },
-    "5g": {
+    "5h": {
       "key": "root.types.api",
       "~k_parent": "4g"
     },
-    "5h": {
+    "5i": {
       "key": "root.types.operators",
       "~k_parent": "4g"
     },
-    "5i": {
-      "key": "root.types.operators.client",
-      "~k_parent": "5h"
-    },
     "5j": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "5i"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.types.operators.server",
-      "~k_parent": "5h"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "5j"
     },
     "5m": {
+      "key": "root.types.operators.server",
+      "~k_parent": "5i"
+    },
+    "5n": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "5n": {
-      "key": "root.imports.actions",
-      "~k_parent": "5m"
-    },
     "5o": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "5n"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "5n"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "5o"
     },
     "5r": {
-      "key": "root.imports.auth",
-      "~k_parent": "5m"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "5o"
     },
     "5s": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "5r"
+      "key": "root.imports.agents",
+      "~k_parent": "5n"
     },
     "5t": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "5r"
+      "key": "root.imports.auth",
+      "~k_parent": "5n"
     },
     "5u": {
-      "key": "root.imports.auth.callbacks[0]",
+      "key": "root.imports.auth.adapters",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.auth.callbacks[1]",
+      "key": "root.imports.auth.callbacks",
       "~k_parent": "5t"
     },
     "5w": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "5r"
+      "key": "root.imports.auth.callbacks[0]",
+      "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "5r"
+      "key": "root.imports.auth.callbacks[1]",
+      "~k_parent": "5v"
     },
     "5y": {
-      "key": "root.imports.auth.providers[0]",
-      "~k_parent": "5x"
+      "key": "root.imports.auth.events",
+      "~k_parent": "5t"
     },
     "5z": {
-      "key": "root.imports.blocks",
-      "~k_parent": "5m"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "5t"
     },
     "6a": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "61"
     },
     "6b": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "61"
     },
     "6c": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "61"
     },
     "6d": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "61"
     },
     "6e": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "61"
     },
     "6f": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "61"
     },
     "6g": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "61"
     },
     "6h": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "61"
     },
     "6i": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "61"
     },
     "6j": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "61"
     },
     "6k": {
-      "key": "root.imports.connections",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "61"
     },
     "6l": {
-      "key": "root.imports.icons",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "61"
     },
     "6m": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "6l"
+      "key": "root.imports.connections",
+      "~k_parent": "5n"
     },
     "6n": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "6m"
+      "key": "root.imports.icons",
+      "~k_parent": "5n"
     },
     "6o": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "6n"
     },
     "6p": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "6o"
     },
     "6q": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "6n"
     },
     "6r": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "6q"
     },
     "6s": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "6n"
     },
     "6t": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "6s"
     },
     "6u": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "6n"
     },
     "6v": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "6u"
     },
     "6w": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "6n"
     },
     "6x": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "6w"
     },
     "6y": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "6n"
     },
     "6z": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "6y"
     },
     "7a": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "6n"
     },
     "7b": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "7a"
     },
     "7c": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "6n"
     },
     "7d": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "7c"
     },
     "7e": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "6n"
     },
     "7f": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "7e"
     },
     "7g": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "6n"
     },
     "7h": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "7g"
     },
     "7i": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "6n"
     },
     "7j": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "7i"
     },
     "7k": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "6n"
     },
     "7l": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "7k"
     },
     "7m": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "6n"
     },
     "7n": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "7m"
     },
     "7o": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "6n"
     },
     "7p": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "7o"
     },
     "7q": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "6n"
     },
     "7r": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "7q"
     },
     "7s": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "6n"
     },
     "7t": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "7s"
     },
     "7u": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "6n"
     },
     "7v": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "7u"
     },
     "7w": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "6n"
     },
     "7x": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "7w"
     },
     "7y": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "6l"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "6n"
     },
     "7z": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "7y"
     },
     "8a": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "88"
+      "key": "root.imports.operators.client",
+      "~k_parent": "89"
     },
     "8b": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "8a"
+    },
+    "8c": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "8a"
+    },
+    "8d": {
       "key": "root.imports.operators.server",
-      "~k_parent": "87"
+      "~k_parent": "89"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "27"
   },
@@ -1976,6 +1985,7 @@
     }
   },
   "plugins/actions.js": "import { Login as Login } from '@lowdefy/actions-core/actions';\nimport { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Login,\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "import { JwtCallback as JwtCallback } from '@lowdefy/plugin-next-auth/auth/callbacks';\nimport { SessionCallback as SessionCallback } from '@lowdefy/plugin-next-auth/auth/callbacks';\nexport default {\n  JwtCallback,\n  SessionCallback,\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -6469,170 +6479,173 @@
       },
       "~k": "4h"
     },
+    "agents": {
+      "~k": "4l"
+    },
     "auth": {
       "adapters": {
-        "~k": "4m"
+        "~k": "4n"
       },
       "callbacks": {
         "JwtCallback": {
           "originalTypeName": "JwtCallback",
           "package": "@lowdefy/plugin-next-auth",
           "count": 1,
-          "~k": "4o"
+          "~k": "4p"
         },
         "SessionCallback": {
           "originalTypeName": "SessionCallback",
           "package": "@lowdefy/plugin-next-auth",
           "count": 1,
-          "~k": "4p"
+          "~k": "4q"
         },
-        "~k": "4n"
+        "~k": "4o"
       },
       "events": {
-        "~k": "4q"
+        "~k": "4r"
       },
       "providers": {
         "CredentialsProvider": {
           "originalTypeName": "CredentialsProvider",
           "package": "next-auth",
           "count": 1,
-          "~k": "4s"
+          "~k": "4t"
         },
-        "~k": "4r"
+        "~k": "4s"
       },
-      "~k": "4l"
+      "~k": "4m"
     },
     "blocks": {
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "4u"
+        "~k": "4v"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "4v"
+        "~k": "4w"
       },
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "4w"
+        "~k": "4x"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 6,
-        "~k": "4x"
+        "~k": "4y"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4y"
+        "~k": "4z"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4z"
+        "~k": "50"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "50"
+        "~k": "51"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "51"
+        "~k": "52"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "52"
+        "~k": "53"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "53"
+        "~k": "54"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "54"
+        "~k": "55"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "55"
+        "~k": "56"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "56"
+        "~k": "57"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "57"
+        "~k": "58"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "58"
+        "~k": "59"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "59"
+        "~k": "5a"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5a"
+        "~k": "5b"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5b"
+        "~k": "5c"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5c"
+        "~k": "5d"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "5d"
+        "~k": "5e"
       },
-      "~k": "4t"
+      "~k": "4u"
     },
     "connections": {
-      "~k": "5e"
-    },
-    "requests": {
       "~k": "5f"
     },
-    "api": {
+    "requests": {
       "~k": "5g"
+    },
+    "api": {
+      "~k": "5h"
     },
     "operators": {
       "client": {
@@ -6640,20 +6653,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5j"
+          "~k": "5k"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5k"
+          "~k": "5l"
         },
-        "~k": "5i"
+        "~k": "5j"
       },
       "server": {
-        "~k": "5l"
+        "~k": "5m"
       },
-      "~k": "5h"
+      "~k": "5i"
     },
     "~k": "4g"
   }

--- a/packages/build/src/tests/success/37-api-endpoints-app/snapshot.json
+++ b/packages/build/src/tests/success/37-api-endpoints-app/snapshot.json
@@ -159,131 +159,131 @@
       "~k_parent": "25"
     },
     "28": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "24"
     },
     "29": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "28"
+      "key": "root.types.auth",
+      "~k_parent": "24"
     },
     "30": {
-      "key": "root.types.requests",
+      "key": "root.types.connections",
       "~k_parent": "24"
     },
     "31": {
-      "key": "root.types.api",
+      "key": "root.types.requests",
       "~k_parent": "24"
     },
     "32": {
-      "key": "root.types.operators",
+      "key": "root.types.api",
       "~k_parent": "24"
     },
     "33": {
-      "key": "root.types.operators.client",
-      "~k_parent": "32"
+      "key": "root.types.operators",
+      "~k_parent": "24"
     },
     "34": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "33"
     },
     "35": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "33"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "34"
     },
     "36": {
-      "key": "root.types.operators.server",
-      "~k_parent": "32"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "34"
     },
     "37": {
+      "key": "root.types.operators.server",
+      "~k_parent": "33"
+    },
+    "38": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "38": {
-      "key": "root.imports.actions",
-      "~k_parent": "37"
-    },
     "39": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "38"
     },
     "40": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3i"
     },
     "41": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3i"
     },
     "42": {
-      "key": "root.imports.connections",
-      "~k_parent": "37"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3i"
     },
     "43": {
-      "key": "root.imports.icons",
-      "~k_parent": "37"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "3i"
     },
     "44": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "43"
+      "key": "root.imports.connections",
+      "~k_parent": "38"
     },
     "45": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "44"
+      "key": "root.imports.icons",
+      "~k_parent": "38"
     },
     "46": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "45"
     },
     "49": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "45"
     },
     "51": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "45"
     },
     "53": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "45"
     },
     "55": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "45"
     },
     "57": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "45"
     },
     "59": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "58"
     },
     "a": {
@@ -511,398 +511,407 @@
       "~k_parent": "1y"
     },
     "2a": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "28"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "29"
     },
     "2b": {
-      "key": "root.types.auth.events",
-      "~k_parent": "28"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "29"
     },
     "2c": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "28"
+      "key": "root.types.auth.events",
+      "~k_parent": "29"
     },
     "2d": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "29"
+    },
+    "2e": {
       "key": "root.types.blocks",
       "~k_parent": "24"
     },
-    "2e": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2d"
-    },
     "2f": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2e"
     },
     "2g": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2e"
     },
     "2h": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "2e"
     },
     "2i": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2e"
     },
     "2j": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2e"
     },
     "2k": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2e"
     },
     "2l": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2e"
     },
     "2m": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2e"
     },
     "2n": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2e"
     },
     "2o": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2e"
     },
     "2p": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2e"
     },
     "2q": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2e"
     },
     "2r": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2e"
     },
     "2s": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2e"
     },
     "2t": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2e"
     },
     "2u": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2e"
     },
     "2v": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2e"
     },
     "2w": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2e"
     },
     "2x": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2e"
     },
     "2y": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2e"
     },
     "2z": {
-      "key": "root.types.connections",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2e"
     },
     "3a": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "38"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "39"
     },
     "3b": {
-      "key": "root.imports.auth",
-      "~k_parent": "37"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "39"
     },
     "3c": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3b"
+      "key": "root.imports.agents",
+      "~k_parent": "38"
     },
     "3d": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3b"
+      "key": "root.imports.auth",
+      "~k_parent": "38"
     },
     "3e": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3b"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3d"
     },
     "3f": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3b"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3d"
     },
     "3g": {
-      "key": "root.imports.blocks",
-      "~k_parent": "37"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3d"
     },
     "3h": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3g"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3d"
     },
     "3i": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks",
+      "~k_parent": "38"
     },
     "3j": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3i"
     },
     "3l": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3i"
     },
     "3m": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3i"
     },
     "3n": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3i"
     },
     "3o": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3i"
     },
     "3p": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3i"
     },
     "3q": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3i"
     },
     "3r": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3i"
     },
     "3s": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3i"
     },
     "3t": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3i"
     },
     "3u": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3i"
     },
     "3v": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3i"
     },
     "3w": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3i"
     },
     "3x": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3i"
     },
     "3y": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3i"
     },
     "3z": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3i"
     },
     "4a": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "45"
     },
     "4b": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "45"
     },
     "4d": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "45"
     },
     "4f": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "45"
     },
     "4h": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "45"
     },
     "4j": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "45"
     },
     "4l": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "45"
     },
     "4n": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "45"
     },
     "4p": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "45"
     },
     "4r": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "45"
     },
     "4t": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "45"
     },
     "4v": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "45"
     },
     "4x": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "45"
     },
     "4z": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "45"
     },
     "5b": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "45"
     },
     "5d": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "45"
     },
     "5f": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "45"
     },
     "5h": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "45"
     },
     "5j": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "45"
     },
     "5l": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "45"
     },
     "5n": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.requests",
-      "~k_parent": "37"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "45"
     },
     "5p": {
-      "key": "root.imports.operators",
-      "~k_parent": "37"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5p"
+      "key": "root.imports.requests",
+      "~k_parent": "38"
     },
     "5r": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5q"
+      "key": "root.imports.operators",
+      "~k_parent": "38"
     },
     "5s": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5q"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5r"
     },
     "5t": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5s"
+    },
+    "5u": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5s"
+    },
+    "5v": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5p"
+      "~k_parent": "5r"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "11"
   },
@@ -1181,6 +1190,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5678,158 +5688,161 @@
       },
       "~k": "25"
     },
+    "agents": {
+      "~k": "28"
+    },
     "auth": {
       "adapters": {
-        "~k": "29"
-      },
-      "callbacks": {
         "~k": "2a"
       },
-      "events": {
+      "callbacks": {
         "~k": "2b"
       },
-      "providers": {
+      "events": {
         "~k": "2c"
       },
-      "~k": "28"
+      "providers": {
+        "~k": "2d"
+      },
+      "~k": "29"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
-      "~k": "2d"
+      "~k": "2e"
     },
     "connections": {
-      "~k": "2z"
-    },
-    "requests": {
       "~k": "30"
     },
-    "api": {
+    "requests": {
       "~k": "31"
+    },
+    "api": {
+      "~k": "32"
     },
     "operators": {
       "client": {
@@ -5837,20 +5850,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "34"
+          "~k": "35"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "35"
+          "~k": "36"
         },
-        "~k": "33"
+        "~k": "34"
       },
       "server": {
-        "~k": "36"
+        "~k": "37"
       },
-      "~k": "32"
+      "~k": "33"
     },
     "~k": "24"
   }

--- a/packages/build/src/tests/success/38-menu-navigation-app/snapshot.json
+++ b/packages/build/src/tests/success/38-menu-navigation-app/snapshot.json
@@ -303,163 +303,163 @@
       "~k_parent": "57"
     },
     "60": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "5y"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "5z"
     },
     "61": {
-      "key": "root.types.auth.events",
-      "~k_parent": "5y"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "5z"
     },
     "62": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "5y"
+      "key": "root.types.auth.events",
+      "~k_parent": "5z"
     },
     "63": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "5z"
+    },
+    "64": {
       "key": "root.types.blocks",
       "~k_parent": "5u"
     },
-    "64": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "63"
-    },
     "65": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "63"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "64"
     },
     "66": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "63"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "64"
     },
     "67": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "63"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "64"
     },
     "68": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "63"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "64"
     },
     "69": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "63"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "64"
     },
     "70": {
-      "key": "root.imports.auth",
-      "~k_parent": "6w"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "6y"
     },
     "71": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "70"
+      "key": "root.imports.agents",
+      "~k_parent": "6x"
     },
     "72": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "70"
+      "key": "root.imports.auth",
+      "~k_parent": "6x"
     },
     "73": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "70"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "72"
     },
     "74": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "70"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "72"
     },
     "75": {
-      "key": "root.imports.blocks",
-      "~k_parent": "6w"
+      "key": "root.imports.auth.events",
+      "~k_parent": "72"
     },
     "76": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "75"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "72"
     },
     "77": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks",
+      "~k_parent": "6x"
     },
     "78": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "77"
     },
     "79": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "77"
     },
     "80": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "7t"
     },
     "81": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "80"
     },
     "82": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "7t"
     },
     "83": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "82"
     },
     "84": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "7t"
     },
     "85": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "84"
     },
     "86": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "7t"
     },
     "87": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "86"
     },
     "88": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "7t"
     },
     "89": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "88"
     },
     "90": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "7t"
     },
     "91": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "90"
     },
     "92": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "7t"
     },
     "93": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "92"
     },
     "94": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "7t"
     },
     "95": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "94"
     },
     "96": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "7t"
     },
     "97": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "96"
     },
     "98": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "7t"
     },
     "99": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "98"
     },
     "a": {
@@ -1142,358 +1142,367 @@
       "~k_parent": "5v"
     },
     "5y": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "5u"
     },
     "5z": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "5y"
+      "key": "root.types.auth",
+      "~k_parent": "5u"
     },
     "6a": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "63"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "64"
     },
     "6b": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "63"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "64"
     },
     "6c": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "63"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "64"
     },
     "6d": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "63"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "64"
     },
     "6e": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "63"
+      "key": "root.types.blocks.List",
+      "~k_parent": "64"
     },
     "6f": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "63"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "64"
     },
     "6g": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "63"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "64"
     },
     "6h": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "63"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "64"
     },
     "6i": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "63"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "64"
     },
     "6j": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "63"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "64"
     },
     "6k": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "63"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "64"
     },
     "6l": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "63"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "64"
     },
     "6m": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "63"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "64"
     },
     "6n": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "63"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "64"
     },
     "6o": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "64"
+    },
+    "6p": {
       "key": "root.types.connections",
       "~k_parent": "5u"
     },
-    "6p": {
+    "6q": {
       "key": "root.types.requests",
       "~k_parent": "5u"
     },
-    "6q": {
+    "6r": {
       "key": "root.types.api",
       "~k_parent": "5u"
     },
-    "6r": {
+    "6s": {
       "key": "root.types.operators",
       "~k_parent": "5u"
     },
-    "6s": {
-      "key": "root.types.operators.client",
-      "~k_parent": "6r"
-    },
     "6t": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "6s"
     },
     "6u": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "6s"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.types.operators.server",
-      "~k_parent": "6r"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "6t"
     },
     "6w": {
+      "key": "root.types.operators.server",
+      "~k_parent": "6s"
+    },
+    "6x": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "6x": {
-      "key": "root.imports.actions",
-      "~k_parent": "6w"
-    },
     "6y": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "6x"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "6y"
     },
     "7a": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "77"
     },
     "7b": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "77"
     },
     "7c": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "77"
     },
     "7d": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "77"
     },
     "7e": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "77"
     },
     "7f": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "77"
     },
     "7g": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "77"
     },
     "7h": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "77"
     },
     "7i": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "77"
     },
     "7j": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "77"
     },
     "7k": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "77"
     },
     "7l": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "77"
     },
     "7m": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "77"
     },
     "7n": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "77"
     },
     "7o": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "77"
     },
     "7p": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "77"
     },
     "7q": {
-      "key": "root.imports.connections",
-      "~k_parent": "6w"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "77"
     },
     "7r": {
-      "key": "root.imports.icons",
-      "~k_parent": "6w"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "77"
     },
     "7s": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "7r"
+      "key": "root.imports.connections",
+      "~k_parent": "6x"
     },
     "7t": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "7s"
+      "key": "root.imports.icons",
+      "~k_parent": "6x"
     },
     "7u": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "7t"
     },
     "7v": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "7u"
     },
     "7w": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "7t"
     },
     "7x": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "7w"
     },
     "7y": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "7t"
     },
     "7z": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "7y"
     },
     "8a": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "7t"
     },
     "8b": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "8a"
     },
     "8c": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "7t"
     },
     "8d": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "8c"
     },
     "8e": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "7t"
     },
     "8f": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "8e"
     },
     "8g": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "7t"
     },
     "8h": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "8g"
     },
     "8i": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "7t"
     },
     "8j": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "8i"
     },
     "8k": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "7t"
     },
     "8l": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "8k"
     },
     "8m": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "7t"
     },
     "8n": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "8m"
     },
     "8o": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "7t"
     },
     "8p": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "8o"
     },
     "8q": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "7t"
     },
     "8r": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "8q"
     },
     "8s": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "7t"
     },
     "8t": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "8s"
     },
     "8u": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "7t"
     },
     "8v": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "8u"
     },
     "8w": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "7t"
     },
     "8x": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "8w"
     },
     "8y": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "7t"
     },
     "8z": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "8y"
     },
     "9a": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "7t"
     },
     "9b": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "9a"
     },
     "9c": {
-      "key": "root.imports.requests",
-      "~k_parent": "6w"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "7t"
     },
     "9d": {
-      "key": "root.imports.operators",
-      "~k_parent": "6w"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "9c"
     },
     "9e": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "9d"
+      "key": "root.imports.requests",
+      "~k_parent": "6x"
     },
     "9f": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "9e"
+      "key": "root.imports.operators",
+      "~k_parent": "6x"
     },
     "9g": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "9e"
+      "key": "root.imports.operators.client",
+      "~k_parent": "9f"
     },
     "9h": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "9g"
+    },
+    "9i": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "9g"
+    },
+    "9j": {
       "key": "root.imports.operators.server",
-      "~k_parent": "9d"
+      "~k_parent": "9f"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "36"
   },
@@ -2327,6 +2336,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -6814,152 +6824,155 @@
       },
       "~k": "5v"
     },
+    "agents": {
+      "~k": "5y"
+    },
     "auth": {
       "adapters": {
-        "~k": "5z"
-      },
-      "callbacks": {
         "~k": "60"
       },
-      "events": {
+      "callbacks": {
         "~k": "61"
       },
-      "providers": {
+      "events": {
         "~k": "62"
       },
-      "~k": "5y"
+      "providers": {
+        "~k": "63"
+      },
+      "~k": "5z"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 12,
-        "~k": "64"
+        "~k": "65"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 11,
-        "~k": "65"
+        "~k": "66"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "66"
+        "~k": "67"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "67"
+        "~k": "68"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "68"
+        "~k": "69"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "69"
+        "~k": "6a"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6a"
+        "~k": "6b"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6b"
+        "~k": "6c"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6c"
+        "~k": "6d"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6d"
+        "~k": "6e"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6e"
+        "~k": "6f"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6f"
+        "~k": "6g"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6g"
+        "~k": "6h"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6h"
+        "~k": "6i"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6i"
+        "~k": "6j"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6j"
+        "~k": "6k"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6k"
+        "~k": "6l"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6l"
+        "~k": "6m"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6m"
+        "~k": "6n"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "6n"
+        "~k": "6o"
       },
-      "~k": "63"
+      "~k": "64"
     },
     "connections": {
-      "~k": "6o"
-    },
-    "requests": {
       "~k": "6p"
     },
-    "api": {
+    "requests": {
       "~k": "6q"
+    },
+    "api": {
+      "~k": "6r"
     },
     "operators": {
       "client": {
@@ -6967,20 +6980,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "6t"
+          "~k": "6u"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "6u"
+          "~k": "6v"
         },
-        "~k": "6s"
+        "~k": "6t"
       },
       "server": {
-        "~k": "6v"
+        "~k": "6w"
       },
-      "~k": "6r"
+      "~k": "6s"
     },
     "~k": "5u"
   }

--- a/packages/build/src/tests/success/39-global-state-app/snapshot.json
+++ b/packages/build/src/tests/success/39-global-state-app/snapshot.json
@@ -287,164 +287,164 @@
       "~k_parent": "4"
     },
     "50": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "4k"
     },
     "51": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "4k"
     },
     "52": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "4k"
     },
     "53": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "4k"
     },
     "54": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "4k"
     },
     "55": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "4k"
     },
     "56": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "4k"
     },
     "57": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "4k"
     },
     "58": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "4k"
+    },
+    "59": {
       "key": "root.types.connections",
       "~k_parent": "49"
     },
-    "59": {
-      "key": "root.types.requests",
-      "~k_parent": "49"
-    },
     "60": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "5w"
     },
     "61": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "5w"
     },
     "62": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "5w"
     },
     "63": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "5w"
     },
     "64": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "5w"
     },
     "65": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "5w"
     },
     "66": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "5w"
     },
     "67": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "5w"
     },
     "68": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "5w"
     },
     "69": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "5w"
     },
     "70": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "6z"
     },
     "71": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "6m"
     },
     "72": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "71"
     },
     "73": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "6m"
     },
     "74": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "73"
     },
     "75": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "6m"
     },
     "76": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "75"
     },
     "77": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "6m"
     },
     "78": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "77"
     },
     "79": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "6m"
     },
     "80": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "7z"
     },
     "81": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "6m"
     },
     "82": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "81"
     },
     "83": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "6m"
     },
     "84": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "83"
     },
     "85": {
-      "key": "root.imports.requests",
-      "~k_parent": "5k"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "6m"
     },
     "86": {
-      "key": "root.imports.operators",
-      "~k_parent": "5k"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "85"
     },
     "87": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "86"
+      "key": "root.imports.requests",
+      "~k_parent": "5l"
     },
     "88": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "87"
+      "key": "root.imports.operators",
+      "~k_parent": "5l"
     },
     "89": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "87"
+      "key": "root.imports.operators.client",
+      "~k_parent": "88"
     },
     "a": {
       "key": "root.global.settings",
@@ -927,426 +927,435 @@
       "~k_parent": "4a"
     },
     "4e": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "49"
     },
     "4f": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "4e"
+      "key": "root.types.auth",
+      "~k_parent": "49"
     },
     "4g": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "4e"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.types.auth.events",
-      "~k_parent": "4e"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "4f"
     },
     "4i": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "4e"
+      "key": "root.types.auth.events",
+      "~k_parent": "4f"
     },
     "4j": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "4f"
+    },
+    "4k": {
       "key": "root.types.blocks",
       "~k_parent": "49"
     },
-    "4k": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "4j"
-    },
     "4l": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "4k"
     },
     "4n": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "4k"
     },
     "4o": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "4k"
     },
     "4p": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "4k"
     },
     "4q": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "4k"
     },
     "4r": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "4k"
     },
     "4s": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "4k"
     },
     "4t": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "4k"
     },
     "4u": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "4k"
     },
     "4v": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "4k"
     },
     "4w": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "4k"
     },
     "4x": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "4k"
     },
     "4y": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.List",
+      "~k_parent": "4k"
     },
     "4z": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "4j"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "4k"
     },
     "5a": {
-      "key": "root.types.api",
+      "key": "root.types.requests",
       "~k_parent": "49"
     },
     "5b": {
-      "key": "root.types.operators",
+      "key": "root.types.api",
       "~k_parent": "49"
     },
     "5c": {
-      "key": "root.types.operators.client",
-      "~k_parent": "5b"
+      "key": "root.types.operators",
+      "~k_parent": "49"
     },
     "5d": {
-      "key": "root.types.operators.client._date",
+      "key": "root.types.operators.client",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.types.operators.client._global",
-      "~k_parent": "5c"
+      "key": "root.types.operators.client._date",
+      "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.types.operators.client._state",
-      "~k_parent": "5c"
+      "key": "root.types.operators.client._global",
+      "~k_parent": "5d"
     },
     "5g": {
-      "key": "root.types.operators.client._array",
-      "~k_parent": "5c"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "5d"
     },
     "5h": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "5c"
+      "key": "root.types.operators.client._array",
+      "~k_parent": "5d"
     },
     "5i": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "5c"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "5d"
     },
     "5j": {
-      "key": "root.types.operators.server",
-      "~k_parent": "5b"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "5d"
     },
     "5k": {
+      "key": "root.types.operators.server",
+      "~k_parent": "5c"
+    },
+    "5l": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "5l": {
-      "key": "root.imports.actions",
-      "~k_parent": "5k"
-    },
     "5m": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "5l"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "5l"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "5m"
     },
     "5p": {
-      "key": "root.imports.auth",
-      "~k_parent": "5k"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "5m"
     },
     "5q": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "5p"
+      "key": "root.imports.agents",
+      "~k_parent": "5l"
     },
     "5r": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "5p"
+      "key": "root.imports.auth",
+      "~k_parent": "5l"
     },
     "5s": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "5p"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "5p"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "5r"
     },
     "5u": {
-      "key": "root.imports.blocks",
-      "~k_parent": "5k"
+      "key": "root.imports.auth.events",
+      "~k_parent": "5r"
     },
     "5v": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "5u"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "5r"
     },
     "5w": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks",
+      "~k_parent": "5l"
     },
     "5x": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "5w"
     },
     "5z": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "5w"
     },
     "6a": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "5w"
     },
     "6b": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "5w"
     },
     "6c": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "5w"
     },
     "6d": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "5w"
     },
     "6e": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "5w"
     },
     "6f": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "5w"
     },
     "6g": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "5w"
     },
     "6h": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "5w"
     },
     "6i": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "5w"
     },
     "6j": {
-      "key": "root.imports.connections",
-      "~k_parent": "5k"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "5w"
     },
     "6k": {
-      "key": "root.imports.icons",
-      "~k_parent": "5k"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "5w"
     },
     "6l": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "6k"
+      "key": "root.imports.connections",
+      "~k_parent": "5l"
     },
     "6m": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "6l"
+      "key": "root.imports.icons",
+      "~k_parent": "5l"
     },
     "6n": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "6m"
     },
     "6o": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "6n"
     },
     "6p": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "6m"
     },
     "6q": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "6m"
     },
     "6s": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "6r"
     },
     "6t": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "6m"
     },
     "6u": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "6m"
     },
     "6w": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "6v"
     },
     "6x": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "6m"
     },
     "6y": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "6m"
     },
     "7a": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "79"
     },
     "7b": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "6m"
     },
     "7c": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "7b"
     },
     "7d": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "6m"
     },
     "7e": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "7d"
     },
     "7f": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "6m"
     },
     "7g": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "7f"
     },
     "7h": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "6m"
     },
     "7i": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "7h"
     },
     "7j": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "6m"
     },
     "7k": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "7j"
     },
     "7l": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "6m"
     },
     "7m": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "7l"
     },
     "7n": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "6m"
     },
     "7o": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "7n"
     },
     "7p": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "6m"
     },
     "7q": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "7p"
     },
     "7r": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "6m"
     },
     "7s": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "7r"
     },
     "7t": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "6m"
     },
     "7u": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "7t"
     },
     "7v": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "6m"
     },
     "7w": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "7v"
     },
     "7x": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "6m"
     },
     "7y": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "7x"
     },
     "7z": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "6k"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "6m"
     },
     "8a": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "87"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "89"
     },
     "8b": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "87"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "89"
     },
     "8c": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "87"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "89"
     },
     "8d": {
-      "key": "root.imports.operators.client[5]",
-      "~k_parent": "87"
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "89"
     },
     "8e": {
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "89"
+    },
+    "8f": {
+      "key": "root.imports.operators.client[5]",
+      "~k_parent": "89"
+    },
+    "8g": {
       "key": "root.imports.operators.server",
-      "~k_parent": "86"
+      "~k_parent": "88"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "2p"
   },
@@ -1927,6 +1936,7 @@
     }
   },
   "plugins/actions.js": "import { SetGlobal as SetGlobal } from '@lowdefy/actions-core/actions';\nimport { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  SetGlobal,\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -8332,176 +8342,179 @@
       },
       "~k": "4a"
     },
+    "agents": {
+      "~k": "4e"
+    },
     "auth": {
       "adapters": {
-        "~k": "4f"
-      },
-      "callbacks": {
         "~k": "4g"
       },
-      "events": {
+      "callbacks": {
         "~k": "4h"
       },
-      "providers": {
+      "events": {
         "~k": "4i"
       },
-      "~k": "4e"
+      "providers": {
+        "~k": "4j"
+      },
+      "~k": "4f"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "4k"
+        "~k": "4l"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "4l"
+        "~k": "4m"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "4m"
+        "~k": "4n"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4n"
+        "~k": "4o"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4o"
+        "~k": "4p"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "4p"
+        "~k": "4q"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "4q"
+        "~k": "4r"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4r"
+        "~k": "4s"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4s"
+        "~k": "4t"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4t"
+        "~k": "4u"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4u"
+        "~k": "4v"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4v"
+        "~k": "4w"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4w"
+        "~k": "4x"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4x"
+        "~k": "4y"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4y"
+        "~k": "4z"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4z"
+        "~k": "50"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "50"
+        "~k": "51"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "51"
+        "~k": "52"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "52"
+        "~k": "53"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "53"
+        "~k": "54"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "54"
+        "~k": "55"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "55"
+        "~k": "56"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "56"
+        "~k": "57"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "57"
+        "~k": "58"
       },
-      "~k": "4j"
+      "~k": "4k"
     },
     "connections": {
-      "~k": "58"
-    },
-    "requests": {
       "~k": "59"
     },
-    "api": {
+    "requests": {
       "~k": "5a"
+    },
+    "api": {
+      "~k": "5b"
     },
     "operators": {
       "client": {
@@ -8509,44 +8522,44 @@
           "originalTypeName": "_date",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5d"
+          "~k": "5e"
         },
         "_global": {
           "originalTypeName": "_global",
           "package": "@lowdefy/operators-js",
           "count": 4,
-          "~k": "5e"
+          "~k": "5f"
         },
         "_state": {
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 3,
-          "~k": "5f"
+          "~k": "5g"
         },
         "_array": {
           "originalTypeName": "_array",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5g"
+          "~k": "5h"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5h"
+          "~k": "5i"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5i"
+          "~k": "5j"
         },
-        "~k": "5c"
+        "~k": "5d"
       },
       "server": {
-        "~k": "5j"
+        "~k": "5k"
       },
-      "~k": "5b"
+      "~k": "5c"
     },
     "~k": "49"
   }

--- a/packages/build/src/tests/success/40-form-validation-app/snapshot.json
+++ b/packages/build/src/tests/success/40-form-validation-app/snapshot.json
@@ -217,164 +217,168 @@
       "~k_parent": "35"
     },
     "40": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "3x"
     },
     "41": {
-      "key": "root.types.blocks.PasswordInput",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "3x"
     },
     "42": {
-      "key": "root.types.blocks.NumberInput",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.PasswordInput",
+      "~k_parent": "3x"
     },
     "43": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.NumberInput",
+      "~k_parent": "3x"
     },
     "44": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "3x"
     },
     "45": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3x"
     },
     "46": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3x"
     },
     "47": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3x"
     },
     "48": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3x"
     },
     "49": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3x"
     },
     "50": {
+      "key": "root.types.operators.server",
+      "~k_parent": "4q"
+    },
+    "51": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "51": {
-      "key": "root.imports.actions",
-      "~k_parent": "50"
-    },
     "52": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "51"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "51"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "52"
     },
     "55": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "51"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "52"
     },
     "56": {
-      "key": "root.imports.auth",
-      "~k_parent": "50"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "52"
     },
     "57": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "56"
+      "key": "root.imports.agents",
+      "~k_parent": "51"
     },
     "58": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "56"
+      "key": "root.imports.auth",
+      "~k_parent": "51"
     },
     "59": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "56"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.blocks[24]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "5d"
     },
     "61": {
-      "key": "root.imports.connections",
-      "~k_parent": "50"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "5d"
     },
     "62": {
-      "key": "root.imports.icons",
-      "~k_parent": "50"
+      "key": "root.imports.blocks[24]",
+      "~k_parent": "5d"
     },
     "63": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "62"
+      "key": "root.imports.connections",
+      "~k_parent": "51"
     },
     "64": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "63"
+      "key": "root.imports.icons",
+      "~k_parent": "51"
     },
     "65": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "64"
     },
     "68": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "64"
     },
     "70": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "6z"
     },
     "71": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "64"
     },
     "72": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "71"
     },
     "73": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "64"
     },
     "74": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "73"
     },
     "75": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "64"
     },
     "76": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "75"
     },
     "77": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "64"
     },
     "78": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "77"
     },
     "79": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "64"
+    },
+    "80": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "7q"
     },
     "a": {
       "key": "root.pages[0:registration:Box].blocks[0:title:Title].properties",
@@ -805,454 +809,459 @@
       "~k_parent": "3m"
     },
     "3r": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "3l"
     },
     "3s": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "3r"
+      "key": "root.types.auth",
+      "~k_parent": "3l"
     },
     "3t": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "3r"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.types.auth.events",
-      "~k_parent": "3r"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "3s"
     },
     "3v": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "3r"
+      "key": "root.types.auth.events",
+      "~k_parent": "3s"
     },
     "3w": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "3s"
+    },
+    "3x": {
       "key": "root.types.blocks",
       "~k_parent": "3l"
     },
-    "3x": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "3w"
-    },
     "3y": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "3x"
     },
     "4a": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3x"
     },
     "4b": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3x"
     },
     "4c": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3x"
     },
     "4d": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3x"
     },
     "4e": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3x"
     },
     "4f": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3x"
     },
     "4g": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3x"
     },
     "4h": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3x"
     },
     "4i": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3x"
     },
     "4j": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3x"
     },
     "4k": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3x"
     },
     "4l": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3x"
     },
     "4m": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3x"
+    },
+    "4n": {
       "key": "root.types.connections",
       "~k_parent": "3l"
     },
-    "4n": {
+    "4o": {
       "key": "root.types.requests",
       "~k_parent": "3l"
     },
-    "4o": {
+    "4p": {
       "key": "root.types.api",
       "~k_parent": "3l"
     },
-    "4p": {
+    "4q": {
       "key": "root.types.operators",
       "~k_parent": "3l"
     },
-    "4q": {
-      "key": "root.types.operators.client",
-      "~k_parent": "4p"
-    },
     "4r": {
-      "key": "root.types.operators.client._gte",
+      "key": "root.types.operators.client",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.types.operators.client._state",
-      "~k_parent": "4q"
+      "key": "root.types.operators.client._gte",
+      "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.types.operators.client._regex",
-      "~k_parent": "4q"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "4r"
     },
     "4u": {
-      "key": "root.types.operators.client._string",
-      "~k_parent": "4q"
+      "key": "root.types.operators.client._regex",
+      "~k_parent": "4r"
     },
     "4v": {
-      "key": "root.types.operators.client._eq",
-      "~k_parent": "4q"
+      "key": "root.types.operators.client._string",
+      "~k_parent": "4r"
     },
     "4w": {
-      "key": "root.types.operators.client._lte",
-      "~k_parent": "4q"
+      "key": "root.types.operators.client._eq",
+      "~k_parent": "4r"
     },
     "4x": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "4q"
+      "key": "root.types.operators.client._lte",
+      "~k_parent": "4r"
     },
     "4y": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "4q"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "4r"
     },
     "4z": {
-      "key": "root.types.operators.server",
-      "~k_parent": "4p"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "4r"
     },
     "5a": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "56"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "58"
     },
     "5b": {
-      "key": "root.imports.blocks",
-      "~k_parent": "50"
+      "key": "root.imports.auth.events",
+      "~k_parent": "58"
     },
     "5c": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "5b"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "58"
     },
     "5d": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks",
+      "~k_parent": "51"
     },
     "5e": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "5d"
     },
     "5g": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "5d"
     },
     "5h": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "5d"
     },
     "5i": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "5d"
     },
     "5j": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "5d"
     },
     "5k": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "5d"
     },
     "5l": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "5d"
     },
     "5m": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "5d"
     },
     "5n": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "5d"
     },
     "5o": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "5d"
     },
     "5p": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "5d"
     },
     "5q": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "5d"
     },
     "5r": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "5d"
     },
     "5s": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "5d"
     },
     "5t": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "5d"
     },
     "5u": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "5d"
     },
     "5v": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "5d"
     },
     "5w": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "5d"
     },
     "5x": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "5d"
     },
     "5y": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "5d"
     },
     "5z": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "5d"
     },
     "6a": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "64"
     },
     "6c": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "64"
     },
     "6e": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "64"
     },
     "6g": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "6f"
     },
     "6h": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "64"
     },
     "6i": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "64"
     },
     "6k": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "6j"
     },
     "6l": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "64"
     },
     "6m": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "6l"
     },
     "6n": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "64"
     },
     "6o": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "6n"
     },
     "6p": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "64"
     },
     "6q": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "64"
     },
     "6s": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "6r"
     },
     "6t": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "64"
     },
     "6u": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "64"
     },
     "6w": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "6v"
     },
     "6x": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "64"
     },
     "6y": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "64"
     },
     "7a": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "79"
     },
     "7b": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "64"
     },
     "7c": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "7b"
     },
     "7d": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "64"
     },
     "7e": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "7d"
     },
     "7f": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "64"
     },
     "7g": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "7f"
     },
     "7h": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "64"
     },
     "7i": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "7h"
     },
     "7j": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "64"
     },
     "7k": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "7j"
     },
     "7l": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "64"
     },
     "7m": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "7l"
     },
     "7n": {
-      "key": "root.imports.requests",
-      "~k_parent": "50"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "64"
     },
     "7o": {
-      "key": "root.imports.operators",
-      "~k_parent": "50"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "7n"
     },
     "7p": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "7o"
+      "key": "root.imports.requests",
+      "~k_parent": "51"
     },
     "7q": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "7p"
+      "key": "root.imports.operators",
+      "~k_parent": "51"
     },
     "7r": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "7p"
+      "key": "root.imports.operators.client",
+      "~k_parent": "7q"
     },
     "7s": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "7p"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "7r"
     },
     "7t": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "7p"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "7r"
     },
     "7u": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "7p"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "7r"
     },
     "7v": {
-      "key": "root.imports.operators.client[5]",
-      "~k_parent": "7p"
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "7r"
     },
     "7w": {
-      "key": "root.imports.operators.client[6]",
-      "~k_parent": "7p"
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "7r"
     },
     "7x": {
-      "key": "root.imports.operators.client[7]",
-      "~k_parent": "7p"
+      "key": "root.imports.operators.client[5]",
+      "~k_parent": "7r"
     },
     "7y": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "7o"
+      "key": "root.imports.operators.client[6]",
+      "~k_parent": "7r"
+    },
+    "7z": {
+      "key": "root.imports.operators.client[7]",
+      "~k_parent": "7r"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "2l"
   },
@@ -1827,6 +1836,7 @@
     }
   },
   "plugins/actions.js": "import { Validate as Validate } from '@lowdefy/actions-core/actions';\nimport { DisplayMessage as DisplayMessage } from '@lowdefy/actions-core/actions';\nimport { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Validate,\n  DisplayMessage,\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -9445,182 +9455,185 @@
       },
       "~k": "3m"
     },
+    "agents": {
+      "~k": "3r"
+    },
     "auth": {
       "adapters": {
-        "~k": "3s"
-      },
-      "callbacks": {
         "~k": "3t"
       },
-      "events": {
+      "callbacks": {
         "~k": "3u"
       },
-      "providers": {
+      "events": {
         "~k": "3v"
       },
-      "~k": "3r"
+      "providers": {
+        "~k": "3w"
+      },
+      "~k": "3s"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "3x"
+        "~k": "3y"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3y"
+        "~k": "3z"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3z"
+        "~k": "40"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "40"
+        "~k": "41"
       },
       "PasswordInput": {
         "originalTypeName": "PasswordInput",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "41"
+        "~k": "42"
       },
       "NumberInput": {
         "originalTypeName": "NumberInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "42"
+        "~k": "43"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "43"
+        "~k": "44"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "44"
+        "~k": "45"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "45"
+        "~k": "46"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "46"
+        "~k": "47"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "47"
+        "~k": "48"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "48"
+        "~k": "49"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "49"
+        "~k": "4a"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4a"
+        "~k": "4b"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4b"
+        "~k": "4c"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4c"
+        "~k": "4d"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4d"
+        "~k": "4e"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4e"
+        "~k": "4f"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4f"
+        "~k": "4g"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4g"
+        "~k": "4h"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4h"
+        "~k": "4i"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4i"
+        "~k": "4j"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4j"
+        "~k": "4k"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4k"
+        "~k": "4l"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4l"
+        "~k": "4m"
       },
-      "~k": "3w"
+      "~k": "3x"
     },
     "connections": {
-      "~k": "4m"
-    },
-    "requests": {
       "~k": "4n"
     },
-    "api": {
+    "requests": {
       "~k": "4o"
+    },
+    "api": {
+      "~k": "4p"
     },
     "operators": {
       "client": {
@@ -9628,56 +9641,56 @@
           "originalTypeName": "_gte",
           "package": "@lowdefy/operators-js",
           "count": 3,
-          "~k": "4r"
+          "~k": "4s"
         },
         "_state": {
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 10,
-          "~k": "4s"
+          "~k": "4t"
         },
         "_regex": {
           "originalTypeName": "_regex",
           "package": "@lowdefy/operators-js",
           "count": 3,
-          "~k": "4t"
+          "~k": "4u"
         },
         "_string": {
           "originalTypeName": "_string",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4u"
+          "~k": "4v"
         },
         "_eq": {
           "originalTypeName": "_eq",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "4v"
+          "~k": "4w"
         },
         "_lte": {
           "originalTypeName": "_lte",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4w"
+          "~k": "4x"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4x"
+          "~k": "4y"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4y"
+          "~k": "4z"
         },
-        "~k": "4q"
+        "~k": "4r"
       },
       "server": {
-        "~k": "4z"
+        "~k": "50"
       },
-      "~k": "4p"
+      "~k": "4q"
     },
     "~k": "3l"
   }

--- a/packages/build/src/tests/success/41-list-crud-app/snapshot.json
+++ b/packages/build/src/tests/success/41-list-crud-app/snapshot.json
@@ -201,152 +201,160 @@
       "~k_parent": "32"
     },
     "36": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "31"
     },
     "37": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "36"
+      "key": "root.types.auth",
+      "~k_parent": "31"
     },
     "38": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "36"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "37"
     },
     "39": {
-      "key": "root.types.auth.events",
-      "~k_parent": "36"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "37"
     },
     "40": {
-      "key": "root.types.api",
+      "key": "root.types.requests",
       "~k_parent": "31"
     },
     "41": {
-      "key": "root.types.operators",
+      "key": "root.types.api",
       "~k_parent": "31"
     },
     "42": {
-      "key": "root.types.operators.client",
-      "~k_parent": "41"
+      "key": "root.types.operators",
+      "~k_parent": "31"
     },
     "43": {
-      "key": "root.types.operators.client._array",
+      "key": "root.types.operators.client",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.types.operators.client._state",
-      "~k_parent": "42"
+      "key": "root.types.operators.client._array",
+      "~k_parent": "43"
     },
     "45": {
-      "key": "root.types.operators.client._random",
-      "~k_parent": "42"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "43"
     },
     "46": {
-      "key": "root.types.operators.client._if",
-      "~k_parent": "42"
+      "key": "root.types.operators.client._random",
+      "~k_parent": "43"
     },
     "47": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "42"
+      "key": "root.types.operators.client._if",
+      "~k_parent": "43"
     },
     "48": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "42"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "43"
     },
     "49": {
-      "key": "root.types.operators.server",
-      "~k_parent": "41"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "43"
     },
     "50": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "4m"
     },
     "51": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "4m"
     },
     "52": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "4m"
     },
     "53": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "4m"
     },
     "54": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "4m"
     },
     "55": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "4m"
     },
     "56": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "4m"
     },
     "57": {
-      "key": "root.imports.connections",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "4m"
     },
     "58": {
-      "key": "root.imports.icons",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "4m"
     },
     "59": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "58"
+      "key": "root.imports.connections",
+      "~k_parent": "4b"
     },
     "60": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "5a"
     },
     "62": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "5a"
     },
     "64": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "5a"
     },
     "66": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "5a"
     },
     "68": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "5a"
     },
     "70": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "6v"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "6x"
     },
     "71": {
-      "key": "root.imports.operators.client[5]",
-      "~k_parent": "6v"
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "6x"
     },
     "72": {
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "6x"
+    },
+    "73": {
+      "key": "root.imports.operators.client[5]",
+      "~k_parent": "6x"
+    },
+    "74": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6u"
+      "~k_parent": "6w"
     },
     "a": {
       "key": "root.pages[0:todos:Box].events.onInit[0:initTodos:SetState]",
@@ -683,422 +691,423 @@
       "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "36"
+      "key": "root.types.auth.events",
+      "~k_parent": "37"
     },
     "3b": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "37"
+    },
+    "3c": {
       "key": "root.types.blocks",
       "~k_parent": "31"
     },
-    "3c": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "3b"
-    },
     "3d": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3c"
     },
     "3e": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "3c"
     },
     "3f": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3c"
     },
     "3g": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3c"
     },
     "3h": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "3c"
     },
     "3i": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "3c"
     },
     "3j": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3c"
     },
     "3k": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3c"
     },
     "3l": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3c"
     },
     "3m": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3c"
     },
     "3n": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3c"
     },
     "3o": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3c"
     },
     "3p": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3c"
     },
     "3q": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3c"
     },
     "3r": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3c"
     },
     "3s": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3c"
     },
     "3t": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3c"
     },
     "3u": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3c"
     },
     "3v": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3c"
     },
     "3w": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3c"
     },
     "3x": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3c"
     },
     "3y": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3c"
+    },
+    "3z": {
       "key": "root.types.connections",
       "~k_parent": "31"
     },
-    "3z": {
-      "key": "root.types.requests",
-      "~k_parent": "31"
-    },
     "4a": {
+      "key": "root.types.operators.server",
+      "~k_parent": "42"
+    },
+    "4b": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "4b": {
-      "key": "root.imports.actions",
-      "~k_parent": "4a"
-    },
     "4c": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "4b"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "4b"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "4c"
     },
     "4f": {
-      "key": "root.imports.auth",
-      "~k_parent": "4a"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "4c"
     },
     "4g": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "4f"
+      "key": "root.imports.agents",
+      "~k_parent": "4b"
     },
     "4h": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "4f"
+      "key": "root.imports.auth",
+      "~k_parent": "4b"
     },
     "4i": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "4f"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "4f"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "4h"
     },
     "4k": {
-      "key": "root.imports.blocks",
-      "~k_parent": "4a"
+      "key": "root.imports.auth.events",
+      "~k_parent": "4h"
     },
     "4l": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "4k"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "4h"
     },
     "4m": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks",
+      "~k_parent": "4b"
     },
     "4n": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "4m"
     },
     "4p": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "4m"
     },
     "4q": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "4m"
     },
     "4r": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "4m"
     },
     "4s": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "4m"
     },
     "4t": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "4m"
     },
     "4u": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "4m"
     },
     "4v": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "4m"
     },
     "4w": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "4m"
     },
     "4x": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "4m"
     },
     "4y": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "4m"
     },
     "4z": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "4m"
     },
     "5a": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "59"
+      "key": "root.imports.icons",
+      "~k_parent": "4b"
     },
     "5b": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "5a"
     },
     "5e": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "5a"
     },
     "5g": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "5a"
     },
     "5i": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "5a"
     },
     "5k": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "5a"
     },
     "5m": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "5a"
     },
     "5o": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "5a"
     },
     "5q": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "5a"
     },
     "5s": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "5a"
     },
     "5u": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "5a"
     },
     "5w": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "5a"
     },
     "5y": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "5a"
     },
     "6a": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "5a"
     },
     "6c": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "5a"
     },
     "6e": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "5a"
     },
     "6g": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "6f"
     },
     "6h": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "5a"
     },
     "6i": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "5a"
     },
     "6k": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "6j"
     },
     "6l": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "5a"
     },
     "6m": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "6l"
     },
     "6n": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "5a"
     },
     "6o": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "6n"
     },
     "6p": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "5a"
     },
     "6q": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "5a"
     },
     "6s": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6r"
     },
     "6t": {
-      "key": "root.imports.requests",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "5a"
     },
     "6u": {
-      "key": "root.imports.operators",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6u"
+      "key": "root.imports.requests",
+      "~k_parent": "4b"
     },
     "6w": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6v"
+      "key": "root.imports.operators",
+      "~k_parent": "4b"
     },
     "6x": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6v"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6w"
     },
     "6y": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "6v"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "6v"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6x"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "1v"
   },
@@ -1512,6 +1521,7 @@
     }
   },
   "plugins/actions.js": "import { SetState as SetState } from '@lowdefy/actions-core/actions';\nimport { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  SetState,\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -7421,164 +7431,167 @@
       },
       "~k": "32"
     },
+    "agents": {
+      "~k": "36"
+    },
     "auth": {
       "adapters": {
-        "~k": "37"
-      },
-      "callbacks": {
         "~k": "38"
       },
-      "events": {
+      "callbacks": {
         "~k": "39"
       },
-      "providers": {
+      "events": {
         "~k": "3a"
       },
-      "~k": "36"
+      "providers": {
+        "~k": "3b"
+      },
+      "~k": "37"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "3c"
+        "~k": "3d"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "3e"
+        "~k": "3f"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "3f"
+        "~k": "3g"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3h"
+        "~k": "3i"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3i"
+        "~k": "3j"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3j"
+        "~k": "3k"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3k"
+        "~k": "3l"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3l"
+        "~k": "3m"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3m"
+        "~k": "3n"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3n"
+        "~k": "3o"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3o"
+        "~k": "3p"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3p"
+        "~k": "3q"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3q"
+        "~k": "3r"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3r"
+        "~k": "3s"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3s"
+        "~k": "3t"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3t"
+        "~k": "3u"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3u"
+        "~k": "3v"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3v"
+        "~k": "3w"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3w"
+        "~k": "3x"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3x"
+        "~k": "3y"
       },
-      "~k": "3b"
+      "~k": "3c"
     },
     "connections": {
-      "~k": "3y"
-    },
-    "requests": {
       "~k": "3z"
     },
-    "api": {
+    "requests": {
       "~k": "40"
+    },
+    "api": {
+      "~k": "41"
     },
     "operators": {
       "client": {
@@ -7586,44 +7599,44 @@
           "originalTypeName": "_array",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "43"
+          "~k": "44"
         },
         "_state": {
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 6,
-          "~k": "44"
+          "~k": "45"
         },
         "_random": {
           "originalTypeName": "_random",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "45"
+          "~k": "46"
         },
         "_if": {
           "originalTypeName": "_if",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "46"
+          "~k": "47"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "47"
+          "~k": "48"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "48"
+          "~k": "49"
         },
-        "~k": "42"
+        "~k": "43"
       },
       "server": {
-        "~k": "49"
+        "~k": "4a"
       },
-      "~k": "41"
+      "~k": "42"
     },
     "~k": "31"
   }

--- a/packages/build/src/tests/success/42-dashboard-app/snapshot.json
+++ b/packages/build/src/tests/success/42-dashboard-app/snapshot.json
@@ -217,124 +217,132 @@
       "~k_parent": "37"
     },
     "40": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3g"
     },
     "41": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3g"
     },
     "42": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3g"
     },
     "43": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3g"
+    },
+    "44": {
       "key": "root.types.connections",
       "~k_parent": "36"
     },
-    "44": {
+    "45": {
       "key": "root.types.requests",
       "~k_parent": "36"
     },
-    "45": {
+    "46": {
       "key": "root.types.api",
       "~k_parent": "36"
     },
-    "46": {
+    "47": {
       "key": "root.types.operators",
       "~k_parent": "36"
     },
-    "47": {
-      "key": "root.types.operators.client",
-      "~k_parent": "46"
-    },
     "48": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "47"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "4m"
     },
     "51": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "4m"
     },
     "52": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "4m"
     },
     "53": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "4m"
     },
     "54": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "4m"
     },
     "55": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "4m"
     },
     "56": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "4m"
     },
     "57": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "4m"
     },
     "58": {
-      "key": "root.imports.connections",
-      "~k_parent": "4b"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "4m"
     },
     "59": {
-      "key": "root.imports.icons",
-      "~k_parent": "4b"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "4m"
     },
     "60": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "5b"
     },
     "61": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "5b"
     },
     "63": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "5b"
     },
     "65": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "5b"
     },
     "67": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "5b"
     },
     "69": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "68"
+    },
+    "70": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6y"
+    },
+    "71": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "6x"
     },
     "a": {
       "key": "root.pages[0:dashboard:PageSiderMenu].areas.content.blocks",
@@ -672,422 +680,423 @@
       "~k_parent": "2q"
     },
     "3a": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "36"
     },
     "3b": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "3a"
+      "key": "root.types.auth",
+      "~k_parent": "36"
     },
     "3c": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "3a"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.types.auth.events",
-      "~k_parent": "3a"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "3b"
     },
     "3e": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "3a"
+      "key": "root.types.auth.events",
+      "~k_parent": "3b"
     },
     "3f": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "3b"
+    },
+    "3g": {
       "key": "root.types.blocks",
       "~k_parent": "36"
     },
-    "3g": {
-      "key": "root.types.blocks.PageSiderMenu",
-      "~k_parent": "3f"
-    },
     "3h": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.PageSiderMenu",
+      "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3g"
     },
     "3j": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "3g"
     },
     "3k": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "3g"
     },
     "3l": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "3g"
     },
     "3m": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3g"
     },
     "3n": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3g"
     },
     "3o": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3g"
     },
     "3p": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3g"
     },
     "3q": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3g"
     },
     "3r": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3g"
     },
     "3s": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3g"
     },
     "3t": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3g"
     },
     "3u": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3g"
     },
     "3v": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3g"
     },
     "3w": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3g"
     },
     "3x": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3g"
     },
     "3y": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3g"
     },
     "3z": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3g"
     },
     "4a": {
-      "key": "root.types.operators.server",
-      "~k_parent": "46"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "48"
     },
     "4b": {
+      "key": "root.types.operators.server",
+      "~k_parent": "47"
+    },
+    "4c": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "4c": {
-      "key": "root.imports.actions",
-      "~k_parent": "4b"
-    },
     "4d": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "4c"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.auth",
-      "~k_parent": "4b"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "4d"
     },
     "4g": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "4f"
+      "key": "root.imports.agents",
+      "~k_parent": "4c"
     },
     "4h": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "4f"
+      "key": "root.imports.auth",
+      "~k_parent": "4c"
     },
     "4i": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "4f"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "4f"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "4h"
     },
     "4k": {
-      "key": "root.imports.blocks",
-      "~k_parent": "4b"
+      "key": "root.imports.auth.events",
+      "~k_parent": "4h"
     },
     "4l": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "4k"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "4h"
     },
     "4m": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks",
+      "~k_parent": "4c"
     },
     "4n": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "4m"
     },
     "4p": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "4m"
     },
     "4q": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "4m"
     },
     "4r": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "4m"
     },
     "4s": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "4m"
     },
     "4t": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "4m"
     },
     "4u": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "4m"
     },
     "4v": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "4m"
     },
     "4w": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "4m"
     },
     "4x": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "4m"
     },
     "4y": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "4m"
     },
     "4z": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "4m"
     },
     "5a": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "59"
+      "key": "root.imports.connections",
+      "~k_parent": "4c"
     },
     "5b": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "5a"
+      "key": "root.imports.icons",
+      "~k_parent": "4c"
     },
     "5c": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "5b"
     },
     "5f": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "5b"
     },
     "5h": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "5b"
     },
     "5j": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "5b"
     },
     "5l": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "5b"
     },
     "5n": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "5b"
     },
     "5p": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "5b"
     },
     "5r": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "5b"
     },
     "5t": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "5b"
     },
     "5v": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "5b"
     },
     "5x": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "5b"
     },
     "5z": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "5b"
     },
     "6b": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "5b"
     },
     "6d": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "5b"
     },
     "6f": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "6e"
     },
     "6g": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "5b"
     },
     "6h": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "6g"
     },
     "6i": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "5b"
     },
     "6j": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "6i"
     },
     "6k": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "5b"
     },
     "6l": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "6k"
     },
     "6m": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "5b"
     },
     "6n": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "6m"
     },
     "6o": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "5b"
     },
     "6p": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "6o"
     },
     "6q": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "5b"
     },
     "6r": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "6q"
     },
     "6s": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "5b"
     },
     "6t": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6s"
     },
     "6u": {
-      "key": "root.imports.requests",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "5b"
     },
     "6v": {
-      "key": "root.imports.operators",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6u"
     },
     "6w": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6v"
+      "key": "root.imports.requests",
+      "~k_parent": "4c"
     },
     "6x": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6w"
+      "key": "root.imports.operators",
+      "~k_parent": "4c"
     },
     "6y": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6w"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "6v"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6y"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "1w"
   },
@@ -1532,6 +1541,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -8261,170 +8271,173 @@
       },
       "~k": "37"
     },
+    "agents": {
+      "~k": "3a"
+    },
     "auth": {
       "adapters": {
-        "~k": "3b"
-      },
-      "callbacks": {
         "~k": "3c"
       },
-      "events": {
+      "callbacks": {
         "~k": "3d"
       },
-      "providers": {
+      "events": {
         "~k": "3e"
       },
-      "~k": "3a"
+      "providers": {
+        "~k": "3f"
+      },
+      "~k": "3b"
     },
     "blocks": {
       "PageSiderMenu": {
         "originalTypeName": "PageSiderMenu",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "3h"
+        "~k": "3i"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 6,
-        "~k": "3i"
+        "~k": "3j"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 4,
-        "~k": "3j"
+        "~k": "3k"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "3k"
+        "~k": "3l"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3l"
+        "~k": "3m"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3m"
+        "~k": "3n"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3n"
+        "~k": "3o"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3o"
+        "~k": "3p"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3p"
+        "~k": "3q"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3q"
+        "~k": "3r"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3r"
+        "~k": "3s"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3s"
+        "~k": "3t"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3t"
+        "~k": "3u"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3u"
+        "~k": "3v"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3v"
+        "~k": "3w"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3w"
+        "~k": "3x"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3x"
+        "~k": "3y"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3y"
+        "~k": "3z"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3z"
+        "~k": "40"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "40"
+        "~k": "41"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "41"
+        "~k": "42"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "42"
+        "~k": "43"
       },
-      "~k": "3f"
+      "~k": "3g"
     },
     "connections": {
-      "~k": "43"
-    },
-    "requests": {
       "~k": "44"
     },
-    "api": {
+    "requests": {
       "~k": "45"
+    },
+    "api": {
+      "~k": "46"
     },
     "operators": {
       "client": {
@@ -8432,20 +8445,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "48"
+          "~k": "49"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "49"
+          "~k": "4a"
         },
-        "~k": "47"
+        "~k": "48"
       },
       "server": {
-        "~k": "4a"
+        "~k": "4b"
       },
-      "~k": "46"
+      "~k": "47"
     },
     "~k": "36"
   }

--- a/packages/build/src/tests/success/43-wizard-flow-app/snapshot.json
+++ b/packages/build/src/tests/success/43-wizard-flow-app/snapshot.json
@@ -263,164 +263,164 @@
       "~k_parent": "41"
     },
     "50": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "4t"
     },
     "51": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "4t"
     },
     "52": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "4t"
     },
     "53": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "4t"
     },
     "54": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "4t"
     },
     "55": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "4t"
     },
     "56": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.List",
+      "~k_parent": "4t"
     },
     "57": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "4t"
     },
     "58": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "4t"
     },
     "59": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "4t"
     },
     "60": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "5y"
+      "key": "root.imports.auth",
+      "~k_parent": "5t"
     },
     "61": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "5y"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "5y"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "60"
     },
     "63": {
-      "key": "root.imports.blocks",
-      "~k_parent": "5s"
+      "key": "root.imports.auth.events",
+      "~k_parent": "60"
     },
     "64": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "63"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "60"
     },
     "65": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks",
+      "~k_parent": "5t"
     },
     "66": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "65"
     },
     "68": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "65"
     },
     "69": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "65"
     },
     "70": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "6z"
     },
     "71": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "6u"
     },
     "72": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "71"
     },
     "73": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "6u"
     },
     "74": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "73"
     },
     "75": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "6u"
     },
     "76": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "75"
     },
     "77": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "6u"
     },
     "78": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "77"
     },
     "79": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "6u"
     },
     "80": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "7z"
     },
     "81": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "6u"
     },
     "82": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "81"
     },
     "83": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "6u"
     },
     "84": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "83"
     },
     "85": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "6u"
     },
     "86": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "85"
     },
     "87": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "6u"
     },
     "88": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "87"
     },
     "89": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "6u"
     },
     "a": {
       "key": "root.pages[0:wizard:Box].events.onInit[0:initStep:SetState]",
@@ -951,422 +951,431 @@
       "~k_parent": "4i"
     },
     "4n": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "4h"
     },
     "4o": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "4n"
+      "key": "root.types.auth",
+      "~k_parent": "4h"
     },
     "4p": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "4n"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.types.auth.events",
-      "~k_parent": "4n"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "4o"
     },
     "4r": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "4n"
+      "key": "root.types.auth.events",
+      "~k_parent": "4o"
     },
     "4s": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "4o"
+    },
+    "4t": {
       "key": "root.types.blocks",
       "~k_parent": "4h"
     },
-    "4t": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "4s"
-    },
     "4u": {
-      "key": "root.types.blocks.Progress",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Progress",
+      "~k_parent": "4t"
     },
     "4w": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "4t"
     },
     "4x": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "4t"
     },
     "4y": {
-      "key": "root.types.blocks.Descriptions",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "4t"
     },
     "4z": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Descriptions",
+      "~k_parent": "4t"
     },
     "5a": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "4t"
     },
     "5b": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "4t"
     },
     "5c": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "4t"
     },
     "5d": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "4t"
     },
     "5e": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "4t"
     },
     "5f": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "4t"
     },
     "5g": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "4t"
+    },
+    "5h": {
       "key": "root.types.connections",
       "~k_parent": "4h"
     },
-    "5h": {
+    "5i": {
       "key": "root.types.requests",
       "~k_parent": "4h"
     },
-    "5i": {
+    "5j": {
       "key": "root.types.api",
       "~k_parent": "4h"
     },
-    "5j": {
+    "5k": {
       "key": "root.types.operators",
       "~k_parent": "4h"
     },
-    "5k": {
-      "key": "root.types.operators.client",
-      "~k_parent": "5j"
-    },
     "5l": {
-      "key": "root.types.operators.client._product",
+      "key": "root.types.operators.client",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.types.operators.client._divide",
-      "~k_parent": "5k"
+      "key": "root.types.operators.client._product",
+      "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.types.operators.client._state",
-      "~k_parent": "5k"
+      "key": "root.types.operators.client._divide",
+      "~k_parent": "5l"
     },
     "5o": {
-      "key": "root.types.operators.client._eq",
-      "~k_parent": "5k"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "5l"
     },
     "5p": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "5k"
+      "key": "root.types.operators.client._eq",
+      "~k_parent": "5l"
     },
     "5q": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "5k"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "5l"
     },
     "5r": {
-      "key": "root.types.operators.server",
-      "~k_parent": "5j"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "5l"
     },
     "5s": {
+      "key": "root.types.operators.server",
+      "~k_parent": "5k"
+    },
+    "5t": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "5t": {
-      "key": "root.imports.actions",
-      "~k_parent": "5s"
-    },
     "5u": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "5t"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "5t"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "5u"
     },
     "5x": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "5t"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "5u"
     },
     "5y": {
-      "key": "root.imports.auth",
-      "~k_parent": "5s"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "5u"
     },
     "5z": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "5y"
+      "key": "root.imports.agents",
+      "~k_parent": "5t"
     },
     "6a": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "65"
     },
     "6b": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "65"
     },
     "6c": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "65"
     },
     "6d": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "65"
     },
     "6e": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "65"
     },
     "6f": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "65"
     },
     "6g": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "65"
     },
     "6h": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "65"
     },
     "6i": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "65"
     },
     "6j": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "65"
     },
     "6k": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "65"
     },
     "6l": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "65"
     },
     "6m": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "65"
     },
     "6n": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "65"
     },
     "6o": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "65"
     },
     "6p": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "65"
     },
     "6q": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "65"
     },
     "6r": {
-      "key": "root.imports.connections",
-      "~k_parent": "5s"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "65"
     },
     "6s": {
-      "key": "root.imports.icons",
-      "~k_parent": "5s"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "65"
     },
     "6t": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "6s"
+      "key": "root.imports.connections",
+      "~k_parent": "5t"
     },
     "6u": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "6t"
+      "key": "root.imports.icons",
+      "~k_parent": "5t"
     },
     "6v": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "6u"
     },
     "6w": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "6v"
     },
     "6x": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "6u"
     },
     "6y": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "6u"
     },
     "7a": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "79"
     },
     "7b": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "6u"
     },
     "7c": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "7b"
     },
     "7d": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "6u"
     },
     "7e": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "7d"
     },
     "7f": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "6u"
     },
     "7g": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "7f"
     },
     "7h": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "6u"
     },
     "7i": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "7h"
     },
     "7j": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "6u"
     },
     "7k": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "7j"
     },
     "7l": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "6u"
     },
     "7m": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "7l"
     },
     "7n": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "6u"
     },
     "7o": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "7n"
     },
     "7p": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "6u"
     },
     "7q": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "7p"
     },
     "7r": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "6u"
     },
     "7s": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "7r"
     },
     "7t": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "6u"
     },
     "7u": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "7t"
     },
     "7v": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "6u"
     },
     "7w": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "7v"
     },
     "7x": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "6u"
     },
     "7y": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "7x"
     },
     "7z": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "6u"
     },
     "8a": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "89"
     },
     "8b": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "6u"
     },
     "8c": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "8b"
     },
     "8d": {
-      "key": "root.imports.requests",
-      "~k_parent": "5s"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "6u"
     },
     "8e": {
-      "key": "root.imports.operators",
-      "~k_parent": "5s"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "8d"
     },
     "8f": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "8e"
+      "key": "root.imports.requests",
+      "~k_parent": "5t"
     },
     "8g": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "8f"
+      "key": "root.imports.operators",
+      "~k_parent": "5t"
     },
     "8h": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "8f"
+      "key": "root.imports.operators.client",
+      "~k_parent": "8g"
     },
     "8i": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "8f"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "8h"
     },
     "8j": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "8f"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "8h"
     },
     "8k": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "8f"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "8h"
     },
     "8l": {
-      "key": "root.imports.operators.client[5]",
-      "~k_parent": "8f"
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "8h"
     },
     "8m": {
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "8h"
+    },
+    "8n": {
+      "key": "root.imports.operators.client[5]",
+      "~k_parent": "8h"
+    },
+    "8o": {
       "key": "root.imports.operators.server",
-      "~k_parent": "8e"
+      "~k_parent": "8g"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "33"
   },
@@ -2043,6 +2052,7 @@
     }
   },
   "plugins/actions.js": "import { SetState as SetState } from '@lowdefy/actions-core/actions';\nimport { Validate as Validate } from '@lowdefy/actions-core/actions';\nimport { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  SetState,\n  Validate,\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -8698,170 +8708,173 @@
       },
       "~k": "4i"
     },
+    "agents": {
+      "~k": "4n"
+    },
     "auth": {
       "adapters": {
-        "~k": "4o"
-      },
-      "callbacks": {
         "~k": "4p"
       },
-      "events": {
+      "callbacks": {
         "~k": "4q"
       },
-      "providers": {
+      "events": {
         "~k": "4r"
       },
-      "~k": "4n"
+      "providers": {
+        "~k": "4s"
+      },
+      "~k": "4o"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "4t"
+        "~k": "4u"
       },
       "Progress": {
         "originalTypeName": "Progress",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4u"
+        "~k": "4v"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "4v"
+        "~k": "4w"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 4,
-        "~k": "4w"
+        "~k": "4x"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 6,
-        "~k": "4x"
+        "~k": "4y"
       },
       "Descriptions": {
         "originalTypeName": "Descriptions",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4y"
+        "~k": "4z"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "4z"
+        "~k": "50"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "50"
+        "~k": "51"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "51"
+        "~k": "52"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "52"
+        "~k": "53"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "53"
+        "~k": "54"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "54"
+        "~k": "55"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "55"
+        "~k": "56"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "56"
+        "~k": "57"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "57"
+        "~k": "58"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "58"
+        "~k": "59"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "59"
+        "~k": "5a"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5a"
+        "~k": "5b"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5b"
+        "~k": "5c"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5c"
+        "~k": "5d"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5d"
+        "~k": "5e"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5e"
+        "~k": "5f"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "5f"
+        "~k": "5g"
       },
-      "~k": "4s"
+      "~k": "4t"
     },
     "connections": {
-      "~k": "5g"
-    },
-    "requests": {
       "~k": "5h"
     },
-    "api": {
+    "requests": {
       "~k": "5i"
+    },
+    "api": {
+      "~k": "5j"
     },
     "operators": {
       "client": {
@@ -8869,44 +8882,44 @@
           "originalTypeName": "_product",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5l"
+          "~k": "5m"
         },
         "_divide": {
           "originalTypeName": "_divide",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5m"
+          "~k": "5n"
         },
         "_state": {
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 9,
-          "~k": "5n"
+          "~k": "5o"
         },
         "_eq": {
           "originalTypeName": "_eq",
           "package": "@lowdefy/operators-js",
           "count": 4,
-          "~k": "5o"
+          "~k": "5p"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5p"
+          "~k": "5q"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5q"
+          "~k": "5r"
         },
-        "~k": "5k"
+        "~k": "5l"
       },
       "server": {
-        "~k": "5r"
+        "~k": "5s"
       },
-      "~k": "5j"
+      "~k": "5k"
     },
     "~k": "4h"
   }

--- a/packages/build/src/tests/success/44-modal-drawer-app/snapshot.json
+++ b/packages/build/src/tests/success/44-modal-drawer-app/snapshot.json
@@ -213,164 +213,164 @@
       "~k_parent": "35"
     },
     "40": {
-      "key": "root.types.blocks.Modal",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3x"
     },
     "41": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Modal",
+      "~k_parent": "3x"
     },
     "42": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "3x"
     },
     "43": {
-      "key": "root.types.blocks.Drawer",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "3x"
     },
     "44": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Drawer",
+      "~k_parent": "3x"
     },
     "45": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3x"
     },
     "46": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3x"
     },
     "47": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3x"
     },
     "48": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3x"
     },
     "49": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3x"
     },
     "50": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "4z"
+      "key": "root.imports.agents",
+      "~k_parent": "4u"
     },
     "51": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "4z"
+      "key": "root.imports.auth",
+      "~k_parent": "4u"
     },
     "52": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "4z"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "4z"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "51"
     },
     "54": {
-      "key": "root.imports.blocks",
-      "~k_parent": "4t"
+      "key": "root.imports.auth.events",
+      "~k_parent": "51"
     },
     "55": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "54"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "51"
     },
     "56": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks",
+      "~k_parent": "4u"
     },
     "57": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "56"
     },
     "59": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "56"
     },
     "60": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "5w"
     },
     "62": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "5w"
     },
     "64": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "5w"
     },
     "66": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "5w"
     },
     "68": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "5w"
     },
     "70": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "6z"
     },
     "71": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "5w"
     },
     "72": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "71"
     },
     "73": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "5w"
     },
     "74": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "73"
     },
     "75": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "5w"
     },
     "76": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "75"
     },
     "77": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "5w"
     },
     "78": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "77"
     },
     "79": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "5w"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[0:title:Title].properties",
@@ -789,398 +789,407 @@
       "~k_parent": "3m"
     },
     "3r": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "3l"
     },
     "3s": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "3r"
+      "key": "root.types.auth",
+      "~k_parent": "3l"
     },
     "3t": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "3r"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.types.auth.events",
-      "~k_parent": "3r"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "3s"
     },
     "3v": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "3r"
+      "key": "root.types.auth.events",
+      "~k_parent": "3s"
     },
     "3w": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "3s"
+    },
+    "3x": {
       "key": "root.types.blocks",
       "~k_parent": "3l"
     },
-    "3x": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "3w"
-    },
     "3y": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "3x"
     },
     "4a": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3x"
     },
     "4b": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3x"
     },
     "4c": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3x"
     },
     "4d": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3x"
     },
     "4e": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3x"
     },
     "4f": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3x"
     },
     "4g": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3x"
     },
     "4h": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3x"
     },
     "4i": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3x"
     },
     "4j": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3x"
     },
     "4k": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3x"
     },
     "4l": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3x"
+    },
+    "4m": {
       "key": "root.types.connections",
       "~k_parent": "3l"
     },
-    "4m": {
+    "4n": {
       "key": "root.types.requests",
       "~k_parent": "3l"
     },
-    "4n": {
+    "4o": {
       "key": "root.types.api",
       "~k_parent": "3l"
     },
-    "4o": {
+    "4p": {
       "key": "root.types.operators",
       "~k_parent": "3l"
     },
-    "4p": {
-      "key": "root.types.operators.client",
-      "~k_parent": "4o"
-    },
     "4q": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "4p"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.types.operators.server",
-      "~k_parent": "4o"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "4q"
     },
     "4t": {
+      "key": "root.types.operators.server",
+      "~k_parent": "4p"
+    },
+    "4u": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "4u": {
-      "key": "root.imports.actions",
-      "~k_parent": "4t"
-    },
     "4v": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "4u"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "4u"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "4v"
     },
     "4y": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "4u"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "4v"
     },
     "4z": {
-      "key": "root.imports.auth",
-      "~k_parent": "4t"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "4v"
     },
     "5a": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "56"
     },
     "5b": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "56"
     },
     "5c": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "56"
     },
     "5d": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "56"
     },
     "5e": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "56"
     },
     "5f": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "56"
     },
     "5g": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "56"
     },
     "5h": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "56"
     },
     "5i": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "56"
     },
     "5j": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "56"
     },
     "5k": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "56"
     },
     "5l": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "56"
     },
     "5m": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "56"
     },
     "5n": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "56"
     },
     "5o": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "56"
     },
     "5p": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "56"
     },
     "5q": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "56"
     },
     "5r": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "56"
     },
     "5s": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "56"
     },
     "5t": {
-      "key": "root.imports.connections",
-      "~k_parent": "4t"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "56"
     },
     "5u": {
-      "key": "root.imports.icons",
-      "~k_parent": "4t"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "56"
     },
     "5v": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "5u"
+      "key": "root.imports.connections",
+      "~k_parent": "4u"
     },
     "5w": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "5v"
+      "key": "root.imports.icons",
+      "~k_parent": "4u"
     },
     "5x": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "5w"
     },
     "6a": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "5w"
     },
     "6c": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "5w"
     },
     "6e": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "5w"
     },
     "6g": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "6f"
     },
     "6h": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "5w"
     },
     "6i": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "5w"
     },
     "6k": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "6j"
     },
     "6l": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "5w"
     },
     "6m": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "6l"
     },
     "6n": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "5w"
     },
     "6o": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "6n"
     },
     "6p": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "5w"
     },
     "6q": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "5w"
     },
     "6s": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "6r"
     },
     "6t": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "5w"
     },
     "6u": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "5w"
     },
     "6w": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "6v"
     },
     "6x": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "5w"
     },
     "6y": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "5w"
     },
     "7a": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "79"
     },
     "7b": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "5w"
     },
     "7c": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "7b"
     },
     "7d": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "5w"
     },
     "7e": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "7d"
     },
     "7f": {
-      "key": "root.imports.requests",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "5w"
     },
     "7g": {
-      "key": "root.imports.operators",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "7f"
     },
     "7h": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "7g"
+      "key": "root.imports.requests",
+      "~k_parent": "4u"
     },
     "7i": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "7h"
+      "key": "root.imports.operators",
+      "~k_parent": "4u"
     },
     "7j": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "7h"
+      "key": "root.imports.operators.client",
+      "~k_parent": "7i"
     },
     "7k": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "7j"
+    },
+    "7l": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "7j"
+    },
+    "7m": {
       "key": "root.imports.operators.server",
-      "~k_parent": "7g"
+      "~k_parent": "7i"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "25"
   },
@@ -1749,6 +1758,7 @@
     }
   },
   "plugins/actions.js": "import { CallMethod as CallMethod } from '@lowdefy/actions-core/actions';\nimport { DisplayMessage as DisplayMessage } from '@lowdefy/actions-core/actions';\nimport { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  CallMethod,\n  DisplayMessage,\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -8731,176 +8741,179 @@
       },
       "~k": "3m"
     },
+    "agents": {
+      "~k": "3r"
+    },
     "auth": {
       "adapters": {
-        "~k": "3s"
-      },
-      "callbacks": {
         "~k": "3t"
       },
-      "events": {
+      "callbacks": {
         "~k": "3u"
       },
-      "providers": {
+      "events": {
         "~k": "3v"
       },
-      "~k": "3r"
+      "providers": {
+        "~k": "3w"
+      },
+      "~k": "3s"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "3x"
+        "~k": "3y"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3y"
+        "~k": "3z"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "3z"
+        "~k": "40"
       },
       "Modal": {
         "originalTypeName": "Modal",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "40"
+        "~k": "41"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "41"
+        "~k": "42"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "42"
+        "~k": "43"
       },
       "Drawer": {
         "originalTypeName": "Drawer",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "43"
+        "~k": "44"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "44"
+        "~k": "45"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "45"
+        "~k": "46"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "46"
+        "~k": "47"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "47"
+        "~k": "48"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "48"
+        "~k": "49"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "49"
+        "~k": "4a"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4a"
+        "~k": "4b"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4b"
+        "~k": "4c"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4c"
+        "~k": "4d"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4d"
+        "~k": "4e"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4e"
+        "~k": "4f"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4f"
+        "~k": "4g"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4g"
+        "~k": "4h"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4h"
+        "~k": "4i"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4i"
+        "~k": "4j"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4j"
+        "~k": "4k"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4k"
+        "~k": "4l"
       },
-      "~k": "3w"
+      "~k": "3x"
     },
     "connections": {
-      "~k": "4l"
-    },
-    "requests": {
       "~k": "4m"
     },
-    "api": {
+    "requests": {
       "~k": "4n"
+    },
+    "api": {
+      "~k": "4o"
     },
     "operators": {
       "client": {
@@ -8908,20 +8921,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4q"
+          "~k": "4r"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4r"
+          "~k": "4s"
         },
-        "~k": "4p"
+        "~k": "4q"
       },
       "server": {
-        "~k": "4s"
+        "~k": "4t"
       },
-      "~k": "4o"
+      "~k": "4p"
     },
     "~k": "3l"
   }

--- a/packages/build/src/tests/success/45-tabs-layout-app/snapshot.json
+++ b/packages/build/src/tests/success/45-tabs-layout-app/snapshot.json
@@ -217,163 +217,163 @@
       "~k_parent": "38"
     },
     "40": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "3u"
     },
     "41": {
-      "key": "root.types.blocks.TextArea",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "3u"
     },
     "42": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.TextArea",
+      "~k_parent": "3u"
     },
     "43": {
-      "key": "root.types.blocks.NumberInput",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "3u"
     },
     "44": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.NumberInput",
+      "~k_parent": "3u"
     },
     "45": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "3u"
     },
     "46": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3u"
     },
     "47": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3u"
     },
     "48": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3u"
     },
     "49": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3u"
     },
     "50": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "4z"
+      "key": "root.imports.agents",
+      "~k_parent": "4w"
     },
     "51": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "4z"
+      "key": "root.imports.auth",
+      "~k_parent": "4w"
     },
     "52": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "4z"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "4z"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "51"
     },
     "54": {
-      "key": "root.imports.blocks",
-      "~k_parent": "4v"
+      "key": "root.imports.auth.events",
+      "~k_parent": "51"
     },
     "55": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "54"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "51"
     },
     "56": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks",
+      "~k_parent": "4w"
     },
     "57": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "56"
     },
     "59": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "56"
     },
     "60": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "5z"
+      "key": "root.imports.connections",
+      "~k_parent": "4w"
     },
     "61": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "60"
+      "key": "root.imports.icons",
+      "~k_parent": "4w"
     },
     "62": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "61"
     },
     "65": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "61"
     },
     "67": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "61"
     },
     "69": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "68"
     },
     "70": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "61"
     },
     "71": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "70"
     },
     "72": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "61"
     },
     "73": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "72"
     },
     "74": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "61"
     },
     "75": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "74"
     },
     "76": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "61"
     },
     "77": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "76"
     },
     "78": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "61"
     },
     "79": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "78"
     },
     "a": {
@@ -788,430 +788,439 @@
       "~k_parent": "3l"
     },
     "3o": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "3k"
     },
     "3p": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "3o"
+      "key": "root.types.auth",
+      "~k_parent": "3k"
     },
     "3q": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "3o"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.types.auth.events",
-      "~k_parent": "3o"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "3p"
     },
     "3s": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "3o"
+      "key": "root.types.auth.events",
+      "~k_parent": "3p"
     },
     "3t": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "3p"
+    },
+    "3u": {
       "key": "root.types.blocks",
       "~k_parent": "3k"
     },
-    "3u": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "3t"
-    },
     "3v": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.types.blocks.Tabs",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "3u"
     },
     "3x": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Tabs",
+      "~k_parent": "3u"
     },
     "3y": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "3u"
     },
     "3z": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "3u"
     },
     "4a": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3u"
     },
     "4b": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3u"
     },
     "4c": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3u"
     },
     "4d": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3u"
     },
     "4e": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3u"
     },
     "4f": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3u"
     },
     "4g": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3u"
     },
     "4h": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3u"
     },
     "4i": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3u"
     },
     "4j": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3u"
     },
     "4k": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3u"
     },
     "4l": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3u"
     },
     "4m": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3u"
     },
     "4n": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3u"
+    },
+    "4o": {
       "key": "root.types.connections",
       "~k_parent": "3k"
     },
-    "4o": {
+    "4p": {
       "key": "root.types.requests",
       "~k_parent": "3k"
     },
-    "4p": {
+    "4q": {
       "key": "root.types.api",
       "~k_parent": "3k"
     },
-    "4q": {
+    "4r": {
       "key": "root.types.operators",
       "~k_parent": "3k"
     },
-    "4r": {
-      "key": "root.types.operators.client",
-      "~k_parent": "4q"
-    },
     "4s": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "4r"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.types.operators.server",
-      "~k_parent": "4q"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "4s"
     },
     "4v": {
+      "key": "root.types.operators.server",
+      "~k_parent": "4r"
+    },
+    "4w": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "4w": {
-      "key": "root.imports.actions",
-      "~k_parent": "4v"
-    },
     "4x": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "4w"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.auth",
-      "~k_parent": "4v"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "4x"
     },
     "5a": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "56"
     },
     "5b": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "56"
     },
     "5c": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "56"
     },
     "5d": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "56"
     },
     "5e": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "56"
     },
     "5f": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "56"
     },
     "5g": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "56"
     },
     "5h": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "56"
     },
     "5i": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "56"
     },
     "5j": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "56"
     },
     "5k": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "56"
     },
     "5l": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "56"
     },
     "5m": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "56"
     },
     "5n": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "56"
     },
     "5o": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "56"
     },
     "5p": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "56"
     },
     "5q": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "56"
     },
     "5r": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "56"
     },
     "5s": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "56"
     },
     "5t": {
-      "key": "root.imports.blocks[24]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "56"
     },
     "5u": {
-      "key": "root.imports.blocks[25]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "56"
     },
     "5v": {
-      "key": "root.imports.blocks[26]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[24]",
+      "~k_parent": "56"
     },
     "5w": {
-      "key": "root.imports.blocks[27]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[25]",
+      "~k_parent": "56"
     },
     "5x": {
-      "key": "root.imports.blocks[28]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[26]",
+      "~k_parent": "56"
     },
     "5y": {
-      "key": "root.imports.connections",
-      "~k_parent": "4v"
+      "key": "root.imports.blocks[27]",
+      "~k_parent": "56"
     },
     "5z": {
-      "key": "root.imports.icons",
-      "~k_parent": "4v"
+      "key": "root.imports.blocks[28]",
+      "~k_parent": "56"
     },
     "6a": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "61"
     },
     "6b": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "61"
     },
     "6d": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "61"
     },
     "6f": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "6e"
     },
     "6g": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "61"
     },
     "6h": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "6g"
     },
     "6i": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "61"
     },
     "6j": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "6i"
     },
     "6k": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "61"
     },
     "6l": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "6k"
     },
     "6m": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "61"
     },
     "6n": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "6m"
     },
     "6o": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "61"
     },
     "6p": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "6o"
     },
     "6q": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "61"
     },
     "6r": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "6q"
     },
     "6s": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "61"
     },
     "6t": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "6s"
     },
     "6u": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "61"
     },
     "6v": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "6u"
     },
     "6w": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "61"
     },
     "6x": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "6w"
     },
     "6y": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "61"
     },
     "6z": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "6y"
     },
     "7a": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "61"
     },
     "7b": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "7a"
     },
     "7c": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "61"
     },
     "7d": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "7c"
     },
     "7e": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "61"
     },
     "7f": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "7e"
     },
     "7g": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "61"
     },
     "7h": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "7g"
     },
     "7i": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "61"
     },
     "7j": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "7i"
     },
     "7k": {
-      "key": "root.imports.requests",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "61"
     },
     "7l": {
-      "key": "root.imports.operators",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "7k"
     },
     "7m": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "7l"
+      "key": "root.imports.requests",
+      "~k_parent": "4w"
     },
     "7n": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "7m"
+      "key": "root.imports.operators",
+      "~k_parent": "4w"
     },
     "7o": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "7m"
+      "key": "root.imports.operators.client",
+      "~k_parent": "7n"
     },
     "7p": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "7o"
+    },
+    "7q": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "7o"
+    },
+    "7r": {
       "key": "root.imports.operators.server",
-      "~k_parent": "7l"
+      "~k_parent": "7n"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "2g"
   },
@@ -1736,6 +1745,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -11121,206 +11131,209 @@
       },
       "~k": "3l"
     },
+    "agents": {
+      "~k": "3o"
+    },
     "auth": {
       "adapters": {
-        "~k": "3p"
-      },
-      "callbacks": {
         "~k": "3q"
       },
-      "events": {
+      "callbacks": {
         "~k": "3r"
       },
-      "providers": {
+      "events": {
         "~k": "3s"
       },
-      "~k": "3o"
+      "providers": {
+        "~k": "3t"
+      },
+      "~k": "3p"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "3u"
+        "~k": "3v"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "3v"
+        "~k": "3w"
       },
       "Tabs": {
         "originalTypeName": "Tabs",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "3w"
+        "~k": "3x"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "3x"
+        "~k": "3y"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "3y"
+        "~k": "3z"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "3z"
+        "~k": "40"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "40"
+        "~k": "41"
       },
       "TextArea": {
         "originalTypeName": "TextArea",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "41"
+        "~k": "42"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "42"
+        "~k": "43"
       },
       "NumberInput": {
         "originalTypeName": "NumberInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "43"
+        "~k": "44"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "44"
+        "~k": "45"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "45"
+        "~k": "46"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "46"
+        "~k": "47"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "47"
+        "~k": "48"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "48"
+        "~k": "49"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "49"
+        "~k": "4a"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4a"
+        "~k": "4b"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4b"
+        "~k": "4c"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4c"
+        "~k": "4d"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4d"
+        "~k": "4e"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4e"
+        "~k": "4f"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4f"
+        "~k": "4g"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4g"
+        "~k": "4h"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4h"
+        "~k": "4i"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4i"
+        "~k": "4j"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4j"
+        "~k": "4k"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4k"
+        "~k": "4l"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4l"
+        "~k": "4m"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4m"
+        "~k": "4n"
       },
-      "~k": "3t"
+      "~k": "3u"
     },
     "connections": {
-      "~k": "4n"
-    },
-    "requests": {
       "~k": "4o"
     },
-    "api": {
+    "requests": {
       "~k": "4p"
+    },
+    "api": {
+      "~k": "4q"
     },
     "operators": {
       "client": {
@@ -11328,20 +11341,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4s"
+          "~k": "4t"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4t"
+          "~k": "4u"
         },
-        "~k": "4r"
+        "~k": "4s"
       },
       "server": {
-        "~k": "4u"
+        "~k": "4v"
       },
-      "~k": "4q"
+      "~k": "4r"
     },
     "~k": "3k"
   }

--- a/packages/build/src/tests/success/46-responsive-layout-app/snapshot.json
+++ b/packages/build/src/tests/success/46-responsive-layout-app/snapshot.json
@@ -217,163 +217,163 @@
       "~k_parent": "2h"
     },
     "40": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "3w"
     },
     "41": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "40"
+      "key": "root.types.auth",
+      "~k_parent": "3w"
     },
     "42": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "40"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "41"
     },
     "43": {
-      "key": "root.types.auth.events",
-      "~k_parent": "40"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "41"
     },
     "44": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "40"
+      "key": "root.types.auth.events",
+      "~k_parent": "41"
     },
     "45": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "41"
+    },
+    "46": {
       "key": "root.types.blocks",
       "~k_parent": "3w"
     },
-    "46": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "45"
-    },
     "47": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "46"
     },
     "48": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "46"
     },
     "49": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "46"
     },
     "50": {
+      "key": "root.types.operators.server",
+      "~k_parent": "4w"
+    },
+    "51": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "51": {
-      "key": "root.imports.actions",
-      "~k_parent": "50"
-    },
     "52": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "51"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.auth",
-      "~k_parent": "50"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "52"
     },
     "55": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "54"
+      "key": "root.imports.agents",
+      "~k_parent": "51"
     },
     "56": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "54"
+      "key": "root.imports.auth",
+      "~k_parent": "51"
     },
     "57": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "54"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "54"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "56"
     },
     "59": {
-      "key": "root.imports.blocks",
-      "~k_parent": "50"
+      "key": "root.imports.auth.events",
+      "~k_parent": "56"
     },
     "60": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "5z"
     },
     "63": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "5z"
     },
     "65": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "5z"
     },
     "67": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "5z"
     },
     "69": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "68"
     },
     "70": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "5z"
     },
     "71": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "70"
     },
     "72": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "5z"
     },
     "73": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "72"
     },
     "74": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "5z"
     },
     "75": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "74"
     },
     "76": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "5z"
     },
     "77": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "76"
     },
     "78": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "5z"
     },
     "79": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "78"
     },
     "a": {
@@ -834,374 +834,383 @@
       "~k_parent": "3x"
     },
     "4a": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "46"
     },
     "4b": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "46"
     },
     "4c": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "46"
     },
     "4d": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "46"
     },
     "4e": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "45"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "46"
     },
     "4f": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "46"
     },
     "4g": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "46"
     },
     "4h": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "46"
     },
     "4i": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "45"
+      "key": "root.types.blocks.List",
+      "~k_parent": "46"
     },
     "4j": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "46"
     },
     "4k": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "46"
     },
     "4l": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "45"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "46"
     },
     "4m": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "46"
     },
     "4n": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "45"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "46"
     },
     "4o": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "45"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "46"
     },
     "4p": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "45"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "46"
     },
     "4q": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "45"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "46"
     },
     "4r": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "46"
     },
     "4s": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "46"
+    },
+    "4t": {
       "key": "root.types.connections",
       "~k_parent": "3w"
     },
-    "4t": {
+    "4u": {
       "key": "root.types.requests",
       "~k_parent": "3w"
     },
-    "4u": {
+    "4v": {
       "key": "root.types.api",
       "~k_parent": "3w"
     },
-    "4v": {
+    "4w": {
       "key": "root.types.operators",
       "~k_parent": "3w"
     },
-    "4w": {
-      "key": "root.types.operators.client",
-      "~k_parent": "4v"
-    },
     "4x": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "4w"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.types.operators.server",
-      "~k_parent": "4v"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "4x"
     },
     "5a": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "59"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "56"
     },
     "5b": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks",
+      "~k_parent": "51"
     },
     "5c": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "5b"
     },
     "5e": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "5b"
     },
     "5f": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "5b"
     },
     "5g": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "5b"
     },
     "5h": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "5b"
     },
     "5i": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "5b"
     },
     "5j": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "5b"
     },
     "5k": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "5b"
     },
     "5l": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "5b"
     },
     "5m": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "5b"
     },
     "5n": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "5b"
     },
     "5o": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "5b"
     },
     "5p": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "5b"
     },
     "5q": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "5b"
     },
     "5r": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "5b"
     },
     "5s": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "5b"
     },
     "5t": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "5b"
     },
     "5u": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "5b"
     },
     "5v": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "5b"
     },
     "5w": {
-      "key": "root.imports.connections",
-      "~k_parent": "50"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "5b"
     },
     "5x": {
-      "key": "root.imports.icons",
-      "~k_parent": "50"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "5b"
     },
     "5y": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "5x"
+      "key": "root.imports.connections",
+      "~k_parent": "51"
     },
     "5z": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "5y"
+      "key": "root.imports.icons",
+      "~k_parent": "51"
     },
     "6a": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "5z"
     },
     "6b": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "5z"
     },
     "6d": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "5z"
     },
     "6f": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "6e"
     },
     "6g": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "5z"
     },
     "6h": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "6g"
     },
     "6i": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "5z"
     },
     "6j": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "6i"
     },
     "6k": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "5z"
     },
     "6l": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "6k"
     },
     "6m": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "5z"
     },
     "6n": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "6m"
     },
     "6o": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "5z"
     },
     "6p": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "6o"
     },
     "6q": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "5z"
     },
     "6r": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "6q"
     },
     "6s": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "5z"
     },
     "6t": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "6s"
     },
     "6u": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "5z"
     },
     "6v": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "6u"
     },
     "6w": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "5z"
     },
     "6x": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "6w"
     },
     "6y": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "5z"
     },
     "6z": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "6y"
     },
     "7a": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "5z"
     },
     "7b": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "7a"
     },
     "7c": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "5z"
     },
     "7d": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "7c"
     },
     "7e": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "5z"
     },
     "7f": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "7e"
     },
     "7g": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "5z"
     },
     "7h": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "7g"
     },
     "7i": {
-      "key": "root.imports.requests",
-      "~k_parent": "50"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "5z"
     },
     "7j": {
-      "key": "root.imports.operators",
-      "~k_parent": "50"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "7i"
     },
     "7k": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "7j"
+      "key": "root.imports.requests",
+      "~k_parent": "51"
     },
     "7l": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "7k"
+      "key": "root.imports.operators",
+      "~k_parent": "51"
     },
     "7m": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "7k"
+      "key": "root.imports.operators.client",
+      "~k_parent": "7l"
     },
     "7n": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "7m"
+    },
+    "7o": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "7m"
+    },
+    "7p": {
       "key": "root.imports.operators.server",
-      "~k_parent": "7j"
+      "~k_parent": "7l"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "2e"
   },
@@ -1772,6 +1781,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -6749,164 +6759,167 @@
       },
       "~k": "3x"
     },
+    "agents": {
+      "~k": "40"
+    },
     "auth": {
       "adapters": {
-        "~k": "41"
-      },
-      "callbacks": {
         "~k": "42"
       },
-      "events": {
+      "callbacks": {
         "~k": "43"
       },
-      "providers": {
+      "events": {
         "~k": "44"
       },
-      "~k": "40"
+      "providers": {
+        "~k": "45"
+      },
+      "~k": "41"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "46"
+        "~k": "47"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "47"
+        "~k": "48"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 7,
-        "~k": "48"
+        "~k": "49"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "49"
+        "~k": "4a"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "4a"
+        "~k": "4b"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4b"
+        "~k": "4c"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4c"
+        "~k": "4d"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4d"
+        "~k": "4e"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4e"
+        "~k": "4f"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4f"
+        "~k": "4g"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4g"
+        "~k": "4h"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4h"
+        "~k": "4i"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4i"
+        "~k": "4j"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4j"
+        "~k": "4k"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4k"
+        "~k": "4l"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4l"
+        "~k": "4m"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4m"
+        "~k": "4n"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4n"
+        "~k": "4o"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4o"
+        "~k": "4p"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4p"
+        "~k": "4q"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4q"
+        "~k": "4r"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4r"
+        "~k": "4s"
       },
-      "~k": "45"
+      "~k": "46"
     },
     "connections": {
-      "~k": "4s"
-    },
-    "requests": {
       "~k": "4t"
     },
-    "api": {
+    "requests": {
       "~k": "4u"
+    },
+    "api": {
+      "~k": "4v"
     },
     "operators": {
       "client": {
@@ -6914,20 +6927,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4x"
+          "~k": "4y"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4y"
+          "~k": "4z"
         },
-        "~k": "4w"
+        "~k": "4x"
       },
       "server": {
-        "~k": "4z"
+        "~k": "50"
       },
-      "~k": "4v"
+      "~k": "4w"
     },
     "~k": "3w"
   }

--- a/packages/build/src/tests/success/47-operators-comprehensive/snapshot.json
+++ b/packages/build/src/tests/success/47-operators-comprehensive/snapshot.json
@@ -341,163 +341,163 @@
       "~k_parent": "47"
     },
     "60": {
-      "key": "root.types.auth.events",
-      "~k_parent": "5x"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "5y"
     },
     "61": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "5x"
+      "key": "root.types.auth.events",
+      "~k_parent": "5y"
     },
     "62": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "5y"
+    },
+    "63": {
       "key": "root.types.blocks",
       "~k_parent": "5t"
     },
-    "63": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "62"
-    },
     "64": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "63"
     },
     "65": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "63"
     },
     "66": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "63"
     },
     "67": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "63"
     },
     "68": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "63"
     },
     "69": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "62"
+      "key": "root.types.blocks.List",
+      "~k_parent": "63"
     },
     "70": {
-      "key": "root.types.operators.client._if",
+      "key": "root.types.operators.client",
       "~k_parent": "6z"
     },
     "71": {
-      "key": "root.types.operators.client._state",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._if",
+      "~k_parent": "70"
     },
     "72": {
-      "key": "root.types.operators.client._array",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "70"
     },
     "73": {
-      "key": "root.types.operators.client._global",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._array",
+      "~k_parent": "70"
     },
     "74": {
-      "key": "root.types.operators.client._function",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._global",
+      "~k_parent": "70"
     },
     "75": {
-      "key": "root.types.operators.client._eq",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._function",
+      "~k_parent": "70"
     },
     "76": {
-      "key": "root.types.operators.client._args",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._eq",
+      "~k_parent": "70"
     },
     "77": {
-      "key": "root.types.operators.client._string",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._args",
+      "~k_parent": "70"
     },
     "78": {
-      "key": "root.types.operators.client._json",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._string",
+      "~k_parent": "70"
     },
     "79": {
-      "key": "root.types.operators.client._object",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._json",
+      "~k_parent": "70"
     },
     "80": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "7t"
     },
     "81": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "7t"
     },
     "82": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "7t"
     },
     "83": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "7t"
     },
     "84": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "7t"
     },
     "85": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "7t"
     },
     "86": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "7t"
     },
     "87": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "7t"
     },
     "88": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "7t"
     },
     "89": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "7t"
     },
     "90": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "8n"
     },
     "91": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "90"
     },
     "92": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "8n"
     },
     "93": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "92"
     },
     "94": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "8n"
     },
     "95": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "94"
     },
     "96": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "8n"
     },
     "97": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "96"
     },
     "98": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "8n"
     },
     "99": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "98"
     },
     "a": {
@@ -1205,542 +1205,551 @@
       "~k_parent": "5u"
     },
     "5x": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "5t"
     },
     "5y": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "5x"
+      "key": "root.types.auth",
+      "~k_parent": "5t"
     },
     "5z": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "5x"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "63"
     },
     "6b": {
-      "key": "root.types.blocks.Tag",
-      "~k_parent": "62"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "63"
     },
     "6c": {
-      "key": "root.types.blocks.NumberInput",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Tag",
+      "~k_parent": "63"
     },
     "6d": {
-      "key": "root.types.blocks.Alert",
-      "~k_parent": "62"
+      "key": "root.types.blocks.NumberInput",
+      "~k_parent": "63"
     },
     "6e": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Alert",
+      "~k_parent": "63"
     },
     "6f": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "63"
     },
     "6g": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "63"
     },
     "6h": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "63"
     },
     "6i": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "62"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "63"
     },
     "6j": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "63"
     },
     "6k": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "63"
     },
     "6l": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "63"
     },
     "6m": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "63"
     },
     "6n": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "63"
     },
     "6o": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "62"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "63"
     },
     "6p": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "63"
     },
     "6q": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "62"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "63"
     },
     "6r": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "62"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "63"
     },
     "6s": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "62"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "63"
     },
     "6t": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "62"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "63"
     },
     "6u": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "63"
     },
     "6v": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "63"
+    },
+    "6w": {
       "key": "root.types.connections",
       "~k_parent": "5t"
     },
-    "6w": {
+    "6x": {
       "key": "root.types.requests",
       "~k_parent": "5t"
     },
-    "6x": {
+    "6y": {
       "key": "root.types.api",
       "~k_parent": "5t"
     },
-    "6y": {
+    "6z": {
       "key": "root.types.operators",
       "~k_parent": "5t"
     },
-    "6z": {
-      "key": "root.types.operators.client",
-      "~k_parent": "6y"
-    },
     "7a": {
-      "key": "root.types.operators.client._gt",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._object",
+      "~k_parent": "70"
     },
     "7b": {
-      "key": "root.types.operators.client._and",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._gt",
+      "~k_parent": "70"
     },
     "7c": {
-      "key": "root.types.operators.client._or",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._and",
+      "~k_parent": "70"
     },
     "7d": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._or",
+      "~k_parent": "70"
     },
     "7e": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "70"
     },
     "7f": {
-      "key": "root.types.operators.client._date",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "70"
     },
     "7g": {
-      "key": "root.types.operators.client._dayjs",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._date",
+      "~k_parent": "70"
     },
     "7h": {
-      "key": "root.types.operators.server",
-      "~k_parent": "6y"
+      "key": "root.types.operators.client._dayjs",
+      "~k_parent": "70"
     },
     "7i": {
+      "key": "root.types.operators.server",
+      "~k_parent": "6z"
+    },
+    "7j": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "7j": {
-      "key": "root.imports.actions",
-      "~k_parent": "7i"
-    },
     "7k": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "7j"
     },
     "7l": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "7j"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "7k"
     },
     "7m": {
-      "key": "root.imports.auth",
-      "~k_parent": "7i"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "7k"
     },
     "7n": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "7m"
+      "key": "root.imports.agents",
+      "~k_parent": "7j"
     },
     "7o": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "7m"
+      "key": "root.imports.auth",
+      "~k_parent": "7j"
     },
     "7p": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "7m"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "7o"
     },
     "7q": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "7m"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "7o"
     },
     "7r": {
-      "key": "root.imports.blocks",
-      "~k_parent": "7i"
+      "key": "root.imports.auth.events",
+      "~k_parent": "7o"
     },
     "7s": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "7r"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "7o"
     },
     "7t": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks",
+      "~k_parent": "7j"
     },
     "7u": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "7t"
     },
     "7v": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "7t"
     },
     "7w": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "7t"
     },
     "7x": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "7t"
     },
     "7y": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "7t"
     },
     "7z": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "7t"
     },
     "8a": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "7t"
     },
     "8b": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "7t"
     },
     "8c": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "7t"
     },
     "8d": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "7t"
     },
     "8e": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "7t"
     },
     "8f": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "7t"
     },
     "8g": {
-      "key": "root.imports.blocks[24]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "7t"
     },
     "8h": {
-      "key": "root.imports.blocks[25]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "7t"
     },
     "8i": {
-      "key": "root.imports.blocks[26]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[24]",
+      "~k_parent": "7t"
     },
     "8j": {
-      "key": "root.imports.blocks[27]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[25]",
+      "~k_parent": "7t"
     },
     "8k": {
-      "key": "root.imports.connections",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[26]",
+      "~k_parent": "7t"
     },
     "8l": {
-      "key": "root.imports.icons",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[27]",
+      "~k_parent": "7t"
     },
     "8m": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "8l"
+      "key": "root.imports.connections",
+      "~k_parent": "7j"
     },
     "8n": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "8m"
+      "key": "root.imports.icons",
+      "~k_parent": "7j"
     },
     "8o": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "8n"
     },
     "8p": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "8o"
     },
     "8q": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "8n"
     },
     "8r": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "8q"
     },
     "8s": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "8n"
     },
     "8t": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "8s"
     },
     "8u": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "8n"
     },
     "8v": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "8u"
     },
     "8w": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "8n"
     },
     "8x": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "8w"
     },
     "8y": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "8n"
     },
     "8z": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "8y"
     },
     "9a": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "8n"
     },
     "9b": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "9a"
     },
     "9c": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "8n"
     },
     "9d": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "9c"
     },
     "9e": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "8n"
     },
     "9f": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "9e"
     },
     "9g": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "8n"
     },
     "9h": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "9g"
     },
     "9i": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "8n"
     },
     "9j": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "9i"
     },
     "9k": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "8n"
     },
     "9l": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "9k"
     },
     "9m": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "8n"
     },
     "9n": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "9m"
     },
     "9o": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "8n"
     },
     "9p": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "9o"
     },
     "9q": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "8n"
     },
     "9r": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "9q"
     },
     "9s": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "8n"
     },
     "9t": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "9s"
     },
     "9u": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "8n"
     },
     "9v": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "9u"
     },
     "9w": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "8n"
     },
     "9x": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "9w"
     },
     "9y": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "8n"
     },
     "9z": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "9y"
     },
     "a0": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "8n"
     },
     "a1": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "a0"
     },
     "a2": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "8n"
     },
     "a3": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "a2"
     },
     "a4": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "8n"
     },
     "a5": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "a4"
     },
     "a6": {
-      "key": "root.imports.requests",
-      "~k_parent": "7i"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "8n"
     },
     "a7": {
-      "key": "root.imports.operators",
-      "~k_parent": "7i"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "a6"
     },
     "a8": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "a7"
+      "key": "root.imports.requests",
+      "~k_parent": "7j"
     },
     "a9": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "a8"
+      "key": "root.imports.operators",
+      "~k_parent": "7j"
     },
     "aa": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "a8"
+      "key": "root.imports.operators.client",
+      "~k_parent": "a9"
     },
     "ab": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "a8"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "aa"
     },
     "ac": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "a8"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "aa"
     },
     "ad": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "a8"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "aa"
     },
     "ae": {
-      "key": "root.imports.operators.client[5]",
-      "~k_parent": "a8"
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "aa"
     },
     "af": {
-      "key": "root.imports.operators.client[6]",
-      "~k_parent": "a8"
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "aa"
     },
     "ag": {
-      "key": "root.imports.operators.client[7]",
-      "~k_parent": "a8"
+      "key": "root.imports.operators.client[5]",
+      "~k_parent": "aa"
     },
     "ah": {
-      "key": "root.imports.operators.client[8]",
-      "~k_parent": "a8"
+      "key": "root.imports.operators.client[6]",
+      "~k_parent": "aa"
     },
     "ai": {
-      "key": "root.imports.operators.client[9]",
-      "~k_parent": "a8"
+      "key": "root.imports.operators.client[7]",
+      "~k_parent": "aa"
     },
     "aj": {
-      "key": "root.imports.operators.client[10]",
-      "~k_parent": "a8"
+      "key": "root.imports.operators.client[8]",
+      "~k_parent": "aa"
     },
     "ak": {
-      "key": "root.imports.operators.client[11]",
-      "~k_parent": "a8"
+      "key": "root.imports.operators.client[9]",
+      "~k_parent": "aa"
     },
     "al": {
-      "key": "root.imports.operators.client[12]",
-      "~k_parent": "a8"
+      "key": "root.imports.operators.client[10]",
+      "~k_parent": "aa"
     },
     "am": {
-      "key": "root.imports.operators.client[13]",
-      "~k_parent": "a8"
+      "key": "root.imports.operators.client[11]",
+      "~k_parent": "aa"
     },
     "an": {
-      "key": "root.imports.operators.client[14]",
-      "~k_parent": "a8"
+      "key": "root.imports.operators.client[12]",
+      "~k_parent": "aa"
     },
     "ao": {
-      "key": "root.imports.operators.client[15]",
-      "~k_parent": "a8"
+      "key": "root.imports.operators.client[13]",
+      "~k_parent": "aa"
     },
     "ap": {
-      "key": "root.imports.operators.client[16]",
-      "~k_parent": "a8"
+      "key": "root.imports.operators.client[14]",
+      "~k_parent": "aa"
     },
     "aq": {
+      "key": "root.imports.operators.client[15]",
+      "~k_parent": "aa"
+    },
+    "ar": {
+      "key": "root.imports.operators.client[16]",
+      "~k_parent": "aa"
+    },
+    "as": {
       "key": "root.imports.operators.server",
-      "~k_parent": "a7"
+      "~k_parent": "a9"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "4d"
   },
@@ -2572,6 +2581,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -10932,200 +10942,203 @@
       },
       "~k": "5u"
     },
+    "agents": {
+      "~k": "5x"
+    },
     "auth": {
       "adapters": {
-        "~k": "5y"
-      },
-      "callbacks": {
         "~k": "5z"
       },
-      "events": {
+      "callbacks": {
         "~k": "60"
       },
-      "providers": {
+      "events": {
         "~k": "61"
       },
-      "~k": "5x"
+      "providers": {
+        "~k": "62"
+      },
+      "~k": "5y"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "63"
+        "~k": "64"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "64"
+        "~k": "65"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "65"
+        "~k": "66"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 8,
-        "~k": "66"
+        "~k": "67"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 5,
-        "~k": "67"
+        "~k": "68"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "68"
+        "~k": "69"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "69"
+        "~k": "6a"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 4,
-        "~k": "6a"
+        "~k": "6b"
       },
       "Tag": {
         "originalTypeName": "Tag",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "6b"
+        "~k": "6c"
       },
       "NumberInput": {
         "originalTypeName": "NumberInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "6c"
+        "~k": "6d"
       },
       "Alert": {
         "originalTypeName": "Alert",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "6d"
+        "~k": "6e"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "6e"
+        "~k": "6f"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6f"
+        "~k": "6g"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6g"
+        "~k": "6h"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6h"
+        "~k": "6i"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6i"
+        "~k": "6j"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6j"
+        "~k": "6k"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6k"
+        "~k": "6l"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6l"
+        "~k": "6m"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6m"
+        "~k": "6n"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6n"
+        "~k": "6o"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6o"
+        "~k": "6p"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6p"
+        "~k": "6q"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6q"
+        "~k": "6r"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6r"
+        "~k": "6s"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6s"
+        "~k": "6t"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6t"
+        "~k": "6u"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "6u"
+        "~k": "6v"
       },
-      "~k": "62"
+      "~k": "63"
     },
     "connections": {
-      "~k": "6v"
-    },
-    "requests": {
       "~k": "6w"
     },
-    "api": {
+    "requests": {
       "~k": "6x"
+    },
+    "api": {
+      "~k": "6y"
     },
     "operators": {
       "client": {
@@ -11133,110 +11146,110 @@
           "originalTypeName": "_if",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "70"
+          "~k": "71"
         },
         "_state": {
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 13,
-          "~k": "71"
+          "~k": "72"
         },
         "_array": {
           "originalTypeName": "_array",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "72"
+          "~k": "73"
         },
         "_global": {
           "originalTypeName": "_global",
           "package": "@lowdefy/operators-js",
           "count": 3,
-          "~k": "73"
+          "~k": "74"
         },
         "_function": {
           "originalTypeName": "_function",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "74"
+          "~k": "75"
         },
         "_eq": {
           "originalTypeName": "_eq",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "75"
+          "~k": "76"
         },
         "_args": {
           "originalTypeName": "_args",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "76"
+          "~k": "77"
         },
         "_string": {
           "originalTypeName": "_string",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "77"
+          "~k": "78"
         },
         "_json": {
           "originalTypeName": "_json",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "78"
+          "~k": "79"
         },
         "_object": {
           "originalTypeName": "_object",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "79"
+          "~k": "7a"
         },
         "_gt": {
           "originalTypeName": "_gt",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "7a"
+          "~k": "7b"
         },
         "_and": {
           "originalTypeName": "_and",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "7b"
+          "~k": "7c"
         },
         "_or": {
           "originalTypeName": "_or",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "7c"
+          "~k": "7d"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "7d"
+          "~k": "7e"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "7e"
+          "~k": "7f"
         },
         "_date": {
           "originalTypeName": "_date",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "7f"
+          "~k": "7g"
         },
         "_dayjs": {
           "originalTypeName": "_dayjs",
           "package": "@lowdefy/operators-dayjs",
           "count": 1,
-          "~k": "7g"
+          "~k": "7h"
         },
-        "~k": "6z"
+        "~k": "70"
       },
       "server": {
-        "~k": "7h"
+        "~k": "7i"
       },
-      "~k": "6y"
+      "~k": "6z"
     },
     "~k": "5t"
   }

--- a/packages/build/src/tests/success/48-events-actions-comprehensive/snapshot.json
+++ b/packages/build/src/tests/success/48-events-actions-comprehensive/snapshot.json
@@ -353,123 +353,123 @@
       "~k_parent": "68"
     },
     "70": {
-      "key": "root.types.auth.events",
-      "~k_parent": "6x"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "6y"
     },
     "71": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "6x"
+      "key": "root.types.auth.events",
+      "~k_parent": "6y"
     },
     "72": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "6y"
+    },
+    "73": {
       "key": "root.types.blocks",
       "~k_parent": "6p"
     },
-    "73": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "72"
-    },
     "74": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "72"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "73"
     },
     "75": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "72"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "73"
     },
     "76": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "72"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "73"
     },
     "77": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "72"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "73"
     },
     "78": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "72"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "73"
     },
     "79": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "72"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "73"
     },
     "80": {
-      "key": "root.types.operators.server",
-      "~k_parent": "7t"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "7v"
     },
     "81": {
+      "key": "root.types.operators.server",
+      "~k_parent": "7u"
+    },
+    "82": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "82": {
-      "key": "root.imports.actions",
-      "~k_parent": "81"
-    },
     "83": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "82"
     },
     "84": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "82"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "83"
     },
     "85": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "82"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "83"
     },
     "86": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "82"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "83"
     },
     "87": {
-      "key": "root.imports.actions[4]",
-      "~k_parent": "82"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "83"
     },
     "88": {
-      "key": "root.imports.actions[5]",
-      "~k_parent": "82"
+      "key": "root.imports.actions[4]",
+      "~k_parent": "83"
     },
     "89": {
-      "key": "root.imports.auth",
-      "~k_parent": "81"
+      "key": "root.imports.actions[5]",
+      "~k_parent": "83"
     },
     "90": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "8g"
     },
     "91": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "8g"
     },
     "92": {
-      "key": "root.imports.connections",
-      "~k_parent": "81"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "8g"
     },
     "93": {
-      "key": "root.imports.icons",
-      "~k_parent": "81"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "8g"
     },
     "94": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "93"
+      "key": "root.imports.connections",
+      "~k_parent": "82"
     },
     "95": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "94"
+      "key": "root.imports.icons",
+      "~k_parent": "82"
     },
     "96": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "95"
     },
     "97": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "96"
     },
     "98": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "95"
     },
     "99": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "98"
     },
     "a": {
@@ -1289,462 +1289,471 @@
       "~k_parent": "6q"
     },
     "6x": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "6p"
     },
     "6y": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "6x"
+      "key": "root.types.auth",
+      "~k_parent": "6p"
     },
     "6z": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "6x"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "6y"
     },
     "7a": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "72"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "73"
     },
     "7b": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "72"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "73"
     },
     "7c": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "72"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "73"
     },
     "7d": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "72"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "73"
     },
     "7e": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "72"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "73"
     },
     "7f": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "72"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "73"
     },
     "7g": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "72"
+      "key": "root.types.blocks.List",
+      "~k_parent": "73"
     },
     "7h": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "72"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "73"
     },
     "7i": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "72"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "73"
     },
     "7j": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "72"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "73"
     },
     "7k": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "72"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "73"
     },
     "7l": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "72"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "73"
     },
     "7m": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "72"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "73"
     },
     "7n": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "72"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "73"
     },
     "7o": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "72"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "73"
     },
     "7p": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "72"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "73"
     },
     "7q": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "73"
+    },
+    "7r": {
       "key": "root.types.connections",
       "~k_parent": "6p"
     },
-    "7r": {
+    "7s": {
       "key": "root.types.requests",
       "~k_parent": "6p"
     },
-    "7s": {
+    "7t": {
       "key": "root.types.api",
       "~k_parent": "6p"
     },
-    "7t": {
+    "7u": {
       "key": "root.types.operators",
       "~k_parent": "6p"
     },
-    "7u": {
-      "key": "root.types.operators.client",
-      "~k_parent": "7t"
-    },
     "7v": {
-      "key": "root.types.operators.client._state",
+      "key": "root.types.operators.client",
       "~k_parent": "7u"
     },
     "7w": {
-      "key": "root.types.operators.client._sum",
-      "~k_parent": "7u"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "7v"
     },
     "7x": {
-      "key": "root.types.operators.client._lte",
-      "~k_parent": "7u"
+      "key": "root.types.operators.client._sum",
+      "~k_parent": "7v"
     },
     "7y": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "7u"
+      "key": "root.types.operators.client._lte",
+      "~k_parent": "7v"
     },
     "7z": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "7u"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "7v"
     },
     "8a": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "89"
+      "key": "root.imports.agents",
+      "~k_parent": "82"
     },
     "8b": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "89"
+      "key": "root.imports.auth",
+      "~k_parent": "82"
     },
     "8c": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "89"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "8b"
     },
     "8d": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "89"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "8b"
     },
     "8e": {
-      "key": "root.imports.blocks",
-      "~k_parent": "81"
+      "key": "root.imports.auth.events",
+      "~k_parent": "8b"
     },
     "8f": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "8e"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "8b"
     },
     "8g": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks",
+      "~k_parent": "82"
     },
     "8h": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "8g"
     },
     "8i": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "8g"
     },
     "8j": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "8g"
     },
     "8k": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "8g"
     },
     "8l": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "8g"
     },
     "8m": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "8g"
     },
     "8n": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "8g"
     },
     "8o": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "8g"
     },
     "8p": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "8g"
     },
     "8q": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "8g"
     },
     "8r": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "8g"
     },
     "8s": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "8g"
     },
     "8t": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "8g"
     },
     "8u": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "8g"
     },
     "8v": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "8g"
     },
     "8w": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "8g"
     },
     "8x": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "8g"
     },
     "8y": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "8g"
     },
     "8z": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "8e"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "8g"
     },
     "9a": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "95"
     },
     "9b": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "9a"
     },
     "9c": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "95"
     },
     "9d": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "9c"
     },
     "9e": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "95"
     },
     "9f": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "9e"
     },
     "9g": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "95"
     },
     "9h": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "9g"
     },
     "9i": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "95"
     },
     "9j": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "9i"
     },
     "9k": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "95"
     },
     "9l": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "9k"
     },
     "9m": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "95"
     },
     "9n": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "9m"
     },
     "9o": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "95"
     },
     "9p": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "9o"
     },
     "9q": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "95"
     },
     "9r": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "9q"
     },
     "9s": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "95"
     },
     "9t": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "9s"
     },
     "9u": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "95"
     },
     "9v": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "9u"
     },
     "9w": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "95"
     },
     "9x": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "9w"
     },
     "9y": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "95"
     },
     "9z": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "9y"
     },
     "a0": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "95"
     },
     "a1": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "a0"
     },
     "a2": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "95"
     },
     "a3": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "a2"
     },
     "a4": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "95"
     },
     "a5": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "a4"
     },
     "a6": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "95"
     },
     "a7": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "a6"
     },
     "a8": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "95"
     },
     "a9": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "a8"
     },
     "aa": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "95"
     },
     "ab": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "aa"
     },
     "ac": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "95"
     },
     "ad": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "ac"
     },
     "ae": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "95"
     },
     "af": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "ae"
     },
     "ag": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "95"
     },
     "ah": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "ag"
     },
     "ai": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "95"
     },
     "aj": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "ai"
     },
     "ak": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "95"
     },
     "al": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "ak"
     },
     "am": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "93"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "95"
     },
     "an": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "am"
     },
     "ao": {
-      "key": "root.imports.requests",
-      "~k_parent": "81"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "95"
     },
     "ap": {
-      "key": "root.imports.operators",
-      "~k_parent": "81"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "ao"
     },
     "aq": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "ap"
+      "key": "root.imports.requests",
+      "~k_parent": "82"
     },
     "ar": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "aq"
+      "key": "root.imports.operators",
+      "~k_parent": "82"
     },
     "as": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "aq"
+      "key": "root.imports.operators.client",
+      "~k_parent": "ar"
     },
     "at": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "aq"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "as"
     },
     "au": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "aq"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "as"
     },
     "av": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "aq"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "as"
     },
     "aw": {
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "as"
+    },
+    "ax": {
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "as"
+    },
+    "ay": {
       "key": "root.imports.operators.server",
-      "~k_parent": "ap"
+      "~k_parent": "ar"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "4h"
   },
@@ -2783,6 +2792,7 @@
     }
   },
   "plugins/actions.js": "import { SetState as SetState } from '@lowdefy/actions-core/actions';\nimport { Reset as Reset } from '@lowdefy/actions-core/actions';\nimport { Link as Link } from '@lowdefy/actions-core/actions';\nimport { DisplayMessage as DisplayMessage } from '@lowdefy/actions-core/actions';\nimport { Wait as Wait } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  SetState,\n  Reset,\n  Link,\n  DisplayMessage,\n  Wait,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -8968,170 +8978,173 @@
       },
       "~k": "6q"
     },
+    "agents": {
+      "~k": "6x"
+    },
     "auth": {
       "adapters": {
-        "~k": "6y"
-      },
-      "callbacks": {
         "~k": "6z"
       },
-      "events": {
+      "callbacks": {
         "~k": "70"
       },
-      "providers": {
+      "events": {
         "~k": "71"
       },
-      "~k": "6x"
+      "providers": {
+        "~k": "72"
+      },
+      "~k": "6y"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "73"
+        "~k": "74"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "74"
+        "~k": "75"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 5,
-        "~k": "75"
+        "~k": "76"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "76"
+        "~k": "77"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 14,
-        "~k": "77"
+        "~k": "78"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "78"
+        "~k": "79"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "79"
+        "~k": "7a"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7a"
+        "~k": "7b"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7b"
+        "~k": "7c"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7c"
+        "~k": "7d"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7d"
+        "~k": "7e"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7e"
+        "~k": "7f"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7f"
+        "~k": "7g"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7g"
+        "~k": "7h"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7h"
+        "~k": "7i"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7i"
+        "~k": "7j"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7j"
+        "~k": "7k"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7k"
+        "~k": "7l"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7l"
+        "~k": "7m"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7m"
+        "~k": "7n"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7n"
+        "~k": "7o"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7o"
+        "~k": "7p"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "7p"
+        "~k": "7q"
       },
-      "~k": "72"
+      "~k": "73"
     },
     "connections": {
-      "~k": "7q"
-    },
-    "requests": {
       "~k": "7r"
     },
-    "api": {
+    "requests": {
       "~k": "7s"
+    },
+    "api": {
+      "~k": "7t"
     },
     "operators": {
       "client": {
@@ -9139,38 +9152,38 @@
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 5,
-          "~k": "7v"
+          "~k": "7w"
         },
         "_sum": {
           "originalTypeName": "_sum",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "7w"
+          "~k": "7x"
         },
         "_lte": {
           "originalTypeName": "_lte",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "7x"
+          "~k": "7y"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "7y"
+          "~k": "7z"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "7z"
+          "~k": "80"
         },
-        "~k": "7u"
+        "~k": "7v"
       },
       "server": {
-        "~k": "80"
+        "~k": "81"
       },
-      "~k": "7t"
+      "~k": "7u"
     },
     "~k": "6p"
   }

--- a/packages/build/src/tests/success/49-request-payload-app/snapshot.json
+++ b/packages/build/src/tests/success/49-request-payload-app/snapshot.json
@@ -335,164 +335,164 @@
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "5z"
     },
     "61": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "5z"
     },
     "62": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "5z"
     },
     "63": {
-      "key": "root.types.blocks.NumberInput",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "5z"
     },
     "64": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.NumberInput",
+      "~k_parent": "5z"
     },
     "65": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "5z"
     },
     "66": {
-      "key": "root.types.blocks.TextArea",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "5z"
     },
     "67": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.TextArea",
+      "~k_parent": "5z"
     },
     "68": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.List",
+      "~k_parent": "5z"
     },
     "69": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "5z"
     },
     "70": {
-      "key": "root.types.operators.client",
-      "~k_parent": "6z"
+      "key": "root.types.operators",
+      "~k_parent": "5n"
     },
     "71": {
-      "key": "root.types.operators.client._state",
+      "key": "root.types.operators.client",
       "~k_parent": "70"
     },
     "72": {
-      "key": "root.types.operators.client._request",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "71"
     },
     "73": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._request",
+      "~k_parent": "71"
     },
     "74": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "71"
     },
     "75": {
-      "key": "root.types.operators.server",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "71"
     },
     "76": {
-      "key": "root.types.operators.server._payload",
-      "~k_parent": "75"
+      "key": "root.types.operators.server",
+      "~k_parent": "70"
     },
     "77": {
+      "key": "root.types.operators.server._payload",
+      "~k_parent": "76"
+    },
+    "78": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "78": {
-      "key": "root.imports.actions",
-      "~k_parent": "77"
-    },
     "79": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "78"
     },
     "80": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "7k"
     },
     "81": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "7k"
     },
     "82": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "7k"
     },
     "83": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "7k"
     },
     "84": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "7k"
     },
     "85": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "7k"
     },
     "86": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "7k"
     },
     "87": {
-      "key": "root.imports.blocks[24]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "7k"
     },
     "88": {
-      "key": "root.imports.blocks[25]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "7k"
     },
     "89": {
-      "key": "root.imports.connections",
-      "~k_parent": "77"
+      "key": "root.imports.blocks[24]",
+      "~k_parent": "7k"
     },
     "90": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "8z"
     },
     "91": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "8e"
     },
     "92": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "91"
     },
     "93": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "8e"
     },
     "94": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "93"
     },
     "95": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "8e"
     },
     "96": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "95"
     },
     "97": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "8e"
     },
     "98": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "97"
     },
     "99": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "8e"
     },
     "a": {
       "key": "root.pages",
@@ -1174,494 +1174,503 @@
       "~k_parent": "5o"
     },
     "5t": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "5n"
     },
     "5u": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "5t"
+      "key": "root.types.auth",
+      "~k_parent": "5n"
     },
     "5v": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "5t"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.types.auth.events",
-      "~k_parent": "5t"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "5u"
     },
     "5x": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "5t"
+      "key": "root.types.auth.events",
+      "~k_parent": "5u"
     },
     "5y": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "5u"
+    },
+    "5z": {
       "key": "root.types.blocks",
       "~k_parent": "5n"
     },
-    "5z": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "5y"
-    },
     "6a": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "5z"
     },
     "6b": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "5z"
     },
     "6c": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "5z"
     },
     "6d": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "5z"
     },
     "6e": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "5z"
     },
     "6f": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "5z"
     },
     "6g": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "5z"
     },
     "6h": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "5z"
     },
     "6i": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "5z"
     },
     "6j": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "5z"
     },
     "6k": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "5z"
     },
     "6l": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "5z"
     },
     "6m": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "5z"
     },
     "6n": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "5z"
     },
     "6o": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "5z"
     },
     "6p": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "5z"
+    },
+    "6q": {
       "key": "root.types.connections",
       "~k_parent": "5n"
     },
-    "6q": {
-      "key": "root.types.connections.AxiosHttp",
-      "~k_parent": "6p"
-    },
     "6r": {
-      "key": "root.types.connections.MongoDBCollection",
-      "~k_parent": "6p"
+      "key": "root.types.connections.AxiosHttp",
+      "~k_parent": "6q"
     },
     "6s": {
+      "key": "root.types.connections.MongoDBCollection",
+      "~k_parent": "6q"
+    },
+    "6t": {
       "key": "root.types.requests",
       "~k_parent": "5n"
     },
-    "6t": {
-      "key": "root.types.requests.AxiosHttp",
-      "~k_parent": "6s"
-    },
     "6u": {
-      "key": "root.types.requests.MongoDBFind",
-      "~k_parent": "6s"
+      "key": "root.types.requests.AxiosHttp",
+      "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.types.requests.MongoDBInsertOne",
-      "~k_parent": "6s"
+      "key": "root.types.requests.MongoDBFind",
+      "~k_parent": "6t"
     },
     "6w": {
-      "key": "root.types.requests.MongoDBUpdateOne",
-      "~k_parent": "6s"
+      "key": "root.types.requests.MongoDBInsertOne",
+      "~k_parent": "6t"
     },
     "6x": {
-      "key": "root.types.requests.MongoDBAggregate",
-      "~k_parent": "6s"
+      "key": "root.types.requests.MongoDBUpdateOne",
+      "~k_parent": "6t"
     },
     "6y": {
+      "key": "root.types.requests.MongoDBAggregate",
+      "~k_parent": "6t"
+    },
+    "6z": {
       "key": "root.types.api",
       "~k_parent": "5n"
     },
-    "6z": {
-      "key": "root.types.operators",
-      "~k_parent": "5n"
-    },
     "7a": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "78"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "79"
     },
     "7b": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "78"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "79"
     },
     "7c": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "78"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "79"
     },
     "7d": {
-      "key": "root.imports.auth",
-      "~k_parent": "77"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "79"
     },
     "7e": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "7d"
+      "key": "root.imports.agents",
+      "~k_parent": "78"
     },
     "7f": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "7d"
+      "key": "root.imports.auth",
+      "~k_parent": "78"
     },
     "7g": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "7d"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "7f"
     },
     "7h": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "7d"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "7f"
     },
     "7i": {
-      "key": "root.imports.blocks",
-      "~k_parent": "77"
+      "key": "root.imports.auth.events",
+      "~k_parent": "7f"
     },
     "7j": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "7i"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "7f"
     },
     "7k": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks",
+      "~k_parent": "78"
     },
     "7l": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "7k"
     },
     "7m": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "7k"
     },
     "7n": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "7k"
     },
     "7o": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "7k"
     },
     "7p": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "7k"
     },
     "7q": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "7k"
     },
     "7r": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "7k"
     },
     "7s": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "7k"
     },
     "7t": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "7k"
     },
     "7u": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "7k"
     },
     "7v": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "7k"
     },
     "7w": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "7k"
     },
     "7x": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "7k"
     },
     "7y": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "7k"
     },
     "7z": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "7k"
     },
     "8a": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "89"
+      "key": "root.imports.blocks[25]",
+      "~k_parent": "7k"
     },
     "8b": {
-      "key": "root.imports.connections[1]",
-      "~k_parent": "89"
+      "key": "root.imports.connections",
+      "~k_parent": "78"
     },
     "8c": {
-      "key": "root.imports.icons",
-      "~k_parent": "77"
+      "key": "root.imports.connections[0]",
+      "~k_parent": "8b"
     },
     "8d": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "8c"
+      "key": "root.imports.connections[1]",
+      "~k_parent": "8b"
     },
     "8e": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "8d"
+      "key": "root.imports.icons",
+      "~k_parent": "78"
     },
     "8f": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "8e"
     },
     "8g": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "8f"
     },
     "8h": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "8e"
     },
     "8i": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "8h"
     },
     "8j": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "8e"
     },
     "8k": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "8j"
     },
     "8l": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "8e"
     },
     "8m": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "8l"
     },
     "8n": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "8e"
     },
     "8o": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "8n"
     },
     "8p": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "8e"
     },
     "8q": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "8p"
     },
     "8r": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "8e"
     },
     "8s": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "8r"
     },
     "8t": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "8e"
     },
     "8u": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "8t"
     },
     "8v": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "8e"
     },
     "8w": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "8v"
     },
     "8x": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "8e"
     },
     "8y": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "8x"
     },
     "8z": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "8e"
     },
     "9a": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "99"
     },
     "9b": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "8e"
     },
     "9c": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "9b"
     },
     "9d": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "8e"
     },
     "9e": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "9d"
     },
     "9f": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "8e"
     },
     "9g": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "9f"
     },
     "9h": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "8e"
     },
     "9i": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "9h"
     },
     "9j": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "8e"
     },
     "9k": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "9j"
     },
     "9l": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "8e"
     },
     "9m": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "9l"
     },
     "9n": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "8e"
     },
     "9o": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "9n"
     },
     "9p": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "8e"
     },
     "9q": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "9p"
     },
     "9r": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "8e"
     },
     "9s": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "9r"
     },
     "9t": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "8e"
     },
     "9u": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "9t"
     },
     "9v": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "8e"
     },
     "9w": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "9v"
     },
     "9x": {
-      "key": "root.imports.requests",
-      "~k_parent": "77"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "8e"
     },
     "9y": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "9x"
     },
     "9z": {
-      "key": "root.imports.requests[1]",
-      "~k_parent": "9x"
+      "key": "root.imports.requests",
+      "~k_parent": "78"
     },
     "a0": {
-      "key": "root.imports.requests[2]",
-      "~k_parent": "9x"
+      "key": "root.imports.requests[0]",
+      "~k_parent": "9z"
     },
     "a1": {
-      "key": "root.imports.requests[3]",
-      "~k_parent": "9x"
+      "key": "root.imports.requests[1]",
+      "~k_parent": "9z"
     },
     "a2": {
-      "key": "root.imports.requests[4]",
-      "~k_parent": "9x"
+      "key": "root.imports.requests[2]",
+      "~k_parent": "9z"
     },
     "a3": {
-      "key": "root.imports.operators",
-      "~k_parent": "77"
+      "key": "root.imports.requests[3]",
+      "~k_parent": "9z"
     },
     "a4": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "a3"
+      "key": "root.imports.requests[4]",
+      "~k_parent": "9z"
     },
     "a5": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "a4"
+      "key": "root.imports.operators",
+      "~k_parent": "78"
     },
     "a6": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "a4"
+      "key": "root.imports.operators.client",
+      "~k_parent": "a5"
     },
     "a7": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "a4"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "a6"
     },
     "a8": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "a4"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "a6"
     },
     "a9": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "a3"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "a6"
     },
     "aa": {
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "a6"
+    },
+    "ab": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "a5"
+    },
+    "ac": {
       "key": "root.imports.operators.server[0]",
-      "~k_parent": "a9"
+      "~k_parent": "ab"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "40"
   },
@@ -2612,6 +2621,7 @@
     }
   },
   "plugins/actions.js": "import { Request as Request } from '@lowdefy/actions-core/actions';\nimport { Validate as Validate } from '@lowdefy/actions-core/actions';\nimport { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Request,\n  Validate,\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -10582,230 +10592,233 @@
       },
       "~k": "5o"
     },
+    "agents": {
+      "~k": "5t"
+    },
     "auth": {
       "adapters": {
-        "~k": "5u"
-      },
-      "callbacks": {
         "~k": "5v"
       },
-      "events": {
+      "callbacks": {
         "~k": "5w"
       },
-      "providers": {
+      "events": {
         "~k": "5x"
       },
-      "~k": "5t"
+      "providers": {
+        "~k": "5y"
+      },
+      "~k": "5u"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "5z"
+        "~k": "60"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "60"
+        "~k": "61"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 5,
-        "~k": "61"
+        "~k": "62"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 5,
-        "~k": "62"
+        "~k": "63"
       },
       "NumberInput": {
         "originalTypeName": "NumberInput",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "63"
+        "~k": "64"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "64"
+        "~k": "65"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "65"
+        "~k": "66"
       },
       "TextArea": {
         "originalTypeName": "TextArea",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "66"
+        "~k": "67"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "67"
+        "~k": "68"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "68"
+        "~k": "69"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "69"
+        "~k": "6a"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6a"
+        "~k": "6b"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6b"
+        "~k": "6c"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6c"
+        "~k": "6d"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6d"
+        "~k": "6e"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6e"
+        "~k": "6f"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6f"
+        "~k": "6g"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6g"
+        "~k": "6h"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6h"
+        "~k": "6i"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6i"
+        "~k": "6j"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6j"
+        "~k": "6k"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6k"
+        "~k": "6l"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6l"
+        "~k": "6m"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6m"
+        "~k": "6n"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6n"
+        "~k": "6o"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "6o"
+        "~k": "6p"
       },
-      "~k": "5y"
+      "~k": "5z"
     },
     "connections": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 1,
-        "~k": "6q"
+        "~k": "6r"
       },
       "MongoDBCollection": {
         "originalTypeName": "MongoDBCollection",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "6r"
+        "~k": "6s"
       },
-      "~k": "6p"
+      "~k": "6q"
     },
     "requests": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 3,
-        "~k": "6t"
+        "~k": "6u"
       },
       "MongoDBFind": {
         "originalTypeName": "MongoDBFind",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "6u"
+        "~k": "6v"
       },
       "MongoDBInsertOne": {
         "originalTypeName": "MongoDBInsertOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "6v"
+        "~k": "6w"
       },
       "MongoDBUpdateOne": {
         "originalTypeName": "MongoDBUpdateOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "6w"
+        "~k": "6x"
       },
       "MongoDBAggregate": {
         "originalTypeName": "MongoDBAggregate",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "6x"
+        "~k": "6y"
       },
-      "~k": "6s"
+      "~k": "6t"
     },
     "api": {
-      "~k": "6y"
+      "~k": "6z"
     },
     "operators": {
       "client": {
@@ -10813,38 +10826,38 @@
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 11,
-          "~k": "71"
+          "~k": "72"
         },
         "_request": {
           "originalTypeName": "_request",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "72"
+          "~k": "73"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "73"
+          "~k": "74"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "74"
+          "~k": "75"
         },
-        "~k": "70"
+        "~k": "71"
       },
       "server": {
         "_payload": {
           "originalTypeName": "_payload",
           "package": "@lowdefy/operators-js",
           "count": 9,
-          "~k": "76"
+          "~k": "77"
         },
-        "~k": "75"
+        "~k": "76"
       },
-      "~k": "6z"
+      "~k": "70"
     },
     "~k": "5n"
   }

--- a/packages/build/src/tests/success/50-logger-sentry-app/snapshot.json
+++ b/packages/build/src/tests/success/50-logger-sentry-app/snapshot.json
@@ -139,148 +139,148 @@
       "~k_parent": "20"
     },
     "24": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1z"
     },
     "25": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "24"
-    },
-    "26": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "24"
-    },
-    "27": {
-      "key": "root.types.auth.events",
-      "~k_parent": "24"
-    },
-    "28": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "24"
-    },
-    "29": {
-      "key": "root.types.blocks",
+      "key": "root.types.auth",
       "~k_parent": "1z"
     },
+    "26": {
+      "key": "root.types.auth.adapters",
+      "~k_parent": "25"
+    },
+    "27": {
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "25"
+    },
+    "28": {
+      "key": "root.types.auth.events",
+      "~k_parent": "25"
+    },
+    "29": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "25"
+    },
     "30": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2y"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2z"
     },
     "31": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2x"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2z"
     },
     "32": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2y"
+    },
+    "33": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "33": {
-      "key": "root.imports.actions",
-      "~k_parent": "32"
-    },
     "34": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "33"
     },
     "35": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "33"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "34"
     },
     "36": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "33"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "34"
     },
     "37": {
-      "key": "root.imports.auth",
-      "~k_parent": "32"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "34"
     },
     "38": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "37"
+      "key": "root.imports.agents",
+      "~k_parent": "33"
     },
     "39": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "37"
+      "key": "root.imports.auth",
+      "~k_parent": "33"
     },
     "40": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3z"
+      "key": "root.imports.icons",
+      "~k_parent": "33"
     },
     "41": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "40"
     },
     "44": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "40"
     },
     "46": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "40"
     },
     "48": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "40"
     },
     "50": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "40"
     },
     "52": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "40"
     },
     "54": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "40"
     },
     "56": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "40"
     },
     "58": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "40"
     },
     "a": {
       "key": "root.pages[0:home:Box].properties",
@@ -497,378 +497,387 @@
       "~k_parent": "4"
     },
     "2a": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "29"
+      "key": "root.types.blocks",
+      "~k_parent": "1z"
     },
     "2b": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2a"
     },
     "2c": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2a"
     },
     "2d": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2a"
     },
     "2e": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2a"
     },
     "2f": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2a"
     },
     "2g": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "29"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2a"
     },
     "2h": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2a"
     },
     "2i": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2a"
     },
     "2j": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2a"
     },
     "2k": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "29"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2a"
     },
     "2l": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2a"
     },
     "2m": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2a"
     },
     "2n": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "29"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2a"
     },
     "2o": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2a"
     },
     "2p": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "29"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2a"
     },
     "2q": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "29"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2a"
     },
     "2r": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "29"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2a"
     },
     "2s": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "29"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2a"
     },
     "2t": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2a"
     },
     "2u": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2a"
+    },
+    "2v": {
       "key": "root.types.connections",
       "~k_parent": "1z"
     },
-    "2v": {
+    "2w": {
       "key": "root.types.requests",
       "~k_parent": "1z"
     },
-    "2w": {
+    "2x": {
       "key": "root.types.api",
       "~k_parent": "1z"
     },
-    "2x": {
+    "2y": {
       "key": "root.types.operators",
       "~k_parent": "1z"
     },
-    "2y": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2x"
-    },
     "2z": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "37"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "39"
     },
     "3b": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "37"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "39"
     },
     "3c": {
-      "key": "root.imports.blocks",
-      "~k_parent": "32"
+      "key": "root.imports.auth.events",
+      "~k_parent": "39"
     },
     "3d": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3c"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "39"
     },
     "3e": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks",
+      "~k_parent": "33"
     },
     "3f": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3e"
     },
     "3h": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3e"
     },
     "3i": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3e"
     },
     "3j": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3e"
     },
     "3k": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3e"
     },
     "3l": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3e"
     },
     "3m": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3e"
     },
     "3n": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3e"
     },
     "3o": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3e"
     },
     "3p": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3e"
     },
     "3q": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3e"
     },
     "3r": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3e"
     },
     "3s": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3e"
     },
     "3t": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3e"
     },
     "3u": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3e"
     },
     "3v": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3e"
     },
     "3w": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3e"
     },
     "3x": {
-      "key": "root.imports.connections",
-      "~k_parent": "32"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3e"
     },
     "3y": {
-      "key": "root.imports.icons",
-      "~k_parent": "32"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3e"
     },
     "3z": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3y"
+      "key": "root.imports.connections",
+      "~k_parent": "33"
     },
     "4a": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "40"
     },
     "4c": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "40"
     },
     "4e": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "40"
     },
     "4g": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "40"
     },
     "4i": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "40"
     },
     "4k": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "40"
     },
     "4m": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "40"
     },
     "4o": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "40"
     },
     "4q": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "40"
     },
     "4s": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "40"
     },
     "4u": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "40"
     },
     "4w": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "40"
     },
     "4y": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "40"
     },
     "5a": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "40"
     },
     "5c": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "40"
     },
     "5e": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "40"
     },
     "5g": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "40"
     },
     "5i": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.requests",
-      "~k_parent": "32"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "40"
     },
     "5k": {
-      "key": "root.imports.operators",
-      "~k_parent": "32"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5k"
+      "key": "root.imports.requests",
+      "~k_parent": "33"
     },
     "5m": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5l"
+      "key": "root.imports.operators",
+      "~k_parent": "33"
     },
     "5n": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5l"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5m"
     },
     "5o": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5n"
+    },
+    "5p": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5n"
+    },
+    "5q": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5k"
+      "~k_parent": "5m"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "sentry": {
       "client": true,
@@ -1153,6 +1162,7 @@
     }
   },
   "plugins/actions.js": "import { Throw as Throw } from '@lowdefy/actions-core/actions';\nimport { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Throw,\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5646,152 +5656,155 @@
       },
       "~k": "20"
     },
+    "agents": {
+      "~k": "24"
+    },
     "auth": {
       "adapters": {
-        "~k": "25"
-      },
-      "callbacks": {
         "~k": "26"
       },
-      "events": {
+      "callbacks": {
         "~k": "27"
       },
-      "providers": {
+      "events": {
         "~k": "28"
       },
-      "~k": "24"
+      "providers": {
+        "~k": "29"
+      },
+      "~k": "25"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
-      "~k": "29"
+      "~k": "2a"
     },
     "connections": {
-      "~k": "2u"
-    },
-    "requests": {
       "~k": "2v"
     },
-    "api": {
+    "requests": {
       "~k": "2w"
+    },
+    "api": {
+      "~k": "2x"
     },
     "operators": {
       "client": {
@@ -5799,20 +5812,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2z"
+          "~k": "30"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "30"
+          "~k": "31"
         },
-        "~k": "2y"
+        "~k": "2z"
       },
       "server": {
-        "~k": "31"
+        "~k": "32"
       },
-      "~k": "2x"
+      "~k": "2y"
     },
     "~k": "1z"
   }

--- a/packages/build/src/tests/success/51-config-options-app/snapshot.json
+++ b/packages/build/src/tests/success/51-config-options-app/snapshot.json
@@ -145,147 +145,147 @@
       "~k_parent": "21"
     },
     "24": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "20"
     },
     "25": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "24"
-    },
-    "26": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "24"
-    },
-    "27": {
-      "key": "root.types.auth.events",
-      "~k_parent": "24"
-    },
-    "28": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "24"
-    },
-    "29": {
-      "key": "root.types.blocks",
+      "key": "root.types.auth",
       "~k_parent": "20"
     },
+    "26": {
+      "key": "root.types.auth.adapters",
+      "~k_parent": "25"
+    },
+    "27": {
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "25"
+    },
+    "28": {
+      "key": "root.types.auth.events",
+      "~k_parent": "25"
+    },
+    "29": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "25"
+    },
     "30": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2y"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2z"
     },
     "31": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2x"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2z"
     },
     "32": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2y"
+    },
+    "33": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "33": {
-      "key": "root.imports.actions",
-      "~k_parent": "32"
-    },
     "34": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "33"
     },
     "35": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "33"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "34"
     },
     "36": {
-      "key": "root.imports.auth",
-      "~k_parent": "32"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "34"
     },
     "37": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "36"
+      "key": "root.imports.agents",
+      "~k_parent": "33"
     },
     "38": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "36"
+      "key": "root.imports.auth",
+      "~k_parent": "33"
     },
     "39": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "36"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "38"
     },
     "40": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3z"
     },
     "43": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3z"
     },
     "45": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3z"
     },
     "47": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3z"
     },
     "49": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3z"
     },
     "51": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3z"
     },
     "53": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3z"
     },
     "55": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3z"
     },
     "57": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3z"
     },
     "59": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "58"
     },
     "a": {
@@ -496,374 +496,383 @@
       "~k_parent": "1y"
     },
     "2a": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "29"
+      "key": "root.types.blocks",
+      "~k_parent": "20"
     },
     "2b": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2a"
     },
     "2c": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2a"
     },
     "2d": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2a"
     },
     "2e": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2a"
     },
     "2f": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2a"
     },
     "2g": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "29"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2a"
     },
     "2h": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2a"
     },
     "2i": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2a"
     },
     "2j": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2a"
     },
     "2k": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "29"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2a"
     },
     "2l": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2a"
     },
     "2m": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2a"
     },
     "2n": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "29"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2a"
     },
     "2o": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2a"
     },
     "2p": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "29"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2a"
     },
     "2q": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "29"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2a"
     },
     "2r": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "29"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2a"
     },
     "2s": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "29"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2a"
     },
     "2t": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2a"
     },
     "2u": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2a"
+    },
+    "2v": {
       "key": "root.types.connections",
       "~k_parent": "20"
     },
-    "2v": {
+    "2w": {
       "key": "root.types.requests",
       "~k_parent": "20"
     },
-    "2w": {
+    "2x": {
       "key": "root.types.api",
       "~k_parent": "20"
     },
-    "2x": {
+    "2y": {
       "key": "root.types.operators",
       "~k_parent": "20"
     },
-    "2y": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2x"
-    },
     "2z": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "36"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "38"
     },
     "3b": {
-      "key": "root.imports.blocks",
-      "~k_parent": "32"
+      "key": "root.imports.auth.events",
+      "~k_parent": "38"
     },
     "3c": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3b"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "38"
     },
     "3d": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks",
+      "~k_parent": "33"
     },
     "3e": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3d"
     },
     "3f": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3d"
     },
     "3g": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3d"
     },
     "3h": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3d"
     },
     "3i": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3d"
     },
     "3j": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3d"
     },
     "3k": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3d"
     },
     "3l": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3d"
     },
     "3m": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3d"
     },
     "3n": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3d"
     },
     "3o": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3d"
     },
     "3p": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3d"
     },
     "3q": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3d"
     },
     "3r": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3d"
     },
     "3s": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3d"
     },
     "3t": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3d"
     },
     "3u": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3d"
     },
     "3v": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3d"
     },
     "3w": {
-      "key": "root.imports.connections",
-      "~k_parent": "32"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3d"
     },
     "3x": {
-      "key": "root.imports.icons",
-      "~k_parent": "32"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3d"
     },
     "3y": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3x"
+      "key": "root.imports.connections",
+      "~k_parent": "33"
     },
     "3z": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3y"
+      "key": "root.imports.icons",
+      "~k_parent": "33"
     },
     "4a": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3z"
     },
     "4b": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3z"
     },
     "4d": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3z"
     },
     "4f": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3z"
     },
     "4h": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3z"
     },
     "4j": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3z"
     },
     "4l": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3z"
     },
     "4n": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3z"
     },
     "4p": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3z"
     },
     "4r": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3z"
     },
     "4t": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3z"
     },
     "4v": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3z"
     },
     "4x": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3z"
     },
     "4z": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3z"
     },
     "5b": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3z"
     },
     "5d": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3z"
     },
     "5f": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3z"
     },
     "5h": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.requests",
-      "~k_parent": "32"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3z"
     },
     "5j": {
-      "key": "root.imports.operators",
-      "~k_parent": "32"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5j"
+      "key": "root.imports.requests",
+      "~k_parent": "33"
     },
     "5l": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5k"
+      "key": "root.imports.operators",
+      "~k_parent": "33"
     },
     "5m": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5k"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5l"
     },
     "5n": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5m"
+    },
+    "5o": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5m"
+    },
+    "5p": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5j"
+      "~k_parent": "5l"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "y"
   },
@@ -1122,6 +1131,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5609,152 +5619,155 @@
       },
       "~k": "21"
     },
+    "agents": {
+      "~k": "24"
+    },
     "auth": {
       "adapters": {
-        "~k": "25"
-      },
-      "callbacks": {
         "~k": "26"
       },
-      "events": {
+      "callbacks": {
         "~k": "27"
       },
-      "providers": {
+      "events": {
         "~k": "28"
       },
-      "~k": "24"
+      "providers": {
+        "~k": "29"
+      },
+      "~k": "25"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
-      "~k": "29"
+      "~k": "2a"
     },
     "connections": {
-      "~k": "2u"
-    },
-    "requests": {
       "~k": "2v"
     },
-    "api": {
+    "requests": {
       "~k": "2w"
+    },
+    "api": {
+      "~k": "2x"
     },
     "operators": {
       "client": {
@@ -5762,20 +5775,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2z"
+          "~k": "30"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "30"
+          "~k": "31"
         },
-        "~k": "2y"
+        "~k": "2z"
       },
       "server": {
-        "~k": "31"
+        "~k": "32"
       },
-      "~k": "2x"
+      "~k": "2y"
     },
     "~k": "20"
   }

--- a/packages/build/src/tests/success/52-skeleton-loading-app/snapshot.json
+++ b/packages/build/src/tests/success/52-skeleton-loading-app/snapshot.json
@@ -165,163 +165,163 @@
       "~k_parent": "25"
     },
     "30": {
-      "key": "root.types.blocks.Avatar",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2v"
     },
     "31": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Avatar",
+      "~k_parent": "2v"
     },
     "32": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2v"
     },
     "33": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2v"
     },
     "34": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2v"
     },
     "35": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2v"
     },
     "36": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2v"
     },
     "37": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2v"
     },
     "38": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2v"
     },
     "39": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2v"
     },
     "40": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3r"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3x"
     },
     "41": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "40"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3x"
     },
     "42": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks",
+      "~k_parent": "3s"
     },
     "43": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "42"
     },
     "45": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "42"
     },
     "46": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "42"
     },
     "47": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "42"
     },
     "48": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "42"
     },
     "49": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "42"
     },
     "50": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4r"
     },
     "51": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4r"
     },
     "53": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4r"
     },
     "55": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4r"
     },
     "57": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4r"
     },
     "59": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4r"
     },
     "61": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4r"
     },
     "63": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4r"
     },
     "65": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4r"
     },
     "67": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4r"
     },
     "69": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "68"
     },
     "a": {
@@ -615,390 +615,399 @@
       "~k_parent": "2m"
     },
     "2p": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "2l"
     },
     "2q": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2p"
+      "key": "root.types.auth",
+      "~k_parent": "2l"
     },
     "2r": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2p"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2p"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2q"
     },
     "2t": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2p"
+      "key": "root.types.auth.events",
+      "~k_parent": "2q"
     },
     "2u": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2q"
+    },
+    "2v": {
       "key": "root.types.blocks",
       "~k_parent": "2l"
     },
-    "2v": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2u"
-    },
     "2w": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2v"
     },
     "2x": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "2v"
     },
     "2y": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "2v"
     },
     "2z": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "2v"
     },
     "3a": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2v"
     },
     "3b": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2v"
     },
     "3c": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2v"
     },
     "3d": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2v"
     },
     "3e": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2v"
     },
     "3f": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2v"
     },
     "3g": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2v"
     },
     "3h": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2v"
     },
     "3i": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2v"
+    },
+    "3j": {
       "key": "root.types.connections",
       "~k_parent": "2l"
     },
-    "3j": {
+    "3k": {
       "key": "root.types.requests",
       "~k_parent": "2l"
     },
-    "3k": {
+    "3l": {
       "key": "root.types.api",
       "~k_parent": "2l"
     },
-    "3l": {
+    "3m": {
       "key": "root.types.operators",
       "~k_parent": "2l"
     },
-    "3m": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3l"
-    },
     "3n": {
-      "key": "root.types.operators.client._state",
+      "key": "root.types.operators.client",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "3m"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3m"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3n"
     },
     "3q": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3l"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3n"
     },
     "3r": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3m"
+    },
+    "3s": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "3s": {
-      "key": "root.imports.actions",
-      "~k_parent": "3r"
-    },
     "3t": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3s"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.auth",
-      "~k_parent": "3r"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3t"
     },
     "3w": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3v"
+      "key": "root.imports.agents",
+      "~k_parent": "3s"
     },
     "3x": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3v"
+      "key": "root.imports.auth",
+      "~k_parent": "3s"
     },
     "3y": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3v"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3v"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3x"
     },
     "4a": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "42"
     },
     "4b": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "42"
     },
     "4c": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "42"
     },
     "4d": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "42"
     },
     "4e": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "42"
     },
     "4f": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "42"
     },
     "4g": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "42"
     },
     "4h": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "42"
     },
     "4i": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "42"
     },
     "4j": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "42"
     },
     "4k": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "42"
     },
     "4l": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "42"
     },
     "4m": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "42"
     },
     "4n": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "42"
     },
     "4o": {
-      "key": "root.imports.connections",
-      "~k_parent": "3r"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "42"
     },
     "4p": {
-      "key": "root.imports.icons",
-      "~k_parent": "3r"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "42"
     },
     "4q": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4p"
+      "key": "root.imports.connections",
+      "~k_parent": "3s"
     },
     "4r": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4q"
+      "key": "root.imports.icons",
+      "~k_parent": "3s"
     },
     "4s": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4r"
     },
     "4v": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4r"
     },
     "4x": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4r"
     },
     "4z": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4r"
     },
     "5b": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4r"
     },
     "5d": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4r"
     },
     "5f": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4r"
     },
     "5h": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4r"
     },
     "5j": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4r"
     },
     "5l": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4r"
     },
     "5n": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4r"
     },
     "5p": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4r"
     },
     "5r": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4r"
     },
     "5t": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4r"
     },
     "5v": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4r"
     },
     "5x": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4r"
     },
     "5z": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.imports.requests",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4r"
     },
     "6b": {
-      "key": "root.imports.operators",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6b"
+      "key": "root.imports.requests",
+      "~k_parent": "3s"
     },
     "6d": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6c"
+      "key": "root.imports.operators",
+      "~k_parent": "3s"
     },
     "6e": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6c"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "6c"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6e"
     },
     "6g": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6e"
+    },
+    "6h": {
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "6e"
+    },
+    "6i": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6b"
+      "~k_parent": "6d"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "1j"
   },
@@ -1353,6 +1362,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -7451,170 +7461,173 @@
       },
       "~k": "2m"
     },
+    "agents": {
+      "~k": "2p"
+    },
     "auth": {
       "adapters": {
-        "~k": "2q"
-      },
-      "callbacks": {
         "~k": "2r"
       },
-      "events": {
+      "callbacks": {
         "~k": "2s"
       },
-      "providers": {
+      "events": {
         "~k": "2t"
       },
-      "~k": "2p"
+      "providers": {
+        "~k": "2u"
+      },
+      "~k": "2q"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 2,
-        "~k": "2z"
+        "~k": "30"
       },
       "Avatar": {
         "originalTypeName": "Avatar",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 2,
-        "~k": "31"
+        "~k": "32"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "32"
+        "~k": "33"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3f"
+        "~k": "3g"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3h"
+        "~k": "3i"
       },
-      "~k": "2u"
+      "~k": "2v"
     },
     "connections": {
-      "~k": "3i"
-    },
-    "requests": {
       "~k": "3j"
     },
-    "api": {
+    "requests": {
       "~k": "3k"
+    },
+    "api": {
+      "~k": "3l"
     },
     "operators": {
       "client": {
@@ -7622,26 +7635,26 @@
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 5,
-          "~k": "3n"
+          "~k": "3o"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 3,
-          "~k": "3o"
+          "~k": "3p"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3p"
+          "~k": "3q"
         },
-        "~k": "3m"
+        "~k": "3n"
       },
       "server": {
-        "~k": "3q"
+        "~k": "3r"
       },
-      "~k": "3l"
+      "~k": "3m"
     },
     "~k": "2l"
   }

--- a/packages/build/src/tests/success/53-deep-nesting-app/snapshot.json
+++ b/packages/build/src/tests/success/53-deep-nesting-app/snapshot.json
@@ -167,152 +167,160 @@
       "~k_parent": "21"
     },
     "30": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2r"
     },
     "31": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2r"
     },
     "32": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2r"
     },
     "33": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2r"
     },
     "34": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2r"
     },
     "35": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2r"
     },
     "36": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2r"
     },
     "37": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2r"
     },
     "38": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2r"
     },
     "39": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2r"
     },
     "40": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3v"
     },
     "41": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3v"
     },
     "42": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3v"
     },
     "43": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3v"
     },
     "44": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3v"
     },
     "45": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3v"
     },
     "46": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3v"
     },
     "47": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3v"
     },
     "48": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3v"
     },
     "49": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3v"
     },
     "50": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4i"
     },
     "52": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4i"
     },
     "54": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4i"
     },
     "56": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4i"
     },
     "58": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4i"
     },
     "60": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.requests",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4i"
     },
     "62": {
-      "key": "root.imports.operators",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "62"
+      "key": "root.imports.requests",
+      "~k_parent": "3l"
     },
     "64": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "63"
+      "key": "root.imports.operators",
+      "~k_parent": "3l"
     },
     "65": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "63"
+      "key": "root.imports.operators.client",
+      "~k_parent": "64"
     },
     "66": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "65"
+    },
+    "67": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "65"
+    },
+    "68": {
       "key": "root.imports.operators.server",
-      "~k_parent": "62"
+      "~k_parent": "64"
     },
     "a": {
       "key": "root.pages[0:nested:Box].blocks[0:level1:Card].properties",
@@ -577,378 +585,379 @@
       "~k_parent": "2i"
     },
     "2l": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "2h"
     },
     "2m": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2l"
+      "key": "root.types.auth",
+      "~k_parent": "2h"
     },
     "2n": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2l"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2l"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2m"
     },
     "2p": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2l"
+      "key": "root.types.auth.events",
+      "~k_parent": "2m"
     },
     "2q": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2m"
+    },
+    "2r": {
       "key": "root.types.blocks",
       "~k_parent": "2h"
     },
-    "2r": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "2r"
     },
     "2u": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "2r"
     },
     "2v": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2r"
     },
     "2w": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2r"
     },
     "2x": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2r"
     },
     "2y": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2r"
     },
     "2z": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2r"
     },
     "3a": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2r"
     },
     "3b": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2r"
     },
     "3c": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2r"
+    },
+    "3d": {
       "key": "root.types.connections",
       "~k_parent": "2h"
     },
-    "3d": {
+    "3e": {
       "key": "root.types.requests",
       "~k_parent": "2h"
     },
-    "3e": {
+    "3f": {
       "key": "root.types.api",
       "~k_parent": "2h"
     },
-    "3f": {
+    "3g": {
       "key": "root.types.operators",
       "~k_parent": "2h"
     },
-    "3g": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3f"
-    },
     "3h": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3g"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3f"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3h"
     },
     "3k": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3g"
+    },
+    "3l": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "3l": {
-      "key": "root.imports.actions",
-      "~k_parent": "3k"
-    },
     "3m": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3l"
     },
     "3n": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3l"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.auth",
-      "~k_parent": "3k"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3m"
     },
     "3p": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3o"
+      "key": "root.imports.agents",
+      "~k_parent": "3l"
     },
     "3q": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3o"
+      "key": "root.imports.auth",
+      "~k_parent": "3l"
     },
     "3r": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3o"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3o"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3q"
     },
     "3t": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3k"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3q"
     },
     "3u": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3t"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3q"
     },
     "3v": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks",
+      "~k_parent": "3l"
     },
     "3w": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3v"
     },
     "3y": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3v"
     },
     "3z": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3v"
     },
     "4a": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3v"
     },
     "4b": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3v"
     },
     "4c": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3v"
     },
     "4d": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3v"
     },
     "4e": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3v"
     },
     "4f": {
-      "key": "root.imports.connections",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3v"
     },
     "4g": {
-      "key": "root.imports.icons",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "3v"
     },
     "4h": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4g"
+      "key": "root.imports.connections",
+      "~k_parent": "3l"
     },
     "4i": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4h"
+      "key": "root.imports.icons",
+      "~k_parent": "3l"
     },
     "4j": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4i"
     },
     "4m": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4i"
     },
     "4o": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4i"
     },
     "4q": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4i"
     },
     "4s": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4i"
     },
     "4u": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4i"
     },
     "4w": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4i"
     },
     "4y": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4i"
     },
     "5a": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4i"
     },
     "5c": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4i"
     },
     "5e": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4i"
     },
     "5g": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4i"
     },
     "5i": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4i"
     },
     "5k": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4i"
     },
     "5m": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4i"
     },
     "5o": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4i"
     },
     "5q": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4i"
     },
     "5s": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4i"
     },
     "5u": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4i"
     },
     "5w": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4i"
     },
     "5y": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4i"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "19"
   },
@@ -1280,6 +1289,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -6257,158 +6267,161 @@
       },
       "~k": "2i"
     },
+    "agents": {
+      "~k": "2l"
+    },
     "auth": {
       "adapters": {
-        "~k": "2m"
-      },
-      "callbacks": {
         "~k": "2n"
       },
-      "events": {
+      "callbacks": {
         "~k": "2o"
       },
-      "providers": {
+      "events": {
         "~k": "2p"
       },
-      "~k": "2l"
+      "providers": {
+        "~k": "2q"
+      },
+      "~k": "2m"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
-      "~k": "2q"
+      "~k": "2r"
     },
     "connections": {
-      "~k": "3c"
-    },
-    "requests": {
       "~k": "3d"
     },
-    "api": {
+    "requests": {
       "~k": "3e"
+    },
+    "api": {
+      "~k": "3f"
     },
     "operators": {
       "client": {
@@ -6416,20 +6429,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3h"
+          "~k": "3i"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3i"
+          "~k": "3j"
         },
-        "~k": "3g"
+        "~k": "3h"
       },
       "server": {
-        "~k": "3j"
+        "~k": "3k"
       },
-      "~k": "3f"
+      "~k": "3g"
     },
     "~k": "2h"
   }

--- a/packages/build/src/tests/success/54-many-pages-app/snapshot.json
+++ b/packages/build/src/tests/success/54-many-pages-app/snapshot.json
@@ -257,152 +257,160 @@
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "4t"
     },
     "51": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "4t"
     },
     "52": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "4t"
     },
     "53": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.List",
+      "~k_parent": "4t"
     },
     "54": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "4t"
     },
     "55": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "4t"
     },
     "56": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "4t"
     },
     "57": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "4t"
     },
     "58": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "4t"
     },
     "59": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "4t"
     },
     "60": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "5w"
     },
     "61": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "5w"
     },
     "62": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "5w"
     },
     "63": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "5w"
     },
     "64": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "5w"
     },
     "65": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "5w"
     },
     "66": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "5w"
     },
     "67": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "5w"
     },
     "68": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "5w"
     },
     "69": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "5w"
     },
     "70": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "6z"
     },
     "71": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "6i"
     },
     "72": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "71"
     },
     "73": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "6i"
     },
     "74": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "73"
     },
     "75": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "6i"
     },
     "76": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "75"
     },
     "77": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "6i"
     },
     "78": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "77"
     },
     "79": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "6i"
     },
     "80": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "7z"
     },
     "81": {
-      "key": "root.imports.requests",
-      "~k_parent": "5l"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "6i"
     },
     "82": {
-      "key": "root.imports.operators",
-      "~k_parent": "5l"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "81"
     },
     "83": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "82"
+      "key": "root.imports.requests",
+      "~k_parent": "5m"
     },
     "84": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "83"
+      "key": "root.imports.operators",
+      "~k_parent": "5m"
     },
     "85": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "83"
+      "key": "root.imports.operators.client",
+      "~k_parent": "84"
     },
     "86": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "85"
+    },
+    "87": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "85"
+    },
+    "88": {
       "key": "root.imports.operators.server",
-      "~k_parent": "82"
+      "~k_parent": "84"
     },
     "a": {
       "key": "root.menus[0:default].links[1:section1:MenuGroup]",
@@ -916,370 +924,371 @@
       "~k_parent": "4k"
     },
     "4n": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "4j"
     },
     "4o": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "4n"
+      "key": "root.types.auth",
+      "~k_parent": "4j"
     },
     "4p": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "4n"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.types.auth.events",
-      "~k_parent": "4n"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "4o"
     },
     "4r": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "4n"
+      "key": "root.types.auth.events",
+      "~k_parent": "4o"
     },
     "4s": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "4o"
+    },
+    "4t": {
       "key": "root.types.blocks",
       "~k_parent": "4j"
     },
-    "4t": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "4s"
-    },
     "4u": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "4t"
     },
     "4w": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "4t"
     },
     "4x": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "4t"
     },
     "4y": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "4t"
     },
     "4z": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "4t"
     },
     "5a": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "4t"
     },
     "5b": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "4t"
     },
     "5c": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "4t"
     },
     "5d": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "4t"
+    },
+    "5e": {
       "key": "root.types.connections",
       "~k_parent": "4j"
     },
-    "5e": {
+    "5f": {
       "key": "root.types.requests",
       "~k_parent": "4j"
     },
-    "5f": {
+    "5g": {
       "key": "root.types.api",
       "~k_parent": "4j"
     },
-    "5g": {
+    "5h": {
       "key": "root.types.operators",
       "~k_parent": "4j"
     },
-    "5h": {
-      "key": "root.types.operators.client",
-      "~k_parent": "5g"
-    },
     "5i": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "5h"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.types.operators.server",
-      "~k_parent": "5g"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "5i"
     },
     "5l": {
+      "key": "root.types.operators.server",
+      "~k_parent": "5h"
+    },
+    "5m": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "5m": {
-      "key": "root.imports.actions",
-      "~k_parent": "5l"
-    },
     "5n": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "5m"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.auth",
-      "~k_parent": "5l"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "5n"
     },
     "5q": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "5p"
+      "key": "root.imports.agents",
+      "~k_parent": "5m"
     },
     "5r": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "5p"
+      "key": "root.imports.auth",
+      "~k_parent": "5m"
     },
     "5s": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "5p"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "5p"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "5r"
     },
     "5u": {
-      "key": "root.imports.blocks",
-      "~k_parent": "5l"
+      "key": "root.imports.auth.events",
+      "~k_parent": "5r"
     },
     "5v": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "5u"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "5r"
     },
     "5w": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks",
+      "~k_parent": "5m"
     },
     "5x": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "5w"
     },
     "5z": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "5w"
     },
     "6a": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "5w"
     },
     "6b": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "5w"
     },
     "6c": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "5w"
     },
     "6d": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "5w"
     },
     "6e": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "5u"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "5w"
     },
     "6f": {
-      "key": "root.imports.connections",
-      "~k_parent": "5l"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "5w"
     },
     "6g": {
-      "key": "root.imports.icons",
-      "~k_parent": "5l"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "5w"
     },
     "6h": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "6g"
+      "key": "root.imports.connections",
+      "~k_parent": "5m"
     },
     "6i": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "6h"
+      "key": "root.imports.icons",
+      "~k_parent": "5m"
     },
     "6j": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "6i"
     },
     "6k": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "6j"
     },
     "6l": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "6i"
     },
     "6m": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "6l"
     },
     "6n": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "6i"
     },
     "6o": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "6n"
     },
     "6p": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "6i"
     },
     "6q": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "6i"
     },
     "6s": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "6r"
     },
     "6t": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "6i"
     },
     "6u": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "6i"
     },
     "6w": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "6v"
     },
     "6x": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "6i"
     },
     "6y": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "6i"
     },
     "7a": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "79"
     },
     "7b": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "6i"
     },
     "7c": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "7b"
     },
     "7d": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "6i"
     },
     "7e": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "7d"
     },
     "7f": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "6i"
     },
     "7g": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "7f"
     },
     "7h": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "6i"
     },
     "7i": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "7h"
     },
     "7j": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "6i"
     },
     "7k": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "7j"
     },
     "7l": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "6i"
     },
     "7m": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "7l"
     },
     "7n": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "6i"
     },
     "7o": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "7n"
     },
     "7p": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "6i"
     },
     "7q": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "7p"
     },
     "7r": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "6i"
     },
     "7s": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "7r"
     },
     "7t": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "6i"
     },
     "7u": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "7t"
     },
     "7v": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "6i"
     },
     "7w": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "7v"
     },
     "7x": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "6i"
     },
     "7y": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "7x"
     },
     "7z": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "6g"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "6i"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "2g"
   },
@@ -1914,6 +1923,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -6401,152 +6411,155 @@
       },
       "~k": "4k"
     },
+    "agents": {
+      "~k": "4n"
+    },
     "auth": {
       "adapters": {
-        "~k": "4o"
-      },
-      "callbacks": {
         "~k": "4p"
       },
-      "events": {
+      "callbacks": {
         "~k": "4q"
       },
-      "providers": {
+      "events": {
         "~k": "4r"
       },
-      "~k": "4n"
+      "providers": {
+        "~k": "4s"
+      },
+      "~k": "4o"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 9,
-        "~k": "4t"
+        "~k": "4u"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 8,
-        "~k": "4u"
+        "~k": "4v"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4v"
+        "~k": "4w"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4w"
+        "~k": "4x"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4x"
+        "~k": "4y"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4y"
+        "~k": "4z"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4z"
+        "~k": "50"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "50"
+        "~k": "51"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "51"
+        "~k": "52"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "52"
+        "~k": "53"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "53"
+        "~k": "54"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "54"
+        "~k": "55"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "55"
+        "~k": "56"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "56"
+        "~k": "57"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "57"
+        "~k": "58"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "58"
+        "~k": "59"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "59"
+        "~k": "5a"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5a"
+        "~k": "5b"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5b"
+        "~k": "5c"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "5c"
+        "~k": "5d"
       },
-      "~k": "4s"
+      "~k": "4t"
     },
     "connections": {
-      "~k": "5d"
-    },
-    "requests": {
       "~k": "5e"
     },
-    "api": {
+    "requests": {
       "~k": "5f"
+    },
+    "api": {
+      "~k": "5g"
     },
     "operators": {
       "client": {
@@ -6554,20 +6567,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5i"
+          "~k": "5j"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5j"
+          "~k": "5k"
         },
-        "~k": "5h"
+        "~k": "5i"
       },
       "server": {
-        "~k": "5k"
+        "~k": "5l"
       },
-      "~k": "5g"
+      "~k": "5h"
     },
     "~k": "4j"
   }

--- a/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
+++ b/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
@@ -2820,790 +2820,799 @@
       "~k_parent": "dd"
     },
     "dm": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "dc"
     },
     "dn": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "dm"
+      "key": "root.types.auth",
+      "~k_parent": "dc"
     },
     "do": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "dm"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "dn"
     },
     "dp": {
-      "key": "root.types.auth.callbacks.JwtCallback",
-      "~k_parent": "do"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "dn"
     },
     "dq": {
-      "key": "root.types.auth.callbacks.SessionCallback",
-      "~k_parent": "do"
+      "key": "root.types.auth.callbacks.JwtCallback",
+      "~k_parent": "dp"
     },
     "dr": {
-      "key": "root.types.auth.events",
-      "~k_parent": "dm"
+      "key": "root.types.auth.callbacks.SessionCallback",
+      "~k_parent": "dp"
     },
     "ds": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "dm"
+      "key": "root.types.auth.events",
+      "~k_parent": "dn"
     },
     "dt": {
-      "key": "root.types.auth.providers.GoogleProvider",
-      "~k_parent": "ds"
+      "key": "root.types.auth.providers",
+      "~k_parent": "dn"
     },
     "du": {
-      "key": "root.types.auth.providers.CredentialsProvider",
-      "~k_parent": "ds"
+      "key": "root.types.auth.providers.GoogleProvider",
+      "~k_parent": "dt"
     },
     "dv": {
+      "key": "root.types.auth.providers.CredentialsProvider",
+      "~k_parent": "dt"
+    },
+    "dw": {
       "key": "root.types.blocks",
       "~k_parent": "dc"
     },
-    "dw": {
-      "key": "root.types.blocks.PageHeaderMenu",
-      "~k_parent": "dv"
-    },
     "dx": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.PageHeaderMenu",
+      "~k_parent": "dw"
     },
     "dy": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "dw"
     },
     "dz": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "dw"
     },
     "e0": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "dw"
     },
     "e1": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "dw"
     },
     "e2": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "dw"
     },
     "e3": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "dw"
     },
     "e4": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "dw"
     },
     "e5": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.List",
+      "~k_parent": "dw"
     },
     "e6": {
-      "key": "root.types.blocks.Tag",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "dw"
     },
     "e7": {
-      "key": "root.types.blocks.TextArea",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Tag",
+      "~k_parent": "dw"
     },
     "e8": {
-      "key": "root.types.blocks.NumberInput",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.TextArea",
+      "~k_parent": "dw"
     },
     "e9": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.NumberInput",
+      "~k_parent": "dw"
     },
     "ea": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "dw"
     },
     "eb": {
-      "key": "root.types.blocks.Divider",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "dw"
     },
     "ec": {
-      "key": "root.types.blocks.PasswordInput",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Divider",
+      "~k_parent": "dw"
     },
     "ed": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.PasswordInput",
+      "~k_parent": "dw"
     },
     "ee": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "dw"
     },
     "ef": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "dw"
     },
     "eg": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "dw"
     },
     "eh": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "dw"
     },
     "ei": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "dw"
     },
     "ej": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "dw"
     },
     "ek": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "dw"
     },
     "el": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "dw"
     },
     "em": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "dw"
     },
     "en": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "dw"
     },
     "eo": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "dw"
     },
     "ep": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "dw"
     },
     "eq": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "dw"
     },
     "er": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "dv"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "dw"
     },
     "es": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "dw"
+    },
+    "et": {
       "key": "root.types.connections",
       "~k_parent": "dc"
     },
-    "et": {
-      "key": "root.types.connections.AxiosHttp",
-      "~k_parent": "es"
-    },
     "eu": {
-      "key": "root.types.connections.MongoDBCollection",
-      "~k_parent": "es"
+      "key": "root.types.connections.AxiosHttp",
+      "~k_parent": "et"
     },
     "ev": {
+      "key": "root.types.connections.MongoDBCollection",
+      "~k_parent": "et"
+    },
+    "ew": {
       "key": "root.types.requests",
       "~k_parent": "dc"
     },
-    "ew": {
-      "key": "root.types.requests.AxiosHttp",
-      "~k_parent": "ev"
-    },
     "ex": {
-      "key": "root.types.requests.MongoDBFind",
-      "~k_parent": "ev"
+      "key": "root.types.requests.AxiosHttp",
+      "~k_parent": "ew"
     },
     "ey": {
-      "key": "root.types.requests.MongoDBFindOne",
-      "~k_parent": "ev"
+      "key": "root.types.requests.MongoDBFind",
+      "~k_parent": "ew"
     },
     "ez": {
-      "key": "root.types.requests.MongoDBUpdateOne",
-      "~k_parent": "ev"
+      "key": "root.types.requests.MongoDBFindOne",
+      "~k_parent": "ew"
     },
     "f0": {
+      "key": "root.types.requests.MongoDBUpdateOne",
+      "~k_parent": "ew"
+    },
+    "f1": {
       "key": "root.types.api",
       "~k_parent": "dc"
     },
-    "f1": {
+    "f2": {
       "key": "root.types.operators",
       "~k_parent": "dc"
     },
-    "f2": {
-      "key": "root.types.operators.client",
-      "~k_parent": "f1"
-    },
     "f3": {
-      "key": "root.types.operators.client._user",
+      "key": "root.types.operators.client",
       "~k_parent": "f2"
     },
     "f4": {
-      "key": "root.types.operators.client._request",
-      "~k_parent": "f2"
+      "key": "root.types.operators.client._user",
+      "~k_parent": "f3"
     },
     "f5": {
-      "key": "root.types.operators.client._state",
-      "~k_parent": "f2"
+      "key": "root.types.operators.client._request",
+      "~k_parent": "f3"
     },
     "f6": {
-      "key": "root.types.operators.client._if",
-      "~k_parent": "f2"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "f3"
     },
     "f7": {
-      "key": "root.types.operators.client._eq",
-      "~k_parent": "f2"
+      "key": "root.types.operators.client._if",
+      "~k_parent": "f3"
     },
     "f8": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "f2"
+      "key": "root.types.operators.client._eq",
+      "~k_parent": "f3"
     },
     "f9": {
-      "key": "root.types.operators.client._url_query",
-      "~k_parent": "f2"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "f3"
     },
     "fa": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "f2"
+      "key": "root.types.operators.client._url_query",
+      "~k_parent": "f3"
     },
     "fb": {
-      "key": "root.types.operators.server",
-      "~k_parent": "f1"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "f3"
     },
     "fc": {
-      "key": "root.types.operators.server._payload",
-      "~k_parent": "fb"
+      "key": "root.types.operators.server",
+      "~k_parent": "f2"
     },
     "fd": {
-      "key": "root.types.operators.server._if",
-      "~k_parent": "fb"
+      "key": "root.types.operators.server._payload",
+      "~k_parent": "fc"
     },
     "fe": {
-      "key": "root.types.operators.server._date",
-      "~k_parent": "fb"
+      "key": "root.types.operators.server._if",
+      "~k_parent": "fc"
     },
     "ff": {
+      "key": "root.types.operators.server._date",
+      "~k_parent": "fc"
+    },
+    "fg": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "fg": {
-      "key": "root.imports.actions",
-      "~k_parent": "ff"
-    },
     "fh": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "fg"
     },
     "fi": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "fg"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "fh"
     },
     "fj": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "fg"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "fh"
     },
     "fk": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "fg"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "fh"
     },
     "fl": {
-      "key": "root.imports.actions[4]",
-      "~k_parent": "fg"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "fh"
     },
     "fm": {
-      "key": "root.imports.actions[5]",
-      "~k_parent": "fg"
+      "key": "root.imports.actions[4]",
+      "~k_parent": "fh"
     },
     "fn": {
-      "key": "root.imports.actions[6]",
-      "~k_parent": "fg"
+      "key": "root.imports.actions[5]",
+      "~k_parent": "fh"
     },
     "fo": {
-      "key": "root.imports.actions[7]",
-      "~k_parent": "fg"
+      "key": "root.imports.actions[6]",
+      "~k_parent": "fh"
     },
     "fp": {
-      "key": "root.imports.auth",
-      "~k_parent": "ff"
+      "key": "root.imports.actions[7]",
+      "~k_parent": "fh"
     },
     "fq": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "fp"
+      "key": "root.imports.agents",
+      "~k_parent": "fg"
     },
     "fr": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "fp"
+      "key": "root.imports.auth",
+      "~k_parent": "fg"
     },
     "fs": {
-      "key": "root.imports.auth.callbacks[0]",
+      "key": "root.imports.auth.adapters",
       "~k_parent": "fr"
     },
     "ft": {
-      "key": "root.imports.auth.callbacks[1]",
+      "key": "root.imports.auth.callbacks",
       "~k_parent": "fr"
     },
     "fu": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "fp"
+      "key": "root.imports.auth.callbacks[0]",
+      "~k_parent": "ft"
     },
     "fv": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "fp"
+      "key": "root.imports.auth.callbacks[1]",
+      "~k_parent": "ft"
     },
     "fw": {
-      "key": "root.imports.auth.providers[0]",
-      "~k_parent": "fv"
+      "key": "root.imports.auth.events",
+      "~k_parent": "fr"
     },
     "fx": {
-      "key": "root.imports.auth.providers[1]",
-      "~k_parent": "fv"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "fr"
     },
     "fy": {
-      "key": "root.imports.blocks",
-      "~k_parent": "ff"
+      "key": "root.imports.auth.providers[0]",
+      "~k_parent": "fx"
     },
     "fz": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "fy"
+      "key": "root.imports.auth.providers[1]",
+      "~k_parent": "fx"
     },
     "g0": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks",
+      "~k_parent": "fg"
     },
     "g1": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "g0"
     },
     "g2": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "g0"
     },
     "g3": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "g0"
     },
     "g4": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "g0"
     },
     "g5": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "g0"
     },
     "g6": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "g0"
     },
     "g7": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "g0"
     },
     "g8": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "g0"
     },
     "g9": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "g0"
     },
     "ga": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "g0"
     },
     "gb": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "g0"
     },
     "gc": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "g0"
     },
     "gd": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "g0"
     },
     "ge": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "g0"
     },
     "gf": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "g0"
     },
     "gg": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "g0"
     },
     "gh": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "g0"
     },
     "gi": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "g0"
     },
     "gj": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "g0"
     },
     "gk": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "g0"
     },
     "gl": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "g0"
     },
     "gm": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "g0"
     },
     "gn": {
-      "key": "root.imports.blocks[24]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "g0"
     },
     "go": {
-      "key": "root.imports.blocks[25]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "g0"
     },
     "gp": {
-      "key": "root.imports.blocks[26]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[24]",
+      "~k_parent": "g0"
     },
     "gq": {
-      "key": "root.imports.blocks[27]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[25]",
+      "~k_parent": "g0"
     },
     "gr": {
-      "key": "root.imports.blocks[28]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[26]",
+      "~k_parent": "g0"
     },
     "gs": {
-      "key": "root.imports.blocks[29]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[27]",
+      "~k_parent": "g0"
     },
     "gt": {
-      "key": "root.imports.blocks[30]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[28]",
+      "~k_parent": "g0"
     },
     "gu": {
-      "key": "root.imports.blocks[31]",
-      "~k_parent": "fy"
+      "key": "root.imports.blocks[29]",
+      "~k_parent": "g0"
     },
     "gv": {
-      "key": "root.imports.connections",
-      "~k_parent": "ff"
+      "key": "root.imports.blocks[30]",
+      "~k_parent": "g0"
     },
     "gw": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "gv"
+      "key": "root.imports.blocks[31]",
+      "~k_parent": "g0"
     },
     "gx": {
-      "key": "root.imports.connections[1]",
-      "~k_parent": "gv"
+      "key": "root.imports.connections",
+      "~k_parent": "fg"
     },
     "gy": {
-      "key": "root.imports.icons",
-      "~k_parent": "ff"
+      "key": "root.imports.connections[0]",
+      "~k_parent": "gx"
     },
     "gz": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "gy"
+      "key": "root.imports.connections[1]",
+      "~k_parent": "gx"
     },
     "h0": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "gz"
+      "key": "root.imports.icons",
+      "~k_parent": "fg"
     },
     "h1": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "h0"
     },
     "h2": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "h1"
     },
     "h3": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "h0"
     },
     "h4": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "h3"
     },
     "h5": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "h0"
     },
     "h6": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "h5"
     },
     "h7": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "h0"
     },
     "h8": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "h7"
     },
     "h9": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "h0"
     },
     "ha": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "h9"
     },
     "hb": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "h0"
     },
     "hc": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "hb"
     },
     "hd": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "h0"
     },
     "he": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "hd"
     },
     "hf": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "h0"
     },
     "hg": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "hf"
     },
     "hh": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "h0"
     },
     "hi": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "hh"
     },
     "hj": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "h0"
     },
     "hk": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "hj"
     },
     "hl": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "h0"
     },
     "hm": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "hl"
     },
     "hn": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "h0"
     },
     "ho": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "hn"
     },
     "hp": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "h0"
     },
     "hq": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "hp"
     },
     "hr": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "h0"
     },
     "hs": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "hr"
     },
     "ht": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "h0"
     },
     "hu": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "ht"
     },
     "hv": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "h0"
     },
     "hw": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "hv"
     },
     "hx": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "h0"
     },
     "hy": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "hx"
     },
     "hz": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "h0"
     },
     "i0": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "hz"
     },
     "i1": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "h0"
     },
     "i2": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "i1"
     },
     "i3": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "h0"
     },
     "i4": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "i3"
     },
     "i5": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "h0"
     },
     "i6": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "i5"
     },
     "i7": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "h0"
     },
     "i8": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "i7"
     },
     "i9": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "h0"
     },
     "ia": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "i9"
     },
     "ib": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "h0"
     },
     "ic": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "ib"
     },
     "id": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "h0"
     },
     "ie": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "id"
     },
     "if": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "h0"
     },
     "ig": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "if"
     },
     "ih": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "gy"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "h0"
     },
     "ii": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "ih"
     },
     "ij": {
-      "key": "root.imports.requests",
-      "~k_parent": "ff"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "h0"
     },
     "ik": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "ij"
     },
     "il": {
-      "key": "root.imports.requests[1]",
-      "~k_parent": "ij"
+      "key": "root.imports.requests",
+      "~k_parent": "fg"
     },
     "im": {
-      "key": "root.imports.requests[2]",
-      "~k_parent": "ij"
+      "key": "root.imports.requests[0]",
+      "~k_parent": "il"
     },
     "in": {
-      "key": "root.imports.requests[3]",
-      "~k_parent": "ij"
+      "key": "root.imports.requests[1]",
+      "~k_parent": "il"
     },
     "io": {
-      "key": "root.imports.operators",
-      "~k_parent": "ff"
+      "key": "root.imports.requests[2]",
+      "~k_parent": "il"
     },
     "ip": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "io"
+      "key": "root.imports.requests[3]",
+      "~k_parent": "il"
     },
     "iq": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "ip"
+      "key": "root.imports.operators",
+      "~k_parent": "fg"
     },
     "ir": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "ip"
+      "key": "root.imports.operators.client",
+      "~k_parent": "iq"
     },
     "is": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "ip"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "ir"
     },
     "it": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "ip"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "ir"
     },
     "iu": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "ip"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "ir"
     },
     "iv": {
-      "key": "root.imports.operators.client[5]",
-      "~k_parent": "ip"
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "ir"
     },
     "iw": {
-      "key": "root.imports.operators.client[6]",
-      "~k_parent": "ip"
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "ir"
     },
     "ix": {
-      "key": "root.imports.operators.client[7]",
-      "~k_parent": "ip"
+      "key": "root.imports.operators.client[5]",
+      "~k_parent": "ir"
     },
     "iy": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "io"
+      "key": "root.imports.operators.client[6]",
+      "~k_parent": "ir"
     },
     "iz": {
-      "key": "root.imports.operators.server[0]",
-      "~k_parent": "iy"
+      "key": "root.imports.operators.client[7]",
+      "~k_parent": "ir"
     },
     "j0": {
-      "key": "root.imports.operators.server[1]",
-      "~k_parent": "iy"
+      "key": "root.imports.operators.server",
+      "~k_parent": "iq"
     },
     "j1": {
+      "key": "root.imports.operators.server[0]",
+      "~k_parent": "j0"
+    },
+    "j2": {
+      "key": "root.imports.operators.server[1]",
+      "~k_parent": "j0"
+    },
+    "j3": {
       "key": "root.imports.operators.server[2]",
-      "~k_parent": "iy"
+      "~k_parent": "j0"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "sentry": {
       "client": true,
@@ -5693,6 +5702,7 @@
     }
   },
   "plugins/actions.js": "import { Request as Request } from '@lowdefy/actions-core/actions';\nimport { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetState as SetState } from '@lowdefy/actions-core/actions';\nimport { Validate as Validate } from '@lowdefy/actions-core/actions';\nimport { DisplayMessage as DisplayMessage } from '@lowdefy/actions-core/actions';\nimport { SetGlobal as SetGlobal } from '@lowdefy/actions-core/actions';\nimport { Login as Login } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Request,\n  Link,\n  SetState,\n  Validate,\n  DisplayMessage,\n  SetGlobal,\n  Login,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "import { JwtCallback as JwtCallback } from '@lowdefy/plugin-next-auth/auth/callbacks';\nimport { SessionCallback as SessionCallback } from '@lowdefy/plugin-next-auth/auth/callbacks';\nexport default {\n  JwtCallback,\n  SessionCallback,\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -17219,284 +17229,287 @@
       },
       "~k": "dd"
     },
+    "agents": {
+      "~k": "dm"
+    },
     "auth": {
       "adapters": {
-        "~k": "dn"
+        "~k": "do"
       },
       "callbacks": {
         "JwtCallback": {
           "originalTypeName": "JwtCallback",
           "package": "@lowdefy/plugin-next-auth",
           "count": 1,
-          "~k": "dp"
+          "~k": "dq"
         },
         "SessionCallback": {
           "originalTypeName": "SessionCallback",
           "package": "@lowdefy/plugin-next-auth",
           "count": 1,
-          "~k": "dq"
+          "~k": "dr"
         },
-        "~k": "do"
+        "~k": "dp"
       },
       "events": {
-        "~k": "dr"
+        "~k": "ds"
       },
       "providers": {
         "GoogleProvider": {
           "originalTypeName": "GoogleProvider",
           "package": "next-auth",
           "count": 1,
-          "~k": "dt"
+          "~k": "du"
         },
         "CredentialsProvider": {
           "originalTypeName": "CredentialsProvider",
           "package": "next-auth",
           "count": 1,
-          "~k": "du"
+          "~k": "dv"
         },
-        "~k": "ds"
+        "~k": "dt"
       },
-      "~k": "dm"
+      "~k": "dn"
     },
     "blocks": {
       "PageHeaderMenu": {
         "originalTypeName": "PageHeaderMenu",
         "package": "@lowdefy/blocks-antd",
         "count": 6,
-        "~k": "dw"
+        "~k": "dx"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "dx"
+        "~k": "dy"
       },
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "dy"
+        "~k": "dz"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 7,
-        "~k": "dz"
+        "~k": "e0"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 4,
-        "~k": "e0"
+        "~k": "e1"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 5,
-        "~k": "e1"
+        "~k": "e2"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "e2"
+        "~k": "e3"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "e3"
+        "~k": "e4"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "e4"
+        "~k": "e5"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "e5"
+        "~k": "e6"
       },
       "Tag": {
         "originalTypeName": "Tag",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "e6"
+        "~k": "e7"
       },
       "TextArea": {
         "originalTypeName": "TextArea",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "e7"
+        "~k": "e8"
       },
       "NumberInput": {
         "originalTypeName": "NumberInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "e8"
+        "~k": "e9"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "e9"
+        "~k": "ea"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "ea"
+        "~k": "eb"
       },
       "Divider": {
         "originalTypeName": "Divider",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "eb"
+        "~k": "ec"
       },
       "PasswordInput": {
         "originalTypeName": "PasswordInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "ec"
+        "~k": "ed"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "ed"
+        "~k": "ee"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "ee"
+        "~k": "ef"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "ef"
+        "~k": "eg"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "eg"
+        "~k": "eh"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "eh"
+        "~k": "ei"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "ei"
+        "~k": "ej"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "ej"
+        "~k": "ek"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "ek"
+        "~k": "el"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "el"
+        "~k": "em"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "em"
+        "~k": "en"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "en"
+        "~k": "eo"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "eo"
+        "~k": "ep"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "ep"
+        "~k": "eq"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "eq"
+        "~k": "er"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "er"
+        "~k": "es"
       },
-      "~k": "dv"
+      "~k": "dw"
     },
     "connections": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 1,
-        "~k": "et"
+        "~k": "eu"
       },
       "MongoDBCollection": {
         "originalTypeName": "MongoDBCollection",
         "package": "@lowdefy/connection-mongodb",
         "count": 2,
-        "~k": "eu"
+        "~k": "ev"
       },
-      "~k": "es"
+      "~k": "et"
     },
     "requests": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 1,
-        "~k": "ew"
+        "~k": "ex"
       },
       "MongoDBFind": {
         "originalTypeName": "MongoDBFind",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "ex"
+        "~k": "ey"
       },
       "MongoDBFindOne": {
         "originalTypeName": "MongoDBFindOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "ey"
+        "~k": "ez"
       },
       "MongoDBUpdateOne": {
         "originalTypeName": "MongoDBUpdateOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "ez"
+        "~k": "f0"
       },
-      "~k": "ev"
+      "~k": "ew"
     },
     "api": {
-      "~k": "f0"
+      "~k": "f1"
     },
     "operators": {
       "client": {
@@ -17504,74 +17517,74 @@
           "originalTypeName": "_user",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "f3"
+          "~k": "f4"
         },
         "_request": {
           "originalTypeName": "_request",
           "package": "@lowdefy/operators-js",
           "count": 10,
-          "~k": "f4"
+          "~k": "f5"
         },
         "_state": {
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 18,
-          "~k": "f5"
+          "~k": "f6"
         },
         "_if": {
           "originalTypeName": "_if",
           "package": "@lowdefy/operators-js",
           "count": 3,
-          "~k": "f6"
+          "~k": "f7"
         },
         "_eq": {
           "originalTypeName": "_eq",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "f7"
+          "~k": "f8"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 4,
-          "~k": "f8"
+          "~k": "f9"
         },
         "_url_query": {
           "originalTypeName": "_url_query",
           "package": "@lowdefy/operators-js",
           "count": 5,
-          "~k": "f9"
+          "~k": "fa"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "fa"
+          "~k": "fb"
         },
-        "~k": "f2"
+        "~k": "f3"
       },
       "server": {
         "_payload": {
           "originalTypeName": "_payload",
           "package": "@lowdefy/operators-js",
           "count": 11,
-          "~k": "fc"
+          "~k": "fd"
         },
         "_if": {
           "originalTypeName": "_if",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "fd"
+          "~k": "fe"
         },
         "_date": {
           "originalTypeName": "_date",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "fe"
+          "~k": "ff"
         },
-        "~k": "fb"
+        "~k": "fc"
       },
-      "~k": "f1"
+      "~k": "f2"
     },
     "~k": "dc"
   }

--- a/packages/build/src/tests/success/56-build-operator-in-ref-vars/snapshot.json
+++ b/packages/build/src/tests/success/56-build-operator-in-ref-vars/snapshot.json
@@ -131,163 +131,163 @@
       "~k_parent": "18"
     },
     "20": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1z"
+      "key": "root.types.auth",
+      "~k_parent": "1u"
     },
     "21": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1z"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "20"
     },
     "22": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1z"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "20"
     },
     "23": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1z"
+      "key": "root.types.auth.events",
+      "~k_parent": "20"
     },
     "24": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "20"
+    },
+    "25": {
       "key": "root.types.blocks",
       "~k_parent": "1u"
     },
-    "25": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "24"
-    },
     "26": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "25"
     },
     "27": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "25"
     },
     "28": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "25"
     },
     "29": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "25"
     },
     "30": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "2x"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2y"
     },
     "31": {
-      "key": "root.imports.auth",
-      "~k_parent": "2w"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "2y"
     },
     "32": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "31"
+      "key": "root.imports.agents",
+      "~k_parent": "2x"
     },
     "33": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "31"
+      "key": "root.imports.auth",
+      "~k_parent": "2x"
     },
     "34": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "31"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "33"
     },
     "35": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "31"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "33"
     },
     "36": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2w"
+      "key": "root.imports.auth.events",
+      "~k_parent": "33"
     },
     "37": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "36"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "33"
     },
     "38": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks",
+      "~k_parent": "2x"
     },
     "39": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "38"
     },
     "40": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3t"
     },
     "41": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3t"
     },
     "43": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3t"
     },
     "45": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3t"
     },
     "47": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3t"
     },
     "49": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3t"
     },
     "51": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3t"
     },
     "53": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3t"
     },
     "55": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3t"
     },
     "57": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3t"
     },
     "59": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "58"
     },
     "a": {
@@ -496,354 +496,363 @@
       "~k_parent": "1v"
     },
     "1z": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1u"
     },
     "2a": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "24"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "25"
     },
     "2b": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "25"
     },
     "2c": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "25"
     },
     "2d": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "25"
     },
     "2e": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "24"
+      "key": "root.types.blocks.List",
+      "~k_parent": "25"
     },
     "2f": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "25"
     },
     "2g": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "25"
     },
     "2h": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "24"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "25"
     },
     "2i": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "25"
     },
     "2j": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "24"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "25"
     },
     "2k": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "24"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "25"
     },
     "2l": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "24"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "25"
     },
     "2m": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "24"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "25"
     },
     "2n": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "25"
     },
     "2o": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "25"
+    },
+    "2p": {
       "key": "root.types.connections",
       "~k_parent": "1u"
     },
-    "2p": {
+    "2q": {
       "key": "root.types.requests",
       "~k_parent": "1u"
     },
-    "2q": {
+    "2r": {
       "key": "root.types.api",
       "~k_parent": "1u"
     },
-    "2r": {
+    "2s": {
       "key": "root.types.operators",
       "~k_parent": "1u"
     },
-    "2s": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2r"
-    },
     "2t": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2s"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2r"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2t"
     },
     "2w": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2s"
+    },
+    "2x": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2x": {
-      "key": "root.imports.actions",
-      "~k_parent": "2w"
-    },
     "2y": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2x"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "38"
     },
     "3b": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "38"
     },
     "3c": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "38"
     },
     "3d": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "38"
     },
     "3e": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "38"
     },
     "3f": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "38"
     },
     "3g": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "38"
     },
     "3h": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "38"
     },
     "3i": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "38"
     },
     "3j": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "38"
     },
     "3k": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "38"
     },
     "3l": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "38"
     },
     "3m": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "38"
     },
     "3n": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "38"
     },
     "3o": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "38"
     },
     "3p": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "38"
     },
     "3q": {
-      "key": "root.imports.connections",
-      "~k_parent": "2w"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "38"
     },
     "3r": {
-      "key": "root.imports.icons",
-      "~k_parent": "2w"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "38"
     },
     "3s": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3r"
+      "key": "root.imports.connections",
+      "~k_parent": "2x"
     },
     "3t": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3s"
+      "key": "root.imports.icons",
+      "~k_parent": "2x"
     },
     "3u": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3t"
     },
     "3x": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3t"
     },
     "3z": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3t"
     },
     "4b": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3t"
     },
     "4d": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3t"
     },
     "4f": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3t"
     },
     "4h": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3t"
     },
     "4j": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3t"
     },
     "4l": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3t"
     },
     "4n": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3t"
     },
     "4p": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3t"
     },
     "4r": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3t"
     },
     "4t": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3t"
     },
     "4v": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3t"
     },
     "4x": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3t"
     },
     "4z": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3t"
     },
     "5b": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.requests",
-      "~k_parent": "2w"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3t"
     },
     "5d": {
-      "key": "root.imports.operators",
-      "~k_parent": "2w"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5d"
+      "key": "root.imports.requests",
+      "~k_parent": "2x"
     },
     "5f": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5e"
+      "key": "root.imports.operators",
+      "~k_parent": "2x"
     },
     "5g": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5e"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5f"
     },
     "5h": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5g"
+    },
+    "5i": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5g"
+    },
+    "5j": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5d"
+      "~k_parent": "5f"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "w"
   },
@@ -1083,6 +1092,7 @@
     }
   },
   "plugins/actions.js": "import { SetState as SetState } from '@lowdefy/actions-core/actions';\nimport { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  SetState,\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5586,146 +5596,149 @@
       },
       "~k": "1v"
     },
+    "agents": {
+      "~k": "1z"
+    },
     "auth": {
       "adapters": {
-        "~k": "20"
-      },
-      "callbacks": {
         "~k": "21"
       },
-      "events": {
+      "callbacks": {
         "~k": "22"
       },
-      "providers": {
+      "events": {
         "~k": "23"
       },
-      "~k": "1z"
+      "providers": {
+        "~k": "24"
+      },
+      "~k": "20"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "25"
+        "~k": "26"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "26"
+        "~k": "27"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
-      "~k": "24"
+      "~k": "25"
     },
     "connections": {
-      "~k": "2o"
-    },
-    "requests": {
       "~k": "2p"
     },
-    "api": {
+    "requests": {
       "~k": "2q"
+    },
+    "api": {
+      "~k": "2r"
     },
     "operators": {
       "client": {
@@ -5733,20 +5746,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2t"
+          "~k": "2u"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2u"
+          "~k": "2v"
         },
-        "~k": "2s"
+        "~k": "2t"
       },
       "server": {
-        "~k": "2v"
+        "~k": "2w"
       },
-      "~k": "2r"
+      "~k": "2s"
     },
     "~k": "1u"
   }

--- a/packages/build/src/tests/success/57-static-op-with-dynamic-child-in-vars/snapshot.json
+++ b/packages/build/src/tests/success/57-static-op-with-dynamic-child-in-vars/snapshot.json
@@ -135,156 +135,156 @@
       "~k_parent": "1z"
     },
     "22": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1y"
     },
     "23": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "22"
+      "key": "root.types.auth",
+      "~k_parent": "1y"
     },
     "24": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "22"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "23"
     },
     "25": {
-      "key": "root.types.auth.events",
-      "~k_parent": "22"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "23"
     },
     "26": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "22"
+      "key": "root.types.auth.events",
+      "~k_parent": "23"
     },
     "27": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "23"
+    },
+    "28": {
       "key": "root.types.blocks",
       "~k_parent": "1y"
     },
-    "28": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "27"
-    },
     "29": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "2w"
+      "key": "root.types.operators.client._url_query",
+      "~k_parent": "2x"
     },
     "31": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2w"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2x"
     },
     "32": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2v"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2x"
     },
     "33": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2w"
+    },
+    "34": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "34": {
-      "key": "root.imports.actions",
-      "~k_parent": "33"
-    },
     "35": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "34"
     },
     "36": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "34"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "35"
     },
     "37": {
-      "key": "root.imports.auth",
-      "~k_parent": "33"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "35"
     },
     "38": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "37"
+      "key": "root.imports.agents",
+      "~k_parent": "34"
     },
     "39": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "37"
+      "key": "root.imports.auth",
+      "~k_parent": "34"
     },
     "40": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3z"
+      "key": "root.imports.icons",
+      "~k_parent": "34"
     },
     "41": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "40"
     },
     "44": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "40"
     },
     "46": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "40"
     },
     "48": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "40"
     },
     "50": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "40"
     },
     "52": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "40"
     },
     "54": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "40"
     },
     "56": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "40"
     },
     "58": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "40"
     },
     "a": {
       "key": "root.pages[0:login:Box].blocks[0:error_message:Paragraph].properties.content",
@@ -513,390 +513,399 @@
       "~k_parent": "1y"
     },
     "2a": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "28"
     },
     "2b": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "28"
     },
     "2c": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "28"
     },
     "2d": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "28"
     },
     "2e": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "27"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "28"
     },
     "2f": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "28"
     },
     "2g": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "28"
     },
     "2h": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "28"
     },
     "2i": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "27"
+      "key": "root.types.blocks.List",
+      "~k_parent": "28"
     },
     "2j": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "28"
     },
     "2k": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "28"
     },
     "2l": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "27"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "28"
     },
     "2m": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "28"
     },
     "2n": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "28"
     },
     "2o": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "28"
     },
     "2p": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "28"
     },
     "2q": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "28"
     },
     "2r": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "28"
     },
     "2s": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "28"
+    },
+    "2t": {
       "key": "root.types.connections",
       "~k_parent": "1y"
     },
-    "2t": {
+    "2u": {
       "key": "root.types.requests",
       "~k_parent": "1y"
     },
-    "2u": {
+    "2v": {
       "key": "root.types.api",
       "~k_parent": "1y"
     },
-    "2v": {
+    "2w": {
       "key": "root.types.operators",
       "~k_parent": "1y"
     },
-    "2w": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2v"
-    },
     "2x": {
-      "key": "root.types.operators.client._switch",
+      "key": "root.types.operators.client",
       "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.types.operators.client._eq",
-      "~k_parent": "2w"
+      "key": "root.types.operators.client._switch",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.types.operators.client._url_query",
-      "~k_parent": "2w"
+      "key": "root.types.operators.client._eq",
+      "~k_parent": "2x"
     },
     "3a": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "37"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "39"
     },
     "3b": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "37"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "39"
     },
     "3c": {
-      "key": "root.imports.blocks",
-      "~k_parent": "33"
+      "key": "root.imports.auth.events",
+      "~k_parent": "39"
     },
     "3d": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3c"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "39"
     },
     "3e": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks",
+      "~k_parent": "34"
     },
     "3f": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3e"
     },
     "3h": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3e"
     },
     "3i": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3e"
     },
     "3j": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3e"
     },
     "3k": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3e"
     },
     "3l": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3e"
     },
     "3m": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3e"
     },
     "3n": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3e"
     },
     "3o": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3e"
     },
     "3p": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3e"
     },
     "3q": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3e"
     },
     "3r": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3e"
     },
     "3s": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3e"
     },
     "3t": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3e"
     },
     "3u": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3e"
     },
     "3v": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3e"
     },
     "3w": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3e"
     },
     "3x": {
-      "key": "root.imports.connections",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3e"
     },
     "3y": {
-      "key": "root.imports.icons",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3e"
     },
     "3z": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3y"
+      "key": "root.imports.connections",
+      "~k_parent": "34"
     },
     "4a": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "40"
     },
     "4c": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "40"
     },
     "4e": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "40"
     },
     "4g": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "40"
     },
     "4i": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "40"
     },
     "4k": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "40"
     },
     "4m": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "40"
     },
     "4o": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "40"
     },
     "4q": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "40"
     },
     "4s": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "40"
     },
     "4u": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "40"
     },
     "4w": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "40"
     },
     "4y": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "40"
     },
     "5a": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "40"
     },
     "5c": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "40"
     },
     "5e": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "40"
     },
     "5g": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "40"
     },
     "5i": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.requests",
-      "~k_parent": "33"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "40"
     },
     "5k": {
-      "key": "root.imports.operators",
-      "~k_parent": "33"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5k"
+      "key": "root.imports.requests",
+      "~k_parent": "34"
     },
     "5m": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5l"
+      "key": "root.imports.operators",
+      "~k_parent": "34"
     },
     "5n": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5l"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "5l"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "5l"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5n"
     },
     "5q": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "5l"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "5n"
     },
     "5r": {
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "5n"
+    },
+    "5s": {
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "5n"
+    },
+    "5t": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5k"
+      "~k_parent": "5m"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "12"
   },
@@ -1145,6 +1154,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5728,152 +5738,155 @@
       },
       "~k": "1z"
     },
+    "agents": {
+      "~k": "22"
+    },
     "auth": {
       "adapters": {
-        "~k": "23"
-      },
-      "callbacks": {
         "~k": "24"
       },
-      "events": {
+      "callbacks": {
         "~k": "25"
       },
-      "providers": {
+      "events": {
         "~k": "26"
       },
-      "~k": "22"
+      "providers": {
+        "~k": "27"
+      },
+      "~k": "23"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "28"
+        "~k": "29"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
-      "~k": "27"
+      "~k": "28"
     },
     "connections": {
-      "~k": "2s"
-    },
-    "requests": {
       "~k": "2t"
     },
-    "api": {
+    "requests": {
       "~k": "2u"
+    },
+    "api": {
+      "~k": "2v"
     },
     "operators": {
       "client": {
@@ -5881,38 +5894,38 @@
           "originalTypeName": "_switch",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2x"
+          "~k": "2y"
         },
         "_eq": {
           "originalTypeName": "_eq",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "2y"
+          "~k": "2z"
         },
         "_url_query": {
           "originalTypeName": "_url_query",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "2z"
+          "~k": "30"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "30"
+          "~k": "31"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "31"
+          "~k": "32"
         },
-        "~k": "2w"
+        "~k": "2x"
       },
       "server": {
-        "~k": "32"
+        "~k": "33"
       },
-      "~k": "2v"
+      "~k": "2w"
     },
     "~k": "1y"
   }

--- a/packages/build/src/tests/success/58-build-array-map-with-var/snapshot.json
+++ b/packages/build/src/tests/success/58-build-array-map-with-var/snapshot.json
@@ -131,164 +131,164 @@
       "~k_parent": "18"
     },
     "20": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1x"
     },
     "21": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1x"
     },
     "22": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1x"
     },
     "23": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1x"
     },
     "24": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1x"
     },
     "25": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1x"
     },
     "26": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1x"
     },
     "27": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1x"
     },
     "28": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1x"
     },
     "29": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1x"
     },
     "30": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks",
+      "~k_parent": "2q"
     },
     "31": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "30"
     },
     "32": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "30"
     },
     "33": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "30"
     },
     "34": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "30"
     },
     "35": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "30"
     },
     "36": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "30"
     },
     "37": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "30"
     },
     "38": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "30"
     },
     "39": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "30"
     },
     "40": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3m"
     },
     "42": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3m"
     },
     "44": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3m"
     },
     "46": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3m"
     },
     "48": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3m"
     },
     "50": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3m"
     },
     "52": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3m"
     },
     "54": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.requests",
-      "~k_parent": "2p"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3m"
     },
     "56": {
-      "key": "root.imports.operators",
-      "~k_parent": "2p"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "56"
+      "key": "root.imports.requests",
+      "~k_parent": "2q"
     },
     "58": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "57"
+      "key": "root.imports.operators",
+      "~k_parent": "2q"
     },
     "59": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "57"
+      "key": "root.imports.operators.client",
+      "~k_parent": "58"
     },
     "b": {
       "key": "root.pages",
@@ -455,358 +455,367 @@
       "~k_parent": "1o"
     },
     "1r": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1n"
     },
     "1s": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1r"
+      "key": "root.types.auth",
+      "~k_parent": "1n"
     },
     "1t": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1r"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1s"
     },
     "1u": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1r"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1r"
+      "key": "root.types.auth.events",
+      "~k_parent": "1s"
     },
     "1w": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1s"
+    },
+    "1x": {
       "key": "root.types.blocks",
       "~k_parent": "1n"
     },
-    "1x": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1w"
-    },
     "1y": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1x"
     },
     "1z": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "1x"
     },
     "2a": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1x"
     },
     "2b": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1x"
     },
     "2c": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1x"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1x"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1x"
     },
     "2f": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1x"
     },
     "2g": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1x"
     },
     "2h": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1x"
+    },
+    "2i": {
       "key": "root.types.connections",
       "~k_parent": "1n"
     },
-    "2i": {
+    "2j": {
       "key": "root.types.requests",
       "~k_parent": "1n"
     },
-    "2j": {
+    "2k": {
       "key": "root.types.api",
       "~k_parent": "1n"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.operators",
       "~k_parent": "1n"
     },
-    "2l": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2k"
-    },
     "2m": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2l"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2k"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2m"
     },
     "2p": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2l"
+    },
+    "2q": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2q": {
-      "key": "root.imports.actions",
-      "~k_parent": "2p"
-    },
     "2r": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2q"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.imports.auth",
-      "~k_parent": "2p"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2r"
     },
     "2u": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2t"
+      "key": "root.imports.agents",
+      "~k_parent": "2q"
     },
     "2v": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2t"
+      "key": "root.imports.auth",
+      "~k_parent": "2q"
     },
     "2w": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2t"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2v"
     },
     "2x": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2t"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2v"
     },
     "2y": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2p"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2v"
     },
     "2z": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2y"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2v"
     },
     "3a": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "30"
     },
     "3b": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "30"
     },
     "3c": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "30"
     },
     "3d": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "30"
     },
     "3e": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "30"
     },
     "3f": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "30"
     },
     "3g": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "30"
     },
     "3h": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "30"
     },
     "3i": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "30"
     },
     "3j": {
-      "key": "root.imports.connections",
-      "~k_parent": "2p"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "30"
     },
     "3k": {
-      "key": "root.imports.icons",
-      "~k_parent": "2p"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "30"
     },
     "3l": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3k"
+      "key": "root.imports.connections",
+      "~k_parent": "2q"
     },
     "3m": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3l"
+      "key": "root.imports.icons",
+      "~k_parent": "2q"
     },
     "3n": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3m"
     },
     "3u": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3m"
     },
     "3w": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3m"
     },
     "3y": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3m"
     },
     "4a": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3m"
     },
     "4c": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3m"
     },
     "4e": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3m"
     },
     "4g": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3m"
     },
     "4i": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3m"
     },
     "4k": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3m"
     },
     "4m": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3m"
     },
     "4o": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3m"
     },
     "4q": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3m"
     },
     "4s": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3m"
     },
     "4u": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3m"
     },
     "4w": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3m"
     },
     "4y": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3m"
     },
     "5a": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "59"
+    },
+    "5b": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "59"
+    },
+    "5c": {
       "key": "root.imports.operators.server",
-      "~k_parent": "56"
+      "~k_parent": "58"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "r"
   },
@@ -1010,6 +1019,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5507,152 +5517,155 @@
       },
       "~k": "1o"
     },
+    "agents": {
+      "~k": "1r"
+    },
     "auth": {
       "adapters": {
-        "~k": "1s"
-      },
-      "callbacks": {
         "~k": "1t"
       },
-      "events": {
+      "callbacks": {
         "~k": "1u"
       },
-      "providers": {
+      "events": {
         "~k": "1v"
       },
-      "~k": "1r"
+      "providers": {
+        "~k": "1w"
+      },
+      "~k": "1s"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
-      "~k": "1w"
+      "~k": "1x"
     },
     "connections": {
-      "~k": "2h"
-    },
-    "requests": {
       "~k": "2i"
     },
-    "api": {
+    "requests": {
       "~k": "2j"
+    },
+    "api": {
+      "~k": "2k"
     },
     "operators": {
       "client": {
@@ -5660,20 +5673,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2m"
+          "~k": "2n"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2n"
+          "~k": "2o"
         },
-        "~k": "2l"
+        "~k": "2m"
       },
       "server": {
-        "~k": "2o"
+        "~k": "2p"
       },
-      "~k": "2k"
+      "~k": "2l"
     },
     "~k": "1n"
   }

--- a/packages/build/src/tests/success/60-module-single-basic/snapshot.json
+++ b/packages/build/src/tests/success/60-module-single-basic/snapshot.json
@@ -134,152 +134,152 @@
       "~k_parent": "20"
     },
     "23": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1z"
     },
     "24": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "23"
+      "key": "root.types.auth",
+      "~k_parent": "1z"
     },
     "25": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "23"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "24"
     },
     "26": {
-      "key": "root.types.auth.events",
-      "~k_parent": "23"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "24"
     },
     "27": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "23"
+      "key": "root.types.auth.events",
+      "~k_parent": "24"
     },
     "28": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "24"
+    },
+    "29": {
       "key": "root.types.blocks",
       "~k_parent": "1z"
     },
-    "29": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "28"
-    },
     "30": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2w"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2y"
     },
     "31": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2x"
+    },
+    "32": {
       "key": "root.imports",
       "~k_parent": "5"
     },
-    "32": {
-      "key": "root.imports.actions",
-      "~k_parent": "31"
-    },
     "33": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "32"
     },
     "34": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "32"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "33"
     },
     "35": {
-      "key": "root.imports.auth",
-      "~k_parent": "31"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "33"
     },
     "36": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "35"
+      "key": "root.imports.agents",
+      "~k_parent": "32"
     },
     "37": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "35"
+      "key": "root.imports.auth",
+      "~k_parent": "32"
     },
     "38": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "35"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "37"
     },
     "39": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "35"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "37"
     },
     "40": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3y"
     },
     "42": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3y"
     },
     "44": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3y"
     },
     "46": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3y"
     },
     "48": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3y"
     },
     "50": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3y"
     },
     "52": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3y"
     },
     "54": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3y"
     },
     "56": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3y"
     },
     "58": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3y"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[0:title:Title].properties",
@@ -491,370 +491,379 @@
       "~k_parent": "5"
     },
     "2a": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "28"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "29"
     },
     "2b": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "28"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "29"
     },
     "2c": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "28"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "29"
     },
     "2d": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "28"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "29"
     },
     "2e": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "28"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "29"
     },
     "2f": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "28"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "29"
     },
     "2g": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "28"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "29"
     },
     "2h": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "28"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "29"
     },
     "2i": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "28"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "29"
     },
     "2j": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "28"
+      "key": "root.types.blocks.List",
+      "~k_parent": "29"
     },
     "2k": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "28"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "29"
     },
     "2l": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "28"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "29"
     },
     "2m": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "28"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "29"
     },
     "2n": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "28"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "29"
     },
     "2o": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "28"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "29"
     },
     "2p": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "28"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "29"
     },
     "2q": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "28"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "29"
     },
     "2r": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "28"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "29"
     },
     "2s": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "28"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "29"
     },
     "2t": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "29"
+    },
+    "2u": {
       "key": "root.types.connections",
       "~k_parent": "1z"
     },
-    "2u": {
+    "2v": {
       "key": "root.types.requests",
       "~k_parent": "1z"
     },
-    "2v": {
+    "2w": {
       "key": "root.types.api",
       "~k_parent": "1z"
     },
-    "2w": {
+    "2x": {
       "key": "root.types.operators",
       "~k_parent": "1z"
     },
-    "2x": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2w"
-    },
     "2y": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2x"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.blocks",
-      "~k_parent": "31"
+      "key": "root.imports.auth.events",
+      "~k_parent": "37"
     },
     "3b": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3a"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "37"
     },
     "3c": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks",
+      "~k_parent": "32"
     },
     "3d": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3c"
     },
     "3e": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3c"
     },
     "3f": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3c"
     },
     "3g": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3c"
     },
     "3h": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3c"
     },
     "3i": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3c"
     },
     "3j": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3c"
     },
     "3k": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3c"
     },
     "3l": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3c"
     },
     "3m": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3c"
     },
     "3n": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3c"
     },
     "3o": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3c"
     },
     "3p": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3c"
     },
     "3q": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3c"
     },
     "3r": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3c"
     },
     "3s": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3c"
     },
     "3t": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3c"
     },
     "3u": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3c"
     },
     "3v": {
-      "key": "root.imports.connections",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3c"
     },
     "3w": {
-      "key": "root.imports.icons",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3c"
     },
     "3x": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3w"
+      "key": "root.imports.connections",
+      "~k_parent": "32"
     },
     "3y": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3x"
+      "key": "root.imports.icons",
+      "~k_parent": "32"
     },
     "3z": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3y"
     },
     "4c": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3y"
     },
     "4e": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3y"
     },
     "4g": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3y"
     },
     "4i": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3y"
     },
     "4k": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3y"
     },
     "4m": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3y"
     },
     "4o": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3y"
     },
     "4q": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3y"
     },
     "4s": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3y"
     },
     "4u": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3y"
     },
     "4w": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3y"
     },
     "4y": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3y"
     },
     "5a": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3y"
     },
     "5c": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3y"
     },
     "5e": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3y"
     },
     "5g": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.requests",
-      "~k_parent": "31"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3y"
     },
     "5i": {
-      "key": "root.imports.operators",
-      "~k_parent": "31"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5i"
+      "key": "root.imports.requests",
+      "~k_parent": "32"
     },
     "5k": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5j"
+      "key": "root.imports.operators",
+      "~k_parent": "32"
     },
     "5l": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5j"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5k"
     },
     "5m": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5l"
+    },
+    "5n": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5l"
+    },
+    "5o": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5i"
+      "~k_parent": "5k"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "w"
   },
@@ -1105,6 +1114,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5600,152 +5610,155 @@
       },
       "~k": "20"
     },
+    "agents": {
+      "~k": "23"
+    },
     "auth": {
       "adapters": {
-        "~k": "24"
-      },
-      "callbacks": {
         "~k": "25"
       },
-      "events": {
+      "callbacks": {
         "~k": "26"
       },
-      "providers": {
+      "events": {
         "~k": "27"
       },
-      "~k": "23"
+      "providers": {
+        "~k": "28"
+      },
+      "~k": "24"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "29"
+        "~k": "2a"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
-      "~k": "28"
+      "~k": "29"
     },
     "connections": {
-      "~k": "2t"
-    },
-    "requests": {
       "~k": "2u"
     },
-    "api": {
+    "requests": {
       "~k": "2v"
+    },
+    "api": {
+      "~k": "2w"
     },
     "operators": {
       "client": {
@@ -5753,20 +5766,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2y"
+          "~k": "2z"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2z"
+          "~k": "30"
         },
-        "~k": "2x"
+        "~k": "2y"
       },
       "server": {
-        "~k": "30"
+        "~k": "31"
       },
-      "~k": "2w"
+      "~k": "2x"
     },
     "~k": "1z"
   }

--- a/packages/build/src/tests/success/61-module-multi-instance/snapshot.json
+++ b/packages/build/src/tests/success/61-module-multi-instance/snapshot.json
@@ -254,136 +254,140 @@
       "~k_parent": "44"
     },
     "47": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "43"
     },
     "48": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "47"
+      "key": "root.types.auth",
+      "~k_parent": "43"
     },
     "49": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "47"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "48"
     },
     "50": {
+      "key": "root.types.connections.MongoDBCollection",
+      "~k_parent": "4z"
+    },
+    "51": {
       "key": "root.types.requests",
       "~k_parent": "43"
     },
-    "51": {
-      "key": "root.types.requests.MongoDBFind",
-      "~k_parent": "50"
-    },
     "52": {
+      "key": "root.types.requests.MongoDBFind",
+      "~k_parent": "51"
+    },
+    "53": {
       "key": "root.types.api",
       "~k_parent": "43"
     },
-    "53": {
+    "54": {
       "key": "root.types.operators",
       "~k_parent": "43"
     },
-    "54": {
-      "key": "root.types.operators.client",
-      "~k_parent": "53"
-    },
     "55": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "54"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "55"
     },
     "57": {
-      "key": "root.types.operators.server",
-      "~k_parent": "53"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "55"
     },
     "58": {
-      "key": "root.types.operators.server._secret",
-      "~k_parent": "57"
+      "key": "root.types.operators.server",
+      "~k_parent": "54"
     },
     "59": {
-      "key": "root.imports",
-      "~k_parent": "9"
+      "key": "root.types.operators.server._secret",
+      "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "5k"
     },
     "61": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "5k"
     },
     "62": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "5k"
     },
     "63": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "5k"
     },
     "64": {
-      "key": "root.imports.connections",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "5k"
     },
     "65": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "64"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "5k"
     },
     "66": {
-      "key": "root.imports.icons",
-      "~k_parent": "59"
+      "key": "root.imports.connections",
+      "~k_parent": "5a"
     },
     "67": {
-      "key": "root.imports.icons[0]",
+      "key": "root.imports.connections[0]",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "67"
+      "key": "root.imports.icons",
+      "~k_parent": "5a"
     },
     "69": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "68"
     },
     "70": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "6z"
     },
     "71": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "68"
     },
     "72": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "71"
     },
     "73": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "68"
     },
     "74": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "73"
     },
     "75": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "68"
     },
     "76": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "75"
     },
     "77": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "68"
     },
     "78": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "77"
     },
     "79": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "68"
+    },
+    "80": {
+      "key": "root.imports.operators.server[0]",
+      "~k_parent": "7z"
     },
     "a": {
       "key": "root.pages",
@@ -875,418 +879,423 @@
       "~k_parent": "3s"
     },
     "4a": {
-      "key": "root.types.auth.events",
-      "~k_parent": "47"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "48"
     },
     "4b": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "47"
+      "key": "root.types.auth.events",
+      "~k_parent": "48"
     },
     "4c": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "48"
+    },
+    "4d": {
       "key": "root.types.blocks",
       "~k_parent": "43"
     },
-    "4d": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "4c"
-    },
     "4e": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "4d"
     },
     "4g": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "4d"
     },
     "4h": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "4d"
     },
     "4i": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "4d"
     },
     "4j": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "4d"
     },
     "4k": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "4d"
     },
     "4l": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "4d"
     },
     "4m": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "4d"
     },
     "4n": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "4d"
     },
     "4o": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.List",
+      "~k_parent": "4d"
     },
     "4p": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "4d"
     },
     "4q": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "4d"
     },
     "4r": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "4d"
     },
     "4s": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "4d"
     },
     "4t": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "4d"
     },
     "4u": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "4d"
     },
     "4v": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "4d"
     },
     "4w": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "4d"
     },
     "4x": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "4c"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "4d"
     },
     "4y": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "4d"
+    },
+    "4z": {
       "key": "root.types.connections",
       "~k_parent": "43"
     },
-    "4z": {
-      "key": "root.types.connections.MongoDBCollection",
-      "~k_parent": "4y"
-    },
     "5a": {
-      "key": "root.imports.actions",
-      "~k_parent": "59"
+      "key": "root.imports",
+      "~k_parent": "9"
     },
     "5b": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "5a"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.auth",
-      "~k_parent": "59"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "5b"
     },
     "5e": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "5d"
+      "key": "root.imports.agents",
+      "~k_parent": "5a"
     },
     "5f": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "5d"
+      "key": "root.imports.auth",
+      "~k_parent": "5a"
     },
     "5g": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "5d"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "5d"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "5f"
     },
     "5i": {
-      "key": "root.imports.blocks",
-      "~k_parent": "59"
+      "key": "root.imports.auth.events",
+      "~k_parent": "5f"
     },
     "5j": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "5i"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "5f"
     },
     "5k": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks",
+      "~k_parent": "5a"
     },
     "5l": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "5k"
     },
     "5n": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "5k"
     },
     "5o": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "5k"
     },
     "5p": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "5k"
     },
     "5q": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "5k"
     },
     "5r": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "5k"
     },
     "5s": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "5k"
     },
     "5t": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "5k"
     },
     "5u": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "5k"
     },
     "5v": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "5k"
     },
     "5w": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "5k"
     },
     "5x": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "5k"
     },
     "5y": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "5k"
     },
     "5z": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "5i"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "5k"
     },
     "6a": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "68"
     },
     "6c": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "68"
     },
     "6e": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "68"
     },
     "6g": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "6f"
     },
     "6h": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "68"
     },
     "6i": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "68"
     },
     "6k": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "6j"
     },
     "6l": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "68"
     },
     "6m": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "6l"
     },
     "6n": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "68"
     },
     "6o": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "6n"
     },
     "6p": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "68"
     },
     "6q": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "68"
     },
     "6s": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "6r"
     },
     "6t": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "68"
     },
     "6u": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "68"
     },
     "6w": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "6v"
     },
     "6x": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "68"
     },
     "6y": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "68"
     },
     "7a": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "79"
     },
     "7b": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "68"
     },
     "7c": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "7b"
     },
     "7d": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "68"
     },
     "7e": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "7d"
     },
     "7f": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "68"
     },
     "7g": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "7f"
     },
     "7h": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "68"
     },
     "7i": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "7h"
     },
     "7j": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "68"
     },
     "7k": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "7j"
     },
     "7l": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "68"
     },
     "7m": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "7l"
     },
     "7n": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "68"
     },
     "7o": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "7n"
     },
     "7p": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "66"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "68"
     },
     "7q": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "7p"
     },
     "7r": {
-      "key": "root.imports.requests",
-      "~k_parent": "59"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "68"
     },
     "7s": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "7r"
     },
     "7t": {
-      "key": "root.imports.operators",
-      "~k_parent": "59"
+      "key": "root.imports.requests",
+      "~k_parent": "5a"
     },
     "7u": {
-      "key": "root.imports.operators.client",
+      "key": "root.imports.requests[0]",
       "~k_parent": "7t"
     },
     "7v": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "7u"
+      "key": "root.imports.operators",
+      "~k_parent": "5a"
     },
     "7w": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "7u"
+      "key": "root.imports.operators.client",
+      "~k_parent": "7v"
     },
     "7x": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "7t"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "7w"
     },
     "7y": {
-      "key": "root.imports.operators.server[0]",
-      "~k_parent": "7x"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "7w"
+    },
+    "7z": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "7v"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "27"
   },
@@ -1832,6 +1841,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -7128,170 +7138,173 @@
       },
       "~k": "44"
     },
+    "agents": {
+      "~k": "47"
+    },
     "auth": {
       "adapters": {
-        "~k": "48"
-      },
-      "callbacks": {
         "~k": "49"
       },
-      "events": {
+      "callbacks": {
         "~k": "4a"
       },
-      "providers": {
+      "events": {
         "~k": "4b"
       },
-      "~k": "47"
+      "providers": {
+        "~k": "4c"
+      },
+      "~k": "48"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 8,
-        "~k": "4d"
+        "~k": "4e"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "4e"
+        "~k": "4f"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "4f"
+        "~k": "4g"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "4g"
+        "~k": "4h"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4h"
+        "~k": "4i"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4i"
+        "~k": "4j"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4j"
+        "~k": "4k"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4k"
+        "~k": "4l"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4l"
+        "~k": "4m"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4m"
+        "~k": "4n"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4n"
+        "~k": "4o"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4o"
+        "~k": "4p"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4p"
+        "~k": "4q"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4q"
+        "~k": "4r"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4r"
+        "~k": "4s"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4s"
+        "~k": "4t"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4t"
+        "~k": "4u"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4u"
+        "~k": "4v"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4v"
+        "~k": "4w"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4w"
+        "~k": "4x"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4x"
+        "~k": "4y"
       },
-      "~k": "4c"
+      "~k": "4d"
     },
     "connections": {
       "MongoDBCollection": {
         "originalTypeName": "MongoDBCollection",
         "package": "@lowdefy/connection-mongodb",
         "count": 2,
-        "~k": "4z"
+        "~k": "50"
       },
-      "~k": "4y"
+      "~k": "4z"
     },
     "requests": {
       "MongoDBFind": {
         "originalTypeName": "MongoDBFind",
         "package": "@lowdefy/connection-mongodb",
         "count": 2,
-        "~k": "51"
+        "~k": "52"
       },
-      "~k": "50"
+      "~k": "51"
     },
     "api": {
-      "~k": "52"
+      "~k": "53"
     },
     "operators": {
       "client": {
@@ -7299,26 +7312,26 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "55"
+          "~k": "56"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "56"
+          "~k": "57"
         },
-        "~k": "54"
+        "~k": "55"
       },
       "server": {
         "_secret": {
           "originalTypeName": "_secret",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "58"
+          "~k": "59"
         },
-        "~k": "57"
+        "~k": "58"
       },
-      "~k": "53"
+      "~k": "54"
     },
     "~k": "43"
   }

--- a/packages/build/src/tests/success/62-module-with-connections/snapshot.json
+++ b/packages/build/src/tests/success/62-module-with-connections/snapshot.json
@@ -162,136 +162,136 @@
       "~k_parent": "24"
     },
     "27": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "23"
     },
     "28": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "27"
+      "key": "root.types.auth",
+      "~k_parent": "23"
     },
     "29": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "27"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "28"
     },
     "30": {
+      "key": "root.types.requests.SendGridMailSend",
+      "~k_parent": "2z"
+    },
+    "31": {
       "key": "root.types.api",
       "~k_parent": "23"
     },
-    "31": {
+    "32": {
       "key": "root.types.operators",
       "~k_parent": "23"
     },
-    "32": {
-      "key": "root.types.operators.client",
-      "~k_parent": "31"
-    },
     "33": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "32"
     },
     "34": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "32"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "33"
     },
     "35": {
-      "key": "root.types.operators.server",
-      "~k_parent": "31"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "33"
     },
     "36": {
-      "key": "root.types.operators.server._secret",
-      "~k_parent": "35"
+      "key": "root.types.operators.server",
+      "~k_parent": "32"
     },
     "37": {
+      "key": "root.types.operators.server._secret",
+      "~k_parent": "36"
+    },
+    "38": {
       "key": "root.imports",
       "~k_parent": "5"
     },
-    "38": {
-      "key": "root.imports.actions",
-      "~k_parent": "37"
-    },
     "39": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "38"
     },
     "40": {
-      "key": "root.imports.connections",
-      "~k_parent": "37"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3i"
     },
     "41": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3i"
     },
     "42": {
-      "key": "root.imports.icons",
-      "~k_parent": "37"
+      "key": "root.imports.connections",
+      "~k_parent": "38"
     },
     "43": {
-      "key": "root.imports.icons[0]",
+      "key": "root.imports.connections[0]",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "43"
+      "key": "root.imports.icons",
+      "~k_parent": "38"
     },
     "45": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "44"
     },
     "48": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "44"
     },
     "50": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "44"
     },
     "52": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "44"
     },
     "54": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "44"
     },
     "56": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "44"
     },
     "58": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "44"
     },
     "a": {
       "key": "root.pages[1:notify/inbox:Box].blocks[0:send-btn:Button]",
@@ -514,402 +514,411 @@
       "~k_parent": "1y"
     },
     "2a": {
-      "key": "root.types.auth.events",
-      "~k_parent": "27"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "28"
     },
     "2b": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "27"
+      "key": "root.types.auth.events",
+      "~k_parent": "28"
     },
     "2c": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "28"
+    },
+    "2d": {
       "key": "root.types.blocks",
       "~k_parent": "23"
     },
-    "2d": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2c"
-    },
     "2e": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2d"
     },
     "2f": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2d"
     },
     "2g": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2d"
     },
     "2h": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2d"
     },
     "2i": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2d"
     },
     "2j": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2d"
     },
     "2k": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2d"
     },
     "2l": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2d"
     },
     "2m": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2d"
     },
     "2n": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2d"
     },
     "2o": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2d"
     },
     "2p": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2d"
     },
     "2q": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2d"
     },
     "2r": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2d"
     },
     "2s": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2d"
     },
     "2t": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2d"
     },
     "2u": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2d"
     },
     "2v": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2d"
     },
     "2w": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2d"
+    },
+    "2x": {
       "key": "root.types.connections",
       "~k_parent": "23"
     },
-    "2x": {
-      "key": "root.types.connections.SendGridMail",
-      "~k_parent": "2w"
-    },
     "2y": {
+      "key": "root.types.connections.SendGridMail",
+      "~k_parent": "2x"
+    },
+    "2z": {
       "key": "root.types.requests",
       "~k_parent": "23"
     },
-    "2z": {
-      "key": "root.types.requests.SendGridMailSend",
-      "~k_parent": "2y"
-    },
     "3a": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "38"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "39"
     },
     "3b": {
-      "key": "root.imports.auth",
-      "~k_parent": "37"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "39"
     },
     "3c": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3b"
+      "key": "root.imports.agents",
+      "~k_parent": "38"
     },
     "3d": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3b"
+      "key": "root.imports.auth",
+      "~k_parent": "38"
     },
     "3e": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3b"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3d"
     },
     "3f": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3b"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3d"
     },
     "3g": {
-      "key": "root.imports.blocks",
-      "~k_parent": "37"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3d"
     },
     "3h": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3g"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3d"
     },
     "3i": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks",
+      "~k_parent": "38"
     },
     "3j": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3i"
     },
     "3l": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3i"
     },
     "3m": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3i"
     },
     "3n": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3i"
     },
     "3o": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3i"
     },
     "3p": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3i"
     },
     "3q": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3i"
     },
     "3r": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3i"
     },
     "3s": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3i"
     },
     "3t": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3i"
     },
     "3u": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3i"
     },
     "3v": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3i"
     },
     "3w": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3i"
     },
     "3x": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3i"
     },
     "3y": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3i"
     },
     "3z": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3i"
     },
     "4a": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "44"
     },
     "4c": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "44"
     },
     "4e": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "44"
     },
     "4g": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "44"
     },
     "4i": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "44"
     },
     "4k": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "44"
     },
     "4m": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "44"
     },
     "4o": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "44"
     },
     "4q": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "44"
     },
     "4s": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "44"
     },
     "4u": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "44"
     },
     "4w": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "44"
     },
     "4y": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "44"
     },
     "5a": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "44"
     },
     "5c": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "44"
     },
     "5e": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "44"
     },
     "5g": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "44"
     },
     "5i": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "44"
     },
     "5k": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "42"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "44"
     },
     "5m": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.requests",
-      "~k_parent": "37"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "44"
     },
     "5o": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.operators",
-      "~k_parent": "37"
+      "key": "root.imports.requests",
+      "~k_parent": "38"
     },
     "5q": {
-      "key": "root.imports.operators.client",
+      "key": "root.imports.requests[0]",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5q"
+      "key": "root.imports.operators",
+      "~k_parent": "38"
     },
     "5s": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5q"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "5p"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5s"
     },
     "5u": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5s"
+    },
+    "5v": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "5r"
+    },
+    "5w": {
       "key": "root.imports.operators.server[0]",
-      "~k_parent": "5t"
+      "~k_parent": "5v"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "10"
   },
@@ -1169,6 +1178,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5705,158 +5715,161 @@
       },
       "~k": "24"
     },
+    "agents": {
+      "~k": "27"
+    },
     "auth": {
       "adapters": {
-        "~k": "28"
-      },
-      "callbacks": {
         "~k": "29"
       },
-      "events": {
+      "callbacks": {
         "~k": "2a"
       },
-      "providers": {
+      "events": {
         "~k": "2b"
       },
-      "~k": "27"
+      "providers": {
+        "~k": "2c"
+      },
+      "~k": "28"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
-      "~k": "2c"
+      "~k": "2d"
     },
     "connections": {
       "SendGridMail": {
         "originalTypeName": "SendGridMail",
         "package": "@lowdefy/connection-sendgrid",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
-      "~k": "2w"
+      "~k": "2x"
     },
     "requests": {
       "SendGridMailSend": {
         "originalTypeName": "SendGridMailSend",
         "package": "@lowdefy/connection-sendgrid",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
-      "~k": "2y"
+      "~k": "2z"
     },
     "api": {
-      "~k": "30"
+      "~k": "31"
     },
     "operators": {
       "client": {
@@ -5864,26 +5877,26 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "33"
+          "~k": "34"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "34"
+          "~k": "35"
         },
-        "~k": "32"
+        "~k": "33"
       },
       "server": {
         "_secret": {
           "originalTypeName": "_secret",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "36"
+          "~k": "37"
         },
-        "~k": "35"
+        "~k": "36"
       },
-      "~k": "31"
+      "~k": "32"
     },
     "~k": "23"
   }

--- a/packages/build/src/tests/success/63-module-connection-remapping/snapshot.json
+++ b/packages/build/src/tests/success/63-module-connection-remapping/snapshot.json
@@ -182,163 +182,163 @@
       "~k_parent": "26"
     },
     "30": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2z"
+      "key": "root.types.blocks",
+      "~k_parent": "2q"
     },
     "31": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "30"
     },
     "32": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "30"
     },
     "33": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "30"
     },
     "34": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "30"
     },
     "35": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "30"
     },
     "36": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "30"
     },
     "37": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "30"
     },
     "38": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "30"
     },
     "39": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.List",
+      "~k_parent": "30"
     },
     "40": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3z"
+      "key": "root.imports.agents",
+      "~k_parent": "3w"
     },
     "41": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3z"
+      "key": "root.imports.auth",
+      "~k_parent": "3w"
     },
     "42": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3z"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3z"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "41"
     },
     "44": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3v"
+      "key": "root.imports.auth.events",
+      "~k_parent": "41"
     },
     "45": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "44"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "41"
     },
     "46": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks",
+      "~k_parent": "3w"
     },
     "47": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "46"
     },
     "49": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "46"
     },
     "50": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4t"
     },
     "51": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4t"
     },
     "53": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4t"
     },
     "55": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4t"
     },
     "57": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4t"
     },
     "59": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4t"
     },
     "61": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4t"
     },
     "63": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4t"
     },
     "65": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4t"
     },
     "67": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4t"
     },
     "69": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "68"
     },
     "a": {
@@ -662,382 +662,391 @@
       "~k_parent": "2r"
     },
     "2u": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "2q"
     },
     "2v": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2u"
-    },
-    "2w": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2u"
-    },
-    "2x": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2u"
-    },
-    "2y": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2u"
-    },
-    "2z": {
-      "key": "root.types.blocks",
+      "key": "root.types.auth",
       "~k_parent": "2q"
     },
+    "2w": {
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2v"
+    },
+    "2x": {
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2v"
+    },
+    "2y": {
+      "key": "root.types.auth.events",
+      "~k_parent": "2v"
+    },
+    "2z": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2v"
+    },
     "3a": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "30"
     },
     "3b": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "30"
     },
     "3c": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "30"
     },
     "3d": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "30"
     },
     "3e": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "30"
     },
     "3f": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "30"
     },
     "3g": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "30"
     },
     "3h": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "30"
     },
     "3i": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2z"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "30"
     },
     "3j": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "30"
+    },
+    "3k": {
       "key": "root.types.connections",
       "~k_parent": "2q"
     },
-    "3k": {
-      "key": "root.types.connections.MongoDBCollection",
-      "~k_parent": "3j"
-    },
     "3l": {
-      "key": "root.types.connections.SendGridMail",
-      "~k_parent": "3j"
+      "key": "root.types.connections.MongoDBCollection",
+      "~k_parent": "3k"
     },
     "3m": {
+      "key": "root.types.connections.SendGridMail",
+      "~k_parent": "3k"
+    },
+    "3n": {
       "key": "root.types.requests",
       "~k_parent": "2q"
     },
-    "3n": {
-      "key": "root.types.requests.SendGridMailSend",
-      "~k_parent": "3m"
-    },
     "3o": {
+      "key": "root.types.requests.SendGridMailSend",
+      "~k_parent": "3n"
+    },
+    "3p": {
       "key": "root.types.api",
       "~k_parent": "2q"
     },
-    "3p": {
+    "3q": {
       "key": "root.types.operators",
       "~k_parent": "2q"
     },
-    "3q": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3p"
-    },
     "3r": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3q"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3p"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3r"
     },
     "3u": {
-      "key": "root.types.operators.server._secret",
-      "~k_parent": "3t"
+      "key": "root.types.operators.server",
+      "~k_parent": "3q"
     },
     "3v": {
+      "key": "root.types.operators.server._secret",
+      "~k_parent": "3u"
+    },
+    "3w": {
       "key": "root.imports",
       "~k_parent": "8"
     },
-    "3w": {
-      "key": "root.imports.actions",
-      "~k_parent": "3v"
-    },
     "3x": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3w"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.auth",
-      "~k_parent": "3v"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3x"
     },
     "4a": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "46"
     },
     "4b": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "46"
     },
     "4c": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "46"
     },
     "4d": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "46"
     },
     "4e": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "46"
     },
     "4f": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "46"
     },
     "4g": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "46"
     },
     "4h": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "46"
     },
     "4i": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "46"
     },
     "4j": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "46"
     },
     "4k": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "46"
     },
     "4l": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "46"
     },
     "4m": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "46"
     },
     "4n": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "46"
     },
     "4o": {
-      "key": "root.imports.connections",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "46"
     },
     "4p": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "46"
     },
     "4q": {
-      "key": "root.imports.connections[1]",
-      "~k_parent": "4o"
+      "key": "root.imports.connections",
+      "~k_parent": "3w"
     },
     "4r": {
-      "key": "root.imports.icons",
-      "~k_parent": "3v"
+      "key": "root.imports.connections[0]",
+      "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4r"
+      "key": "root.imports.connections[1]",
+      "~k_parent": "4q"
     },
     "4t": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4s"
+      "key": "root.imports.icons",
+      "~k_parent": "3w"
     },
     "4u": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4t"
     },
     "4x": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4t"
     },
     "4z": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4t"
     },
     "5b": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4t"
     },
     "5d": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4t"
     },
     "5f": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4t"
     },
     "5h": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4t"
     },
     "5j": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4t"
     },
     "5l": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4t"
     },
     "5n": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4t"
     },
     "5p": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4t"
     },
     "5r": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4t"
     },
     "5t": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4t"
     },
     "5v": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4t"
     },
     "5x": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4t"
     },
     "5z": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4t"
     },
     "6b": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.requests",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4t"
     },
     "6d": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.operators",
-      "~k_parent": "3v"
+      "key": "root.imports.requests",
+      "~k_parent": "3w"
     },
     "6f": {
-      "key": "root.imports.operators.client",
+      "key": "root.imports.requests[0]",
       "~k_parent": "6e"
     },
     "6g": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6f"
+      "key": "root.imports.operators",
+      "~k_parent": "3w"
     },
     "6h": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6f"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6g"
     },
     "6i": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "6e"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6h"
     },
     "6j": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6h"
+    },
+    "6k": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "6g"
+    },
+    "6l": {
       "key": "root.imports.operators.server[0]",
-      "~k_parent": "6i"
+      "~k_parent": "6k"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "1e"
   },
@@ -1372,6 +1381,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5921,164 +5931,167 @@
       },
       "~k": "2r"
     },
+    "agents": {
+      "~k": "2u"
+    },
     "auth": {
       "adapters": {
-        "~k": "2v"
-      },
-      "callbacks": {
         "~k": "2w"
       },
-      "events": {
+      "callbacks": {
         "~k": "2x"
       },
-      "providers": {
+      "events": {
         "~k": "2y"
       },
-      "~k": "2u"
+      "providers": {
+        "~k": "2z"
+      },
+      "~k": "2v"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "30"
+        "~k": "31"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "31"
+        "~k": "32"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3f"
+        "~k": "3g"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3h"
+        "~k": "3i"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3i"
+        "~k": "3j"
       },
-      "~k": "2z"
+      "~k": "30"
     },
     "connections": {
       "MongoDBCollection": {
         "originalTypeName": "MongoDBCollection",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "3k"
+        "~k": "3l"
       },
       "SendGridMail": {
         "originalTypeName": "SendGridMail",
         "package": "@lowdefy/connection-sendgrid",
         "count": 2,
-        "~k": "3l"
+        "~k": "3m"
       },
-      "~k": "3j"
+      "~k": "3k"
     },
     "requests": {
       "SendGridMailSend": {
         "originalTypeName": "SendGridMailSend",
         "package": "@lowdefy/connection-sendgrid",
         "count": 2,
-        "~k": "3n"
+        "~k": "3o"
       },
-      "~k": "3m"
+      "~k": "3n"
     },
     "api": {
-      "~k": "3o"
+      "~k": "3p"
     },
     "operators": {
       "client": {
@@ -6086,26 +6099,26 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3r"
+          "~k": "3s"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3s"
+          "~k": "3t"
         },
-        "~k": "3q"
+        "~k": "3r"
       },
       "server": {
         "_secret": {
           "originalTypeName": "_secret",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3u"
+          "~k": "3v"
         },
-        "~k": "3t"
+        "~k": "3u"
       },
-      "~k": "3p"
+      "~k": "3q"
     },
     "~k": "2q"
   }

--- a/packages/build/src/tests/success/64-module-exposed-component/snapshot.json
+++ b/packages/build/src/tests/success/64-module-exposed-component/snapshot.json
@@ -117,164 +117,164 @@
       "~k_parent": "p"
     },
     "20": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1x"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1y"
     },
     "21": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1x"
+      "key": "root.types.auth.events",
+      "~k_parent": "1y"
     },
     "22": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1y"
+    },
+    "23": {
       "key": "root.types.blocks",
       "~k_parent": "1t"
     },
-    "23": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "22"
-    },
     "24": {
-      "key": "root.types.blocks.Badge",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "23"
     },
     "25": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Badge",
+      "~k_parent": "23"
     },
     "26": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "23"
     },
     "27": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "23"
     },
     "28": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "23"
     },
     "29": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "22"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "23"
     },
     "30": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2z"
+      "key": "root.imports.agents",
+      "~k_parent": "2w"
     },
     "31": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2z"
+      "key": "root.imports.auth",
+      "~k_parent": "2w"
     },
     "32": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2z"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "31"
     },
     "33": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2z"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "31"
     },
     "34": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2v"
+      "key": "root.imports.auth.events",
+      "~k_parent": "31"
     },
     "35": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "34"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "31"
     },
     "36": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks",
+      "~k_parent": "2w"
     },
     "37": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "36"
     },
     "38": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "36"
     },
     "39": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "36"
     },
     "40": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3s"
     },
     "42": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3s"
     },
     "44": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3s"
     },
     "46": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3s"
     },
     "48": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3s"
     },
     "50": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3s"
     },
     "52": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3s"
     },
     "54": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3s"
     },
     "56": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3s"
     },
     "58": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3s"
     },
     "a": {
       "key": "root.pages[0:dashboard:Box].blocks[0:header:Box]",
@@ -471,358 +471,367 @@
       "~k_parent": "1u"
     },
     "1x": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1t"
     },
     "1y": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1x"
+      "key": "root.types.auth",
+      "~k_parent": "1t"
     },
     "1z": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1x"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1y"
     },
     "2a": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "23"
     },
     "2b": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "23"
     },
     "2c": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "23"
     },
     "2d": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "22"
+      "key": "root.types.blocks.List",
+      "~k_parent": "23"
     },
     "2e": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "23"
     },
     "2f": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "23"
     },
     "2g": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "22"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "23"
     },
     "2h": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "23"
     },
     "2i": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "22"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "23"
     },
     "2j": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "22"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "23"
     },
     "2k": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "22"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "23"
     },
     "2l": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "22"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "23"
     },
     "2m": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "23"
     },
     "2n": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "23"
+    },
+    "2o": {
       "key": "root.types.connections",
       "~k_parent": "1t"
     },
-    "2o": {
+    "2p": {
       "key": "root.types.requests",
       "~k_parent": "1t"
     },
-    "2p": {
+    "2q": {
       "key": "root.types.api",
       "~k_parent": "1t"
     },
-    "2q": {
+    "2r": {
       "key": "root.types.operators",
       "~k_parent": "1t"
     },
-    "2r": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2r"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2q"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2s"
     },
     "2v": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2r"
+    },
+    "2w": {
       "key": "root.imports",
       "~k_parent": "6"
     },
-    "2w": {
-      "key": "root.imports.actions",
-      "~k_parent": "2v"
-    },
     "2x": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2w"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.auth",
-      "~k_parent": "2v"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2x"
     },
     "3a": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "36"
     },
     "3b": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "36"
     },
     "3c": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "36"
     },
     "3d": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "36"
     },
     "3e": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "36"
     },
     "3f": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "36"
     },
     "3g": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "36"
     },
     "3h": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "36"
     },
     "3i": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "36"
     },
     "3j": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "36"
     },
     "3k": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "36"
     },
     "3l": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "36"
     },
     "3m": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "36"
     },
     "3n": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "36"
     },
     "3o": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "36"
     },
     "3p": {
-      "key": "root.imports.connections",
-      "~k_parent": "2v"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "36"
     },
     "3q": {
-      "key": "root.imports.icons",
-      "~k_parent": "2v"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "36"
     },
     "3r": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3q"
+      "key": "root.imports.connections",
+      "~k_parent": "2w"
     },
     "3s": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3r"
+      "key": "root.imports.icons",
+      "~k_parent": "2w"
     },
     "3t": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3s"
     },
     "3w": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3s"
     },
     "3y": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3s"
     },
     "4a": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3s"
     },
     "4c": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3s"
     },
     "4e": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3s"
     },
     "4g": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3s"
     },
     "4i": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3s"
     },
     "4k": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3s"
     },
     "4m": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3s"
     },
     "4o": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3s"
     },
     "4q": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3s"
     },
     "4s": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3s"
     },
     "4u": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3s"
     },
     "4w": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3s"
     },
     "4y": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3s"
     },
     "5a": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.requests",
-      "~k_parent": "2v"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3s"
     },
     "5c": {
-      "key": "root.imports.operators",
-      "~k_parent": "2v"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5c"
+      "key": "root.imports.requests",
+      "~k_parent": "2w"
     },
     "5e": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5d"
+      "key": "root.imports.operators",
+      "~k_parent": "2w"
     },
     "5f": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5d"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5e"
     },
     "5g": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5f"
+    },
+    "5h": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5f"
+    },
+    "5i": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5c"
+      "~k_parent": "5e"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "v"
   },
@@ -1044,6 +1053,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5959,152 +5969,155 @@
       },
       "~k": "1u"
     },
+    "agents": {
+      "~k": "1x"
+    },
     "auth": {
       "adapters": {
-        "~k": "1y"
-      },
-      "callbacks": {
         "~k": "1z"
       },
-      "events": {
+      "callbacks": {
         "~k": "20"
       },
-      "providers": {
+      "events": {
         "~k": "21"
       },
-      "~k": "1x"
+      "providers": {
+        "~k": "22"
+      },
+      "~k": "1y"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "23"
+        "~k": "24"
       },
       "Badge": {
         "originalTypeName": "Badge",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
-      "~k": "22"
+      "~k": "23"
     },
     "connections": {
-      "~k": "2n"
-    },
-    "requests": {
       "~k": "2o"
     },
-    "api": {
+    "requests": {
       "~k": "2p"
+    },
+    "api": {
+      "~k": "2q"
     },
     "operators": {
       "client": {
@@ -6112,20 +6125,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2s"
+          "~k": "2t"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2t"
+          "~k": "2u"
         },
-        "~k": "2r"
+        "~k": "2s"
       },
       "server": {
-        "~k": "2u"
+        "~k": "2v"
       },
-      "~k": "2q"
+      "~k": "2r"
     },
     "~k": "1t"
   }

--- a/packages/build/src/tests/success/65-module-exposed-menu/snapshot.json
+++ b/packages/build/src/tests/success/65-module-exposed-menu/snapshot.json
@@ -159,124 +159,124 @@
       "~k_parent": "5"
     },
     "30": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2j"
     },
     "31": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2j"
     },
     "32": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2j"
     },
     "33": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2j"
+    },
+    "34": {
       "key": "root.types.connections",
       "~k_parent": "29"
     },
-    "34": {
+    "35": {
       "key": "root.types.requests",
       "~k_parent": "29"
     },
-    "35": {
+    "36": {
       "key": "root.types.api",
       "~k_parent": "29"
     },
-    "36": {
+    "37": {
       "key": "root.types.operators",
       "~k_parent": "29"
     },
-    "37": {
-      "key": "root.types.operators.client",
-      "~k_parent": "36"
-    },
     "38": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "37"
     },
     "39": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "37"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "38"
     },
     "40": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3m"
     },
     "41": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3m"
     },
     "42": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3m"
     },
     "43": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3m"
     },
     "44": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3m"
     },
     "45": {
-      "key": "root.imports.connections",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3m"
     },
     "46": {
-      "key": "root.imports.icons",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3m"
     },
     "47": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "46"
+      "key": "root.imports.connections",
+      "~k_parent": "3c"
     },
     "48": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "47"
+      "key": "root.imports.icons",
+      "~k_parent": "3c"
     },
     "49": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "48"
     },
     "52": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "48"
     },
     "54": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "48"
     },
     "56": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "48"
     },
     "58": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "48"
     },
     "a": {
       "key": "root.menus[0:main].links[0:home:MenuLink].properties",
@@ -523,398 +523,407 @@
       "~k_parent": "2a"
     },
     "2d": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "29"
     },
     "2e": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2d"
+      "key": "root.types.auth",
+      "~k_parent": "29"
     },
     "2f": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2d"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2e"
     },
     "2g": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2d"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2e"
     },
     "2h": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2d"
+      "key": "root.types.auth.events",
+      "~k_parent": "2e"
     },
     "2i": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2e"
+    },
+    "2j": {
       "key": "root.types.blocks",
       "~k_parent": "29"
     },
-    "2j": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2i"
-    },
     "2k": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2j"
     },
     "2l": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2j"
     },
     "2m": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2j"
     },
     "2n": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2j"
     },
     "2o": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2j"
     },
     "2p": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2j"
     },
     "2q": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2j"
     },
     "2r": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2j"
     },
     "2s": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2j"
     },
     "2t": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2j"
     },
     "2u": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2j"
     },
     "2v": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2j"
     },
     "2w": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2j"
     },
     "2x": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2j"
     },
     "2y": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2j"
     },
     "2z": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2j"
     },
     "3a": {
-      "key": "root.types.operators.server",
-      "~k_parent": "36"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "38"
     },
     "3b": {
+      "key": "root.types.operators.server",
+      "~k_parent": "37"
+    },
+    "3c": {
       "key": "root.imports",
       "~k_parent": "5"
     },
-    "3c": {
-      "key": "root.imports.actions",
-      "~k_parent": "3b"
-    },
     "3d": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3c"
     },
     "3e": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3c"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3d"
     },
     "3f": {
-      "key": "root.imports.auth",
-      "~k_parent": "3b"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3d"
     },
     "3g": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3f"
+      "key": "root.imports.agents",
+      "~k_parent": "3c"
     },
     "3h": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3f"
+      "key": "root.imports.auth",
+      "~k_parent": "3c"
     },
     "3i": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3f"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3f"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3h"
     },
     "3k": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3b"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3h"
     },
     "3l": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3k"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3h"
     },
     "3m": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks",
+      "~k_parent": "3c"
     },
     "3n": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3m"
     },
     "3p": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3m"
     },
     "3r": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3m"
     },
     "3t": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3m"
     },
     "3u": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3m"
     },
     "3v": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3m"
     },
     "3w": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3m"
     },
     "3x": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3m"
     },
     "3y": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3m"
     },
     "3z": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3m"
     },
     "4a": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "48"
     },
     "4c": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "48"
     },
     "4e": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "48"
     },
     "4g": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "48"
     },
     "4i": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "48"
     },
     "4k": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "48"
     },
     "4m": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "48"
     },
     "4o": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "48"
     },
     "4q": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "48"
     },
     "4s": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "48"
     },
     "4u": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "48"
     },
     "4w": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "48"
     },
     "4y": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "48"
     },
     "5a": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "48"
     },
     "5c": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "48"
     },
     "5e": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "48"
     },
     "5g": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "48"
     },
     "5i": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "48"
     },
     "5k": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "48"
     },
     "5m": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "48"
     },
     "5o": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "48"
     },
     "5q": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.requests",
-      "~k_parent": "3b"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "48"
     },
     "5s": {
-      "key": "root.imports.operators",
-      "~k_parent": "3b"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5s"
+      "key": "root.imports.requests",
+      "~k_parent": "3c"
     },
     "5u": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5t"
+      "key": "root.imports.operators",
+      "~k_parent": "3c"
     },
     "5v": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5t"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5u"
     },
     "5w": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5v"
+    },
+    "5x": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5v"
+    },
+    "5y": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5s"
+      "~k_parent": "5u"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "16"
   },
@@ -1203,6 +1212,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5718,152 +5728,155 @@
       },
       "~k": "2a"
     },
+    "agents": {
+      "~k": "2d"
+    },
     "auth": {
       "adapters": {
-        "~k": "2e"
-      },
-      "callbacks": {
         "~k": "2f"
       },
-      "events": {
+      "callbacks": {
         "~k": "2g"
       },
-      "providers": {
+      "events": {
         "~k": "2h"
       },
-      "~k": "2d"
+      "providers": {
+        "~k": "2i"
+      },
+      "~k": "2e"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
-      "~k": "2i"
+      "~k": "2j"
     },
     "connections": {
-      "~k": "33"
-    },
-    "requests": {
       "~k": "34"
     },
-    "api": {
+    "requests": {
       "~k": "35"
+    },
+    "api": {
+      "~k": "36"
     },
     "operators": {
       "client": {
@@ -5871,20 +5884,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "38"
+          "~k": "39"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "39"
+          "~k": "3a"
         },
-        "~k": "37"
+        "~k": "38"
       },
       "server": {
-        "~k": "3a"
+        "~k": "3b"
       },
-      "~k": "36"
+      "~k": "37"
     },
     "~k": "29"
   }

--- a/packages/build/src/tests/success/66-module-with-api/snapshot.json
+++ b/packages/build/src/tests/success/66-module-with-api/snapshot.json
@@ -209,164 +209,164 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2o"
     },
     "31": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2o"
     },
     "32": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2o"
     },
     "33": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2o"
     },
     "34": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2o"
     },
     "35": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2o"
     },
     "36": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2o"
     },
     "37": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2o"
     },
     "38": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2o"
+    },
+    "39": {
       "key": "root.types.connections",
       "~k_parent": "2d"
     },
-    "39": {
-      "key": "root.types.connections.SendGridMail",
-      "~k_parent": "38"
-    },
     "40": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3w"
     },
     "41": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3w"
     },
     "42": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3w"
     },
     "43": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3w"
     },
     "44": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3w"
     },
     "45": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3w"
     },
     "46": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3w"
     },
     "47": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3w"
     },
     "48": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3w"
     },
     "49": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3w"
     },
     "50": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4j"
     },
     "51": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4j"
     },
     "53": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4j"
     },
     "55": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4j"
     },
     "57": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4j"
     },
     "59": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4j"
     },
     "61": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.requests",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4j"
     },
     "63": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.operators",
-      "~k_parent": "3k"
+      "key": "root.imports.requests",
+      "~k_parent": "3l"
     },
     "65": {
-      "key": "root.imports.operators.client",
+      "key": "root.imports.requests[0]",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "65"
+      "key": "root.imports.operators",
+      "~k_parent": "3l"
     },
     "67": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "65"
+      "key": "root.imports.operators.client",
+      "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "64"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.operators.server[0]",
-      "~k_parent": "68"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "67"
     },
     "a": {
       "key": "root.pages[1:inviter/invite:Box].blocks[0:message:Paragraph]",
@@ -633,394 +633,403 @@
       "~k_parent": "2e"
     },
     "2i": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "2d"
     },
     "2j": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2i"
+      "key": "root.types.auth",
+      "~k_parent": "2d"
     },
     "2k": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2i"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2j"
     },
     "2l": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2i"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2j"
     },
     "2m": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2i"
+      "key": "root.types.auth.events",
+      "~k_parent": "2j"
     },
     "2n": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2j"
+    },
+    "2o": {
       "key": "root.types.blocks",
       "~k_parent": "2d"
     },
-    "2o": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2n"
-    },
     "2p": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2o"
     },
     "2q": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "2o"
     },
     "2r": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2o"
     },
     "2s": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2o"
     },
     "2t": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2o"
     },
     "2u": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2o"
     },
     "2v": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2o"
     },
     "2w": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2o"
     },
     "2x": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2o"
     },
     "2y": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2o"
     },
     "2z": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2n"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2o"
     },
     "3a": {
+      "key": "root.types.connections.SendGridMail",
+      "~k_parent": "39"
+    },
+    "3b": {
       "key": "root.types.requests",
       "~k_parent": "2d"
     },
-    "3b": {
-      "key": "root.types.requests.SendGridMailSend",
-      "~k_parent": "3a"
-    },
     "3c": {
+      "key": "root.types.requests.SendGridMailSend",
+      "~k_parent": "3b"
+    },
+    "3d": {
       "key": "root.types.api",
       "~k_parent": "2d"
     },
-    "3d": {
+    "3e": {
       "key": "root.types.operators",
       "~k_parent": "2d"
     },
-    "3e": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3d"
-    },
     "3f": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3e"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3d"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3f"
     },
     "3i": {
-      "key": "root.types.operators.server._secret",
-      "~k_parent": "3h"
+      "key": "root.types.operators.server",
+      "~k_parent": "3e"
     },
     "3j": {
-      "key": "root.types.operators.server._payload",
-      "~k_parent": "3h"
+      "key": "root.types.operators.server._secret",
+      "~k_parent": "3i"
     },
     "3k": {
+      "key": "root.types.operators.server._payload",
+      "~k_parent": "3i"
+    },
+    "3l": {
       "key": "root.imports",
       "~k_parent": "5"
     },
-    "3l": {
-      "key": "root.imports.actions",
-      "~k_parent": "3k"
-    },
     "3m": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3l"
     },
     "3n": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3l"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "3l"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3m"
     },
     "3p": {
-      "key": "root.imports.auth",
-      "~k_parent": "3k"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3p"
+      "key": "root.imports.agents",
+      "~k_parent": "3l"
     },
     "3r": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3p"
+      "key": "root.imports.auth",
+      "~k_parent": "3l"
     },
     "3s": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3p"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3p"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3r"
     },
     "3u": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3k"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3r"
     },
     "3v": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3u"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3r"
     },
     "3w": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks",
+      "~k_parent": "3l"
     },
     "3x": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3w"
     },
     "3z": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3w"
     },
     "4a": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3w"
     },
     "4b": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3w"
     },
     "4c": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3w"
     },
     "4d": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3w"
     },
     "4e": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3w"
     },
     "4f": {
-      "key": "root.imports.connections",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3w"
     },
     "4g": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "4f"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3w"
     },
     "4h": {
-      "key": "root.imports.icons",
-      "~k_parent": "3k"
+      "key": "root.imports.connections",
+      "~k_parent": "3l"
     },
     "4i": {
-      "key": "root.imports.icons[0]",
+      "key": "root.imports.connections[0]",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4i"
+      "key": "root.imports.icons",
+      "~k_parent": "3l"
     },
     "4k": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4j"
     },
     "4n": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4j"
     },
     "4p": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4j"
     },
     "4r": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4j"
     },
     "4t": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4j"
     },
     "4v": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4j"
     },
     "4x": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4j"
     },
     "4z": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4j"
     },
     "5b": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4j"
     },
     "5d": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4j"
     },
     "5f": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4j"
     },
     "5h": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4j"
     },
     "5j": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4j"
     },
     "5l": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4j"
     },
     "5n": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4j"
     },
     "5p": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4j"
     },
     "5r": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4j"
     },
     "5t": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4j"
     },
     "5v": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4j"
     },
     "5x": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4j"
     },
     "5z": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5y"
     },
     "6a": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "66"
+    },
+    "6b": {
+      "key": "root.imports.operators.server[0]",
+      "~k_parent": "6a"
+    },
+    "6c": {
       "key": "root.imports.operators.server[1]",
-      "~k_parent": "68"
+      "~k_parent": "6a"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "19"
   },
@@ -1306,6 +1315,7 @@
     }
   },
   "plugins/actions.js": "import { Request as Request } from '@lowdefy/actions-core/actions';\nimport { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Request,\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5900,164 +5910,167 @@
       },
       "~k": "2e"
     },
+    "agents": {
+      "~k": "2i"
+    },
     "auth": {
       "adapters": {
-        "~k": "2j"
-      },
-      "callbacks": {
         "~k": "2k"
       },
-      "events": {
+      "callbacks": {
         "~k": "2l"
       },
-      "providers": {
+      "events": {
         "~k": "2m"
       },
-      "~k": "2i"
+      "providers": {
+        "~k": "2n"
+      },
+      "~k": "2j"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
-      "~k": "2n"
+      "~k": "2o"
     },
     "connections": {
       "SendGridMail": {
         "originalTypeName": "SendGridMail",
         "package": "@lowdefy/connection-sendgrid",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
-      "~k": "38"
+      "~k": "39"
     },
     "requests": {
       "SendGridMailSend": {
         "originalTypeName": "SendGridMailSend",
         "package": "@lowdefy/connection-sendgrid",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
-      "~k": "3a"
+      "~k": "3b"
     },
     "api": {
-      "~k": "3c"
+      "~k": "3d"
     },
     "operators": {
       "client": {
@@ -6065,32 +6078,32 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3f"
+          "~k": "3g"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3g"
+          "~k": "3h"
         },
-        "~k": "3e"
+        "~k": "3f"
       },
       "server": {
         "_secret": {
           "originalTypeName": "_secret",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3i"
+          "~k": "3j"
         },
         "_payload": {
           "originalTypeName": "_payload",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3j"
+          "~k": "3k"
         },
-        "~k": "3h"
+        "~k": "3i"
       },
-      "~k": "3d"
+      "~k": "3e"
     },
     "~k": "2d"
   }

--- a/packages/build/src/tests/success/67-module-var-defaults/snapshot.json
+++ b/packages/build/src/tests/success/67-module-var-defaults/snapshot.json
@@ -124,163 +124,163 @@
       "~k_parent": "18"
     },
     "20": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1w"
+      "key": "root.types.auth.events",
+      "~k_parent": "1x"
     },
     "21": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1x"
+    },
+    "22": {
       "key": "root.types.blocks",
       "~k_parent": "1s"
     },
-    "22": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "21"
-    },
     "23": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "22"
     },
     "24": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "22"
     },
     "25": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "22"
     },
     "26": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "22"
     },
     "27": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "22"
     },
     "28": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "21"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "22"
     },
     "29": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "22"
     },
     "30": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2y"
+      "key": "root.imports.auth",
+      "~k_parent": "2v"
     },
     "31": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2y"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "30"
     },
     "32": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2y"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "30"
     },
     "33": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2u"
+      "key": "root.imports.auth.events",
+      "~k_parent": "30"
     },
     "34": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "33"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "30"
     },
     "35": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks",
+      "~k_parent": "2v"
     },
     "36": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "35"
     },
     "37": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "35"
     },
     "38": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "35"
     },
     "39": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "35"
     },
     "40": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3r"
     },
     "41": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3r"
     },
     "43": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3r"
     },
     "45": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3r"
     },
     "47": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3r"
     },
     "49": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3r"
     },
     "51": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3r"
     },
     "53": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3r"
     },
     "55": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3r"
     },
     "57": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3r"
     },
     "59": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "58"
     },
     "a": {
@@ -478,358 +478,367 @@
       "~k_parent": "1t"
     },
     "1w": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1s"
     },
     "1x": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1w"
+      "key": "root.types.auth",
+      "~k_parent": "1s"
     },
     "1y": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1w"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1x"
     },
     "1z": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1w"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1x"
     },
     "2a": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "22"
     },
     "2b": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "22"
     },
     "2c": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "21"
+      "key": "root.types.blocks.List",
+      "~k_parent": "22"
     },
     "2d": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "22"
     },
     "2e": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "22"
     },
     "2f": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "21"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "22"
     },
     "2g": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "22"
     },
     "2h": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "21"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "22"
     },
     "2i": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "21"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "22"
     },
     "2j": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "21"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "22"
     },
     "2k": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "21"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "22"
     },
     "2l": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "22"
     },
     "2m": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "22"
+    },
+    "2n": {
       "key": "root.types.connections",
       "~k_parent": "1s"
     },
-    "2n": {
+    "2o": {
       "key": "root.types.requests",
       "~k_parent": "1s"
     },
-    "2o": {
+    "2p": {
       "key": "root.types.api",
       "~k_parent": "1s"
     },
-    "2p": {
+    "2q": {
       "key": "root.types.operators",
       "~k_parent": "1s"
     },
-    "2q": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2p"
-    },
     "2r": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2q"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2p"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2r"
     },
     "2u": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2q"
+    },
+    "2v": {
       "key": "root.imports",
       "~k_parent": "5"
     },
-    "2v": {
-      "key": "root.imports.actions",
-      "~k_parent": "2u"
-    },
     "2w": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2v"
     },
     "2x": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2v"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.imports.auth",
-      "~k_parent": "2u"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2w"
     },
     "2z": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2y"
+      "key": "root.imports.agents",
+      "~k_parent": "2v"
     },
     "3a": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "35"
     },
     "3b": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "35"
     },
     "3c": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "35"
     },
     "3d": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "35"
     },
     "3e": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "35"
     },
     "3f": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "35"
     },
     "3g": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "35"
     },
     "3h": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "35"
     },
     "3i": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "35"
     },
     "3j": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "35"
     },
     "3k": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "35"
     },
     "3l": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "35"
     },
     "3m": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "35"
     },
     "3n": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "35"
     },
     "3o": {
-      "key": "root.imports.connections",
-      "~k_parent": "2u"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "35"
     },
     "3p": {
-      "key": "root.imports.icons",
-      "~k_parent": "2u"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "35"
     },
     "3q": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3p"
+      "key": "root.imports.connections",
+      "~k_parent": "2v"
     },
     "3r": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3q"
+      "key": "root.imports.icons",
+      "~k_parent": "2v"
     },
     "3s": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3r"
     },
     "3v": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3r"
     },
     "3x": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3r"
     },
     "3z": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3r"
     },
     "4b": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3r"
     },
     "4d": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3r"
     },
     "4f": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3r"
     },
     "4h": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3r"
     },
     "4j": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3r"
     },
     "4l": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3r"
     },
     "4n": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3r"
     },
     "4p": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3r"
     },
     "4r": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3r"
     },
     "4t": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3r"
     },
     "4v": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3r"
     },
     "4x": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3r"
     },
     "4z": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.requests",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3r"
     },
     "5b": {
-      "key": "root.imports.operators",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5b"
+      "key": "root.imports.requests",
+      "~k_parent": "2v"
     },
     "5d": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5c"
+      "key": "root.imports.operators",
+      "~k_parent": "2v"
     },
     "5e": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5c"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5d"
     },
     "5f": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5e"
+    },
+    "5g": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5e"
+    },
+    "5h": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5b"
+      "~k_parent": "5d"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "w"
   },
@@ -1053,6 +1062,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5548,152 +5558,155 @@
       },
       "~k": "1t"
     },
+    "agents": {
+      "~k": "1w"
+    },
     "auth": {
       "adapters": {
-        "~k": "1x"
-      },
-      "callbacks": {
         "~k": "1y"
       },
-      "events": {
+      "callbacks": {
         "~k": "1z"
       },
-      "providers": {
+      "events": {
         "~k": "20"
       },
-      "~k": "1w"
+      "providers": {
+        "~k": "21"
+      },
+      "~k": "1x"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "22"
+        "~k": "23"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "23"
+        "~k": "24"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
-      "~k": "21"
+      "~k": "22"
     },
     "connections": {
-      "~k": "2m"
-    },
-    "requests": {
       "~k": "2n"
     },
-    "api": {
+    "requests": {
       "~k": "2o"
+    },
+    "api": {
+      "~k": "2p"
     },
     "operators": {
       "client": {
@@ -5701,20 +5714,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2r"
+          "~k": "2s"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2s"
+          "~k": "2t"
         },
-        "~k": "2q"
+        "~k": "2r"
       },
       "server": {
-        "~k": "2t"
+        "~k": "2u"
       },
-      "~k": "2p"
+      "~k": "2q"
     },
     "~k": "1s"
   }

--- a/packages/build/src/tests/success/68-module-nested-refs/snapshot.json
+++ b/packages/build/src/tests/success/68-module-nested-refs/snapshot.json
@@ -164,148 +164,156 @@
       "~k_parent": "5"
     },
     "30": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2q"
     },
     "31": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2q"
     },
     "32": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2q"
     },
     "33": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2q"
     },
     "34": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2q"
     },
     "35": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2q"
     },
     "36": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2q"
     },
     "37": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2q"
     },
     "38": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2q"
     },
     "39": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2q"
     },
     "40": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3u"
     },
     "41": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3u"
     },
     "42": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3u"
     },
     "43": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3u"
     },
     "44": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3u"
     },
     "45": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3u"
     },
     "46": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3u"
     },
     "47": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3u"
     },
     "48": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3u"
     },
     "49": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3u"
     },
     "50": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4h"
     },
     "51": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4h"
     },
     "53": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4h"
     },
     "55": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4h"
     },
     "57": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4h"
     },
     "59": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.requests",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4h"
     },
     "61": {
-      "key": "root.imports.operators",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "61"
+      "key": "root.imports.requests",
+      "~k_parent": "3k"
     },
     "63": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "62"
+      "key": "root.imports.operators",
+      "~k_parent": "3k"
     },
     "64": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "62"
+      "key": "root.imports.operators.client",
+      "~k_parent": "63"
     },
     "65": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "64"
+    },
+    "66": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "64"
+    },
+    "67": {
       "key": "root.imports.operators.server",
-      "~k_parent": "61"
+      "~k_parent": "63"
     },
     "a": {
       "key": "root.pages[1:dash/overview:Box].blocks[0:page-title:Title]",
@@ -584,382 +592,383 @@
       "~k_parent": "2h"
     },
     "2k": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "2g"
     },
     "2l": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2k"
+      "key": "root.types.auth",
+      "~k_parent": "2g"
     },
     "2m": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2k"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2k"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2l"
     },
     "2o": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2k"
+      "key": "root.types.auth.events",
+      "~k_parent": "2l"
     },
     "2p": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2l"
+    },
+    "2q": {
       "key": "root.types.blocks",
       "~k_parent": "2g"
     },
-    "2q": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2p"
-    },
     "2r": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2q"
     },
     "2t": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "2q"
     },
     "2u": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2q"
     },
     "2v": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2q"
     },
     "2w": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2q"
     },
     "2x": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2q"
     },
     "2y": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2q"
     },
     "2z": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2q"
     },
     "3a": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2p"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2q"
     },
     "3b": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2q"
+    },
+    "3c": {
       "key": "root.types.connections",
       "~k_parent": "2g"
     },
-    "3c": {
+    "3d": {
       "key": "root.types.requests",
       "~k_parent": "2g"
     },
-    "3d": {
+    "3e": {
       "key": "root.types.api",
       "~k_parent": "2g"
     },
-    "3e": {
+    "3f": {
       "key": "root.types.operators",
       "~k_parent": "2g"
     },
-    "3f": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3e"
-    },
     "3g": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3f"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3e"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3g"
     },
     "3j": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3f"
+    },
+    "3k": {
       "key": "root.imports",
       "~k_parent": "5"
     },
-    "3k": {
-      "key": "root.imports.actions",
-      "~k_parent": "3j"
-    },
     "3l": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3k"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3l"
     },
     "3n": {
-      "key": "root.imports.auth",
-      "~k_parent": "3j"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3l"
     },
     "3o": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3n"
+      "key": "root.imports.agents",
+      "~k_parent": "3k"
     },
     "3p": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3n"
+      "key": "root.imports.auth",
+      "~k_parent": "3k"
     },
     "3q": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3n"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3n"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3p"
     },
     "3s": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3j"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3p"
     },
     "3t": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3s"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3p"
     },
     "3u": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks",
+      "~k_parent": "3k"
     },
     "3v": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3u"
     },
     "3x": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3u"
     },
     "3y": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3u"
     },
     "3z": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3u"
     },
     "4a": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3u"
     },
     "4b": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3u"
     },
     "4c": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3u"
     },
     "4d": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3u"
     },
     "4e": {
-      "key": "root.imports.connections",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3u"
     },
     "4f": {
-      "key": "root.imports.icons",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "3u"
     },
     "4g": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4f"
+      "key": "root.imports.connections",
+      "~k_parent": "3k"
     },
     "4h": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4g"
+      "key": "root.imports.icons",
+      "~k_parent": "3k"
     },
     "4i": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4h"
     },
     "4l": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4h"
     },
     "4n": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4h"
     },
     "4p": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4h"
     },
     "4r": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4h"
     },
     "4t": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4h"
     },
     "4v": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4h"
     },
     "4x": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4h"
     },
     "4z": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4h"
     },
     "5b": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4h"
     },
     "5d": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4h"
     },
     "5f": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4h"
     },
     "5h": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4h"
     },
     "5j": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4h"
     },
     "5l": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4h"
     },
     "5n": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4h"
     },
     "5p": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4h"
     },
     "5r": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4h"
     },
     "5t": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4h"
     },
     "5v": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4h"
     },
     "5x": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4f"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4h"
     },
     "5z": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5y"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "19"
   },
@@ -1283,6 +1292,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5788,158 +5798,161 @@
       },
       "~k": "2h"
     },
+    "agents": {
+      "~k": "2k"
+    },
     "auth": {
       "adapters": {
-        "~k": "2l"
-      },
-      "callbacks": {
         "~k": "2m"
       },
-      "events": {
+      "callbacks": {
         "~k": "2n"
       },
-      "providers": {
+      "events": {
         "~k": "2o"
       },
-      "~k": "2k"
+      "providers": {
+        "~k": "2p"
+      },
+      "~k": "2l"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
-      "~k": "2p"
+      "~k": "2q"
     },
     "connections": {
-      "~k": "3b"
-    },
-    "requests": {
       "~k": "3c"
     },
-    "api": {
+    "requests": {
       "~k": "3d"
+    },
+    "api": {
+      "~k": "3e"
     },
     "operators": {
       "client": {
@@ -5947,20 +5960,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3g"
+          "~k": "3h"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3h"
+          "~k": "3i"
         },
-        "~k": "3f"
+        "~k": "3g"
       },
       "server": {
-        "~k": "3i"
+        "~k": "3j"
       },
-      "~k": "3e"
+      "~k": "3f"
     },
     "~k": "2g"
   }

--- a/packages/build/src/tests/success/69-module-with-app-pages/snapshot.json
+++ b/packages/build/src/tests/success/69-module-with-app-pages/snapshot.json
@@ -208,124 +208,128 @@
       "~k_parent": "5"
     },
     "40": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3j"
     },
     "41": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3j"
     },
     "42": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3j"
     },
     "43": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3j"
     },
     "44": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3j"
+    },
+    "45": {
       "key": "root.types.connections",
       "~k_parent": "39"
     },
-    "45": {
+    "46": {
       "key": "root.types.requests",
       "~k_parent": "39"
     },
-    "46": {
+    "47": {
       "key": "root.types.api",
       "~k_parent": "39"
     },
-    "47": {
+    "48": {
       "key": "root.types.operators",
       "~k_parent": "39"
     },
-    "48": {
-      "key": "root.types.operators.client",
-      "~k_parent": "47"
-    },
     "49": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "4n"
     },
     "51": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "4n"
     },
     "52": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "4n"
     },
     "53": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "4n"
     },
     "54": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "4n"
     },
     "55": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "4n"
     },
     "56": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "4n"
     },
     "57": {
-      "key": "root.imports.connections",
-      "~k_parent": "4c"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "4n"
     },
     "58": {
-      "key": "root.imports.icons",
-      "~k_parent": "4c"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "4n"
     },
     "59": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "58"
+      "key": "root.imports.connections",
+      "~k_parent": "4d"
     },
     "60": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "5a"
     },
     "62": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "5a"
     },
     "64": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "5a"
     },
     "66": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "5a"
     },
     "68": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "5a"
+    },
+    "70": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "6w"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[0:welcome:Title].properties",
@@ -689,406 +693,411 @@
       "~k_parent": "3a"
     },
     "3d": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "39"
     },
     "3e": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "3d"
+      "key": "root.types.auth",
+      "~k_parent": "39"
     },
     "3f": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "3d"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.types.auth.events",
-      "~k_parent": "3d"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "3e"
     },
     "3h": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "3d"
+      "key": "root.types.auth.events",
+      "~k_parent": "3e"
     },
     "3i": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "3e"
+    },
+    "3j": {
       "key": "root.types.blocks",
       "~k_parent": "39"
     },
-    "3j": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "3i"
-    },
     "3k": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3j"
     },
     "3l": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "3j"
     },
     "3m": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3j"
     },
     "3n": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "3j"
     },
     "3o": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3j"
     },
     "3p": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3j"
     },
     "3q": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3j"
     },
     "3r": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3j"
     },
     "3s": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3j"
     },
     "3t": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3j"
     },
     "3u": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3j"
     },
     "3v": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3j"
     },
     "3w": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3j"
     },
     "3x": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3j"
     },
     "3y": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3j"
     },
     "3z": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3j"
     },
     "4a": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "48"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "49"
     },
     "4b": {
-      "key": "root.types.operators.server",
-      "~k_parent": "47"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "49"
     },
     "4c": {
+      "key": "root.types.operators.server",
+      "~k_parent": "48"
+    },
+    "4d": {
       "key": "root.imports",
       "~k_parent": "5"
     },
-    "4d": {
-      "key": "root.imports.actions",
-      "~k_parent": "4c"
-    },
     "4e": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "4d"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.auth",
-      "~k_parent": "4c"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "4e"
     },
     "4h": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "4g"
+      "key": "root.imports.agents",
+      "~k_parent": "4d"
     },
     "4i": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "4g"
+      "key": "root.imports.auth",
+      "~k_parent": "4d"
     },
     "4j": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "4g"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "4g"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "4i"
     },
     "4l": {
-      "key": "root.imports.blocks",
-      "~k_parent": "4c"
+      "key": "root.imports.auth.events",
+      "~k_parent": "4i"
     },
     "4m": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "4l"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "4i"
     },
     "4n": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks",
+      "~k_parent": "4d"
     },
     "4o": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "4n"
     },
     "4q": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "4n"
     },
     "4r": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "4n"
     },
     "4s": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "4n"
     },
     "4t": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "4n"
     },
     "4u": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "4n"
     },
     "4v": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "4n"
     },
     "4w": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "4n"
     },
     "4x": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "4n"
     },
     "4y": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "4n"
     },
     "4z": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "4l"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "4n"
     },
     "5a": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "59"
+      "key": "root.imports.icons",
+      "~k_parent": "4d"
     },
     "5b": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "5a"
     },
     "5e": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "5a"
     },
     "5g": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "5a"
     },
     "5i": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "5a"
     },
     "5k": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "5a"
     },
     "5m": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "5a"
     },
     "5o": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "5a"
     },
     "5q": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "5a"
     },
     "5s": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "5a"
     },
     "5u": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "5a"
     },
     "5w": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "5a"
     },
     "5y": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "5a"
     },
     "6a": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "5a"
     },
     "6c": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "5a"
     },
     "6e": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "5a"
     },
     "6g": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "6f"
     },
     "6h": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "5a"
     },
     "6i": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "5a"
     },
     "6k": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "6j"
     },
     "6l": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "5a"
     },
     "6m": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "6l"
     },
     "6n": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "5a"
     },
     "6o": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "6n"
     },
     "6p": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "5a"
     },
     "6q": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "5a"
     },
     "6s": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6r"
     },
     "6t": {
-      "key": "root.imports.requests",
-      "~k_parent": "4c"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "5a"
     },
     "6u": {
-      "key": "root.imports.operators",
-      "~k_parent": "4c"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6u"
+      "key": "root.imports.requests",
+      "~k_parent": "4d"
     },
     "6w": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6v"
+      "key": "root.imports.operators",
+      "~k_parent": "4d"
     },
     "6x": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6v"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6w"
     },
     "6y": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "6u"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6x"
+    },
+    "6z": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6x"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "1m"
   },
@@ -1537,6 +1546,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -6037,158 +6047,161 @@
       },
       "~k": "3a"
     },
+    "agents": {
+      "~k": "3d"
+    },
     "auth": {
       "adapters": {
-        "~k": "3e"
-      },
-      "callbacks": {
         "~k": "3f"
       },
-      "events": {
+      "callbacks": {
         "~k": "3g"
       },
-      "providers": {
+      "events": {
         "~k": "3h"
       },
-      "~k": "3d"
+      "providers": {
+        "~k": "3i"
+      },
+      "~k": "3e"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "3j"
+        "~k": "3k"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "3k"
+        "~k": "3l"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "3l"
+        "~k": "3m"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3m"
+        "~k": "3n"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3n"
+        "~k": "3o"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3o"
+        "~k": "3p"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3p"
+        "~k": "3q"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3q"
+        "~k": "3r"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3r"
+        "~k": "3s"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3s"
+        "~k": "3t"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3t"
+        "~k": "3u"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3u"
+        "~k": "3v"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3v"
+        "~k": "3w"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3w"
+        "~k": "3x"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3x"
+        "~k": "3y"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3y"
+        "~k": "3z"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3z"
+        "~k": "40"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "40"
+        "~k": "41"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "41"
+        "~k": "42"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "42"
+        "~k": "43"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "43"
+        "~k": "44"
       },
-      "~k": "3i"
+      "~k": "3j"
     },
     "connections": {
-      "~k": "44"
-    },
-    "requests": {
       "~k": "45"
     },
-    "api": {
+    "requests": {
       "~k": "46"
+    },
+    "api": {
+      "~k": "47"
     },
     "operators": {
       "client": {
@@ -6196,20 +6209,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "49"
+          "~k": "4a"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4a"
+          "~k": "4b"
         },
-        "~k": "48"
+        "~k": "49"
       },
       "server": {
-        "~k": "4b"
+        "~k": "4c"
       },
-      "~k": "47"
+      "~k": "48"
     },
     "~k": "39"
   }

--- a/packages/build/src/tests/success/70-cross-module-shared-layout/snapshot.json
+++ b/packages/build/src/tests/success/70-cross-module-shared-layout/snapshot.json
@@ -134,144 +134,144 @@
       "~k_parent": "22"
     },
     "25": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "21"
     },
     "26": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "25"
+      "key": "root.types.auth",
+      "~k_parent": "21"
     },
     "27": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "25"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "26"
     },
     "28": {
-      "key": "root.types.auth.events",
-      "~k_parent": "25"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "26"
     },
     "29": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "25"
+      "key": "root.types.auth.events",
+      "~k_parent": "26"
     },
     "30": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2z"
     },
     "31": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2z"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "30"
     },
     "32": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2y"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "30"
     },
     "33": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2z"
+    },
+    "34": {
       "key": "root.imports",
       "~k_parent": "6"
     },
-    "34": {
-      "key": "root.imports.actions",
-      "~k_parent": "33"
-    },
     "35": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "34"
     },
     "36": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "34"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "35"
     },
     "37": {
-      "key": "root.imports.auth",
-      "~k_parent": "33"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "35"
     },
     "38": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "37"
+      "key": "root.imports.agents",
+      "~k_parent": "34"
     },
     "39": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "37"
+      "key": "root.imports.auth",
+      "~k_parent": "34"
     },
     "40": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3z"
+      "key": "root.imports.icons",
+      "~k_parent": "34"
     },
     "41": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "40"
     },
     "44": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "40"
     },
     "46": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "40"
     },
     "48": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "40"
     },
     "50": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "40"
     },
     "52": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "40"
     },
     "54": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "40"
     },
     "56": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "40"
     },
     "58": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "40"
     },
     "a": {
       "key": "root.pages[1:contacts/contact-list:Box].blocks",
@@ -492,378 +492,387 @@
       "~k_parent": "1w"
     },
     "2a": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "26"
+    },
+    "2b": {
       "key": "root.types.blocks",
       "~k_parent": "21"
     },
-    "2b": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2a"
-    },
     "2c": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2b"
     },
     "2d": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2b"
     },
     "2e": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2b"
     },
     "2f": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2b"
     },
     "2g": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2b"
     },
     "2h": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2b"
     },
     "2i": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2b"
     },
     "2j": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2b"
     },
     "2k": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2b"
     },
     "2l": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2b"
     },
     "2m": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2b"
     },
     "2n": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2b"
     },
     "2o": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2b"
     },
     "2p": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2b"
     },
     "2q": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2b"
     },
     "2r": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2b"
     },
     "2s": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2b"
     },
     "2t": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2b"
     },
     "2u": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2b"
     },
     "2v": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2b"
+    },
+    "2w": {
       "key": "root.types.connections",
       "~k_parent": "21"
     },
-    "2w": {
+    "2x": {
       "key": "root.types.requests",
       "~k_parent": "21"
     },
-    "2x": {
+    "2y": {
       "key": "root.types.api",
       "~k_parent": "21"
     },
-    "2y": {
+    "2z": {
       "key": "root.types.operators",
       "~k_parent": "21"
     },
-    "2z": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2y"
-    },
     "3a": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "37"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "39"
     },
     "3b": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "37"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "39"
     },
     "3c": {
-      "key": "root.imports.blocks",
-      "~k_parent": "33"
+      "key": "root.imports.auth.events",
+      "~k_parent": "39"
     },
     "3d": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3c"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "39"
     },
     "3e": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks",
+      "~k_parent": "34"
     },
     "3f": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3e"
     },
     "3h": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3e"
     },
     "3i": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3e"
     },
     "3j": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3e"
     },
     "3k": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3e"
     },
     "3l": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3e"
     },
     "3m": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3e"
     },
     "3n": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3e"
     },
     "3o": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3e"
     },
     "3p": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3e"
     },
     "3q": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3e"
     },
     "3r": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3e"
     },
     "3s": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3e"
     },
     "3t": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3e"
     },
     "3u": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3e"
     },
     "3v": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3e"
     },
     "3w": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3e"
     },
     "3x": {
-      "key": "root.imports.connections",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3e"
     },
     "3y": {
-      "key": "root.imports.icons",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3e"
     },
     "3z": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3y"
+      "key": "root.imports.connections",
+      "~k_parent": "34"
     },
     "4a": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "40"
     },
     "4c": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "40"
     },
     "4e": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "40"
     },
     "4g": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "40"
     },
     "4i": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "40"
     },
     "4k": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "40"
     },
     "4m": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "40"
     },
     "4o": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "40"
     },
     "4q": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "40"
     },
     "4s": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "40"
     },
     "4u": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "40"
     },
     "4w": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "40"
     },
     "4y": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "40"
     },
     "5a": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "40"
     },
     "5c": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "40"
     },
     "5e": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "40"
     },
     "5g": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "40"
     },
     "5i": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.requests",
-      "~k_parent": "33"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "40"
     },
     "5k": {
-      "key": "root.imports.operators",
-      "~k_parent": "33"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5k"
+      "key": "root.imports.requests",
+      "~k_parent": "34"
     },
     "5m": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5l"
+      "key": "root.imports.operators",
+      "~k_parent": "34"
     },
     "5n": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5l"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5m"
     },
     "5o": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5n"
+    },
+    "5p": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5n"
+    },
+    "5q": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5k"
+      "~k_parent": "5m"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "y"
   },
@@ -1120,6 +1129,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5640,152 +5650,155 @@
       },
       "~k": "22"
     },
+    "agents": {
+      "~k": "25"
+    },
     "auth": {
       "adapters": {
-        "~k": "26"
-      },
-      "callbacks": {
         "~k": "27"
       },
-      "events": {
+      "callbacks": {
         "~k": "28"
       },
-      "providers": {
+      "events": {
         "~k": "29"
       },
-      "~k": "25"
+      "providers": {
+        "~k": "2a"
+      },
+      "~k": "26"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
-      "~k": "2a"
+      "~k": "2b"
     },
     "connections": {
-      "~k": "2v"
-    },
-    "requests": {
       "~k": "2w"
     },
-    "api": {
+    "requests": {
       "~k": "2x"
+    },
+    "api": {
+      "~k": "2y"
     },
     "operators": {
       "client": {
@@ -5793,20 +5806,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "30"
+          "~k": "31"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "31"
+          "~k": "32"
         },
-        "~k": "2z"
+        "~k": "30"
       },
       "server": {
-        "~k": "32"
+        "~k": "33"
       },
-      "~k": "2y"
+      "~k": "2z"
     },
     "~k": "21"
   }

--- a/packages/build/src/tests/success/71-cross-module-mutual-refs/snapshot.json
+++ b/packages/build/src/tests/success/71-cross-module-mutual-refs/snapshot.json
@@ -137,156 +137,164 @@
       "~k_parent": "a"
     },
     "30": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2s"
     },
     "31": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2s"
     },
     "32": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2s"
     },
     "33": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2s"
     },
     "34": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2s"
     },
     "35": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2s"
     },
     "36": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2s"
     },
     "37": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2s"
     },
     "38": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2s"
     },
     "39": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2s"
     },
     "40": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3w"
     },
     "41": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3w"
     },
     "42": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3w"
     },
     "43": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3w"
     },
     "44": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3w"
     },
     "45": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3w"
     },
     "46": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3w"
     },
     "47": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3w"
     },
     "48": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3w"
     },
     "49": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3w"
     },
     "50": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4j"
     },
     "51": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4j"
     },
     "53": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4j"
     },
     "55": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4j"
     },
     "57": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4j"
     },
     "59": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4j"
     },
     "61": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.requests",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4j"
     },
     "63": {
-      "key": "root.imports.operators",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "63"
+      "key": "root.imports.requests",
+      "~k_parent": "3m"
     },
     "65": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "64"
+      "key": "root.imports.operators",
+      "~k_parent": "3m"
     },
     "66": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "64"
+      "key": "root.imports.operators.client",
+      "~k_parent": "65"
     },
     "67": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "66"
+    },
+    "68": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "66"
+    },
+    "69": {
       "key": "root.imports.operators.server",
-      "~k_parent": "63"
+      "~k_parent": "65"
     },
     "a": {
       "key": "root",
@@ -572,374 +580,375 @@
       "~k_parent": "2j"
     },
     "2m": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "2i"
     },
     "2n": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2m"
+      "key": "root.types.auth",
+      "~k_parent": "2i"
     },
     "2o": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2m"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2m"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2n"
     },
     "2q": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2m"
+      "key": "root.types.auth.events",
+      "~k_parent": "2n"
     },
     "2r": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2n"
+    },
+    "2s": {
       "key": "root.types.blocks",
       "~k_parent": "2i"
     },
-    "2s": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2r"
-    },
     "2t": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2s"
     },
     "2v": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "2s"
     },
     "2w": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2s"
     },
     "2x": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2s"
     },
     "2y": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2s"
     },
     "2z": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2s"
     },
     "3a": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2s"
     },
     "3b": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2s"
     },
     "3c": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2s"
     },
     "3d": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2s"
+    },
+    "3e": {
       "key": "root.types.connections",
       "~k_parent": "2i"
     },
-    "3e": {
+    "3f": {
       "key": "root.types.requests",
       "~k_parent": "2i"
     },
-    "3f": {
+    "3g": {
       "key": "root.types.api",
       "~k_parent": "2i"
     },
-    "3g": {
+    "3h": {
       "key": "root.types.operators",
       "~k_parent": "2i"
     },
-    "3h": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3g"
-    },
     "3i": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3h"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3g"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3i"
     },
     "3l": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3h"
+    },
+    "3m": {
       "key": "root.imports",
       "~k_parent": "a"
     },
-    "3m": {
-      "key": "root.imports.actions",
-      "~k_parent": "3l"
-    },
     "3n": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3m"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.auth",
-      "~k_parent": "3l"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3n"
     },
     "3q": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3p"
+      "key": "root.imports.agents",
+      "~k_parent": "3m"
     },
     "3r": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3p"
+      "key": "root.imports.auth",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3p"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3p"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3r"
     },
     "3u": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3l"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3r"
     },
     "3v": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3u"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3r"
     },
     "3w": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks",
+      "~k_parent": "3m"
     },
     "3x": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3w"
     },
     "3z": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3w"
     },
     "4a": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3w"
     },
     "4b": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3w"
     },
     "4c": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3w"
     },
     "4d": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3w"
     },
     "4e": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3w"
     },
     "4f": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3w"
     },
     "4g": {
-      "key": "root.imports.connections",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3w"
     },
     "4h": {
-      "key": "root.imports.icons",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "3w"
     },
     "4i": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4h"
+      "key": "root.imports.connections",
+      "~k_parent": "3m"
     },
     "4j": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4i"
+      "key": "root.imports.icons",
+      "~k_parent": "3m"
     },
     "4k": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4j"
     },
     "4n": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4j"
     },
     "4p": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4j"
     },
     "4r": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4j"
     },
     "4t": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4j"
     },
     "4v": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4j"
     },
     "4x": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4j"
     },
     "4z": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4j"
     },
     "5b": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4j"
     },
     "5d": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4j"
     },
     "5f": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4j"
     },
     "5h": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4j"
     },
     "5j": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4j"
     },
     "5l": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4j"
     },
     "5n": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4j"
     },
     "5p": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4j"
     },
     "5r": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4j"
     },
     "5t": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4j"
     },
     "5v": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4j"
     },
     "5x": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4j"
     },
     "5z": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5y"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "1a"
   },
@@ -1256,6 +1265,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -6656,158 +6666,161 @@
       },
       "~k": "2j"
     },
+    "agents": {
+      "~k": "2m"
+    },
     "auth": {
       "adapters": {
-        "~k": "2n"
-      },
-      "callbacks": {
         "~k": "2o"
       },
-      "events": {
+      "callbacks": {
         "~k": "2p"
       },
-      "providers": {
+      "events": {
         "~k": "2q"
       },
-      "~k": "2m"
+      "providers": {
+        "~k": "2r"
+      },
+      "~k": "2n"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
-      "~k": "2r"
+      "~k": "2s"
     },
     "connections": {
-      "~k": "3d"
-    },
-    "requests": {
       "~k": "3e"
     },
-    "api": {
+    "requests": {
       "~k": "3f"
+    },
+    "api": {
+      "~k": "3g"
     },
     "operators": {
       "client": {
@@ -6815,20 +6828,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3i"
+          "~k": "3j"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3j"
+          "~k": "3k"
         },
-        "~k": "3h"
+        "~k": "3i"
       },
       "server": {
-        "~k": "3k"
+        "~k": "3l"
       },
-      "~k": "3g"
+      "~k": "3h"
     },
     "~k": "2i"
   }

--- a/packages/build/src/tests/success/72-cross-module-audit-events/snapshot.json
+++ b/packages/build/src/tests/success/72-cross-module-audit-events/snapshot.json
@@ -192,124 +192,124 @@
       "~k_parent": "27"
     },
     "30": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2g"
+    },
+    "31": {
       "key": "root.types.connections",
       "~k_parent": "26"
     },
-    "31": {
-      "key": "root.types.connections.AxiosHttp",
-      "~k_parent": "30"
-    },
     "32": {
+      "key": "root.types.connections.AxiosHttp",
+      "~k_parent": "31"
+    },
+    "33": {
       "key": "root.types.requests",
       "~k_parent": "26"
     },
-    "33": {
-      "key": "root.types.requests.AxiosHttp",
-      "~k_parent": "32"
-    },
     "34": {
+      "key": "root.types.requests.AxiosHttp",
+      "~k_parent": "33"
+    },
+    "35": {
       "key": "root.types.api",
       "~k_parent": "26"
     },
-    "35": {
+    "36": {
       "key": "root.types.operators",
       "~k_parent": "26"
     },
-    "36": {
-      "key": "root.types.operators.client",
-      "~k_parent": "35"
-    },
     "37": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "36"
     },
     "38": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "36"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "37"
     },
     "39": {
-      "key": "root.types.operators.server",
-      "~k_parent": "35"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "37"
     },
     "40": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3l"
     },
     "41": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3l"
     },
     "42": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3l"
     },
     "43": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3l"
     },
     "44": {
-      "key": "root.imports.connections",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3l"
     },
     "45": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "44"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3l"
     },
     "46": {
-      "key": "root.imports.icons",
-      "~k_parent": "3a"
+      "key": "root.imports.connections",
+      "~k_parent": "3b"
     },
     "47": {
-      "key": "root.imports.icons[0]",
+      "key": "root.imports.connections[0]",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "47"
+      "key": "root.imports.icons",
+      "~k_parent": "3b"
     },
     "49": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "48"
     },
     "52": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "48"
     },
     "54": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "48"
     },
     "56": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "48"
     },
     "58": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "48"
     },
     "a": {
       "key": "root.pages[1:companies/company-detail:Box].blocks",
@@ -536,414 +536,423 @@
       "~k_parent": "6"
     },
     "2a": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "26"
     },
     "2b": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2a"
+      "key": "root.types.auth",
+      "~k_parent": "26"
     },
     "2c": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2a"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2b"
     },
     "2d": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2a"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2b"
     },
     "2e": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2a"
+      "key": "root.types.auth.events",
+      "~k_parent": "2b"
     },
     "2f": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2b"
+    },
+    "2g": {
       "key": "root.types.blocks",
       "~k_parent": "26"
     },
-    "2g": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2f"
-    },
     "2h": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2g"
     },
     "2i": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2g"
     },
     "2j": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2g"
     },
     "2k": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2g"
     },
     "2l": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2g"
     },
     "2m": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2g"
     },
     "2n": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2g"
     },
     "2o": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2g"
     },
     "2p": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2g"
     },
     "2q": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2g"
     },
     "2r": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2g"
     },
     "2s": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2g"
     },
     "2t": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2g"
     },
     "2u": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2g"
     },
     "2v": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2g"
     },
     "2w": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2g"
     },
     "2x": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2g"
     },
     "2y": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2g"
     },
     "2z": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2g"
     },
     "3a": {
+      "key": "root.types.operators.server",
+      "~k_parent": "36"
+    },
+    "3b": {
       "key": "root.imports",
       "~k_parent": "6"
     },
-    "3b": {
-      "key": "root.imports.actions",
-      "~k_parent": "3a"
-    },
     "3c": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3b"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3c"
     },
     "3e": {
-      "key": "root.imports.auth",
-      "~k_parent": "3a"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3c"
     },
     "3f": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3e"
+      "key": "root.imports.agents",
+      "~k_parent": "3b"
     },
     "3g": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3e"
+      "key": "root.imports.auth",
+      "~k_parent": "3b"
     },
     "3h": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3e"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3e"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3g"
     },
     "3j": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3a"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3g"
     },
     "3k": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3j"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3g"
     },
     "3l": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks",
+      "~k_parent": "3b"
     },
     "3m": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3l"
     },
     "3n": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3l"
     },
     "3o": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3l"
     },
     "3p": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3l"
     },
     "3q": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3l"
     },
     "3r": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3l"
     },
     "3s": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3l"
     },
     "3t": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3l"
     },
     "3u": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3l"
     },
     "3v": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3l"
     },
     "3w": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3l"
     },
     "3x": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3l"
     },
     "3y": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3l"
     },
     "3z": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3l"
     },
     "4a": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "48"
     },
     "4c": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "48"
     },
     "4e": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "48"
     },
     "4g": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "48"
     },
     "4i": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "48"
     },
     "4k": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "48"
     },
     "4m": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "48"
     },
     "4o": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "48"
     },
     "4q": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "48"
     },
     "4s": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "48"
     },
     "4u": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "48"
     },
     "4w": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "48"
     },
     "4y": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "48"
     },
     "5a": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "48"
     },
     "5c": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "48"
     },
     "5e": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "48"
     },
     "5g": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "48"
     },
     "5i": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "48"
     },
     "5k": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "48"
     },
     "5m": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "48"
     },
     "5o": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "48"
     },
     "5q": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.requests",
-      "~k_parent": "3a"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "48"
     },
     "5s": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.operators",
-      "~k_parent": "3a"
+      "key": "root.imports.requests",
+      "~k_parent": "3b"
     },
     "5u": {
-      "key": "root.imports.operators.client",
+      "key": "root.imports.requests[0]",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5u"
+      "key": "root.imports.operators",
+      "~k_parent": "3b"
     },
     "5w": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5u"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5v"
     },
     "5x": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5w"
+    },
+    "5y": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5w"
+    },
+    "5z": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5t"
+      "~k_parent": "5v"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "14"
   },
@@ -1184,6 +1193,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5687,164 +5697,167 @@
       },
       "~k": "27"
     },
+    "agents": {
+      "~k": "2a"
+    },
     "auth": {
       "adapters": {
-        "~k": "2b"
-      },
-      "callbacks": {
         "~k": "2c"
       },
-      "events": {
+      "callbacks": {
         "~k": "2d"
       },
-      "providers": {
+      "events": {
         "~k": "2e"
       },
-      "~k": "2a"
+      "providers": {
+        "~k": "2f"
+      },
+      "~k": "2b"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
-      "~k": "2f"
+      "~k": "2g"
     },
     "connections": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
-      "~k": "30"
+      "~k": "31"
     },
     "requests": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
-      "~k": "32"
+      "~k": "33"
     },
     "api": {
-      "~k": "34"
+      "~k": "35"
     },
     "operators": {
       "client": {
@@ -5852,20 +5865,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "37"
+          "~k": "38"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "38"
+          "~k": "39"
         },
-        "~k": "36"
+        "~k": "37"
       },
       "server": {
-        "~k": "39"
+        "~k": "3a"
       },
-      "~k": "35"
+      "~k": "36"
     },
     "~k": "26"
   }

--- a/packages/build/src/tests/success/73-cross-module-diamond-deps/snapshot.json
+++ b/packages/build/src/tests/success/73-cross-module-diamond-deps/snapshot.json
@@ -142,160 +142,164 @@
       "~k_parent": "21"
     },
     "30": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2v"
     },
     "31": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2v"
     },
     "32": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2v"
     },
     "33": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2v"
     },
     "34": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2v"
     },
     "35": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2v"
     },
     "36": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2v"
     },
     "37": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2v"
     },
     "38": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2v"
     },
     "39": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2v"
     },
     "40": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3y"
     },
     "41": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3y"
     },
     "42": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3y"
     },
     "43": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3y"
     },
     "44": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3y"
     },
     "45": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3y"
     },
     "46": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3y"
     },
     "47": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3y"
     },
     "48": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3y"
     },
     "49": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3y"
     },
     "50": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4k"
     },
     "52": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4k"
     },
     "54": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4k"
     },
     "56": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4k"
     },
     "58": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4k"
     },
     "60": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4k"
     },
     "62": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.requests",
-      "~k_parent": "3n"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4k"
     },
     "64": {
-      "key": "root.imports.operators",
-      "~k_parent": "3n"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "64"
+      "key": "root.imports.requests",
+      "~k_parent": "3o"
     },
     "66": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "65"
+      "key": "root.imports.operators",
+      "~k_parent": "3o"
     },
     "67": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "65"
+      "key": "root.imports.operators.client",
+      "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "64"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "67"
+    },
+    "69": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "67"
     },
     "a": {
       "key": "root.pages",
@@ -592,362 +596,367 @@
       "~k_parent": "2m"
     },
     "2p": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "2l"
     },
     "2q": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2p"
+      "key": "root.types.auth",
+      "~k_parent": "2l"
     },
     "2r": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2p"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2p"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2q"
     },
     "2t": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2p"
+      "key": "root.types.auth.events",
+      "~k_parent": "2q"
     },
     "2u": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2q"
+    },
+    "2v": {
       "key": "root.types.blocks",
       "~k_parent": "2l"
     },
-    "2v": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2u"
-    },
     "2w": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2v"
     },
     "2x": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2v"
     },
     "2y": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2v"
     },
     "2z": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2v"
     },
     "3a": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2v"
     },
     "3b": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2v"
     },
     "3c": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2v"
     },
     "3d": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2v"
     },
     "3e": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2v"
     },
     "3f": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2v"
+    },
+    "3g": {
       "key": "root.types.connections",
       "~k_parent": "2l"
     },
-    "3g": {
+    "3h": {
       "key": "root.types.requests",
       "~k_parent": "2l"
     },
-    "3h": {
+    "3i": {
       "key": "root.types.api",
       "~k_parent": "2l"
     },
-    "3i": {
+    "3j": {
       "key": "root.types.operators",
       "~k_parent": "2l"
     },
-    "3j": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3i"
-    },
     "3k": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3j"
     },
     "3l": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3j"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3i"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3k"
     },
     "3n": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3j"
+    },
+    "3o": {
       "key": "root.imports",
       "~k_parent": "9"
     },
-    "3o": {
-      "key": "root.imports.actions",
-      "~k_parent": "3n"
-    },
     "3p": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3o"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.auth",
-      "~k_parent": "3n"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3p"
     },
     "3s": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3r"
+      "key": "root.imports.agents",
+      "~k_parent": "3o"
     },
     "3t": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3r"
+      "key": "root.imports.auth",
+      "~k_parent": "3o"
     },
     "3u": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3r"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3r"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3t"
     },
     "3w": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3n"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3t"
     },
     "3x": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3w"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3t"
     },
     "3y": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks",
+      "~k_parent": "3o"
     },
     "3z": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3y"
     },
     "4b": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3y"
     },
     "4c": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3y"
     },
     "4d": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3y"
     },
     "4e": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3y"
     },
     "4f": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3y"
     },
     "4g": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3y"
     },
     "4h": {
-      "key": "root.imports.connections",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3y"
     },
     "4i": {
-      "key": "root.imports.icons",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3y"
     },
     "4j": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4i"
+      "key": "root.imports.connections",
+      "~k_parent": "3o"
     },
     "4k": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4j"
+      "key": "root.imports.icons",
+      "~k_parent": "3o"
     },
     "4l": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4k"
     },
     "4o": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4k"
     },
     "4q": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4k"
     },
     "4s": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4k"
     },
     "4u": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4k"
     },
     "4w": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4k"
     },
     "4y": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4k"
     },
     "5a": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4k"
     },
     "5c": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4k"
     },
     "5e": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4k"
     },
     "5g": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4k"
     },
     "5i": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4k"
     },
     "5k": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4k"
     },
     "5m": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4k"
     },
     "5o": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4k"
     },
     "5q": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4k"
     },
     "5s": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4k"
     },
     "5u": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4k"
     },
     "5w": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4k"
     },
     "5y": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4k"
+    },
+    "6a": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "66"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "19"
   },
@@ -1278,6 +1287,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5828,152 +5838,155 @@
       },
       "~k": "2m"
     },
+    "agents": {
+      "~k": "2p"
+    },
     "auth": {
       "adapters": {
-        "~k": "2q"
-      },
-      "callbacks": {
         "~k": "2r"
       },
-      "events": {
+      "callbacks": {
         "~k": "2s"
       },
-      "providers": {
+      "events": {
         "~k": "2t"
       },
-      "~k": "2p"
+      "providers": {
+        "~k": "2u"
+      },
+      "~k": "2q"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 6,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
-      "~k": "2u"
+      "~k": "2v"
     },
     "connections": {
-      "~k": "3f"
-    },
-    "requests": {
       "~k": "3g"
     },
-    "api": {
+    "requests": {
       "~k": "3h"
+    },
+    "api": {
+      "~k": "3i"
     },
     "operators": {
       "client": {
@@ -5981,20 +5994,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3k"
+          "~k": "3l"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3l"
+          "~k": "3m"
         },
-        "~k": "3j"
+        "~k": "3k"
       },
       "server": {
-        "~k": "3m"
+        "~k": "3n"
       },
-      "~k": "3i"
+      "~k": "3j"
     },
     "~k": "2l"
   }

--- a/packages/build/src/tests/success/74-cross-module-multi-instance/snapshot.json
+++ b/packages/build/src/tests/success/74-cross-module-multi-instance/snapshot.json
@@ -173,128 +173,128 @@
       "~k_parent": "36"
     },
     "39": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "35"
     },
     "40": {
-      "key": "root.types.requests",
+      "key": "root.types.connections",
       "~k_parent": "35"
     },
     "41": {
-      "key": "root.types.api",
+      "key": "root.types.requests",
       "~k_parent": "35"
     },
     "42": {
-      "key": "root.types.operators",
+      "key": "root.types.api",
       "~k_parent": "35"
     },
     "43": {
-      "key": "root.types.operators.client",
-      "~k_parent": "42"
+      "key": "root.types.operators",
+      "~k_parent": "35"
     },
     "44": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "43"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "44"
     },
     "46": {
-      "key": "root.types.operators.server",
-      "~k_parent": "42"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "44"
     },
     "47": {
+      "key": "root.types.operators.server",
+      "~k_parent": "43"
+    },
+    "48": {
       "key": "root.imports",
       "~k_parent": "b"
     },
-    "48": {
-      "key": "root.imports.actions",
-      "~k_parent": "47"
-    },
     "49": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "4i"
     },
     "51": {
-      "key": "root.imports.connections",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "4i"
     },
     "52": {
-      "key": "root.imports.icons",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "4i"
     },
     "53": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "52"
+      "key": "root.imports.connections",
+      "~k_parent": "48"
     },
     "54": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "53"
+      "key": "root.imports.icons",
+      "~k_parent": "48"
     },
     "55": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "54"
     },
     "58": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "54"
     },
     "60": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "54"
     },
     "62": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "54"
     },
     "64": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "54"
     },
     "66": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "54"
     },
     "68": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "54"
     },
     "b": {
       "key": "root",
@@ -648,394 +648,403 @@
       "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "39"
+      "key": "root.types.auth",
+      "~k_parent": "35"
     },
     "3b": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "39"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "3a"
     },
     "3c": {
-      "key": "root.types.auth.events",
-      "~k_parent": "39"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "3a"
     },
     "3d": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "39"
+      "key": "root.types.auth.events",
+      "~k_parent": "3a"
     },
     "3e": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "3a"
+    },
+    "3f": {
       "key": "root.types.blocks",
       "~k_parent": "35"
     },
-    "3f": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "3e"
-    },
     "3g": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "3f"
     },
     "3i": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3f"
     },
     "3k": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3f"
     },
     "3m": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3f"
     },
     "3n": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3f"
     },
     "3o": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3f"
     },
     "3q": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3f"
     },
     "3r": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3f"
     },
     "3s": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3f"
     },
     "3t": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3f"
     },
     "3u": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3f"
     },
     "3v": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3f"
     },
     "3w": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3f"
     },
     "3x": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3f"
     },
     "3y": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3f"
     },
     "3z": {
-      "key": "root.types.connections",
-      "~k_parent": "35"
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3f"
     },
     "4a": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "48"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.auth",
-      "~k_parent": "47"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "49"
     },
     "4c": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "4b"
+      "key": "root.imports.agents",
+      "~k_parent": "48"
     },
     "4d": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "4b"
+      "key": "root.imports.auth",
+      "~k_parent": "48"
     },
     "4e": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "4b"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "4b"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "4d"
     },
     "4g": {
-      "key": "root.imports.blocks",
-      "~k_parent": "47"
+      "key": "root.imports.auth.events",
+      "~k_parent": "4d"
     },
     "4h": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "4g"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "4d"
     },
     "4i": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks",
+      "~k_parent": "48"
     },
     "4j": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "4i"
     },
     "4l": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "4i"
     },
     "4m": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "4i"
     },
     "4n": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "4i"
     },
     "4o": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "4i"
     },
     "4p": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "4i"
     },
     "4q": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "4i"
     },
     "4r": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "4i"
     },
     "4s": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "4i"
     },
     "4t": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "4i"
     },
     "4u": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "4i"
     },
     "4v": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "4i"
     },
     "4w": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "4i"
     },
     "4x": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "4i"
     },
     "4y": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "4i"
     },
     "4z": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "4i"
     },
     "5a": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "54"
     },
     "5c": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "54"
     },
     "5e": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "54"
     },
     "5g": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "54"
     },
     "5i": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "54"
     },
     "5k": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "54"
     },
     "5m": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "54"
     },
     "5o": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "54"
     },
     "5q": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "54"
     },
     "5s": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "54"
     },
     "5u": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "54"
     },
     "5w": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "54"
     },
     "5y": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "54"
     },
     "6a": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "54"
     },
     "6c": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "54"
     },
     "6e": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "54"
     },
     "6g": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "6f"
     },
     "6h": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "54"
     },
     "6i": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "54"
     },
     "6k": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "6j"
     },
     "6l": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "52"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "54"
     },
     "6m": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6l"
     },
     "6n": {
-      "key": "root.imports.requests",
-      "~k_parent": "47"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "54"
     },
     "6o": {
-      "key": "root.imports.operators",
-      "~k_parent": "47"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6n"
     },
     "6p": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6o"
+      "key": "root.imports.requests",
+      "~k_parent": "48"
     },
     "6q": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6p"
+      "key": "root.imports.operators",
+      "~k_parent": "48"
     },
     "6r": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6p"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6q"
     },
     "6s": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6r"
+    },
+    "6t": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6r"
+    },
+    "6u": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6o"
+      "~k_parent": "6q"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "1j"
   },
@@ -1446,6 +1455,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5965,152 +5975,155 @@
       },
       "~k": "36"
     },
+    "agents": {
+      "~k": "39"
+    },
     "auth": {
       "adapters": {
-        "~k": "3a"
-      },
-      "callbacks": {
         "~k": "3b"
       },
-      "events": {
+      "callbacks": {
         "~k": "3c"
       },
-      "providers": {
+      "events": {
         "~k": "3d"
       },
-      "~k": "39"
+      "providers": {
+        "~k": "3e"
+      },
+      "~k": "3a"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 6,
-        "~k": "3f"
+        "~k": "3g"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "3g"
+        "~k": "3h"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "3h"
+        "~k": "3i"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3i"
+        "~k": "3j"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3j"
+        "~k": "3k"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3k"
+        "~k": "3l"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3l"
+        "~k": "3m"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3m"
+        "~k": "3n"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3n"
+        "~k": "3o"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3o"
+        "~k": "3p"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3p"
+        "~k": "3q"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3q"
+        "~k": "3r"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3r"
+        "~k": "3s"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3s"
+        "~k": "3t"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3t"
+        "~k": "3u"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3u"
+        "~k": "3v"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3v"
+        "~k": "3w"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3w"
+        "~k": "3x"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3x"
+        "~k": "3y"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3y"
+        "~k": "3z"
       },
-      "~k": "3e"
+      "~k": "3f"
     },
     "connections": {
-      "~k": "3z"
-    },
-    "requests": {
       "~k": "40"
     },
-    "api": {
+    "requests": {
       "~k": "41"
+    },
+    "api": {
+      "~k": "42"
     },
     "operators": {
       "client": {
@@ -6118,20 +6131,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "44"
+          "~k": "45"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "45"
+          "~k": "46"
         },
-        "~k": "43"
+        "~k": "44"
       },
       "server": {
-        "~k": "46"
+        "~k": "47"
       },
-      "~k": "42"
+      "~k": "43"
     },
     "~k": "35"
   }

--- a/packages/build/src/tests/success/75-cross-module-connection-remap/snapshot.json
+++ b/packages/build/src/tests/success/75-cross-module-connection-remap/snapshot.json
@@ -159,124 +159,132 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2k"
     },
     "31": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2k"
     },
     "32": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2k"
     },
     "33": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2k"
     },
     "34": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2k"
+    },
+    "35": {
       "key": "root.types.connections",
       "~k_parent": "2a"
     },
-    "35": {
-      "key": "root.types.connections.MongoDBCollection",
-      "~k_parent": "34"
-    },
     "36": {
+      "key": "root.types.connections.MongoDBCollection",
+      "~k_parent": "35"
+    },
+    "37": {
       "key": "root.types.requests",
       "~k_parent": "2a"
     },
-    "37": {
+    "38": {
       "key": "root.types.api",
       "~k_parent": "2a"
     },
-    "38": {
+    "39": {
       "key": "root.types.operators",
       "~k_parent": "2a"
     },
-    "39": {
-      "key": "root.types.operators.client",
-      "~k_parent": "38"
-    },
     "40": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3o"
     },
     "41": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3o"
     },
     "42": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3o"
     },
     "43": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3o"
     },
     "44": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3o"
     },
     "45": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3o"
     },
     "46": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3o"
     },
     "47": {
-      "key": "root.imports.connections",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3o"
     },
     "48": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3o"
     },
     "49": {
-      "key": "root.imports.icons",
-      "~k_parent": "3d"
+      "key": "root.imports.connections",
+      "~k_parent": "3e"
     },
     "50": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4b"
     },
     "51": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4b"
     },
     "53": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4b"
     },
     "55": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4b"
     },
     "57": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4b"
     },
     "59": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "58"
+    },
+    "60": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5y"
+    },
+    "61": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "5x"
     },
     "a": {
       "key": "root.connections[0:shared-mongodb:MongoDBCollection].properties",
@@ -518,406 +526,407 @@
       "~k_parent": "2b"
     },
     "2e": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "2a"
     },
     "2f": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2e"
+      "key": "root.types.auth",
+      "~k_parent": "2a"
     },
     "2g": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2e"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2f"
     },
     "2h": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2e"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2f"
     },
     "2i": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2e"
+      "key": "root.types.auth.events",
+      "~k_parent": "2f"
     },
     "2j": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2f"
+    },
+    "2k": {
       "key": "root.types.blocks",
       "~k_parent": "2a"
     },
-    "2k": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2j"
-    },
     "2l": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2k"
     },
     "2m": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2k"
     },
     "2n": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2k"
     },
     "2o": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2k"
     },
     "2p": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2k"
     },
     "2q": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2k"
     },
     "2r": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2k"
     },
     "2s": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2k"
     },
     "2t": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2k"
     },
     "2u": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2k"
     },
     "2v": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2k"
     },
     "2w": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2k"
     },
     "2x": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2k"
     },
     "2y": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2k"
     },
     "2z": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2j"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2k"
     },
     "3a": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "39"
     },
     "3b": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "39"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3a"
     },
     "3c": {
-      "key": "root.types.operators.server",
-      "~k_parent": "38"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3a"
     },
     "3d": {
+      "key": "root.types.operators.server",
+      "~k_parent": "39"
+    },
+    "3e": {
       "key": "root.imports",
       "~k_parent": "7"
     },
-    "3e": {
-      "key": "root.imports.actions",
-      "~k_parent": "3d"
-    },
     "3f": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3e"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.auth",
-      "~k_parent": "3d"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3f"
     },
     "3i": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3h"
+      "key": "root.imports.agents",
+      "~k_parent": "3e"
     },
     "3j": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3h"
+      "key": "root.imports.auth",
+      "~k_parent": "3e"
     },
     "3k": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3h"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3j"
     },
     "3l": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3h"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3j"
     },
     "3m": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3d"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3j"
     },
     "3n": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3m"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3j"
     },
     "3o": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks",
+      "~k_parent": "3e"
     },
     "3p": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3o"
     },
     "3r": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3o"
     },
     "3s": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3o"
     },
     "3t": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3o"
     },
     "3u": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3o"
     },
     "3v": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3o"
     },
     "3w": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3o"
     },
     "3x": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3o"
     },
     "3y": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3o"
     },
     "3z": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3o"
     },
     "4a": {
-      "key": "root.imports.icons[0]",
+      "key": "root.imports.connections[0]",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4a"
+      "key": "root.imports.icons",
+      "~k_parent": "3e"
     },
     "4c": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4b"
     },
     "4f": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4b"
     },
     "4h": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4b"
     },
     "4j": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4b"
     },
     "4l": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4b"
     },
     "4n": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4b"
     },
     "4p": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4b"
     },
     "4r": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4b"
     },
     "4t": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4b"
     },
     "4v": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4b"
     },
     "4x": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4b"
     },
     "4z": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4b"
     },
     "5b": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4b"
     },
     "5d": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4b"
     },
     "5f": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4b"
     },
     "5h": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4b"
     },
     "5j": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4b"
     },
     "5l": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4b"
     },
     "5n": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4b"
     },
     "5p": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4b"
     },
     "5r": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "49"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4b"
     },
     "5t": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.requests",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4b"
     },
     "5v": {
-      "key": "root.imports.operators",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5v"
+      "key": "root.imports.requests",
+      "~k_parent": "3e"
     },
     "5x": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5w"
+      "key": "root.imports.operators",
+      "~k_parent": "3e"
     },
     "5y": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5w"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "5v"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5y"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "12"
   },
@@ -1195,6 +1204,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5703,158 +5713,161 @@
       },
       "~k": "2b"
     },
+    "agents": {
+      "~k": "2e"
+    },
     "auth": {
       "adapters": {
-        "~k": "2f"
-      },
-      "callbacks": {
         "~k": "2g"
       },
-      "events": {
+      "callbacks": {
         "~k": "2h"
       },
-      "providers": {
+      "events": {
         "~k": "2i"
       },
-      "~k": "2e"
+      "providers": {
+        "~k": "2j"
+      },
+      "~k": "2f"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
-      "~k": "2j"
+      "~k": "2k"
     },
     "connections": {
       "MongoDBCollection": {
         "originalTypeName": "MongoDBCollection",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
-      "~k": "34"
+      "~k": "35"
     },
     "requests": {
-      "~k": "36"
+      "~k": "37"
     },
     "api": {
-      "~k": "37"
+      "~k": "38"
     },
     "operators": {
       "client": {
@@ -5862,20 +5875,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3a"
+          "~k": "3b"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3b"
+          "~k": "3c"
         },
-        "~k": "39"
+        "~k": "3a"
       },
       "server": {
-        "~k": "3c"
+        "~k": "3d"
       },
-      "~k": "38"
+      "~k": "39"
     },
     "~k": "2a"
   }

--- a/packages/build/src/tests/success/76-cross-module-nested-refs/snapshot.json
+++ b/packages/build/src/tests/success/76-cross-module-nested-refs/snapshot.json
@@ -142,160 +142,164 @@
       "~k_parent": "21"
     },
     "30": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2v"
     },
     "31": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2v"
     },
     "32": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2v"
     },
     "33": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2v"
     },
     "34": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2v"
     },
     "35": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2v"
     },
     "36": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2v"
     },
     "37": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2v"
     },
     "38": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2v"
     },
     "39": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2v"
     },
     "40": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3y"
     },
     "41": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3y"
     },
     "42": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3y"
     },
     "43": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3y"
     },
     "44": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3y"
     },
     "45": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3y"
     },
     "46": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3y"
     },
     "47": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3y"
     },
     "48": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3y"
     },
     "49": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3y"
     },
     "50": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4k"
     },
     "52": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4k"
     },
     "54": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4k"
     },
     "56": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4k"
     },
     "58": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4k"
     },
     "60": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4k"
     },
     "62": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.requests",
-      "~k_parent": "3n"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4k"
     },
     "64": {
-      "key": "root.imports.operators",
-      "~k_parent": "3n"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "64"
+      "key": "root.imports.requests",
+      "~k_parent": "3o"
     },
     "66": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "65"
+      "key": "root.imports.operators",
+      "~k_parent": "3o"
     },
     "67": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "65"
+      "key": "root.imports.operators.client",
+      "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "64"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "67"
+    },
+    "69": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "67"
     },
     "a": {
       "key": "root.pages",
@@ -592,362 +596,367 @@
       "~k_parent": "2m"
     },
     "2p": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "2l"
     },
     "2q": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2p"
+      "key": "root.types.auth",
+      "~k_parent": "2l"
     },
     "2r": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2p"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2p"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2q"
     },
     "2t": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2p"
+      "key": "root.types.auth.events",
+      "~k_parent": "2q"
     },
     "2u": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2q"
+    },
+    "2v": {
       "key": "root.types.blocks",
       "~k_parent": "2l"
     },
-    "2v": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2u"
-    },
     "2w": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2v"
     },
     "2x": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2v"
     },
     "2y": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2v"
     },
     "2z": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2v"
     },
     "3a": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2v"
     },
     "3b": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2v"
     },
     "3c": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2v"
     },
     "3d": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2v"
     },
     "3e": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2v"
     },
     "3f": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2v"
+    },
+    "3g": {
       "key": "root.types.connections",
       "~k_parent": "2l"
     },
-    "3g": {
+    "3h": {
       "key": "root.types.requests",
       "~k_parent": "2l"
     },
-    "3h": {
+    "3i": {
       "key": "root.types.api",
       "~k_parent": "2l"
     },
-    "3i": {
+    "3j": {
       "key": "root.types.operators",
       "~k_parent": "2l"
     },
-    "3j": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3i"
-    },
     "3k": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3j"
     },
     "3l": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3j"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3i"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3k"
     },
     "3n": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3j"
+    },
+    "3o": {
       "key": "root.imports",
       "~k_parent": "9"
     },
-    "3o": {
-      "key": "root.imports.actions",
-      "~k_parent": "3n"
-    },
     "3p": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3o"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.auth",
-      "~k_parent": "3n"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3p"
     },
     "3s": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3r"
+      "key": "root.imports.agents",
+      "~k_parent": "3o"
     },
     "3t": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3r"
+      "key": "root.imports.auth",
+      "~k_parent": "3o"
     },
     "3u": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3r"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3r"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3t"
     },
     "3w": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3n"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3t"
     },
     "3x": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3w"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3t"
     },
     "3y": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks",
+      "~k_parent": "3o"
     },
     "3z": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3y"
     },
     "4b": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3y"
     },
     "4c": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3y"
     },
     "4d": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3y"
     },
     "4e": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3y"
     },
     "4f": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3y"
     },
     "4g": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3y"
     },
     "4h": {
-      "key": "root.imports.connections",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3y"
     },
     "4i": {
-      "key": "root.imports.icons",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3y"
     },
     "4j": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4i"
+      "key": "root.imports.connections",
+      "~k_parent": "3o"
     },
     "4k": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4j"
+      "key": "root.imports.icons",
+      "~k_parent": "3o"
     },
     "4l": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4k"
     },
     "4o": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4k"
     },
     "4q": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4k"
     },
     "4s": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4k"
     },
     "4u": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4k"
     },
     "4w": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4k"
     },
     "4y": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4k"
     },
     "5a": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4k"
     },
     "5c": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4k"
     },
     "5e": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4k"
     },
     "5g": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4k"
     },
     "5i": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4k"
     },
     "5k": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4k"
     },
     "5m": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4k"
     },
     "5o": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4k"
     },
     "5q": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4k"
     },
     "5s": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4k"
     },
     "5u": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4k"
     },
     "5w": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4k"
     },
     "5y": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4k"
+    },
+    "6a": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "66"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "19"
   },
@@ -1278,6 +1287,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5821,152 +5831,155 @@
       },
       "~k": "2m"
     },
+    "agents": {
+      "~k": "2p"
+    },
     "auth": {
       "adapters": {
-        "~k": "2q"
-      },
-      "callbacks": {
         "~k": "2r"
       },
-      "events": {
+      "callbacks": {
         "~k": "2s"
       },
-      "providers": {
+      "events": {
         "~k": "2t"
       },
-      "~k": "2p"
+      "providers": {
+        "~k": "2u"
+      },
+      "~k": "2q"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 6,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
-      "~k": "2u"
+      "~k": "2v"
     },
     "connections": {
-      "~k": "3f"
-    },
-    "requests": {
       "~k": "3g"
     },
-    "api": {
+    "requests": {
       "~k": "3h"
+    },
+    "api": {
+      "~k": "3i"
     },
     "operators": {
       "client": {
@@ -5974,20 +5987,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3k"
+          "~k": "3l"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3l"
+          "~k": "3m"
         },
-        "~k": "3j"
+        "~k": "3k"
       },
       "server": {
-        "~k": "3m"
+        "~k": "3n"
       },
-      "~k": "3i"
+      "~k": "3j"
     },
     "~k": "2l"
   }

--- a/packages/build/src/tests/success/77-cross-module-menu-refs/snapshot.json
+++ b/packages/build/src/tests/success/77-cross-module-menu-refs/snapshot.json
@@ -143,152 +143,160 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2t"
     },
     "31": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2t"
     },
     "32": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2t"
     },
     "33": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2t"
     },
     "34": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2t"
     },
     "35": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2t"
     },
     "36": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2t"
     },
     "37": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2t"
     },
     "38": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2t"
     },
     "39": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2t"
     },
     "40": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3w"
     },
     "41": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3w"
     },
     "42": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3w"
     },
     "43": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3w"
     },
     "44": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3w"
     },
     "45": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3w"
     },
     "46": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3w"
     },
     "47": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3w"
     },
     "48": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3w"
     },
     "49": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3w"
     },
     "50": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4i"
     },
     "52": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4i"
     },
     "54": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4i"
     },
     "56": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4i"
     },
     "58": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4i"
     },
     "60": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.requests",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4i"
     },
     "62": {
-      "key": "root.imports.operators",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "62"
+      "key": "root.imports.requests",
+      "~k_parent": "3m"
     },
     "64": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "63"
+      "key": "root.imports.operators",
+      "~k_parent": "3m"
     },
     "65": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "63"
+      "key": "root.imports.operators.client",
+      "~k_parent": "64"
     },
     "66": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "65"
+    },
+    "67": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "65"
+    },
+    "68": {
       "key": "root.imports.operators.server",
-      "~k_parent": "62"
+      "~k_parent": "64"
     },
     "a": {
       "key": "root.pages[0:home:Box]",
@@ -572,370 +580,371 @@
       "~k_parent": "2k"
     },
     "2n": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "2j"
     },
     "2o": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2n"
+      "key": "root.types.auth",
+      "~k_parent": "2j"
     },
     "2p": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2n"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2o"
     },
     "2q": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2n"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2o"
     },
     "2r": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2n"
+      "key": "root.types.auth.events",
+      "~k_parent": "2o"
     },
     "2s": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2o"
+    },
+    "2t": {
       "key": "root.types.blocks",
       "~k_parent": "2j"
     },
-    "2t": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2s"
-    },
     "2u": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2t"
     },
     "2w": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2t"
     },
     "2x": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2t"
     },
     "2y": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2t"
     },
     "2z": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2t"
     },
     "3a": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2t"
     },
     "3b": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2t"
     },
     "3c": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2t"
     },
     "3d": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2t"
+    },
+    "3e": {
       "key": "root.types.connections",
       "~k_parent": "2j"
     },
-    "3e": {
+    "3f": {
       "key": "root.types.requests",
       "~k_parent": "2j"
     },
-    "3f": {
+    "3g": {
       "key": "root.types.api",
       "~k_parent": "2j"
     },
-    "3g": {
+    "3h": {
       "key": "root.types.operators",
       "~k_parent": "2j"
     },
-    "3h": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3g"
-    },
     "3i": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3h"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3g"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3i"
     },
     "3l": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3h"
+    },
+    "3m": {
       "key": "root.imports",
       "~k_parent": "8"
     },
-    "3m": {
-      "key": "root.imports.actions",
-      "~k_parent": "3l"
-    },
     "3n": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3m"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.auth",
-      "~k_parent": "3l"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3n"
     },
     "3q": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3p"
+      "key": "root.imports.agents",
+      "~k_parent": "3m"
     },
     "3r": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3p"
+      "key": "root.imports.auth",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3p"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3p"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3r"
     },
     "3u": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3l"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3r"
     },
     "3v": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3u"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3r"
     },
     "3w": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks",
+      "~k_parent": "3m"
     },
     "3x": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3w"
     },
     "3z": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3w"
     },
     "4a": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3w"
     },
     "4b": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3w"
     },
     "4c": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3w"
     },
     "4d": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3w"
     },
     "4e": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3w"
     },
     "4f": {
-      "key": "root.imports.connections",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3w"
     },
     "4g": {
-      "key": "root.imports.icons",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3w"
     },
     "4h": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4g"
+      "key": "root.imports.connections",
+      "~k_parent": "3m"
     },
     "4i": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4h"
+      "key": "root.imports.icons",
+      "~k_parent": "3m"
     },
     "4j": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4i"
     },
     "4m": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4i"
     },
     "4o": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4i"
     },
     "4q": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4i"
     },
     "4s": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4i"
     },
     "4u": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4i"
     },
     "4w": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4i"
     },
     "4y": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4i"
     },
     "5a": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4i"
     },
     "5c": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4i"
     },
     "5e": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4i"
     },
     "5g": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4i"
     },
     "5i": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4i"
     },
     "5k": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4i"
     },
     "5m": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4i"
     },
     "5o": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4i"
     },
     "5q": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4i"
     },
     "5s": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4i"
     },
     "5u": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4i"
     },
     "5w": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4i"
     },
     "5y": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4i"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "14"
   },
@@ -1259,6 +1268,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5788,152 +5798,155 @@
       },
       "~k": "2k"
     },
+    "agents": {
+      "~k": "2n"
+    },
     "auth": {
       "adapters": {
-        "~k": "2o"
-      },
-      "callbacks": {
         "~k": "2p"
       },
-      "events": {
+      "callbacks": {
         "~k": "2q"
       },
-      "providers": {
+      "events": {
         "~k": "2r"
       },
-      "~k": "2n"
+      "providers": {
+        "~k": "2s"
+      },
+      "~k": "2o"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
-      "~k": "2s"
+      "~k": "2t"
     },
     "connections": {
-      "~k": "3d"
-    },
-    "requests": {
       "~k": "3e"
     },
-    "api": {
+    "requests": {
       "~k": "3f"
+    },
+    "api": {
+      "~k": "3g"
     },
     "operators": {
       "client": {
@@ -5941,20 +5954,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3i"
+          "~k": "3j"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3j"
+          "~k": "3k"
         },
-        "~k": "3h"
+        "~k": "3i"
       },
       "server": {
-        "~k": "3k"
+        "~k": "3l"
       },
-      "~k": "3g"
+      "~k": "3h"
     },
     "~k": "2j"
   }

--- a/packages/build/src/tests/success/78-cross-module-mutual-nested/snapshot.json
+++ b/packages/build/src/tests/success/78-cross-module-mutual-nested/snapshot.json
@@ -138,152 +138,160 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2r"
     },
     "31": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2r"
     },
     "32": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2r"
     },
     "33": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2r"
     },
     "34": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2r"
     },
     "35": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2r"
     },
     "36": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2r"
     },
     "37": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2r"
     },
     "38": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2r"
     },
     "39": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2r"
     },
     "40": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3v"
     },
     "41": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3v"
     },
     "42": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3v"
     },
     "43": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3v"
     },
     "44": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3v"
     },
     "45": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3v"
     },
     "46": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3v"
     },
     "47": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3v"
     },
     "48": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3v"
     },
     "49": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3v"
     },
     "50": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4i"
     },
     "52": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4i"
     },
     "54": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4i"
     },
     "56": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4i"
     },
     "58": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4i"
     },
     "60": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.requests",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4i"
     },
     "62": {
-      "key": "root.imports.operators",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "62"
+      "key": "root.imports.requests",
+      "~k_parent": "3l"
     },
     "64": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "63"
+      "key": "root.imports.operators",
+      "~k_parent": "3l"
     },
     "65": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "63"
+      "key": "root.imports.operators.client",
+      "~k_parent": "64"
     },
     "66": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "65"
+    },
+    "67": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "65"
+    },
+    "68": {
       "key": "root.imports.operators.server",
-      "~k_parent": "62"
+      "~k_parent": "64"
     },
     "a": {
       "key": "root.pages",
@@ -564,378 +572,379 @@
       "~k_parent": "2i"
     },
     "2l": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "2h"
     },
     "2m": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2l"
+      "key": "root.types.auth",
+      "~k_parent": "2h"
     },
     "2n": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2l"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2l"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2m"
     },
     "2p": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2l"
+      "key": "root.types.auth.events",
+      "~k_parent": "2m"
     },
     "2q": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2m"
+    },
+    "2r": {
       "key": "root.types.blocks",
       "~k_parent": "2h"
     },
-    "2r": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2r"
     },
     "2u": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "2r"
     },
     "2v": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2r"
     },
     "2w": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2r"
     },
     "2x": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2r"
     },
     "2y": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2r"
     },
     "2z": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2r"
     },
     "3a": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2r"
     },
     "3b": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2r"
     },
     "3c": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2r"
+    },
+    "3d": {
       "key": "root.types.connections",
       "~k_parent": "2h"
     },
-    "3d": {
+    "3e": {
       "key": "root.types.requests",
       "~k_parent": "2h"
     },
-    "3e": {
+    "3f": {
       "key": "root.types.api",
       "~k_parent": "2h"
     },
-    "3f": {
+    "3g": {
       "key": "root.types.operators",
       "~k_parent": "2h"
     },
-    "3g": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3f"
-    },
     "3h": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3g"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3f"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3h"
     },
     "3k": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3g"
+    },
+    "3l": {
       "key": "root.imports",
       "~k_parent": "9"
     },
-    "3l": {
-      "key": "root.imports.actions",
-      "~k_parent": "3k"
-    },
     "3m": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3l"
     },
     "3n": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3l"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.auth",
-      "~k_parent": "3k"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3m"
     },
     "3p": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3o"
+      "key": "root.imports.agents",
+      "~k_parent": "3l"
     },
     "3q": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3o"
+      "key": "root.imports.auth",
+      "~k_parent": "3l"
     },
     "3r": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3o"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3o"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3q"
     },
     "3t": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3k"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3q"
     },
     "3u": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3t"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3q"
     },
     "3v": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks",
+      "~k_parent": "3l"
     },
     "3w": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3v"
     },
     "3y": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3v"
     },
     "3z": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3v"
     },
     "4a": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3v"
     },
     "4b": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3v"
     },
     "4c": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3v"
     },
     "4d": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3v"
     },
     "4e": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3v"
     },
     "4f": {
-      "key": "root.imports.connections",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3v"
     },
     "4g": {
-      "key": "root.imports.icons",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "3v"
     },
     "4h": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4g"
+      "key": "root.imports.connections",
+      "~k_parent": "3l"
     },
     "4i": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4h"
+      "key": "root.imports.icons",
+      "~k_parent": "3l"
     },
     "4j": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4i"
     },
     "4m": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4i"
     },
     "4o": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4i"
     },
     "4q": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4i"
     },
     "4s": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4i"
     },
     "4u": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4i"
     },
     "4w": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4i"
     },
     "4y": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4i"
     },
     "5a": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4i"
     },
     "5c": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4i"
     },
     "5e": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4i"
     },
     "5g": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4i"
     },
     "5i": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4i"
     },
     "5k": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4i"
     },
     "5m": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4i"
     },
     "5o": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4i"
     },
     "5q": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4i"
     },
     "5s": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4i"
     },
     "5u": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4i"
     },
     "5w": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4i"
     },
     "5y": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4i"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "17"
   },
@@ -1249,6 +1258,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -6649,158 +6659,161 @@
       },
       "~k": "2i"
     },
+    "agents": {
+      "~k": "2l"
+    },
     "auth": {
       "adapters": {
-        "~k": "2m"
-      },
-      "callbacks": {
         "~k": "2n"
       },
-      "events": {
+      "callbacks": {
         "~k": "2o"
       },
-      "providers": {
+      "events": {
         "~k": "2p"
       },
-      "~k": "2l"
+      "providers": {
+        "~k": "2q"
+      },
+      "~k": "2m"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
-      "~k": "2q"
+      "~k": "2r"
     },
     "connections": {
-      "~k": "3c"
-    },
-    "requests": {
       "~k": "3d"
     },
-    "api": {
+    "requests": {
       "~k": "3e"
+    },
+    "api": {
+      "~k": "3f"
     },
     "operators": {
       "client": {
@@ -6808,20 +6821,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3h"
+          "~k": "3i"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3i"
+          "~k": "3j"
         },
-        "~k": "3g"
+        "~k": "3h"
       },
       "server": {
-        "~k": "3j"
+        "~k": "3k"
       },
-      "~k": "3f"
+      "~k": "3g"
     },
     "~k": "2h"
   }

--- a/packages/build/src/tests/success/79-cross-module-build-op-wrapping/snapshot.json
+++ b/packages/build/src/tests/success/79-cross-module-build-op-wrapping/snapshot.json
@@ -122,160 +122,160 @@
       "~k_parent": "1y"
     },
     "21": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1x"
     },
     "22": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "21"
+      "key": "root.types.auth",
+      "~k_parent": "1x"
     },
     "23": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "21"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "22"
     },
     "24": {
-      "key": "root.types.auth.events",
-      "~k_parent": "21"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "22"
     },
     "25": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "21"
+      "key": "root.types.auth.events",
+      "~k_parent": "22"
     },
     "26": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "22"
+    },
+    "27": {
       "key": "root.types.blocks",
       "~k_parent": "1x"
     },
-    "27": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "26"
-    },
     "28": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "27"
     },
     "29": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "27"
     },
     "30": {
-      "key": "root.imports.actions",
-      "~k_parent": "2z"
+      "key": "root.imports",
+      "~k_parent": "6"
     },
     "31": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "30"
     },
     "32": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "30"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "31"
     },
     "33": {
-      "key": "root.imports.auth",
-      "~k_parent": "2z"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "31"
     },
     "34": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "33"
+      "key": "root.imports.agents",
+      "~k_parent": "30"
     },
     "35": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "33"
+      "key": "root.imports.auth",
+      "~k_parent": "30"
     },
     "36": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "33"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "35"
     },
     "37": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "33"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "35"
     },
     "38": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2z"
+      "key": "root.imports.auth.events",
+      "~k_parent": "35"
     },
     "39": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "38"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "35"
     },
     "40": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3w"
     },
     "42": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3w"
     },
     "44": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3w"
     },
     "46": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3w"
     },
     "48": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3w"
     },
     "50": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3w"
     },
     "52": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3w"
     },
     "54": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3w"
     },
     "56": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3w"
     },
     "58": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3w"
     },
     "a": {
       "key": "root.pages[1:contacts/contact-list:Box].blocks",
@@ -487,362 +487,371 @@
       "~k_parent": "1y"
     },
     "2a": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "27"
     },
     "2b": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "27"
     },
     "2c": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "27"
     },
     "2d": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "26"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "27"
     },
     "2e": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "27"
     },
     "2f": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "27"
     },
     "2g": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "27"
     },
     "2h": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "26"
+      "key": "root.types.blocks.List",
+      "~k_parent": "27"
     },
     "2i": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "27"
     },
     "2j": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "27"
     },
     "2k": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "26"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "27"
     },
     "2l": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "27"
     },
     "2m": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "26"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "27"
     },
     "2n": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "26"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "27"
     },
     "2o": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "26"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "27"
     },
     "2p": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "26"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "27"
     },
     "2q": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "27"
     },
     "2r": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "27"
+    },
+    "2s": {
       "key": "root.types.connections",
       "~k_parent": "1x"
     },
-    "2s": {
+    "2t": {
       "key": "root.types.requests",
       "~k_parent": "1x"
     },
-    "2t": {
+    "2u": {
       "key": "root.types.api",
       "~k_parent": "1x"
     },
-    "2u": {
+    "2v": {
       "key": "root.types.operators",
       "~k_parent": "1x"
     },
-    "2v": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2u"
-    },
     "2w": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2v"
     },
     "2x": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2v"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2u"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2w"
     },
     "2z": {
-      "key": "root.imports",
-      "~k_parent": "6"
+      "key": "root.types.operators.server",
+      "~k_parent": "2v"
     },
     "3a": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks",
+      "~k_parent": "30"
     },
     "3b": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3a"
     },
     "3c": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3a"
     },
     "3d": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3a"
     },
     "3e": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3a"
     },
     "3f": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3a"
     },
     "3g": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3a"
     },
     "3h": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3a"
     },
     "3i": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3a"
     },
     "3j": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3a"
     },
     "3k": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3a"
     },
     "3l": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3a"
     },
     "3m": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3a"
     },
     "3n": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3a"
     },
     "3o": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3a"
     },
     "3p": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3a"
     },
     "3q": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3a"
     },
     "3r": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3a"
     },
     "3s": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3a"
     },
     "3t": {
-      "key": "root.imports.connections",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3a"
     },
     "3u": {
-      "key": "root.imports.icons",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3a"
     },
     "3v": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3u"
+      "key": "root.imports.connections",
+      "~k_parent": "30"
     },
     "3w": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3v"
+      "key": "root.imports.icons",
+      "~k_parent": "30"
     },
     "3x": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3w"
     },
     "4a": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3w"
     },
     "4c": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3w"
     },
     "4e": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3w"
     },
     "4g": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3w"
     },
     "4i": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3w"
     },
     "4k": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3w"
     },
     "4m": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3w"
     },
     "4o": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3w"
     },
     "4q": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3w"
     },
     "4s": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3w"
     },
     "4u": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3w"
     },
     "4w": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3w"
     },
     "4y": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3w"
     },
     "5a": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3w"
     },
     "5c": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3w"
     },
     "5e": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.requests",
-      "~k_parent": "2z"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3w"
     },
     "5g": {
-      "key": "root.imports.operators",
-      "~k_parent": "2z"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5g"
+      "key": "root.imports.requests",
+      "~k_parent": "30"
     },
     "5i": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5h"
+      "key": "root.imports.operators",
+      "~k_parent": "30"
     },
     "5j": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5h"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5i"
     },
     "5k": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5j"
+    },
+    "5l": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5j"
+    },
+    "5m": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5g"
+      "~k_parent": "5i"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "w"
   },
@@ -1082,6 +1091,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5594,152 +5604,155 @@
       },
       "~k": "1y"
     },
+    "agents": {
+      "~k": "21"
+    },
     "auth": {
       "adapters": {
-        "~k": "22"
-      },
-      "callbacks": {
         "~k": "23"
       },
-      "events": {
+      "callbacks": {
         "~k": "24"
       },
-      "providers": {
+      "events": {
         "~k": "25"
       },
-      "~k": "21"
+      "providers": {
+        "~k": "26"
+      },
+      "~k": "22"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "27"
+        "~k": "28"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "28"
+        "~k": "29"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
-      "~k": "26"
+      "~k": "27"
     },
     "connections": {
-      "~k": "2r"
-    },
-    "requests": {
       "~k": "2s"
     },
-    "api": {
+    "requests": {
       "~k": "2t"
+    },
+    "api": {
+      "~k": "2u"
     },
     "operators": {
       "client": {
@@ -5747,20 +5760,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2w"
+          "~k": "2x"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2x"
+          "~k": "2y"
         },
-        "~k": "2v"
+        "~k": "2w"
       },
       "server": {
-        "~k": "2y"
+        "~k": "2z"
       },
-      "~k": "2u"
+      "~k": "2v"
     },
     "~k": "1x"
   }

--- a/packages/build/src/tests/success/80-cross-module-ref-in-vars/snapshot.json
+++ b/packages/build/src/tests/success/80-cross-module-ref-in-vars/snapshot.json
@@ -138,123 +138,123 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2i"
     },
     "31": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2i"
     },
     "32": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2i"
+    },
+    "33": {
       "key": "root.types.connections",
       "~k_parent": "28"
     },
-    "33": {
+    "34": {
       "key": "root.types.requests",
       "~k_parent": "28"
     },
-    "34": {
+    "35": {
       "key": "root.types.api",
       "~k_parent": "28"
     },
-    "35": {
+    "36": {
       "key": "root.types.operators",
       "~k_parent": "28"
     },
-    "36": {
-      "key": "root.types.operators.client",
-      "~k_parent": "35"
-    },
     "37": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "36"
     },
     "38": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "36"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "37"
     },
     "39": {
-      "key": "root.types.operators.server",
-      "~k_parent": "35"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "37"
     },
     "40": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3l"
     },
     "41": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3l"
     },
     "42": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3l"
     },
     "43": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3l"
     },
     "44": {
-      "key": "root.imports.connections",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3l"
     },
     "45": {
-      "key": "root.imports.icons",
-      "~k_parent": "3a"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3l"
     },
     "46": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "45"
+      "key": "root.imports.connections",
+      "~k_parent": "3b"
     },
     "47": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "46"
+      "key": "root.imports.icons",
+      "~k_parent": "3b"
     },
     "48": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "47"
     },
     "51": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "47"
     },
     "53": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "47"
     },
     "55": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "47"
     },
     "57": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "47"
     },
     "59": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "58"
     },
     "a": {
@@ -492,398 +492,407 @@
       "~k_parent": "29"
     },
     "2c": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "28"
     },
     "2d": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2c"
+      "key": "root.types.auth",
+      "~k_parent": "28"
     },
     "2e": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2c"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2d"
     },
     "2f": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2c"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2d"
     },
     "2g": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2c"
+      "key": "root.types.auth.events",
+      "~k_parent": "2d"
     },
     "2h": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2d"
+    },
+    "2i": {
       "key": "root.types.blocks",
       "~k_parent": "28"
     },
-    "2i": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2h"
-    },
     "2j": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2i"
     },
     "2k": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2i"
     },
     "2l": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2i"
     },
     "2m": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2i"
     },
     "2n": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2i"
     },
     "2o": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2i"
     },
     "2p": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2i"
     },
     "2q": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2i"
     },
     "2r": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2i"
     },
     "2s": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2i"
     },
     "2t": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2i"
     },
     "2u": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2i"
     },
     "2v": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2i"
     },
     "2w": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2i"
     },
     "2x": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2i"
     },
     "2y": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2i"
     },
     "2z": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2h"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2i"
     },
     "3a": {
+      "key": "root.types.operators.server",
+      "~k_parent": "36"
+    },
+    "3b": {
       "key": "root.imports",
       "~k_parent": "9"
     },
-    "3b": {
-      "key": "root.imports.actions",
-      "~k_parent": "3a"
-    },
     "3c": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3b"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3c"
     },
     "3e": {
-      "key": "root.imports.auth",
-      "~k_parent": "3a"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3c"
     },
     "3f": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3e"
+      "key": "root.imports.agents",
+      "~k_parent": "3b"
     },
     "3g": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3e"
+      "key": "root.imports.auth",
+      "~k_parent": "3b"
     },
     "3h": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3e"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3e"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3g"
     },
     "3j": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3a"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3g"
     },
     "3k": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3j"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3g"
     },
     "3l": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks",
+      "~k_parent": "3b"
     },
     "3m": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3l"
     },
     "3n": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3l"
     },
     "3o": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3l"
     },
     "3p": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3l"
     },
     "3q": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3l"
     },
     "3r": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3l"
     },
     "3s": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3l"
     },
     "3t": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3l"
     },
     "3u": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3l"
     },
     "3v": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3l"
     },
     "3w": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3l"
     },
     "3x": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3l"
     },
     "3y": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3l"
     },
     "3z": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3j"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3l"
     },
     "4a": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "47"
     },
     "4b": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "47"
     },
     "4d": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "47"
     },
     "4f": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "47"
     },
     "4h": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "47"
     },
     "4j": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "47"
     },
     "4l": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "47"
     },
     "4n": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "47"
     },
     "4p": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "47"
     },
     "4r": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "47"
     },
     "4t": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "47"
     },
     "4v": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "47"
     },
     "4x": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "47"
     },
     "4z": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "47"
     },
     "5b": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "47"
     },
     "5d": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "47"
     },
     "5f": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "47"
     },
     "5h": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "47"
     },
     "5j": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "47"
     },
     "5l": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "47"
     },
     "5n": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "45"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "47"
     },
     "5p": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.requests",
-      "~k_parent": "3a"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "47"
     },
     "5r": {
-      "key": "root.imports.operators",
-      "~k_parent": "3a"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5r"
+      "key": "root.imports.requests",
+      "~k_parent": "3b"
     },
     "5t": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5s"
+      "key": "root.imports.operators",
+      "~k_parent": "3b"
     },
     "5u": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5s"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5t"
     },
     "5v": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5u"
+    },
+    "5w": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5u"
+    },
+    "5x": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5r"
+      "~k_parent": "5t"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "13"
   },
@@ -1157,6 +1166,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5703,152 +5713,155 @@
       },
       "~k": "29"
     },
+    "agents": {
+      "~k": "2c"
+    },
     "auth": {
       "adapters": {
-        "~k": "2d"
-      },
-      "callbacks": {
         "~k": "2e"
       },
-      "events": {
+      "callbacks": {
         "~k": "2f"
       },
-      "providers": {
+      "events": {
         "~k": "2g"
       },
-      "~k": "2c"
+      "providers": {
+        "~k": "2h"
+      },
+      "~k": "2d"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
-      "~k": "2h"
+      "~k": "2i"
     },
     "connections": {
-      "~k": "32"
-    },
-    "requests": {
       "~k": "33"
     },
-    "api": {
+    "requests": {
       "~k": "34"
+    },
+    "api": {
+      "~k": "35"
     },
     "operators": {
       "client": {
@@ -5856,20 +5869,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "37"
+          "~k": "38"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "38"
+          "~k": "39"
         },
-        "~k": "36"
+        "~k": "37"
       },
       "server": {
-        "~k": "39"
+        "~k": "3a"
       },
-      "~k": "35"
+      "~k": "36"
     },
     "~k": "28"
   }

--- a/packages/build/src/tests/success/81-cross-module-build-op-components/snapshot.json
+++ b/packages/build/src/tests/success/81-cross-module-build-op-components/snapshot.json
@@ -134,144 +134,144 @@
       "~k_parent": "22"
     },
     "25": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "21"
     },
     "26": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "25"
+      "key": "root.types.auth",
+      "~k_parent": "21"
     },
     "27": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "25"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "26"
     },
     "28": {
-      "key": "root.types.auth.events",
-      "~k_parent": "25"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "26"
     },
     "29": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "25"
+      "key": "root.types.auth.events",
+      "~k_parent": "26"
     },
     "30": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2z"
     },
     "31": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2z"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "30"
     },
     "32": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2y"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "30"
     },
     "33": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2z"
+    },
+    "34": {
       "key": "root.imports",
       "~k_parent": "6"
     },
-    "34": {
-      "key": "root.imports.actions",
-      "~k_parent": "33"
-    },
     "35": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "34"
     },
     "36": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "34"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "35"
     },
     "37": {
-      "key": "root.imports.auth",
-      "~k_parent": "33"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "35"
     },
     "38": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "37"
+      "key": "root.imports.agents",
+      "~k_parent": "34"
     },
     "39": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "37"
+      "key": "root.imports.auth",
+      "~k_parent": "34"
     },
     "40": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3z"
+      "key": "root.imports.icons",
+      "~k_parent": "34"
     },
     "41": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "40"
     },
     "44": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "40"
     },
     "46": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "40"
     },
     "48": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "40"
     },
     "50": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "40"
     },
     "52": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "40"
     },
     "54": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "40"
     },
     "56": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "40"
     },
     "58": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "40"
     },
     "a": {
       "key": "root.pages[1:contacts/contact-list:Box].blocks",
@@ -492,378 +492,387 @@
       "~k_parent": "1w"
     },
     "2a": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "26"
+    },
+    "2b": {
       "key": "root.types.blocks",
       "~k_parent": "21"
     },
-    "2b": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2a"
-    },
     "2c": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2b"
     },
     "2d": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2b"
     },
     "2e": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2b"
     },
     "2f": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2b"
     },
     "2g": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2b"
     },
     "2h": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2b"
     },
     "2i": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2b"
     },
     "2j": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2b"
     },
     "2k": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2b"
     },
     "2l": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2b"
     },
     "2m": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2b"
     },
     "2n": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2b"
     },
     "2o": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2b"
     },
     "2p": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2b"
     },
     "2q": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2b"
     },
     "2r": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2b"
     },
     "2s": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2b"
     },
     "2t": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2b"
     },
     "2u": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2b"
     },
     "2v": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2b"
+    },
+    "2w": {
       "key": "root.types.connections",
       "~k_parent": "21"
     },
-    "2w": {
+    "2x": {
       "key": "root.types.requests",
       "~k_parent": "21"
     },
-    "2x": {
+    "2y": {
       "key": "root.types.api",
       "~k_parent": "21"
     },
-    "2y": {
+    "2z": {
       "key": "root.types.operators",
       "~k_parent": "21"
     },
-    "2z": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2y"
-    },
     "3a": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "37"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "39"
     },
     "3b": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "37"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "39"
     },
     "3c": {
-      "key": "root.imports.blocks",
-      "~k_parent": "33"
+      "key": "root.imports.auth.events",
+      "~k_parent": "39"
     },
     "3d": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3c"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "39"
     },
     "3e": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks",
+      "~k_parent": "34"
     },
     "3f": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3e"
     },
     "3h": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3e"
     },
     "3i": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3e"
     },
     "3j": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3e"
     },
     "3k": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3e"
     },
     "3l": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3e"
     },
     "3m": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3e"
     },
     "3n": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3e"
     },
     "3o": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3e"
     },
     "3p": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3e"
     },
     "3q": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3e"
     },
     "3r": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3e"
     },
     "3s": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3e"
     },
     "3t": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3e"
     },
     "3u": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3e"
     },
     "3v": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3e"
     },
     "3w": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3e"
     },
     "3x": {
-      "key": "root.imports.connections",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3e"
     },
     "3y": {
-      "key": "root.imports.icons",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3e"
     },
     "3z": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3y"
+      "key": "root.imports.connections",
+      "~k_parent": "34"
     },
     "4a": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "40"
     },
     "4c": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "40"
     },
     "4e": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "40"
     },
     "4g": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "40"
     },
     "4i": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "40"
     },
     "4k": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "40"
     },
     "4m": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "40"
     },
     "4o": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "40"
     },
     "4q": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "40"
     },
     "4s": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "40"
     },
     "4u": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "40"
     },
     "4w": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "40"
     },
     "4y": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "40"
     },
     "5a": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "40"
     },
     "5c": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "40"
     },
     "5e": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "40"
     },
     "5g": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "40"
     },
     "5i": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.requests",
-      "~k_parent": "33"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "40"
     },
     "5k": {
-      "key": "root.imports.operators",
-      "~k_parent": "33"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5k"
+      "key": "root.imports.requests",
+      "~k_parent": "34"
     },
     "5m": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5l"
+      "key": "root.imports.operators",
+      "~k_parent": "34"
     },
     "5n": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5l"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5m"
     },
     "5o": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5n"
+    },
+    "5p": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5n"
+    },
+    "5q": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5k"
+      "~k_parent": "5m"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "y"
   },
@@ -1120,6 +1129,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5633,152 +5643,155 @@
       },
       "~k": "22"
     },
+    "agents": {
+      "~k": "25"
+    },
     "auth": {
       "adapters": {
-        "~k": "26"
-      },
-      "callbacks": {
         "~k": "27"
       },
-      "events": {
+      "callbacks": {
         "~k": "28"
       },
-      "providers": {
+      "events": {
         "~k": "29"
       },
-      "~k": "25"
+      "providers": {
+        "~k": "2a"
+      },
+      "~k": "26"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
-      "~k": "2a"
+      "~k": "2b"
     },
     "connections": {
-      "~k": "2v"
-    },
-    "requests": {
       "~k": "2w"
     },
-    "api": {
+    "requests": {
       "~k": "2x"
+    },
+    "api": {
+      "~k": "2y"
     },
     "operators": {
       "client": {
@@ -5786,20 +5799,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "30"
+          "~k": "31"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "31"
+          "~k": "32"
         },
-        "~k": "2z"
+        "~k": "30"
       },
       "server": {
-        "~k": "32"
+        "~k": "33"
       },
-      "~k": "2y"
+      "~k": "2z"
     },
     "~k": "21"
   }

--- a/packages/build/src/tests/success/82-cross-module-mutual-refs-reversed/snapshot.json
+++ b/packages/build/src/tests/success/82-cross-module-mutual-refs-reversed/snapshot.json
@@ -137,156 +137,164 @@
       "~k_parent": "a"
     },
     "30": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2s"
     },
     "31": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2s"
     },
     "32": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2s"
     },
     "33": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2s"
     },
     "34": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2s"
     },
     "35": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2s"
     },
     "36": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2s"
     },
     "37": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2s"
     },
     "38": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2s"
     },
     "39": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2s"
     },
     "40": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3w"
     },
     "41": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3w"
     },
     "42": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3w"
     },
     "43": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3w"
     },
     "44": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3w"
     },
     "45": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3w"
     },
     "46": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3w"
     },
     "47": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3w"
     },
     "48": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3w"
     },
     "49": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3w"
     },
     "50": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4j"
     },
     "51": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4j"
     },
     "53": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4j"
     },
     "55": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4j"
     },
     "57": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4j"
     },
     "59": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4j"
     },
     "61": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.requests",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4j"
     },
     "63": {
-      "key": "root.imports.operators",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "63"
+      "key": "root.imports.requests",
+      "~k_parent": "3m"
     },
     "65": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "64"
+      "key": "root.imports.operators",
+      "~k_parent": "3m"
     },
     "66": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "64"
+      "key": "root.imports.operators.client",
+      "~k_parent": "65"
     },
     "67": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "66"
+    },
+    "68": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "66"
+    },
+    "69": {
       "key": "root.imports.operators.server",
-      "~k_parent": "63"
+      "~k_parent": "65"
     },
     "a": {
       "key": "root",
@@ -572,374 +580,375 @@
       "~k_parent": "2j"
     },
     "2m": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "2i"
     },
     "2n": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2m"
+      "key": "root.types.auth",
+      "~k_parent": "2i"
     },
     "2o": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2m"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2m"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2n"
     },
     "2q": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2m"
+      "key": "root.types.auth.events",
+      "~k_parent": "2n"
     },
     "2r": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2n"
+    },
+    "2s": {
       "key": "root.types.blocks",
       "~k_parent": "2i"
     },
-    "2s": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2r"
-    },
     "2t": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2s"
     },
     "2v": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "2s"
     },
     "2w": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2s"
     },
     "2x": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2s"
     },
     "2y": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2s"
     },
     "2z": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2s"
     },
     "3a": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2s"
     },
     "3b": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2s"
     },
     "3c": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2r"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2s"
     },
     "3d": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2s"
+    },
+    "3e": {
       "key": "root.types.connections",
       "~k_parent": "2i"
     },
-    "3e": {
+    "3f": {
       "key": "root.types.requests",
       "~k_parent": "2i"
     },
-    "3f": {
+    "3g": {
       "key": "root.types.api",
       "~k_parent": "2i"
     },
-    "3g": {
+    "3h": {
       "key": "root.types.operators",
       "~k_parent": "2i"
     },
-    "3h": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3g"
-    },
     "3i": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3h"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3g"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3i"
     },
     "3l": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3h"
+    },
+    "3m": {
       "key": "root.imports",
       "~k_parent": "a"
     },
-    "3m": {
-      "key": "root.imports.actions",
-      "~k_parent": "3l"
-    },
     "3n": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3m"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.auth",
-      "~k_parent": "3l"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3n"
     },
     "3q": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3p"
+      "key": "root.imports.agents",
+      "~k_parent": "3m"
     },
     "3r": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3p"
+      "key": "root.imports.auth",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3p"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3p"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3r"
     },
     "3u": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3l"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3r"
     },
     "3v": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3u"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3r"
     },
     "3w": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks",
+      "~k_parent": "3m"
     },
     "3x": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3w"
     },
     "3z": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3w"
     },
     "4a": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3w"
     },
     "4b": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3w"
     },
     "4c": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3w"
     },
     "4d": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3w"
     },
     "4e": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3w"
     },
     "4f": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3w"
     },
     "4g": {
-      "key": "root.imports.connections",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3w"
     },
     "4h": {
-      "key": "root.imports.icons",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "3w"
     },
     "4i": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4h"
+      "key": "root.imports.connections",
+      "~k_parent": "3m"
     },
     "4j": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4i"
+      "key": "root.imports.icons",
+      "~k_parent": "3m"
     },
     "4k": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4j"
     },
     "4n": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4j"
     },
     "4p": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4j"
     },
     "4r": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4j"
     },
     "4t": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4j"
     },
     "4v": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4j"
     },
     "4x": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4j"
     },
     "4z": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4j"
     },
     "5b": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4j"
     },
     "5d": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4j"
     },
     "5f": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4j"
     },
     "5h": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4j"
     },
     "5j": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4j"
     },
     "5l": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4j"
     },
     "5n": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4j"
     },
     "5p": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4j"
     },
     "5r": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4j"
     },
     "5t": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4j"
     },
     "5v": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4j"
     },
     "5x": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4j"
     },
     "5z": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5y"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "1a"
   },
@@ -1256,6 +1265,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -6595,12 +6605,12 @@
     "4": {
       "parent": "pages.0.blocks.1",
       "lineNumber": 16,
-      "path": "/Users/sam/Developer/lowdefy/lowdefy/packages/build/src/tests/success/71-cross-module-mutual-refs/modules/contacts/components/contact-selector.yaml"
+      "path": "/Users/machiel/Documents/GitHub/lowdefy/packages/build/src/tests/success/71-cross-module-mutual-refs/modules/contacts/components/contact-selector.yaml"
     },
     "5": {
       "parent": "3",
       "lineNumber": 20,
-      "path": "/Users/sam/Developer/lowdefy/lowdefy/packages/build/src/tests/success/71-cross-module-mutual-refs/modules/contacts/pages/contact-detail.yaml"
+      "path": "/Users/machiel/Documents/GitHub/lowdefy/packages/build/src/tests/success/71-cross-module-mutual-refs/modules/contacts/pages/contact-detail.yaml"
     },
     "6": {
       "parent": "5",
@@ -6615,7 +6625,7 @@
     "7": {
       "parent": "6",
       "lineNumber": 16,
-      "path": "/Users/sam/Developer/lowdefy/lowdefy/packages/build/src/tests/success/71-cross-module-mutual-refs/modules/companies/components/company-selector.yaml"
+      "path": "/Users/machiel/Documents/GitHub/lowdefy/packages/build/src/tests/success/71-cross-module-mutual-refs/modules/companies/components/company-selector.yaml"
     },
     "8": {
       "parent": null
@@ -6623,7 +6633,7 @@
     "pages.0": {
       "parent": "2",
       "lineNumber": 20,
-      "path": "/Users/sam/Developer/lowdefy/lowdefy/packages/build/src/tests/success/71-cross-module-mutual-refs/modules/companies/pages/company-detail.yaml"
+      "path": "/Users/machiel/Documents/GitHub/lowdefy/packages/build/src/tests/success/71-cross-module-mutual-refs/modules/companies/pages/company-detail.yaml"
     },
     "pages.0.blocks.1": {
       "parent": "pages.0",
@@ -6656,158 +6666,161 @@
       },
       "~k": "2j"
     },
+    "agents": {
+      "~k": "2m"
+    },
     "auth": {
       "adapters": {
-        "~k": "2n"
-      },
-      "callbacks": {
         "~k": "2o"
       },
-      "events": {
+      "callbacks": {
         "~k": "2p"
       },
-      "providers": {
+      "events": {
         "~k": "2q"
       },
-      "~k": "2m"
+      "providers": {
+        "~k": "2r"
+      },
+      "~k": "2n"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
-      "~k": "2r"
+      "~k": "2s"
     },
     "connections": {
-      "~k": "3d"
-    },
-    "requests": {
       "~k": "3e"
     },
-    "api": {
+    "requests": {
       "~k": "3f"
+    },
+    "api": {
+      "~k": "3g"
     },
     "operators": {
       "client": {
@@ -6815,20 +6828,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3i"
+          "~k": "3j"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3j"
+          "~k": "3k"
         },
-        "~k": "3h"
+        "~k": "3i"
       },
       "server": {
-        "~k": "3k"
+        "~k": "3l"
       },
-      "~k": "3g"
+      "~k": "3h"
     },
     "~k": "2i"
   }

--- a/packages/build/src/tests/success/83-cross-module-multi-consumer-vars/snapshot.json
+++ b/packages/build/src/tests/success/83-cross-module-multi-consumer-vars/snapshot.json
@@ -138,124 +138,124 @@
       "~k_parent": "9"
     },
     "30": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2j"
     },
     "31": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2j"
     },
     "32": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2j"
     },
     "33": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2j"
+    },
+    "34": {
       "key": "root.types.connections",
       "~k_parent": "29"
     },
-    "34": {
+    "35": {
       "key": "root.types.requests",
       "~k_parent": "29"
     },
-    "35": {
+    "36": {
       "key": "root.types.api",
       "~k_parent": "29"
     },
-    "36": {
+    "37": {
       "key": "root.types.operators",
       "~k_parent": "29"
     },
-    "37": {
-      "key": "root.types.operators.client",
-      "~k_parent": "36"
-    },
     "38": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "37"
     },
     "39": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "37"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "38"
     },
     "40": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3m"
     },
     "41": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3m"
     },
     "42": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3m"
     },
     "43": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3m"
     },
     "44": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3m"
     },
     "45": {
-      "key": "root.imports.connections",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3m"
     },
     "46": {
-      "key": "root.imports.icons",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3m"
     },
     "47": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "46"
+      "key": "root.imports.connections",
+      "~k_parent": "3c"
     },
     "48": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "47"
+      "key": "root.imports.icons",
+      "~k_parent": "3c"
     },
     "49": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "48"
     },
     "52": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "48"
     },
     "54": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "48"
     },
     "56": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "48"
     },
     "58": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "48"
     },
     "a": {
       "key": "root.pages",
@@ -492,398 +492,407 @@
       "~k_parent": "2a"
     },
     "2d": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "29"
     },
     "2e": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2d"
+      "key": "root.types.auth",
+      "~k_parent": "29"
     },
     "2f": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2d"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2e"
     },
     "2g": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2d"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2e"
     },
     "2h": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2d"
+      "key": "root.types.auth.events",
+      "~k_parent": "2e"
     },
     "2i": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2e"
+    },
+    "2j": {
       "key": "root.types.blocks",
       "~k_parent": "29"
     },
-    "2j": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2i"
-    },
     "2k": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2j"
     },
     "2l": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2j"
     },
     "2m": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2j"
     },
     "2n": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2j"
     },
     "2o": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2j"
     },
     "2p": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2j"
     },
     "2q": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2j"
     },
     "2r": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2j"
     },
     "2s": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2j"
     },
     "2t": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2j"
     },
     "2u": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2j"
     },
     "2v": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2j"
     },
     "2w": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2j"
     },
     "2x": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2j"
     },
     "2y": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2j"
     },
     "2z": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2j"
     },
     "3a": {
-      "key": "root.types.operators.server",
-      "~k_parent": "36"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "38"
     },
     "3b": {
+      "key": "root.types.operators.server",
+      "~k_parent": "37"
+    },
+    "3c": {
       "key": "root.imports",
       "~k_parent": "9"
     },
-    "3c": {
-      "key": "root.imports.actions",
-      "~k_parent": "3b"
-    },
     "3d": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3c"
     },
     "3e": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3c"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3d"
     },
     "3f": {
-      "key": "root.imports.auth",
-      "~k_parent": "3b"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3d"
     },
     "3g": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3f"
+      "key": "root.imports.agents",
+      "~k_parent": "3c"
     },
     "3h": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3f"
+      "key": "root.imports.auth",
+      "~k_parent": "3c"
     },
     "3i": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3f"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3f"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3h"
     },
     "3k": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3b"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3h"
     },
     "3l": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3k"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3h"
     },
     "3m": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks",
+      "~k_parent": "3c"
     },
     "3n": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3m"
     },
     "3p": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3m"
     },
     "3r": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3m"
     },
     "3t": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3m"
     },
     "3u": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3m"
     },
     "3v": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3m"
     },
     "3w": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3m"
     },
     "3x": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3m"
     },
     "3y": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3m"
     },
     "3z": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3m"
     },
     "4a": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "48"
     },
     "4c": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "48"
     },
     "4e": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "48"
     },
     "4g": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "48"
     },
     "4i": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "48"
     },
     "4k": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "48"
     },
     "4m": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "48"
     },
     "4o": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "48"
     },
     "4q": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "48"
     },
     "4s": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "48"
     },
     "4u": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "48"
     },
     "4w": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "48"
     },
     "4y": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "48"
     },
     "5a": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "48"
     },
     "5c": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "48"
     },
     "5e": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "48"
     },
     "5g": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "48"
     },
     "5i": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "48"
     },
     "5k": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "48"
     },
     "5m": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "48"
     },
     "5o": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "48"
     },
     "5q": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.requests",
-      "~k_parent": "3b"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "48"
     },
     "5s": {
-      "key": "root.imports.operators",
-      "~k_parent": "3b"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5s"
+      "key": "root.imports.requests",
+      "~k_parent": "3c"
     },
     "5u": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5t"
+      "key": "root.imports.operators",
+      "~k_parent": "3c"
     },
     "5v": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5t"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5u"
     },
     "5w": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5v"
+    },
+    "5x": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5v"
+    },
+    "5y": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5s"
+      "~k_parent": "5u"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "11"
   },
@@ -1160,6 +1169,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5694,152 +5704,155 @@
       },
       "~k": "2a"
     },
+    "agents": {
+      "~k": "2d"
+    },
     "auth": {
       "adapters": {
-        "~k": "2e"
-      },
-      "callbacks": {
         "~k": "2f"
       },
-      "events": {
+      "callbacks": {
         "~k": "2g"
       },
-      "providers": {
+      "events": {
         "~k": "2h"
       },
-      "~k": "2d"
+      "providers": {
+        "~k": "2i"
+      },
+      "~k": "2e"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
-      "~k": "2i"
+      "~k": "2j"
     },
     "connections": {
-      "~k": "33"
-    },
-    "requests": {
       "~k": "34"
     },
-    "api": {
+    "requests": {
       "~k": "35"
+    },
+    "api": {
+      "~k": "36"
     },
     "operators": {
       "client": {
@@ -5847,20 +5860,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "38"
+          "~k": "39"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "39"
+          "~k": "3a"
         },
-        "~k": "37"
+        "~k": "38"
       },
       "server": {
-        "~k": "3a"
+        "~k": "3b"
       },
-      "~k": "36"
+      "~k": "37"
     },
     "~k": "29"
   }

--- a/packages/build/src/tests/success/84-cross-module-multi-consumer-menus/snapshot.json
+++ b/packages/build/src/tests/success/84-cross-module-multi-consumer-menus/snapshot.json
@@ -138,163 +138,163 @@
       "~k_parent": "1p"
     },
     "30": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2y"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2z"
     },
     "31": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2y"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2z"
     },
     "32": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2y"
+      "key": "root.types.auth.events",
+      "~k_parent": "2z"
     },
     "33": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2z"
+    },
+    "34": {
       "key": "root.types.blocks",
       "~k_parent": "2u"
     },
-    "34": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "33"
-    },
     "35": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "33"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "34"
     },
     "36": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "33"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "34"
     },
     "37": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "33"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "34"
     },
     "38": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "33"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "34"
     },
     "39": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "33"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "34"
     },
     "40": {
-      "key": "root.imports.auth",
-      "~k_parent": "3w"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3y"
     },
     "41": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "40"
+      "key": "root.imports.agents",
+      "~k_parent": "3x"
     },
     "42": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "40"
+      "key": "root.imports.auth",
+      "~k_parent": "3x"
     },
     "43": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "40"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "40"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "42"
     },
     "45": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3w"
+      "key": "root.imports.auth.events",
+      "~k_parent": "42"
     },
     "46": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "45"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "42"
     },
     "47": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks",
+      "~k_parent": "3x"
     },
     "48": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "47"
     },
     "50": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4t"
     },
     "51": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4t"
     },
     "53": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4t"
     },
     "55": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4t"
     },
     "57": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4t"
     },
     "59": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4t"
     },
     "61": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4t"
     },
     "63": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4t"
     },
     "65": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4t"
     },
     "67": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4t"
     },
     "69": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "68"
     },
     "a": {
@@ -642,358 +642,367 @@
       "~k_parent": "2v"
     },
     "2y": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "2u"
     },
     "2z": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2y"
+      "key": "root.types.auth",
+      "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "33"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "34"
     },
     "3b": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "33"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "34"
     },
     "3c": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "33"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "34"
     },
     "3d": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "33"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "34"
     },
     "3e": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "33"
+      "key": "root.types.blocks.List",
+      "~k_parent": "34"
     },
     "3f": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "33"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "34"
     },
     "3g": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "33"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "34"
     },
     "3h": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "33"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "34"
     },
     "3i": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "33"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "34"
     },
     "3j": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "33"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "34"
     },
     "3k": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "33"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "34"
     },
     "3l": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "33"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "34"
     },
     "3m": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "33"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "34"
     },
     "3n": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "33"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "34"
     },
     "3o": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "34"
+    },
+    "3p": {
       "key": "root.types.connections",
       "~k_parent": "2u"
     },
-    "3p": {
+    "3q": {
       "key": "root.types.requests",
       "~k_parent": "2u"
     },
-    "3q": {
+    "3r": {
       "key": "root.types.api",
       "~k_parent": "2u"
     },
-    "3r": {
+    "3s": {
       "key": "root.types.operators",
       "~k_parent": "2u"
     },
-    "3s": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3r"
-    },
     "3t": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3s"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3r"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3t"
     },
     "3w": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3s"
+    },
+    "3x": {
       "key": "root.imports",
       "~k_parent": "9"
     },
-    "3x": {
-      "key": "root.imports.actions",
-      "~k_parent": "3w"
-    },
     "3y": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3x"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "47"
     },
     "4b": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "47"
     },
     "4c": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "47"
     },
     "4d": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "47"
     },
     "4e": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "47"
     },
     "4f": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "47"
     },
     "4g": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "47"
     },
     "4h": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "47"
     },
     "4i": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "47"
     },
     "4j": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "47"
     },
     "4k": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "47"
     },
     "4l": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "47"
     },
     "4m": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "47"
     },
     "4n": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "47"
     },
     "4o": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "47"
     },
     "4p": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "47"
     },
     "4q": {
-      "key": "root.imports.connections",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "47"
     },
     "4r": {
-      "key": "root.imports.icons",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "47"
     },
     "4s": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4r"
+      "key": "root.imports.connections",
+      "~k_parent": "3x"
     },
     "4t": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4s"
+      "key": "root.imports.icons",
+      "~k_parent": "3x"
     },
     "4u": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4t"
     },
     "4x": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4t"
     },
     "4z": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4t"
     },
     "5b": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4t"
     },
     "5d": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4t"
     },
     "5f": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4t"
     },
     "5h": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4t"
     },
     "5j": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4t"
     },
     "5l": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4t"
     },
     "5n": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4t"
     },
     "5p": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4t"
     },
     "5r": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4t"
     },
     "5t": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4t"
     },
     "5v": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4t"
     },
     "5x": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4t"
     },
     "5z": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4t"
     },
     "6b": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.requests",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4t"
     },
     "6d": {
-      "key": "root.imports.operators",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6d"
+      "key": "root.imports.requests",
+      "~k_parent": "3x"
     },
     "6f": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6e"
+      "key": "root.imports.operators",
+      "~k_parent": "3x"
     },
     "6g": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6e"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6f"
     },
     "6h": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6g"
+    },
+    "6i": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6g"
+    },
+    "6j": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6d"
+      "~k_parent": "6f"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "1h"
   },
@@ -1357,6 +1366,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5903,152 +5913,155 @@
       },
       "~k": "2v"
     },
+    "agents": {
+      "~k": "2y"
+    },
     "auth": {
       "adapters": {
-        "~k": "2z"
-      },
-      "callbacks": {
         "~k": "30"
       },
-      "events": {
+      "callbacks": {
         "~k": "31"
       },
-      "providers": {
+      "events": {
         "~k": "32"
       },
-      "~k": "2y"
+      "providers": {
+        "~k": "33"
+      },
+      "~k": "2z"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "34"
+        "~k": "35"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "35"
+        "~k": "36"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3f"
+        "~k": "3g"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3h"
+        "~k": "3i"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3i"
+        "~k": "3j"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3j"
+        "~k": "3k"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3k"
+        "~k": "3l"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3l"
+        "~k": "3m"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3m"
+        "~k": "3n"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3n"
+        "~k": "3o"
       },
-      "~k": "33"
+      "~k": "34"
     },
     "connections": {
-      "~k": "3o"
-    },
-    "requests": {
       "~k": "3p"
     },
-    "api": {
+    "requests": {
       "~k": "3q"
+    },
+    "api": {
+      "~k": "3r"
     },
     "operators": {
       "client": {
@@ -6056,20 +6069,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3t"
+          "~k": "3u"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3u"
+          "~k": "3v"
         },
-        "~k": "3s"
+        "~k": "3t"
       },
       "server": {
-        "~k": "3v"
+        "~k": "3w"
       },
-      "~k": "3r"
+      "~k": "3s"
     },
     "~k": "2u"
   }

--- a/packages/build/src/tests/success/85-module-component-data-export/snapshot.json
+++ b/packages/build/src/tests/success/85-module-component-data-export/snapshot.json
@@ -152,124 +152,132 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2m"
     },
     "31": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2m"
     },
     "32": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2m"
     },
     "33": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2m"
     },
     "34": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2m"
     },
     "35": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2m"
+    },
+    "36": {
       "key": "root.types.connections",
       "~k_parent": "2c"
     },
-    "36": {
+    "37": {
       "key": "root.types.requests",
       "~k_parent": "2c"
     },
-    "37": {
+    "38": {
       "key": "root.types.api",
       "~k_parent": "2c"
     },
-    "38": {
+    "39": {
       "key": "root.types.operators",
       "~k_parent": "2c"
     },
-    "39": {
-      "key": "root.types.operators.client",
-      "~k_parent": "38"
-    },
     "40": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3p"
     },
     "41": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3p"
     },
     "42": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3p"
     },
     "43": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3p"
     },
     "44": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3p"
     },
     "45": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3p"
     },
     "46": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3p"
     },
     "47": {
-      "key": "root.imports.connections",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3p"
     },
     "48": {
-      "key": "root.imports.icons",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3p"
     },
     "49": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "48"
+      "key": "root.imports.connections",
+      "~k_parent": "3f"
     },
     "50": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4a"
     },
     "52": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4a"
     },
     "54": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4a"
     },
     "56": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4a"
     },
     "58": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4a"
+    },
+    "60": {
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "5x"
+    },
+    "61": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "5w"
     },
     "a": {
       "key": "root.pages[0:dashboard:Box].blocks",
@@ -533,398 +541,399 @@
       "~k_parent": "2d"
     },
     "2g": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "2c"
     },
     "2h": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2g"
+      "key": "root.types.auth",
+      "~k_parent": "2c"
     },
     "2i": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2g"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "2h"
     },
     "2j": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2g"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "2h"
     },
     "2k": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2g"
+      "key": "root.types.auth.events",
+      "~k_parent": "2h"
     },
     "2l": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "2h"
+    },
+    "2m": {
       "key": "root.types.blocks",
       "~k_parent": "2c"
     },
-    "2m": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2l"
-    },
     "2n": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2m"
     },
     "2p": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2m"
     },
     "2q": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2m"
     },
     "2r": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2m"
     },
     "2s": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2m"
     },
     "2t": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2m"
     },
     "2u": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2m"
     },
     "2v": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2m"
     },
     "2w": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2m"
     },
     "2x": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2m"
     },
     "2y": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2m"
     },
     "2z": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2m"
     },
     "3a": {
-      "key": "root.types.operators.client._user",
+      "key": "root.types.operators.client",
       "~k_parent": "39"
     },
     "3b": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "39"
+      "key": "root.types.operators.client._user",
+      "~k_parent": "3a"
     },
     "3c": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "39"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3a"
     },
     "3d": {
-      "key": "root.types.operators.server",
-      "~k_parent": "38"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3a"
     },
     "3e": {
+      "key": "root.types.operators.server",
+      "~k_parent": "39"
+    },
+    "3f": {
       "key": "root.imports",
       "~k_parent": "7"
     },
-    "3f": {
-      "key": "root.imports.actions",
-      "~k_parent": "3e"
-    },
     "3g": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3f"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.auth",
-      "~k_parent": "3e"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3g"
     },
     "3j": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3i"
+      "key": "root.imports.agents",
+      "~k_parent": "3f"
     },
     "3k": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "3i"
+      "key": "root.imports.auth",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "3i"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3i"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "3k"
     },
     "3n": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3e"
+      "key": "root.imports.auth.events",
+      "~k_parent": "3k"
     },
     "3o": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3n"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3k"
     },
     "3p": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks",
+      "~k_parent": "3f"
     },
     "3q": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3p"
     },
     "3s": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3p"
     },
     "3t": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3p"
     },
     "3u": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3p"
     },
     "3v": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3p"
     },
     "3w": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3p"
     },
     "3x": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3p"
     },
     "3y": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3p"
     },
     "3z": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3p"
     },
     "4a": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "49"
+      "key": "root.imports.icons",
+      "~k_parent": "3f"
     },
     "4b": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4a"
     },
     "4e": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4a"
     },
     "4g": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4a"
     },
     "4i": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4a"
     },
     "4k": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4a"
     },
     "4m": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4a"
     },
     "4o": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4a"
     },
     "4q": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4a"
     },
     "4s": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4a"
     },
     "4u": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4a"
     },
     "4w": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4a"
     },
     "4y": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4a"
     },
     "5a": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4a"
     },
     "5c": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4a"
     },
     "5e": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4a"
     },
     "5g": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4a"
     },
     "5i": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4a"
     },
     "5k": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4a"
     },
     "5m": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4a"
     },
     "5o": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4a"
     },
     "5q": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4a"
     },
     "5s": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.requests",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4a"
     },
     "5u": {
-      "key": "root.imports.operators",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5u"
+      "key": "root.imports.requests",
+      "~k_parent": "3f"
     },
     "5w": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5v"
+      "key": "root.imports.operators",
+      "~k_parent": "3f"
     },
     "5x": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5v"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "5v"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "5u"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5x"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "1g"
   },
@@ -1225,6 +1234,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5851,146 +5861,149 @@
       },
       "~k": "2d"
     },
+    "agents": {
+      "~k": "2g"
+    },
     "auth": {
       "adapters": {
-        "~k": "2h"
-      },
-      "callbacks": {
         "~k": "2i"
       },
-      "events": {
+      "callbacks": {
         "~k": "2j"
       },
-      "providers": {
+      "events": {
         "~k": "2k"
       },
-      "~k": "2g"
+      "providers": {
+        "~k": "2l"
+      },
+      "~k": "2h"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 8,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
-      "~k": "2l"
+      "~k": "2m"
     },
     "connections": {
-      "~k": "35"
-    },
-    "requests": {
       "~k": "36"
     },
-    "api": {
+    "requests": {
       "~k": "37"
+    },
+    "api": {
+      "~k": "38"
     },
     "operators": {
       "client": {
@@ -5998,26 +6011,26 @@
           "originalTypeName": "_user",
           "package": "@lowdefy/operators-js",
           "count": 5,
-          "~k": "3a"
+          "~k": "3b"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3b"
+          "~k": "3c"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3c"
+          "~k": "3d"
         },
-        "~k": "39"
+        "~k": "3a"
       },
       "server": {
-        "~k": "3d"
+        "~k": "3e"
       },
-      "~k": "38"
+      "~k": "39"
     },
     "~k": "2c"
   }

--- a/packages/build/src/tests/success/86-module-component-cross-ref-vars/snapshot.json
+++ b/packages/build/src/tests/success/86-module-component-cross-ref-vars/snapshot.json
@@ -142,163 +142,163 @@
       "~k_parent": "24"
     },
     "30": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "2z"
+      "key": "root.types.auth",
+      "~k_parent": "2v"
     },
     "31": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "2z"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "30"
     },
     "32": {
-      "key": "root.types.auth.events",
-      "~k_parent": "2z"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "30"
     },
     "33": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "2z"
+      "key": "root.types.auth.events",
+      "~k_parent": "30"
     },
     "34": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "30"
+    },
+    "35": {
       "key": "root.types.blocks",
       "~k_parent": "2v"
     },
-    "35": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "34"
-    },
     "36": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "34"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "35"
     },
     "37": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "34"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "35"
     },
     "38": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "34"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "35"
     },
     "39": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "34"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "35"
     },
     "40": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3z"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.auth",
-      "~k_parent": "3y"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "40"
     },
     "43": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "42"
+      "key": "root.imports.agents",
+      "~k_parent": "3z"
     },
     "44": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "42"
+      "key": "root.imports.auth",
+      "~k_parent": "3z"
     },
     "45": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "42"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "42"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "44"
     },
     "47": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3y"
+      "key": "root.imports.auth.events",
+      "~k_parent": "44"
     },
     "48": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "47"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "44"
     },
     "49": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks",
+      "~k_parent": "3z"
     },
     "50": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4v"
     },
     "51": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4v"
     },
     "53": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4v"
     },
     "55": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4v"
     },
     "57": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4v"
     },
     "59": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4v"
     },
     "61": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4v"
     },
     "63": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4v"
     },
     "65": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4v"
     },
     "67": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4v"
     },
     "69": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "68"
     },
     "a": {
@@ -643,366 +643,375 @@
       "~k_parent": "2w"
     },
     "2z": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "2v"
     },
     "3a": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "34"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "35"
     },
     "3b": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "34"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "35"
     },
     "3c": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "34"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "35"
     },
     "3d": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "34"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "35"
     },
     "3e": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "34"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "35"
     },
     "3f": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "34"
+      "key": "root.types.blocks.List",
+      "~k_parent": "35"
     },
     "3g": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "34"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "35"
     },
     "3h": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "34"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "35"
     },
     "3i": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "34"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "35"
     },
     "3j": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "34"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "35"
     },
     "3k": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "34"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "35"
     },
     "3l": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "34"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "35"
     },
     "3m": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "34"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "35"
     },
     "3n": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "34"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "35"
     },
     "3o": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "34"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "35"
     },
     "3p": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "35"
+    },
+    "3q": {
       "key": "root.types.connections",
       "~k_parent": "2v"
     },
-    "3q": {
+    "3r": {
       "key": "root.types.requests",
       "~k_parent": "2v"
     },
-    "3r": {
+    "3s": {
       "key": "root.types.api",
       "~k_parent": "2v"
     },
-    "3s": {
+    "3t": {
       "key": "root.types.operators",
       "~k_parent": "2v"
     },
-    "3t": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3s"
-    },
     "3u": {
-      "key": "root.types.operators.client._user",
+      "key": "root.types.operators.client",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "3t"
+      "key": "root.types.operators.client._user",
+      "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3t"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3u"
     },
     "3x": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3s"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3u"
     },
     "3y": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3t"
+    },
+    "3z": {
       "key": "root.imports",
       "~k_parent": "9"
     },
-    "3z": {
-      "key": "root.imports.actions",
-      "~k_parent": "3y"
-    },
     "4a": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "49"
     },
     "4c": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "49"
     },
     "4d": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "49"
     },
     "4e": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "49"
     },
     "4f": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "49"
     },
     "4g": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "49"
     },
     "4h": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "49"
     },
     "4i": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "49"
     },
     "4j": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "49"
     },
     "4k": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "49"
     },
     "4l": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "49"
     },
     "4m": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "49"
     },
     "4n": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "49"
     },
     "4o": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "49"
     },
     "4p": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "49"
     },
     "4q": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "49"
     },
     "4r": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "47"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "49"
     },
     "4s": {
-      "key": "root.imports.connections",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "49"
     },
     "4t": {
-      "key": "root.imports.icons",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "49"
     },
     "4u": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4t"
+      "key": "root.imports.connections",
+      "~k_parent": "3z"
     },
     "4v": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4u"
+      "key": "root.imports.icons",
+      "~k_parent": "3z"
     },
     "4w": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4v"
     },
     "4z": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4v"
     },
     "5b": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4v"
     },
     "5d": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4v"
     },
     "5f": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4v"
     },
     "5h": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4v"
     },
     "5j": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4v"
     },
     "5l": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4v"
     },
     "5n": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4v"
     },
     "5p": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4v"
     },
     "5r": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4v"
     },
     "5t": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4v"
     },
     "5v": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4v"
     },
     "5x": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4v"
     },
     "5z": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4v"
     },
     "6b": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4v"
     },
     "6d": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.requests",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4v"
     },
     "6f": {
-      "key": "root.imports.operators",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6e"
     },
     "6g": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6f"
+      "key": "root.imports.requests",
+      "~k_parent": "3z"
     },
     "6h": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6g"
+      "key": "root.imports.operators",
+      "~k_parent": "3z"
     },
     "6i": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6g"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "6g"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6i"
     },
     "6k": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6i"
+    },
+    "6l": {
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "6i"
+    },
+    "6m": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6f"
+      "~k_parent": "6h"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "1l"
   },
@@ -1371,6 +1380,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5996,152 +6006,155 @@
       },
       "~k": "2w"
     },
+    "agents": {
+      "~k": "2z"
+    },
     "auth": {
       "adapters": {
-        "~k": "30"
-      },
-      "callbacks": {
         "~k": "31"
       },
-      "events": {
+      "callbacks": {
         "~k": "32"
       },
-      "providers": {
+      "events": {
         "~k": "33"
       },
-      "~k": "2z"
+      "providers": {
+        "~k": "34"
+      },
+      "~k": "30"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 8,
-        "~k": "35"
+        "~k": "36"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "36"
+        "~k": "37"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3f"
+        "~k": "3g"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3h"
+        "~k": "3i"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3i"
+        "~k": "3j"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3j"
+        "~k": "3k"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3k"
+        "~k": "3l"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3l"
+        "~k": "3m"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3m"
+        "~k": "3n"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3n"
+        "~k": "3o"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3o"
+        "~k": "3p"
       },
-      "~k": "34"
+      "~k": "35"
     },
     "connections": {
-      "~k": "3p"
-    },
-    "requests": {
       "~k": "3q"
     },
-    "api": {
+    "requests": {
       "~k": "3r"
+    },
+    "api": {
+      "~k": "3s"
     },
     "operators": {
       "client": {
@@ -6149,26 +6162,26 @@
           "originalTypeName": "_user",
           "package": "@lowdefy/operators-js",
           "count": 6,
-          "~k": "3u"
+          "~k": "3v"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3v"
+          "~k": "3w"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3w"
+          "~k": "3x"
         },
-        "~k": "3t"
+        "~k": "3u"
       },
       "server": {
-        "~k": "3x"
+        "~k": "3y"
       },
-      "~k": "3s"
+      "~k": "3t"
     },
     "~k": "2v"
   }

--- a/packages/build/src/tests/success/87-module-default-plugin/snapshot.json
+++ b/packages/build/src/tests/success/87-module-default-plugin/snapshot.json
@@ -118,164 +118,164 @@
       "~k_parent": "18"
     },
     "20": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1z"
     },
     "21": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1z"
     },
     "22": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1z"
     },
     "23": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1z"
     },
     "24": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1z"
     },
     "25": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1z"
     },
     "26": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1z"
     },
     "27": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1z"
     },
     "28": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1z"
     },
     "29": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1z"
     },
     "30": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2z"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2w"
     },
     "31": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks",
+      "~k_parent": "2r"
     },
     "32": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "31"
     },
     "33": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "31"
     },
     "34": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "31"
     },
     "35": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "31"
     },
     "36": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "31"
     },
     "37": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "31"
     },
     "38": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "31"
     },
     "39": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "31"
     },
     "40": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3m"
     },
     "42": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3m"
     },
     "44": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3m"
     },
     "46": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3m"
     },
     "48": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3m"
     },
     "50": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3m"
     },
     "52": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3m"
     },
     "54": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.requests",
-      "~k_parent": "2q"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3m"
     },
     "56": {
-      "key": "root.imports.operators",
-      "~k_parent": "2q"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "56"
+      "key": "root.imports.requests",
+      "~k_parent": "2r"
     },
     "58": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "57"
+      "key": "root.imports.operators",
+      "~k_parent": "2r"
     },
     "59": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "57"
+      "key": "root.imports.operators.client",
+      "~k_parent": "58"
     },
     "a": {
       "key": "root.pages",
@@ -454,350 +454,359 @@
       "~k_parent": "1q"
     },
     "1t": {
-      "key": "root.types.auth",
+      "key": "root.types.agents",
       "~k_parent": "1p"
     },
     "1u": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "1t"
+      "key": "root.types.auth",
+      "~k_parent": "1p"
     },
     "1v": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "1t"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "1u"
     },
     "1w": {
-      "key": "root.types.auth.events",
-      "~k_parent": "1t"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "1u"
     },
     "1x": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "1t"
+      "key": "root.types.auth.events",
+      "~k_parent": "1u"
     },
     "1y": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "1u"
+    },
+    "1z": {
       "key": "root.types.blocks",
       "~k_parent": "1p"
     },
-    "1z": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1y"
-    },
     "2a": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1z"
     },
     "2b": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1z"
     },
     "2c": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1z"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1z"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1z"
     },
     "2f": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1z"
     },
     "2g": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1z"
     },
     "2h": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1z"
     },
     "2i": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1z"
+    },
+    "2j": {
       "key": "root.types.connections",
       "~k_parent": "1p"
     },
-    "2j": {
+    "2k": {
       "key": "root.types.requests",
       "~k_parent": "1p"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.api",
       "~k_parent": "1p"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.operators",
       "~k_parent": "1p"
     },
-    "2m": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2l"
-    },
     "2n": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2m"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2l"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2n"
     },
     "2q": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2m"
+    },
+    "2r": {
       "key": "root.imports",
       "~k_parent": "5"
     },
-    "2r": {
-      "key": "root.imports.actions",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2r"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.imports.auth",
-      "~k_parent": "2q"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2s"
     },
     "2v": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2u"
+      "key": "root.imports.agents",
+      "~k_parent": "2r"
     },
     "2w": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "2u"
+      "key": "root.imports.auth",
+      "~k_parent": "2r"
     },
     "2x": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "2u"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2u"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "2w"
     },
     "2z": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2q"
+      "key": "root.imports.auth.events",
+      "~k_parent": "2w"
     },
     "3a": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "31"
     },
     "3b": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "31"
     },
     "3c": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "31"
     },
     "3d": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "31"
     },
     "3e": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "31"
     },
     "3f": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "31"
     },
     "3g": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "31"
     },
     "3h": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "31"
     },
     "3i": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "31"
     },
     "3j": {
-      "key": "root.imports.connections",
-      "~k_parent": "2q"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "31"
     },
     "3k": {
-      "key": "root.imports.icons",
-      "~k_parent": "2q"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "31"
     },
     "3l": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3k"
+      "key": "root.imports.connections",
+      "~k_parent": "2r"
     },
     "3m": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3l"
+      "key": "root.imports.icons",
+      "~k_parent": "2r"
     },
     "3n": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3m"
     },
     "3u": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3m"
     },
     "3w": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3m"
     },
     "3y": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3m"
     },
     "4a": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3m"
     },
     "4c": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3m"
     },
     "4e": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3m"
     },
     "4g": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3m"
     },
     "4i": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3m"
     },
     "4k": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3m"
     },
     "4m": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3m"
     },
     "4o": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3m"
     },
     "4q": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3m"
     },
     "4s": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3m"
     },
     "4u": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3m"
     },
     "4w": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3m"
     },
     "4y": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3m"
     },
     "5a": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "59"
+    },
+    "5b": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "59"
+    },
+    "5c": {
       "key": "root.imports.operators.server",
-      "~k_parent": "56"
+      "~k_parent": "58"
     }
   },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
     "~k": "q"
   },
@@ -1006,6 +1015,7 @@
     }
   },
   "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/callbacks.js": "export default {\n  };",
   "plugins/auth/events.js": "export default {\n  };",
@@ -5501,146 +5511,149 @@
       },
       "~k": "1q"
     },
+    "agents": {
+      "~k": "1t"
+    },
     "auth": {
       "adapters": {
-        "~k": "1u"
-      },
-      "callbacks": {
         "~k": "1v"
       },
-      "events": {
+      "callbacks": {
         "~k": "1w"
       },
-      "providers": {
+      "events": {
         "~k": "1x"
       },
-      "~k": "1t"
+      "providers": {
+        "~k": "1y"
+      },
+      "~k": "1u"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "1z"
+        "~k": "20"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
-      "~k": "1y"
+      "~k": "1z"
     },
     "connections": {
-      "~k": "2i"
-    },
-    "requests": {
       "~k": "2j"
     },
-    "api": {
+    "requests": {
       "~k": "2k"
+    },
+    "api": {
+      "~k": "2l"
     },
     "operators": {
       "client": {
@@ -5648,20 +5661,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2n"
+          "~k": "2o"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2o"
+          "~k": "2p"
         },
-        "~k": "2m"
+        "~k": "2n"
       },
       "server": {
-        "~k": "2p"
+        "~k": "2q"
       },
-      "~k": "2l"
+      "~k": "2m"
     },
     "~k": "1p"
   }

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js
@@ -25,7 +25,13 @@ import {
   ThoughtChain,
   Think,
 } from '@ant-design/x';
-import { DeleteOutlined, DislikeOutlined, LikeOutlined, ReloadOutlined } from '@ant-design/icons';
+import {
+  DeleteOutlined,
+  DislikeOutlined,
+  LikeOutlined,
+  ReloadOutlined,
+  RobotOutlined,
+} from '@ant-design/icons';
 
 import { getFileCardType, getFileCardIcon, getFileName } from './fileCardUtils.js';
 import formatToolResult from './formatToolResult.js';
@@ -372,6 +378,11 @@ function MessageBubble({
             } else if (tool.state === 'output-error') {
               status = 'error';
             }
+
+            // Detect sub-agent results
+            const isSubAgent = tool.output?._subAgent === true;
+            const toolOutput = isSubAgent ? tool.output.text : tool.output;
+
             let description;
             let content;
             let collapsible = false;
@@ -384,28 +395,43 @@ function MessageBubble({
               }
             } else if (status === 'error') {
               description = 'Tool execution failed';
-            } else if (tool.output?.display && typeof tool.output.display === 'string') {
-              description = summarizeToolOutput(tool.output.display);
+            } else if (toolOutput?.display && typeof toolOutput.display === 'string') {
+              description = summarizeToolOutput(toolOutput.display);
               content = (
                 <Markdown components={markdownComponents} config={markdownConfig}>
-                  {tool.output.display}
+                  {toolOutput.display}
+                </Markdown>
+              );
+              collapsible = true;
+            } else if (isSubAgent) {
+              // Sub-agent results: show as collapsible markdown
+              description = summarizeToolOutput(toolOutput);
+              content = (
+                <Markdown components={markdownComponents} config={markdownConfig}>
+                  {typeof toolOutput === 'string' ? toolOutput : JSON.stringify(toolOutput, null, 2)}
                 </Markdown>
               );
               collapsible = true;
             } else {
               const mode = resolveToolResultMode(toolResultDisplay, tool.toolName);
               if (mode === 'readable') {
-                description = summarizeToolOutput(tool.output);
-                content = formatToolResult(tool.output);
+                description = summarizeToolOutput(toolOutput);
+                content = formatToolResult(toolOutput);
                 collapsible = true;
               } else if (mode === 'full') {
-                description = summarizeToolOutput(tool.output);
-                content = JSON.stringify(tool.output, null, 2);
+                description = summarizeToolOutput(toolOutput);
+                content = JSON.stringify(toolOutput, null, 2);
                 collapsible = true;
               } else if (mode === 'none') {
                 description = 'Completed';
               } else {
-                description = summarizeToolOutput(tool.output);
+                // summary mode: show summary, add readable content behind collapse
+                description = summarizeToolOutput(toolOutput);
+                const readable = formatToolResult(toolOutput);
+                if (readable != null) {
+                  content = readable;
+                  collapsible = true;
+                }
               }
             }
             return {
@@ -414,6 +440,8 @@ function MessageBubble({
               description,
               ...(content != null ? { content } : {}),
               ...(collapsible ? { collapsible: true } : {}),
+              ...(isSubAgent ? { icon: <RobotOutlined /> } : {}),
+              ...(status === 'loading' ? { blink: true } : {}),
               status,
             };
           });

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js
@@ -373,6 +373,8 @@ function MessageBubble({
               status = 'error';
             }
             let description;
+            let content;
+            let collapsible = false;
             if (status === 'loading') {
               const showInput = config?.showToolInputStreaming !== false;
               if (showInput && tool.input && Object.keys(tool.input).length > 0) {
@@ -383,17 +385,23 @@ function MessageBubble({
             } else if (status === 'error') {
               description = 'Tool execution failed';
             } else if (tool.output?.display && typeof tool.output.display === 'string') {
-              description = (
+              description = summarizeToolOutput(tool.output.display);
+              content = (
                 <Markdown components={markdownComponents} config={markdownConfig}>
                   {tool.output.display}
                 </Markdown>
               );
+              collapsible = true;
             } else {
               const mode = resolveToolResultMode(toolResultDisplay, tool.toolName);
               if (mode === 'readable') {
-                description = formatToolResult(tool.output);
+                description = summarizeToolOutput(tool.output);
+                content = formatToolResult(tool.output);
+                collapsible = true;
               } else if (mode === 'full') {
-                description = JSON.stringify(tool.output, null, 2);
+                description = summarizeToolOutput(tool.output);
+                content = JSON.stringify(tool.output, null, 2);
+                collapsible = true;
               } else if (mode === 'none') {
                 description = 'Completed';
               } else {
@@ -404,6 +412,8 @@ function MessageBubble({
               key: tool.toolCallId,
               title: tool.toolName,
               description,
+              ...(content != null ? { content } : {}),
+              ...(collapsible ? { collapsible: true } : {}),
               status,
             };
           });

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js
@@ -404,12 +404,23 @@ function MessageBubble({
               );
               collapsible = true;
             } else if (isSubAgent) {
-              // Sub-agent results: show as collapsible markdown
-              description = summarizeToolOutput(toolOutput);
+              // Sub-agent results: short status in description, full response in styled content
+              description = 'Completed';
+              const subAgentText =
+                typeof toolOutput === 'string' ? toolOutput : JSON.stringify(toolOutput, null, 2);
               content = (
-                <Markdown components={markdownComponents} config={markdownConfig}>
-                  {typeof toolOutput === 'string' ? toolOutput : JSON.stringify(toolOutput, null, 2)}
-                </Markdown>
+                <div
+                  style={{
+                    fontSize: '0.85em',
+                    color: 'rgba(0, 0, 0, 0.65)',
+                    borderLeft: '2px solid #d9d9d9',
+                    paddingLeft: 12,
+                  }}
+                >
+                  <Markdown components={markdownComponents} config={markdownConfig}>
+                    {subAgentText}
+                  </Markdown>
+                </div>
               );
               collapsible = true;
             } else {

--- a/packages/utils/ai-utils/src/buildAgentTools.js
+++ b/packages/utils/ai-utils/src/buildAgentTools.js
@@ -160,11 +160,11 @@ async function buildAgentTools({ agent, context, depth = 0 }) {
         // Cleanup sub-agent's MCP clients
         await Promise.all(subMcpClients.map(({ client }) => client.close().catch(() => {})));
 
-        return result.text;
+        return { _subAgent: true, agentId: subAgentRef.agentId, text: result.text };
       },
       toModelOutput: ({ output }) => ({
         type: 'text',
-        value: output,
+        value: output.text ?? String(output),
       }),
     });
   }

--- a/packages/utils/ai-utils/src/buildAgentTools.js
+++ b/packages/utils/ai-utils/src/buildAgentTools.js
@@ -162,6 +162,10 @@ async function buildAgentTools({ agent, context, depth = 0 }) {
 
         return result.text;
       },
+      toModelOutput: ({ output }) => ({
+        type: 'text',
+        value: output,
+      }),
     });
   }
 

--- a/packages/utils/ai-utils/src/buildAgentTools.js
+++ b/packages/utils/ai-utils/src/buildAgentTools.js
@@ -1,0 +1,114 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { tool, jsonSchema } from 'ai';
+import { createMCPClient } from '@ai-sdk/mcp';
+import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
+import { serializer } from '@lowdefy/helpers';
+
+// Build artifacts contain serializer markers (~k, ~r, ~l) as non-enumerable
+// properties and ~arr wrappers for arrays. JSON.parse(JSON.stringify(obj))
+// strips non-enumerable props and produces a clean JSON Schema for the AI SDK.
+function cleanBuildArtifact(obj) {
+  return JSON.parse(
+    JSON.stringify(obj, (key, value) => {
+      if (key.startsWith('~')) return undefined;
+      return value;
+    })
+  );
+}
+
+async function buildAgentTools({ agent, context }) {
+  const tools = {};
+  const mcpClients = [];
+
+  // Build endpoint tools
+  for (const toolConfig of agent.tools ?? []) {
+    const { endpointId, confirm } = toolConfig;
+    const endpointConfig = await context.getEndpointConfig({ endpointId });
+
+    tools[endpointId] = tool({
+      description: endpointConfig.description,
+      inputSchema: jsonSchema(cleanBuildArtifact(endpointConfig.payloadSchema)),
+      ...(confirm ? { needsApproval: true } : {}),
+      execute: async (input) => {
+        const result = await context.callEndpoint(endpointId, { payload: input });
+        if (!result.success) {
+          const err = serializer.deserialize(result.error);
+          throw new Error(err?.message ?? 'Endpoint execution failed');
+        }
+        return cleanBuildArtifact(result.response);
+      },
+    });
+  }
+
+  // Build MCP clients and merge their tools
+  for (const mcpSource of agent.mcp ?? []) {
+    const evaluatedSource = context.evaluateOperators(mcpSource);
+
+    try {
+      let transport;
+      if (evaluatedSource.transport === 'stdio') {
+        transport = new Experimental_StdioMCPTransport({
+          command: evaluatedSource.command,
+          args: evaluatedSource.args,
+          env: { ...process.env, ...(evaluatedSource.env ?? {}) },
+        });
+      } else {
+        transport = {
+          type: evaluatedSource.transport ?? 'http',
+          url: evaluatedSource.url,
+          ...(evaluatedSource.headers ? { headers: evaluatedSource.headers } : {}),
+        };
+      }
+      const client = await createMCPClient({ transport });
+      mcpClients.push({ client, source: evaluatedSource });
+    } catch (err) {
+      const label =
+        evaluatedSource.transport === 'stdio' ? evaluatedSource.command : evaluatedSource.url;
+      console.warn(`MCP server "${label}" unreachable: ${err.message}`);
+    }
+  }
+
+  // Merge MCP tools with endpoint tools
+  for (const { client, source } of mcpClients) {
+    try {
+      const mcpTools = await client.tools();
+      for (const [name, mcpTool] of Object.entries(mcpTools)) {
+        if (tools[name]) {
+          console.warn(
+            `MCP tool "${name}" from ${
+              source.url ?? source.command
+            } conflicts with endpoint tool — skipped.`
+          );
+          continue;
+        }
+        if (source.confirm) {
+          tools[name] = { ...mcpTool, needsApproval: true };
+        } else {
+          tools[name] = mcpTool;
+        }
+      }
+    } catch (err) {
+      const label = source.transport === 'stdio' ? source.command : source.url;
+      console.warn(`MCP server "${label}" tool listing failed: ${err.message}`);
+    }
+  }
+
+  return { tools, mcpClients };
+}
+
+export default buildAgentTools;

--- a/packages/utils/ai-utils/src/buildAgentTools.js
+++ b/packages/utils/ai-utils/src/buildAgentTools.js
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-import { tool, jsonSchema } from 'ai';
+import { ToolLoopAgent, tool, jsonSchema, stepCountIs } from 'ai';
 import { createMCPClient } from '@ai-sdk/mcp';
 import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
 import { serializer } from '@lowdefy/helpers';
@@ -31,7 +31,12 @@ function cleanBuildArtifact(obj) {
   );
 }
 
-async function buildAgentTools({ agent, context }) {
+async function buildAgentTools({ agent, context, depth = 0 }) {
+  const MAX_DEPTH = 5;
+  if (depth > MAX_DEPTH) {
+    throw new Error(`Sub-agent nesting exceeds maximum depth of ${MAX_DEPTH}.`);
+  }
+
   const tools = {};
   const mcpClients = [];
 
@@ -106,6 +111,58 @@ async function buildAgentTools({ agent, context }) {
       const label = source.transport === 'stdio' ? source.command : source.url;
       console.warn(`MCP server "${label}" tool listing failed: ${err.message}`);
     }
+  }
+
+  // Build sub-agent tools
+  for (const subAgentRef of agent.agents ?? []) {
+    const subAgentConfig = await context.getAgentConfig({ agentId: subAgentRef.agentId });
+    const subConnection = await context.getConnectionForAgent({ agentConfig: subAgentConfig });
+    subAgentConfig.mcp = await context.resolveMcpSources({ agentConfig: subAgentConfig });
+
+    // Recursively build sub-agent's tools
+    const { tools: subTools, mcpClients: subMcpClients } = await buildAgentTools({
+      agent: subAgentConfig,
+      context,
+      depth: depth + 1,
+    });
+
+    const subModel = subConnection.provider(subAgentConfig.properties.model);
+
+    const subAgent = new ToolLoopAgent({
+      model: subModel,
+      instructions: subAgentConfig.properties.instructions,
+      tools: subTools,
+      stopWhen: stepCountIs(subAgentConfig.properties.maxSteps ?? 10),
+      maxOutputTokens: subAgentConfig.properties.maxOutputTokens,
+      temperature: subAgentConfig.properties.temperature,
+      toolChoice: subAgentConfig.properties.toolChoice ?? 'auto',
+      providerOptions: subAgentConfig.properties.providerOptions,
+    });
+
+    const description =
+      subAgentRef.description ?? `Delegate task to the ${subAgentRef.agentId} agent`;
+
+    const inputSchema = subAgentRef.inputSchema
+      ? jsonSchema(subAgentRef.inputSchema)
+      : jsonSchema({
+          type: 'object',
+          properties: { task: { type: 'string', description: 'The task to delegate' } },
+          required: ['task'],
+        });
+
+    tools[subAgentRef.agentId] = tool({
+      description,
+      inputSchema,
+      execute: async (input, { abortSignal }) => {
+        const prompt = input.task ?? JSON.stringify(input);
+        const result = await subAgent.generate({ prompt, abortSignal });
+
+        // Cleanup sub-agent's MCP clients
+        await Promise.all(subMcpClients.map(({ client }) => client.close().catch(() => {})));
+
+        return result.text;
+      },
+    });
   }
 
   return { tools, mcpClients };

--- a/packages/utils/ai-utils/src/buildAgentTools.test.js
+++ b/packages/utils/ai-utils/src/buildAgentTools.test.js
@@ -162,7 +162,7 @@ test('buildAgentTools sub-agent tool execute calls generate and returns text', a
   // Execute the sub-agent tool
   const result = await tools.researcher.execute({ task: 'Research AI' }, { abortSignal: null });
   expect(mockGenerate).toHaveBeenCalledWith({ prompt: 'Research AI', abortSignal: null });
-  expect(result).toBe('Sub-agent result');
+  expect(result).toEqual({ _subAgent: true, agentId: 'researcher', text: 'Sub-agent result' });
 });
 
 test('buildAgentTools sub-agent tool uses custom inputSchema', async () => {
@@ -266,7 +266,9 @@ test('buildAgentTools sub-agent tool has toModelOutput that returns text type', 
   const { tools } = await buildAgentTools({ agent, context });
 
   expect(tools.researcher.toModelOutput).toBeDefined();
-  const result = tools.researcher.toModelOutput({ output: 'Sub-agent findings here' });
+  const result = tools.researcher.toModelOutput({
+    output: { _subAgent: true, agentId: 'researcher', text: 'Sub-agent findings here' },
+  });
   expect(result).toEqual({ type: 'text', value: 'Sub-agent findings here' });
 });
 

--- a/packages/utils/ai-utils/src/buildAgentTools.test.js
+++ b/packages/utils/ai-utils/src/buildAgentTools.test.js
@@ -237,6 +237,39 @@ test('buildAgentTools throws when sub-agent nesting exceeds max depth', async ()
   );
 });
 
+test('buildAgentTools sub-agent tool has toModelOutput that returns text type', async () => {
+  const { default: buildAgentTools } = await import('./buildAgentTools.js');
+
+  const subAgentConfig = {
+    agentId: 'researcher',
+    connectionId: 'anthropic',
+    tools: [],
+    mcp: [],
+    properties: { model: 'test', maxSteps: 5 },
+  };
+
+  const agent = {
+    tools: [],
+    mcp: [],
+    agents: [{ agentId: 'researcher' }],
+  };
+
+  const context = {
+    getEndpointConfig: jest.fn(),
+    callEndpoint: jest.fn(),
+    evaluateOperators: jest.fn((x) => x),
+    getAgentConfig: jest.fn().mockResolvedValue(subAgentConfig),
+    getConnectionForAgent: jest.fn().mockResolvedValue({ provider: jest.fn().mockReturnValue({}) }),
+    resolveMcpSources: jest.fn().mockResolvedValue([]),
+  };
+
+  const { tools } = await buildAgentTools({ agent, context });
+
+  expect(tools.researcher.toModelOutput).toBeDefined();
+  const result = tools.researcher.toModelOutput({ output: 'Sub-agent findings here' });
+  expect(result).toEqual({ type: 'text', value: 'Sub-agent findings here' });
+});
+
 test('buildAgentTools with no agents property returns only endpoint tools', async () => {
   const { default: buildAgentTools } = await import('./buildAgentTools.js');
 

--- a/packages/utils/ai-utils/src/buildAgentTools.test.js
+++ b/packages/utils/ai-utils/src/buildAgentTools.test.js
@@ -1,0 +1,257 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+
+const mockTool = jest.fn();
+const mockJsonSchema = jest.fn();
+
+let lastAgentConfig = null;
+const mockGenerate = jest.fn().mockResolvedValue({ text: 'Sub-agent result' });
+
+class MockToolLoopAgent {
+  constructor(config) {
+    this.config = config;
+    lastAgentConfig = config;
+  }
+  generate(opts) {
+    return mockGenerate(opts);
+  }
+}
+
+jest.unstable_mockModule('ai', () => ({
+  ToolLoopAgent: MockToolLoopAgent,
+  tool: mockTool,
+  jsonSchema: mockJsonSchema,
+  stepCountIs: jest.fn((n) => ({ type: 'stepCount', count: n })),
+  hasToolCall: jest.fn((name) => ({ type: 'hasToolCall', toolName: name })),
+}));
+
+const mockCreateMCPClient = jest.fn();
+jest.unstable_mockModule('@ai-sdk/mcp', () => ({
+  createMCPClient: mockCreateMCPClient,
+}));
+
+jest.unstable_mockModule('@ai-sdk/mcp/mcp-stdio', () => ({
+  Experimental_StdioMCPTransport: class MockStdio {
+    constructor(config) {
+      this.config = config;
+    }
+  },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  lastAgentConfig = null;
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockImplementation((schema) => schema);
+});
+
+test('buildAgentTools creates sub-agent tools from agent.agents references', async () => {
+  const { default: buildAgentTools } = await import('./buildAgentTools.js');
+
+  const subAgentConfig = {
+    agentId: 'researcher',
+    connectionId: 'anthropic',
+    tools: [],
+    mcp: [],
+    properties: {
+      model: 'claude-haiku-4-5-20251001',
+      instructions: 'You research topics.',
+      maxSteps: 10,
+    },
+  };
+
+  const mockSubConnection = { provider: jest.fn().mockReturnValue('sub-model') };
+
+  const agent = {
+    tools: [],
+    mcp: [],
+    agents: [{ agentId: 'researcher' }],
+  };
+
+  const context = {
+    getEndpointConfig: jest.fn(),
+    callEndpoint: jest.fn(),
+    evaluateOperators: jest.fn((x) => x),
+    getAgentConfig: jest.fn().mockResolvedValue(subAgentConfig),
+    getConnectionForAgent: jest.fn().mockResolvedValue(mockSubConnection),
+    resolveMcpSources: jest.fn().mockResolvedValue([]),
+  };
+
+  const { tools } = await buildAgentTools({ agent, context });
+
+  expect(context.getAgentConfig).toHaveBeenCalledWith({ agentId: 'researcher' });
+  expect(context.getConnectionForAgent).toHaveBeenCalledWith({ agentConfig: subAgentConfig });
+  expect(tools.researcher).toBeDefined();
+  expect(tools.researcher.description).toBe('Delegate task to the researcher agent');
+});
+
+test('buildAgentTools sub-agent tool uses custom description when provided', async () => {
+  const { default: buildAgentTools } = await import('./buildAgentTools.js');
+
+  const subAgentConfig = {
+    agentId: 'researcher',
+    connectionId: 'anthropic',
+    tools: [],
+    mcp: [],
+    properties: { model: 'test', maxSteps: 5 },
+  };
+
+  const agent = {
+    tools: [],
+    mcp: [],
+    agents: [{ agentId: 'researcher', description: 'Research topics thoroughly' }],
+  };
+
+  const context = {
+    getEndpointConfig: jest.fn(),
+    callEndpoint: jest.fn(),
+    evaluateOperators: jest.fn((x) => x),
+    getAgentConfig: jest.fn().mockResolvedValue(subAgentConfig),
+    getConnectionForAgent: jest.fn().mockResolvedValue({ provider: jest.fn().mockReturnValue({}) }),
+    resolveMcpSources: jest.fn().mockResolvedValue([]),
+  };
+
+  const { tools } = await buildAgentTools({ agent, context });
+
+  expect(tools.researcher.description).toBe('Research topics thoroughly');
+});
+
+test('buildAgentTools sub-agent tool execute calls generate and returns text', async () => {
+  const { default: buildAgentTools } = await import('./buildAgentTools.js');
+
+  const subAgentConfig = {
+    agentId: 'researcher',
+    connectionId: 'anthropic',
+    tools: [],
+    mcp: [],
+    properties: { model: 'test', maxSteps: 5 },
+  };
+
+  const agent = {
+    tools: [],
+    mcp: [],
+    agents: [{ agentId: 'researcher' }],
+  };
+
+  const context = {
+    getEndpointConfig: jest.fn(),
+    callEndpoint: jest.fn(),
+    evaluateOperators: jest.fn((x) => x),
+    getAgentConfig: jest.fn().mockResolvedValue(subAgentConfig),
+    getConnectionForAgent: jest.fn().mockResolvedValue({ provider: jest.fn().mockReturnValue({}) }),
+    resolveMcpSources: jest.fn().mockResolvedValue([]),
+  };
+
+  const { tools } = await buildAgentTools({ agent, context });
+
+  // Execute the sub-agent tool
+  const result = await tools.researcher.execute({ task: 'Research AI' }, { abortSignal: null });
+  expect(mockGenerate).toHaveBeenCalledWith({ prompt: 'Research AI', abortSignal: null });
+  expect(result).toBe('Sub-agent result');
+});
+
+test('buildAgentTools sub-agent tool uses custom inputSchema', async () => {
+  const { default: buildAgentTools } = await import('./buildAgentTools.js');
+
+  const subAgentConfig = {
+    agentId: 'analyzer',
+    connectionId: 'anthropic',
+    tools: [],
+    mcp: [],
+    properties: { model: 'test', maxSteps: 5 },
+  };
+
+  const customSchema = {
+    type: 'object',
+    properties: {
+      dataset: { type: 'string' },
+      metrics: { type: 'array', items: { type: 'string' } },
+    },
+    required: ['dataset'],
+  };
+
+  const agent = {
+    tools: [],
+    mcp: [],
+    agents: [{ agentId: 'analyzer', inputSchema: customSchema }],
+  };
+
+  const context = {
+    getEndpointConfig: jest.fn(),
+    callEndpoint: jest.fn(),
+    evaluateOperators: jest.fn((x) => x),
+    getAgentConfig: jest.fn().mockResolvedValue(subAgentConfig),
+    getConnectionForAgent: jest.fn().mockResolvedValue({ provider: jest.fn().mockReturnValue({}) }),
+    resolveMcpSources: jest.fn().mockResolvedValue([]),
+  };
+
+  const { tools } = await buildAgentTools({ agent, context });
+
+  expect(mockJsonSchema).toHaveBeenCalledWith(customSchema);
+});
+
+test('buildAgentTools throws when sub-agent nesting exceeds max depth', async () => {
+  const { default: buildAgentTools } = await import('./buildAgentTools.js');
+
+  const subAgentConfig = {
+    agentId: 'deep-agent',
+    connectionId: 'anthropic',
+    tools: [],
+    mcp: [],
+    agents: [{ agentId: 'deep-agent' }],
+    properties: { model: 'test', maxSteps: 5 },
+  };
+
+  const agent = {
+    tools: [],
+    mcp: [],
+    agents: [{ agentId: 'deep-agent' }],
+  };
+
+  const context = {
+    getEndpointConfig: jest.fn(),
+    callEndpoint: jest.fn(),
+    evaluateOperators: jest.fn((x) => x),
+    getAgentConfig: jest.fn().mockResolvedValue(subAgentConfig),
+    getConnectionForAgent: jest.fn().mockResolvedValue({ provider: jest.fn().mockReturnValue({}) }),
+    resolveMcpSources: jest.fn().mockResolvedValue([]),
+  };
+
+  await expect(buildAgentTools({ agent, context, depth: 5 })).rejects.toThrow(
+    'Sub-agent nesting exceeds maximum depth of 5.'
+  );
+});
+
+test('buildAgentTools with no agents property returns only endpoint tools', async () => {
+  const { default: buildAgentTools } = await import('./buildAgentTools.js');
+
+  const agent = {
+    tools: [],
+    mcp: [],
+  };
+
+  const context = {
+    getEndpointConfig: jest.fn(),
+    callEndpoint: jest.fn(),
+    evaluateOperators: jest.fn((x) => x),
+  };
+
+  const { tools } = await buildAgentTools({ agent, context });
+
+  expect(Object.keys(tools)).toEqual([]);
+});

--- a/packages/utils/ai-utils/src/handleAgentChat.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.js
@@ -19,26 +19,11 @@ import {
   createAgentUIStream,
   createUIMessageStream,
   createUIMessageStreamResponse,
-  tool,
-  jsonSchema,
   stepCountIs,
   hasToolCall,
 } from 'ai';
-import { createMCPClient } from '@ai-sdk/mcp';
-import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
-import { serializer } from '@lowdefy/helpers';
 
-// Build artifacts contain serializer markers (~k, ~r, ~l) as non-enumerable
-// properties and ~arr wrappers for arrays. JSON.parse(JSON.stringify(obj))
-// strips non-enumerable props and produces a clean JSON Schema for the AI SDK.
-function cleanBuildArtifact(obj) {
-  return JSON.parse(
-    JSON.stringify(obj, (key, value) => {
-      if (key.startsWith('~')) return undefined;
-      return value;
-    })
-  );
-}
+import buildAgentTools from './buildAgentTools.js';
 
 // Strip non-serializable fields from agent-level hook events before sending as payload.
 // messages excluded here — the stream-level onFinish sends UIMessage[] directly.
@@ -105,81 +90,7 @@ async function handleAgentChat({ connection, properties, context }) {
   const { agent, messages: rawMessages } = properties;
   const messages = convertDataUrlsToBase64(rawMessages);
 
-  const tools = {};
-
-  for (const toolConfig of agent.tools ?? []) {
-    const { endpointId, confirm } = toolConfig;
-    const endpointConfig = await context.getEndpointConfig({ endpointId });
-
-    tools[endpointId] = tool({
-      description: endpointConfig.description,
-      inputSchema: jsonSchema(cleanBuildArtifact(endpointConfig.payloadSchema)),
-      ...(confirm ? { needsApproval: true } : {}),
-      execute: async (input) => {
-        const result = await context.callEndpoint(endpointId, { payload: input });
-        if (!result.success) {
-          const err = serializer.deserialize(result.error);
-          throw new Error(err?.message ?? 'Endpoint execution failed');
-        }
-        return cleanBuildArtifact(result.response);
-      },
-    });
-  }
-
-  // Create MCP clients
-  const mcpClients = [];
-
-  for (const mcpSource of agent.mcp ?? []) {
-    const evaluatedSource = context.evaluateOperators(mcpSource);
-
-    try {
-      let transport;
-      if (evaluatedSource.transport === 'stdio') {
-        transport = new Experimental_StdioMCPTransport({
-          command: evaluatedSource.command,
-          args: evaluatedSource.args,
-          env: { ...process.env, ...(evaluatedSource.env ?? {}) },
-        });
-      } else {
-        transport = {
-          type: evaluatedSource.transport ?? 'http',
-          url: evaluatedSource.url,
-          ...(evaluatedSource.headers ? { headers: evaluatedSource.headers } : {}),
-        };
-      }
-      const client = await createMCPClient({ transport });
-      mcpClients.push({ client, source: evaluatedSource });
-    } catch (err) {
-      const label =
-        evaluatedSource.transport === 'stdio' ? evaluatedSource.command : evaluatedSource.url;
-      console.warn(`MCP server "${label}" unreachable: ${err.message}`);
-    }
-  }
-
-  // Merge MCP tools with endpoint tools
-  for (const { client, source } of mcpClients) {
-    try {
-      const mcpTools = await client.tools();
-      for (const [name, mcpTool] of Object.entries(mcpTools)) {
-        if (tools[name]) {
-          console.warn(
-            `MCP tool "${name}" from ${
-              source.url ?? source.command
-            } conflicts with endpoint tool — skipped.`
-          );
-          continue;
-        }
-        if (source.confirm) {
-          tools[name] = { ...mcpTool, needsApproval: true };
-        } else {
-          tools[name] = mcpTool;
-        }
-      }
-    } catch (err) {
-      const label = source.transport === 'stdio' ? source.command : source.url;
-      console.warn(`MCP server "${label}" tool listing failed: ${err.message}`);
-    }
-  }
+  const { tools, mcpClients } = await buildAgentTools({ agent, context });
 
   const model = connection.provider(agent.properties.model);
 


### PR DESCRIPTION
## Summary

Allows Lowdefy agents to delegate tasks to other agents via a new `agents` config property. A parent agent sees each sub-agent as a tool — it sends a task, the sub-agent runs autonomously with its own model, instructions, tools, and MCP servers, then returns a result. Built on the AI SDK's `ToolLoopAgent` sub-agent pattern.

Config example:
```yaml
agents:
  - id: researcher
    type: ClaudeAgent
    connectionId: anthropic
    properties:
      model: claude-haiku-4-5-20251001
      instructions: "Research topics..."
    tools: [search_web]

  - id: orchestrator
    type: ClaudeAgent
    connectionId: anthropic
    properties:
      model: claude-sonnet-4-5-20250514
      instructions: "Coordinate research..."
    agents:
      - researcher                    # shorthand
      - agentId: analyzer             # full form
        description: "Custom desc"
```

## Changes

- **@lowdefy/build**: Added `agents` array property to agent schema (string shorthand + object form with `agentId`, `description`, `inputSchema`). Build validation normalizes shorthand, validates references exist, detects circular references via DFS, warns when sub-agent has `confirm: true` tools (unsupported in sub-agent context), and errors on tool name collisions.
- **@lowdefy/api**: Added three resolver context methods (`getAgentConfig`, `getConnectionForAgent`, `resolveMcpSources`) so the runtime can load sub-agent configs, create their connections, and resolve MCP sources.
- **@lowdefy/ai-utils**: Extracted tool-building into reusable `buildAgentTools.js`, then added sub-agent tool creation — recursively builds `ToolLoopAgent` instances with depth limiting (max 5), `abortSignal` propagation, and MCP client cleanup.

## Key Files

- `packages/build/src/build/buildAgents.js` — Normalize, validate, cycle detection, confirm warning
- `packages/api/src/routes/agent/callAgent.js` — New resolver context methods for sub-agent resolution
- `packages/utils/ai-utils/src/buildAgentTools.js` — Core sub-agent tool creation with recursive building
- `packages/build/src/lowdefySchema.js` — Schema definition for the `agents` property

## Notes

- Sub-agents inherit the parent's resolver context (auth, endpoints) but NOT conversation history — each invocation starts fresh.
- Streaming sub-agents (`async function*`) deferred to a future enhancement. Initial implementation uses blocking `generate()`.
- `toModelOutput` for context-efficient summarization also deferred — rely on sub-agent instructions for now.
- 82 build artifact snapshots updated due to the schema change.