### PR TITLE
Add config-driven development article to website

### DIFF
--- a/packages/website/content/articles/case-for-config-driven-development.md
+++ b/packages/website/content/articles/case-for-config-driven-development.md
@@ -1,0 +1,84 @@
+---
+title: 'The Case for Config-Driven Development in the Age of AI'
+subtitle: 'AI can write code faster than any human. The real question is whether anyone can understand what it wrote six months later.'
+authorId: 'stephanie'
+publishedAt: '2026-04-10'
+readTimeMinutes: 4
+tags:
+  - 'AI'
+  - 'Config-Driven Development'
+  - 'Opinion'
+draft: false
+---
+
+AI can write code faster than any human. That's not up for debate anymore. The real question is whether anyone can understand what it wrote six months later.
+
+Vibe coding took off in 2025 and hasn't slowed down. Developers describe what they want in plain English, and AI tools spit out working applications. It's fast. It feels productive. And for prototypes and throwaway projects, it genuinely works.
+
+But production is a different story.
+
+Studies show that AI-generated code accumulates technical debt roughly three times faster than code written by humans. Security audits consistently flag that close to half of all AI-generated code contains vulnerabilities. And a common frustration among senior engineers is that they're spending more time cleaning up AI output than they would have spent writing it themselves.
+
+The problem isn't that AI is bad at writing code. The problem is what comes after, especially when there's no structure or guardrails around the output. Without rules or constraints, every prompt produces a different structure. There's no consistency between sessions. One generation uses one set of patterns and dependencies, the next uses something completely different. When a new developer inherits that codebase, they're not reading someone's code. They're reading the accumulated output of dozens of unrelated AI conversations.
+
+This is where config-driven development starts to make a compelling argument.
+
+## What config-driven development actually means
+
+Instead of generating hundreds of lines of React components, state management, and custom logic, a config-driven framework lets you describe your application in a structured format like YAML. You declare what the app should do. The framework handles how.
+
+A basic CRUD interface that might take 500 lines of custom React can often be expressed in about 50 lines of config. The UI components, data connections, actions, and permissions are all defined declaratively. There's no custom state management to untangle and no bespoke component trees to reverse-engineer.
+
+This matters even without AI in the picture. But it matters a lot more when AI is doing the writing.
+
+## Why this changes the AI conversation
+
+When you point an AI at a config-driven framework, the output is fundamentally different from raw code generation.
+
+First, it's shorter. Much shorter. Fewer lines means less to review. A developer can read through an AI-generated config file and actually understand what it does in a reasonable amount of time.
+
+Second, it's consistent. Config files follow a schema. Every block has a type. Every action has a defined structure. Even if the AI names things poorly or organizes the file in an odd way, you can still figure out what a component is supposed to do just by looking at its type. A TextInput is a TextInput. A Card is a Card. A MongoDBFind is a MongoDBFind. The structure tells you the intent.
+
+Third, and this is the part that doesn't get talked about enough, the complexity stays where it belongs. With config-driven development, most of the real work goes into your database queries and business logic, not into UI state management and component plumbing. That's a much better distribution of effort, whether a human or an AI is doing the building.
+
+## The maintenance argument
+
+Software doesn't end when it ships. Somebody has to maintain it. Somebody has to fix bugs, add features, and onboard the next developer who touches it.
+
+With AI-generated code, that maintenance burden is significant. The person inheriting the codebase didn't write it. The AI that generated it doesn't remember it. And the code itself often lacks the kind of structure and documentation that makes handoffs manageable. It's a codebase with no author and no institutional memory.
+
+Config is different. Not because it's magic, but because it's constrained. The schema limits what's possible, which also limits what can go wrong. When you open a config file, you're reading a declaration of what the app does. You're not tracing execution paths through custom hooks and nested components. The framework handles the runtime. You just describe the application.
+
+That constraint is a feature. It means a developer picking up someone else's project, or an AI's project, can orient themselves quickly. They can find the page they need, read the blocks, understand the data connections, and make changes with confidence that they're not breaking something three files away.
+
+## Security by structure
+
+One of the quieter benefits of config-driven development is a smaller attack surface. When config is interpreted by a runtime rather than executed as arbitrary code, entire categories of vulnerabilities become harder to introduce. There's no opportunity for code injection in the traditional sense because there's no arbitrary code path to exploit.
+
+That said, it's not a free pass. You still need to follow good practices. Sensitive values need proper handling. Permissions need to be configured correctly. Database queries still need to be written carefully. The config layer reduces risk, but it doesn't eliminate responsibility. Any honest developer will tell you the same about any framework.
+
+The difference is that AI-generated config gives you fewer places where things can go sideways compared to AI-generated code. And the places that do need attention, like your data queries and auth setup, are the same places you'd be paying attention to anyway.
+
+## Framework updates without the pain
+
+There's another practical benefit that's easy to overlook. When a config-driven framework ships an update, every app built on it benefits. You update the framework once and move on. The config doesn't change. The runtime handles the rest.
+
+Compare that to AI-generated code. When Next.js ships a breaking change, you have to go through every AI-generated codebase individually and fix what broke. Each one is its own unique set of dependencies and patterns. There's no shared runtime absorbing the impact. It's just you, a pile of code you didn't write, and a changelog.
+
+For teams managing multiple internal tools, this alone can save a significant amount of time and frustration.
+
+## Where this approach fits
+
+Config-driven development isn't the right tool for everything. If you're building a consumer-facing product with highly custom UI interactions and pixel-perfect design requirements, you probably want full control over your frontend code.
+
+But for internal tools, admin panels, dashboards, CRUD apps, approval workflows, and reporting interfaces, it's hard to argue against. These are applications where the value is in the data and the business logic, not in the UI itself. They need to work reliably, be easy to maintain, and not become a burden on the team that built them.
+
+That's exactly the kind of application where AI generation paired with config-driven structure makes the most sense. The AI handles the tedious parts. The config format keeps it reviewable. The framework keeps it maintainable. And the developer stays in control of what actually matters.
+
+## The real point
+
+AI is useful for building software faster. The problem is that most AI-generated output is optimized for creation, not for the entire lifecycle of an application.
+
+Config-driven development doesn't reject AI. It gives AI a better output format. One that humans can review, understand, and maintain long after the prompt that created it has been forgotten.
+
+The tools that win in the long run won't just be the ones that generate code the fastest. They'll be the ones that produce something a team can actually live with.

--- a/packages/website/src/app/articles/case-for-config-driven-development/layout.jsx
+++ b/packages/website/src/app/articles/case-for-config-driven-development/layout.jsx
@@ -1,0 +1,28 @@
+import articles from '@/content/articles';
+
+const article = articles.find((a) => a.id === 'case-for-config-driven-development');
+
+export const metadata = {
+  title: `${article.title} | Lowdefy`,
+  description: article.subtitle,
+  openGraph: {
+    title: article.title,
+    description: article.subtitle,
+    type: 'article',
+    url: `https://lowdefy.com/articles/${article.id}`,
+    siteName: 'Lowdefy',
+    publishedTime: article.publishedAt.toISOString(),
+    tags: article.tags,
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: article.title,
+    description: article.subtitle,
+    site: '@lowdefy',
+    creator: '@lowdefy',
+  },
+};
+
+export default function ArticleLayout({ children }) {
+  return children;
+}

--- a/packages/website/src/app/articles/case-for-config-driven-development/page.jsx
+++ b/packages/website/src/app/articles/case-for-config-driven-development/page.jsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { Header, Footer } from '@/components';
+import ArticlePage from '@/components/ArticlePage';
+import articles from '@/content/articles';
+
+const content = articles.find((a) => a.id === 'case-for-config-driven-development');
+
+export default function Article() {
+  return (
+    <>
+      <Header />
+      <main>
+        <ArticlePage article={content} />
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/packages/website/src/content/articles/index.js
+++ b/packages/website/src/content/articles/index.js
@@ -4,6 +4,7 @@ import buildFasterRaw from '../../../content/articles/lowdefy-4-6-build-faster-b
 import jsonParseRaw from '../../../content/articles/lowdefy-4-7-faster-builds-json-parse.md';
 import yamlAiEraRaw from '../../../content/articles/yaml-best-language-ai-era.md';
 import fiftyLinesRaw from '../../../content/articles/what-can-you-build-in-50-lines-of-yaml.md';
+import configDrivenRaw from '../../../content/articles/case-for-config-driven-development.md';
 
 function parseArticle(slug, raw) {
   const { data, content } = matter(raw);
@@ -25,6 +26,7 @@ const articles = [
   parseArticle('lowdefy-4-7-faster-builds-json-parse', jsonParseRaw),
   parseArticle('yaml-best-language-ai-era', yamlAiEraRaw),
   parseArticle('what-can-you-build-in-50-lines-of-yaml', fiftyLinesRaw),
+  parseArticle('case-for-config-driven-development', configDrivenRaw),
 ]
   .filter((a) => !a.draft)
   .sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());

--- a/packages/website/src/lib/authors.js
+++ b/packages/website/src/lib/authors.js
@@ -44,6 +44,15 @@ const authors = {
     github: 'https://github.com/Yianni99',
     linkedin: 'https://www.linkedin.com/in/ioannis-ktistakis-38a750183/',
   },
+  stephanie: {
+    id: 'stephanie',
+    name: 'Stephanie Smit',
+    title: 'Software Developer at Lowdefy',
+    bio: 'Stephanie is a software developer at Lowdefy, building enterprise web applications and contributing to the development of the Lowdefy framework.',
+    image: 'https://avatars.githubusercontent.com/u/47713197?v=4',
+    github: 'https://github.com/StephanieJKS',
+    linkedin: 'https://za.linkedin.com/in/stephaniejksmit',
+  },
   lowdefy: {
     id: 'lowdefy',
     name: 'Lowdefy',


### PR DESCRIPTION
## Summary

Adds a new article "The Case for Config-Driven Development in the Age of AI" to the Lowdefy website, along with a new author profile for Stephanie Smit.

## Changes

- **@lowdefy/website**: New article with frontmatter, page route, layout with SEO metadata (OpenGraph + Twitter), and new author entry in authors.js