### PR TITLE
Enrich agent onFinish payload, operator evaluation, and onDataPart event

### DIFF
--- a/packages/api/src/routes/agent/callAgent.js
+++ b/packages/api/src/routes/agent/callAgent.js
@@ -25,7 +25,7 @@ import getAgentResolver from './getAgentResolver.js';
 import getConnectionConfig from '../request/getConnectionConfig.js';
 import getConnection from '../request/getConnection.js';
 
-async function callAgent(context, { agentId, pageId, messages }) {
+async function callAgent(context, { agentId, pageId, messages, conversationId, urlQuery }) {
   const { logger } = context;
 
   context.pageId = pageId;
@@ -33,6 +33,21 @@ async function callAgent(context, { agentId, pageId, messages }) {
 
   logger.debug({ event: 'debug_agent', agentId, pageId });
   const agentConfig = await getAgentConfig(context, { agentId });
+
+  const agentContext = {
+    conversationId: conversationId ?? undefined,
+    pageId,
+    urlQuery: urlQuery ?? {},
+    userId: context.user?.sub ?? context.user?.id ?? null,
+  };
+
+  // Evaluate operators in agent properties (e.g. _user, _secret, _payload)
+  agentConfig.properties = context.evaluateOperators({
+    input: agentConfig.properties ?? {},
+    location: agentConfig.agentId,
+    payload: agentContext,
+    steps: {},
+  });
 
   // Load connection config from build artifacts using agent's connectionId
   const connectionConfig = await getConnectionConfig(context, {
@@ -62,11 +77,12 @@ async function callAgent(context, { agentId, pageId, messages }) {
 
   // Build resolver context with callEndpoint that allows InternalApi endpoints
   const resolverContext = {
+    agentContext,
     evaluateOperators: (input) =>
       context.evaluateOperators({
         input,
         location: agentConfig.agentId,
-        payload: {},
+        payload: agentContext,
         steps: {},
       }),
     callEndpoint: async (endpointId, { payload, abortSignal }) => {

--- a/packages/api/src/routes/agent/callAgent.test.js
+++ b/packages/api/src/routes/agent/callAgent.test.js
@@ -581,6 +581,132 @@ test('callAgent resolver context getEndpointConfig throws for missing endpoint',
   ).rejects.toThrow();
 });
 
+test('callAgent passes agentContext with conversationId, pageId, urlQuery, userId to resolver context', async () => {
+  const mockResolver = jest.fn().mockResolvedValue({ response: {} });
+  const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
+
+  const agentConfig = {
+    agentId: 'my-agent',
+    id: 'agent:my-agent',
+    type: 'ClaudeAgent',
+    connectionId: 'my-anthropic',
+    tools: [],
+    properties: { model: 'claude-3-5-sonnet' },
+  };
+  const connectionConfig = {
+    connectionId: 'my-anthropic',
+    id: 'connection:my-anthropic',
+    type: 'Anthropic',
+    properties: {},
+  };
+
+  const readConfigFile = createMockReadConfigFile({ agentConfig, connectionConfig });
+  const context = testContext({
+    logger,
+    readConfigFile,
+    connections: {
+      Anthropic: { create: mockCreate, requests: {} },
+    },
+    session: { user: { sub: 'user_abc', id: 'user_id_fallback' } },
+  });
+  context.agents = { ClaudeAgent: { resolver: mockResolver, schema: {} } };
+
+  await callAgent(context, {
+    agentId: 'my-agent',
+    pageId: 'principle-view',
+    messages: [],
+    conversationId: 'conv_123',
+    urlQuery: { principle_id: 'P3' },
+  });
+
+  const resolverContext = mockResolver.mock.calls[0][0].context;
+  expect(resolverContext.agentContext).toEqual({
+    conversationId: 'conv_123',
+    pageId: 'principle-view',
+    urlQuery: { principle_id: 'P3' },
+    userId: 'user_abc',
+  });
+});
+
+test('callAgent passes userId from context.user.id when sub is not present', async () => {
+  const mockResolver = jest.fn().mockResolvedValue({ response: {} });
+  const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
+
+  const agentConfig = {
+    agentId: 'my-agent',
+    id: 'agent:my-agent',
+    type: 'ClaudeAgent',
+    connectionId: 'my-anthropic',
+    tools: [],
+    properties: { model: 'claude-3-5-sonnet' },
+  };
+  const connectionConfig = {
+    connectionId: 'my-anthropic',
+    id: 'connection:my-anthropic',
+    type: 'Anthropic',
+    properties: {},
+  };
+
+  const readConfigFile = createMockReadConfigFile({ agentConfig, connectionConfig });
+  const context = testContext({
+    logger,
+    readConfigFile,
+    connections: {
+      Anthropic: { create: mockCreate, requests: {} },
+    },
+    session: { user: { id: 'user_456' } },
+  });
+  context.agents = { ClaudeAgent: { resolver: mockResolver, schema: {} } };
+
+  await callAgent(context, {
+    agentId: 'my-agent',
+    pageId: 'page1',
+    messages: [],
+  });
+
+  const resolverContext = mockResolver.mock.calls[0][0].context;
+  expect(resolverContext.agentContext.userId).toBe('user_456');
+});
+
+test('callAgent passes null userId when no user session', async () => {
+  const mockResolver = jest.fn().mockResolvedValue({ response: {} });
+  const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
+
+  const agentConfig = {
+    agentId: 'my-agent',
+    id: 'agent:my-agent',
+    type: 'ClaudeAgent',
+    connectionId: 'my-anthropic',
+    tools: [],
+    properties: { model: 'claude-3-5-sonnet' },
+  };
+  const connectionConfig = {
+    connectionId: 'my-anthropic',
+    id: 'connection:my-anthropic',
+    type: 'Anthropic',
+    properties: {},
+  };
+
+  const readConfigFile = createMockReadConfigFile({ agentConfig, connectionConfig });
+  const context = testContext({
+    logger,
+    readConfigFile,
+    connections: {
+      Anthropic: { create: mockCreate, requests: {} },
+    },
+  });
+  context.agents = { ClaudeAgent: { resolver: mockResolver, schema: {} } };
+
+  await callAgent(context, {
+    agentId: 'my-agent',
+    pageId: 'page1',
+    messages: [],
+  });
+
+  const resolverContext = mockResolver.mock.calls[0][0].context;
+  expect(resolverContext.agentContext.userId).toBeNull();
+});
+
 test('callAgent passes getAgentConfig in resolver context', async () => {
   const mockResolver = jest.fn().mockResolvedValue({ response: {} });
   const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
@@ -680,6 +806,106 @@ test('callAgent passes getConnectionForAgent in resolver context', async () => {
   expect(connInstance).toBeDefined();
   // mockCreate is called once for the parent agent, then again for getConnectionForAgent
   expect(mockCreate.mock.calls.length).toBeGreaterThanOrEqual(2);
+});
+
+test('callAgent evaluates operators in agent properties before passing to resolver', async () => {
+  const mockResolver = jest.fn().mockResolvedValue({ response: {} });
+  const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
+
+  const agentConfig = {
+    agentId: 'my-agent',
+    id: 'agent:my-agent',
+    type: 'ClaudeAgent',
+    connectionId: 'my-anthropic',
+    tools: [],
+    properties: { model: 'claude-3-5-sonnet', instructions: { _test: true } },
+  };
+  const connectionConfig = {
+    connectionId: 'my-anthropic',
+    id: 'connection:my-anthropic',
+    type: 'Anthropic',
+    properties: {},
+  };
+
+  const readConfigFile = createMockReadConfigFile({ agentConfig, connectionConfig });
+  const context = testContext({
+    logger,
+    readConfigFile,
+    connections: {
+      Anthropic: { create: mockCreate, requests: {} },
+    },
+    session: { user: { id: 'user_1' } },
+  });
+  context.agents = { ClaudeAgent: { resolver: mockResolver, schema: {} } };
+
+  await callAgent(context, {
+    agentId: 'my-agent',
+    pageId: 'page1',
+    messages: [],
+  });
+
+  // The _test operator resolves to 'test', so instructions should be 'test' not { _test: true }
+  const resolvedAgent = mockResolver.mock.calls[0][0].properties.agent;
+  expect(resolvedAgent.properties.instructions).toBe('test');
+});
+
+test('callAgent provides agentContext as payload for operator evaluation', async () => {
+  let capturedPayload;
+  const mockResolver = jest.fn().mockResolvedValue({ response: {} });
+  const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
+
+  const agentConfig = {
+    agentId: 'my-agent',
+    id: 'agent:my-agent',
+    type: 'ClaudeAgent',
+    connectionId: 'my-anthropic',
+    tools: [],
+    properties: { model: 'claude-3-5-sonnet', instructions: { _payload: 'pageId' } },
+  };
+  const connectionConfig = {
+    connectionId: 'my-anthropic',
+    id: 'connection:my-anthropic',
+    type: 'Anthropic',
+    properties: {},
+  };
+
+  const readConfigFile = createMockReadConfigFile({ agentConfig, connectionConfig });
+
+  // Use a custom _payload operator that captures and resolves the payload
+  const context = testContext({
+    logger,
+    readConfigFile,
+    connections: {
+      Anthropic: { create: mockCreate, requests: {} },
+    },
+    operators: {
+      _payload: ({ params, payload }) => {
+        capturedPayload = payload;
+        if (typeof params === 'string') return payload?.[params];
+        return payload;
+      },
+    },
+    session: { user: { sub: 'user_xyz' } },
+  });
+  context.agents = { ClaudeAgent: { resolver: mockResolver, schema: {} } };
+
+  await callAgent(context, {
+    agentId: 'my-agent',
+    pageId: 'principle-view',
+    messages: [],
+    conversationId: 'conv_abc',
+    urlQuery: { principle_id: 'P3' },
+  });
+
+  expect(capturedPayload).toEqual({
+    conversationId: 'conv_abc',
+    pageId: 'principle-view',
+    urlQuery: { principle_id: 'P3' },
+    userId: 'user_xyz',
+  });
+
+  const resolvedAgent = mockResolver.mock.calls[0][0].properties.agent;
+  expect(resolvedAgent.properties.instructions).toBe('principle-view');
 });
 
 test('callAgent passes resolveMcpSources in resolver context', async () => {

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
@@ -34,6 +34,7 @@ import WelcomeScreen from './WelcomeScreen.js';
 function AgentChat({ blockId, components: { Icon }, methods, pageId, properties }) {
   const {
     agentId,
+    urlQuery,
     welcome,
     messageDisplay,
     sender,
@@ -58,9 +59,10 @@ function AgentChat({ blockId, components: { Icon }, methods, pageId, properties 
     return initial;
   });
 
+  const urlQueryKey = JSON.stringify(urlQuery ?? null);
   const transport = useMemo(
-    () => new LowdefyChatTransport({ pageId, agentId, conversationId }),
-    [pageId, agentId, conversationId]
+    () => new LowdefyChatTransport({ pageId, agentId, conversationId, urlQuery }),
+    [pageId, agentId, conversationId, urlQueryKey]
   );
 
   const bubbleListRef = useRef(null);
@@ -90,6 +92,12 @@ function AgentChat({ blockId, components: { Icon }, methods, pageId, properties 
         isAbort: options.isAbort,
         isDisconnect: options.isDisconnect,
       };
+    },
+    onData: (dataPart) => {
+      methods.triggerEvent({
+        name: 'onDataPart',
+        event: { type: dataPart.type, data: dataPart.data, id: dataPart.id },
+      });
     },
   });
 

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
@@ -26,7 +26,7 @@ import { type } from '@lowdefy/helpers';
 import { getFileCardType, getFileCardIcon } from './fileCardUtils.js';
 
 import DrawerWrapper from './DrawerWrapper.js';
-import LowdefyChatTransport from './LowdefyChatTransport.js';
+import createLowdefyChatTransport from './LowdefyChatTransport.js';
 import MessageList from './MessageList.js';
 import useAgentEvents from './useAgentEvents.js';
 import WelcomeScreen from './WelcomeScreen.js';
@@ -61,7 +61,7 @@ function AgentChat({ blockId, components: { Icon }, methods, pageId, properties 
 
   const urlQueryKey = JSON.stringify(urlQuery ?? null);
   const transport = useMemo(
-    () => new LowdefyChatTransport({ pageId, agentId, conversationId, urlQuery }),
+    () => createLowdefyChatTransport({ pageId, agentId, conversationId, urlQuery }),
     [pageId, agentId, conversationId, urlQueryKey]
   );
 

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/LowdefyChatTransport.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/LowdefyChatTransport.js
@@ -16,18 +16,16 @@
 
 import { DefaultChatTransport } from 'ai';
 
-class LowdefyChatTransport extends DefaultChatTransport {
-  constructor({ pageId, agentId, conversationId, urlQuery }) {
-    const base = `/api/agent/${pageId}/${agentId}`;
-    const api = conversationId
-      ? `${base}?conversationId=${encodeURIComponent(conversationId)}`
-      : base;
-    super({
-      api,
-      credentials: 'include',
-      body: urlQuery ? { urlQuery } : undefined,
-    });
-  }
+function createLowdefyChatTransport({ pageId, agentId, conversationId, urlQuery }) {
+  const base = `/api/agent/${pageId}/${agentId}`;
+  const api = conversationId
+    ? `${base}?conversationId=${encodeURIComponent(conversationId)}`
+    : base;
+  return new DefaultChatTransport({
+    api,
+    credentials: 'include',
+    body: urlQuery ? { urlQuery } : undefined,
+  });
 }
 
-export default LowdefyChatTransport;
+export default createLowdefyChatTransport;

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/LowdefyChatTransport.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/LowdefyChatTransport.js
@@ -17,12 +17,15 @@
 import { DefaultChatTransport } from 'ai';
 
 class LowdefyChatTransport extends DefaultChatTransport {
-  constructor({ pageId, agentId, conversationId }) {
+  constructor({ pageId, agentId, conversationId, urlQuery }) {
     const base = `/api/agent/${pageId}/${agentId}`;
-    const api = conversationId ? `${base}?conversationId=${encodeURIComponent(conversationId)}` : base;
+    const api = conversationId
+      ? `${base}?conversationId=${encodeURIComponent(conversationId)}`
+      : base;
     super({
       api,
       credentials: 'include',
+      body: urlQuery ? { urlQuery } : undefined,
     });
   }
 }

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/meta.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/meta.js
@@ -33,9 +33,12 @@ export default {
     onSuggestionClick: 'Trigger when the user clicks a follow-up suggestion.',
     onTitleGenerated: 'Trigger when the agent generates a conversation title.',
     onSwitchChange: 'Trigger when the user toggles a sender switch.',
+    onDataPart:
+      'Trigger when the agent sends a custom data part. Event contains type, data, and id.',
   },
   methods: {
-    regenerate: 'Regenerate the last assistant message. Accepts optional args.messageId to regenerate a specific message.',
+    regenerate:
+      'Regenerate the last assistant message. Accepts optional args.messageId to regenerate a specific message.',
     setMessages: 'Replace the message list. Accepts args.messages array.',
     sendMessage: 'Send a message programmatically. Accepts args.text string.',
     clearMessages: 'Clear all messages from the chat.',

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/schema.json
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/schema.json
@@ -147,6 +147,10 @@
       "type": "string",
       "description": "Active conversation ID. When this value changes, messages are automatically cleared."
     },
+    "urlQuery": {
+      "type": "object",
+      "description": "URL query parameters to send with each agent request. Available server-side in onFinish hook payload and via _payload operator in agent properties."
+    },
     "sender": {
       "type": "object",
       "properties": {

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/useAgentEvents.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/useAgentEvents.js
@@ -26,7 +26,7 @@ function useAgentEvents({ messages, status, methods, finishMetaRef }) {
 
   // Fire onMessageComplete when streaming finishes
   useEffect(() => {
-    if (prevStatusRef.current === 'streaming' && status === 'idle') {
+    if (prevStatusRef.current === 'streaming' && (status === 'ready' || status === 'idle')) {
       const lastAssistantMessage = [...messages].reverse().find((m) => m.role === 'assistant');
       if (lastAssistantMessage) {
         const textContent = lastAssistantMessage.parts

--- a/packages/plugins/connections/connection-anthropic/src/connections/Anthropic/ClaudeAgent/schema.js
+++ b/packages/plugins/connections/connection-anthropic/src/connections/Anthropic/ClaudeAgent/schema.js
@@ -83,6 +83,14 @@ export default {
         enum: 'ClaudeAgent agent property "effort" should be one of "low", "medium", or "high".',
       },
     },
+    pageContext: {
+      type: 'boolean',
+      description:
+        'When true, prepend page context (pageId, userId, conversationId, urlQuery) to instructions.',
+      errorMessage: {
+        type: 'ClaudeAgent agent property "pageContext" should be a boolean.',
+      },
+    },
     providerOptions: {
       type: 'object',
       description: 'Provider-specific options passed to the AI SDK.',

--- a/packages/plugins/connections/connection-openai/src/connections/OpenAI/OpenAIAgent/schema.js
+++ b/packages/plugins/connections/connection-openai/src/connections/OpenAI/OpenAIAgent/schema.js
@@ -84,6 +84,14 @@ export default {
     toolChoice: {
       description: 'Tool choice configuration.',
     },
+    pageContext: {
+      type: 'boolean',
+      description:
+        'When true, prepend page context (pageId, userId, conversationId, urlQuery) to instructions.',
+      errorMessage: {
+        type: 'OpenAIAgent agent property "pageContext" should be a boolean.',
+      },
+    },
     providerOptions: {
       type: 'object',
       description: 'Provider-specific options passed to the AI SDK (e.g. OpenAI reasoningEffort).',

--- a/packages/servers/server-dev/pages/api/agent/[...path].js
+++ b/packages/servers/server-dev/pages/api/agent/[...path].js
@@ -36,6 +36,10 @@ async function handler({ context, req, res }) {
     res.status(400).json({ error: 'messages must be an array' });
     return;
   }
+  if (urlQuery != null && (typeof urlQuery !== 'object' || Array.isArray(urlQuery))) {
+    res.status(400).json({ error: 'urlQuery must be an object' });
+    return;
+  }
   const { response: webResponse } = await callAgent(context, {
     agentId,
     pageId,

--- a/packages/servers/server-dev/pages/api/agent/[...path].js
+++ b/packages/servers/server-dev/pages/api/agent/[...path].js
@@ -30,7 +30,8 @@ async function handler({ context, req, res }) {
   const agentId = segments[segments.length - 1];
   const pageId = segments.slice(0, -1).join('/');
   context.logger.info({ color: 'gray' }, `Agent: ${pageId} → ${agentId}`);
-  const { messages } = req.body;
+  const { conversationId } = req.query;
+  const { messages, urlQuery } = req.body;
   if (!Array.isArray(messages)) {
     res.status(400).json({ error: 'messages must be an array' });
     return;
@@ -39,6 +40,8 @@ async function handler({ context, req, res }) {
     agentId,
     pageId,
     messages,
+    conversationId: conversationId ?? undefined,
+    urlQuery: urlQuery ?? undefined,
   });
 
   // Stream the Web Response body to the Next.js response

--- a/packages/servers/server/pages/api/agent/[...path].js
+++ b/packages/servers/server/pages/api/agent/[...path].js
@@ -36,6 +36,10 @@ async function handler({ context, req, res }) {
     res.status(400).json({ error: 'messages must be an array' });
     return;
   }
+  if (urlQuery != null && (typeof urlQuery !== 'object' || Array.isArray(urlQuery))) {
+    res.status(400).json({ error: 'urlQuery must be an object' });
+    return;
+  }
   const { response: webResponse } = await callAgent(context, {
     agentId,
     pageId,

--- a/packages/servers/server/pages/api/agent/[...path].js
+++ b/packages/servers/server/pages/api/agent/[...path].js
@@ -30,7 +30,8 @@ async function handler({ context, req, res }) {
   const agentId = segments[segments.length - 1];
   const pageId = segments.slice(0, -1).join('/');
   context.logger.info({ event: 'call_agent', agentId, pageId });
-  const { messages } = req.body;
+  const { conversationId } = req.query;
+  const { messages, urlQuery } = req.body;
   if (!Array.isArray(messages)) {
     res.status(400).json({ error: 'messages must be an array' });
     return;
@@ -39,6 +40,8 @@ async function handler({ context, req, res }) {
     agentId,
     pageId,
     messages,
+    conversationId: conversationId ?? undefined,
+    urlQuery: urlQuery ?? undefined,
   });
 
   // Stream the Web Response body to the Next.js response

--- a/packages/utils/ai-utils/src/AISDKAgentSchema.js
+++ b/packages/utils/ai-utils/src/AISDKAgentSchema.js
@@ -175,6 +175,14 @@ export default {
           'AISDKAgent agent property "timeout" should be a number or an object with totalMs, stepMs, and/or chunkMs.',
       },
     },
+    pageContext: {
+      type: 'boolean',
+      description:
+        'When true, prepend page context (pageId, userId, conversationId, urlQuery) to instructions.',
+      errorMessage: {
+        type: 'AISDKAgent agent property "pageContext" should be a boolean.',
+      },
+    },
     repairToolCall: {
       type: 'boolean',
       description:

--- a/packages/utils/ai-utils/src/handleAgentChat.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.js
@@ -39,7 +39,13 @@ function createUsageAccumulator() {
     cacheWriteTokens: 0,
   };
 
-  function add(stepUsage) {
+  let finishReason = 'stop';
+
+  function add(stepResult) {
+    const stepUsage = stepResult?.usage ?? stepResult;
+    if (stepResult?.finishReason) {
+      finishReason = stepResult.finishReason;
+    }
     if (!stepUsage) return;
     usage.inputTokens += stepUsage.inputTokens ?? 0;
     usage.outputTokens += stepUsage.outputTokens ?? 0;
@@ -49,7 +55,7 @@ function createUsageAccumulator() {
     usage.cacheWriteTokens += stepUsage.inputTokenDetails?.cacheWriteTokens ?? 0;
   }
 
-  return { usage, add };
+  return { usage, add, getFinishReason: () => finishReason };
 }
 
 // Strip non-serializable fields from agent-level hook events before sending as payload.
@@ -212,7 +218,7 @@ async function handleAgentChat({ connection, properties, context }) {
           prompt: prunedMessages,
           ...timeoutConfig,
           onStepFinish: (stepResult) => {
-            usageAccumulator.add(stepResult.usage);
+            usageAccumulator.add(stepResult);
           },
         });
         agentStream = result.toUIMessageStream({
@@ -227,7 +233,7 @@ async function handleAgentChat({ connection, properties, context }) {
           uiMessages: messages,
           ...timeoutConfig,
           onStepFinish: (stepResult) => {
-            usageAccumulator.add(stepResult.usage);
+            usageAccumulator.add(stepResult);
           },
         });
       }
@@ -239,7 +245,7 @@ async function handleAgentChat({ connection, properties, context }) {
       if (hasOnFinishHooks) {
         const finishPayload = {
           messages,
-          finishReason: 'stop',
+          finishReason: usageAccumulator.getFinishReason(),
           isAborted: false,
           ...(context.agentContext ?? {}),
           usage: usageAccumulator.usage,

--- a/packages/utils/ai-utils/src/handleAgentChat.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.js
@@ -26,6 +26,8 @@ import {
   validateUIMessages,
 } from 'ai';
 
+import { serializer } from '@lowdefy/helpers';
+
 import buildAgentTools from './buildAgentTools.js';
 import buildPrepareStep from './buildPrepareStep.js';
 
@@ -255,8 +257,9 @@ async function handleAgentChat({ connection, properties, context }) {
             const hookResponse = await context.callEndpoint(endpointId, {
               payload: finishPayload,
             });
-            if (hookResponse?.dataParts) {
-              for (const part of hookResponse.dataParts) {
+            const responseData = serializer.deserialize(hookResponse?.response);
+            if (Array.isArray(responseData?.dataParts)) {
+              for (const part of responseData.dataParts) {
                 writer.write(part);
               }
             }

--- a/packages/utils/ai-utils/src/handleAgentChat.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.js
@@ -26,6 +26,29 @@ import {
 import buildAgentTools from './buildAgentTools.js';
 import buildPrepareStep from './buildPrepareStep.js';
 
+function createUsageAccumulator() {
+  const usage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    reasoningTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+  };
+
+  function add(stepUsage) {
+    if (!stepUsage) return;
+    usage.inputTokens += stepUsage.inputTokens ?? 0;
+    usage.outputTokens += stepUsage.outputTokens ?? 0;
+    usage.totalTokens += stepUsage.totalTokens ?? 0;
+    usage.reasoningTokens += stepUsage.outputTokenDetails?.reasoningTokens ?? 0;
+    usage.cacheReadTokens += stepUsage.inputTokenDetails?.cacheReadTokens ?? 0;
+    usage.cacheWriteTokens += stepUsage.inputTokenDetails?.cacheWriteTokens ?? 0;
+  }
+
+  return { usage, add };
+}
+
 // Strip non-serializable fields from agent-level hook events before sending as payload.
 // messages excluded here — the stream-level onFinish sends UIMessage[] directly.
 function cleanHookEvent(event) {
@@ -100,6 +123,21 @@ async function handleAgentChat({ connection, properties, context }) {
     callEndpoint: context.callEndpoint,
   });
 
+  // Prepend page context to instructions when pageContext is enabled
+  let instructions = agent.properties.instructions;
+  if (agent.properties.pageContext && context.agentContext) {
+    const ctx = context.agentContext;
+    const contextLines = ['<context>'];
+    if (ctx.pageId) contextLines.push(`  pageId: ${ctx.pageId}`);
+    if (ctx.userId) contextLines.push(`  userId: ${ctx.userId}`);
+    if (ctx.conversationId) contextLines.push(`  conversationId: ${ctx.conversationId}`);
+    if (ctx.urlQuery && Object.keys(ctx.urlQuery).length > 0) {
+      contextLines.push(`  urlQuery: ${JSON.stringify(ctx.urlQuery)}`);
+    }
+    contextLines.push('</context>');
+    instructions = `${contextLines.join('\n')}\n\n${instructions ?? ''}`;
+  }
+
   // Build stop conditions
   const stopConditions = [stepCountIs(agent.properties.maxSteps ?? 10)];
   const stopOnToolCall = agent.properties.stopOnToolCall;
@@ -112,7 +150,7 @@ async function handleAgentChat({ connection, properties, context }) {
 
   const agentInstance = new ToolLoopAgent({
     model,
-    instructions: agent.properties.instructions,
+    instructions,
     tools,
     stopWhen: stopConditions.length === 1 ? stopConditions[0] : stopConditions,
     maxOutputTokens: agent.properties.maxOutputTokens,
@@ -146,6 +184,8 @@ async function handleAgentChat({ connection, properties, context }) {
 
   const stream = createUIMessageStream({
     execute: async ({ writer }) => {
+      const usageAccumulator = createUsageAccumulator();
+
       // createAgentUIStream validates UIMessages, converts to ModelMessages,
       // runs the agent, and returns a UIMessageStream — handling the full
       // UI→model→UI conversion that ToolLoopAgent.stream() does not.
@@ -153,6 +193,9 @@ async function handleAgentChat({ connection, properties, context }) {
         agent: agentInstance,
         uiMessages: messages,
         ...(agent.properties.timeout != null ? { timeout: agent.properties.timeout } : {}),
+        onStepFinish: (stepResult) => {
+          usageAccumulator.add(stepResult.usage);
+        },
       });
 
       writer.merge(agentStream);
@@ -160,10 +203,17 @@ async function handleAgentChat({ connection, properties, context }) {
       // After merge resolves the agent stream is complete.
       // Call onFinish hooks — awaited so dataParts can be written to stream.
       if (hasOnFinishHooks) {
+        const finishPayload = {
+          messages,
+          finishReason: 'stop',
+          isAborted: false,
+          ...(context.agentContext ?? {}),
+          usage: usageAccumulator.usage,
+        };
         for (const endpointId of onFinishEndpointIds) {
           try {
             const hookResponse = await context.callEndpoint(endpointId, {
-              payload: { messages, finishReason: 'stop', isAborted: false },
+              payload: finishPayload,
             });
             if (hookResponse?.dataParts) {
               for (const part of hookResponse.dataParts) {

--- a/packages/utils/ai-utils/src/handleAgentChat.test.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.test.js
@@ -941,11 +941,11 @@ test('stream-level onFinish calls hook endpoints with messages payload', async (
   await execute({ writer: localWriter });
 
   expect(callEndpoint).toHaveBeenCalledWith('save-conversation', {
-    payload: {
+    payload: expect.objectContaining({
       messages,
       finishReason: 'stop',
       isAborted: false,
-    },
+    }),
   });
 });
 
@@ -1460,4 +1460,270 @@ test('onFinish hook receives original input messages in payload', async () => {
       isAborted: false,
     }),
   });
+});
+
+test('onFinish hook payload includes agentContext fields', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
+
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+
+  const callEndpoint = jest.fn().mockResolvedValue({ success: true, response: {} });
+  const messages = [{ role: 'user', parts: [{ type: 'text', text: 'hi' }] }];
+  const agentContext = {
+    conversationId: 'conv_123',
+    pageId: 'my-page',
+    urlQuery: { principle_id: 'P3' },
+    userId: 'user_abc',
+  };
+
+  await handleAgentChat({
+    connection: { provider: jest.fn().mockReturnValue({}) },
+    properties: {
+      agent: {
+        tools: [],
+        hooks: { onFinish: ['save-conversation'] },
+        properties: { model: 'gpt-4o' },
+      },
+      messages,
+    },
+    context: { callEndpoint, getEndpointConfig: jest.fn(), agentContext },
+  });
+
+  await mockCreateUIMessageStream._lastExecute({ writer: mockWriter });
+
+  expect(callEndpoint).toHaveBeenCalledWith('save-conversation', {
+    payload: expect.objectContaining({
+      conversationId: 'conv_123',
+      pageId: 'my-page',
+      urlQuery: { principle_id: 'P3' },
+      userId: 'user_abc',
+    }),
+  });
+});
+
+test('onFinish hook payload includes aggregated usage from multiple steps', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
+
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+
+  const callEndpoint = jest.fn().mockResolvedValue({ success: true, response: {} });
+
+  // Mock createAgentUIStream to capture onStepFinish and simulate multiple steps
+  let capturedOnStepFinish;
+  mockCreateAgentUIStream.mockImplementation(async (opts) => {
+    capturedOnStepFinish = opts.onStepFinish;
+    return { type: 'agent-ui-stream' };
+  });
+  // Make merge call onStepFinish to simulate steps completing before merge resolves
+  mockWriter.merge.mockImplementation(async () => {
+    if (capturedOnStepFinish) {
+      capturedOnStepFinish({
+        usage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          totalTokens: 150,
+          inputTokenDetails: { cacheReadTokens: 20, cacheWriteTokens: 10 },
+          outputTokenDetails: { reasoningTokens: 5 },
+        },
+      });
+      capturedOnStepFinish({
+        usage: {
+          inputTokens: 200,
+          outputTokens: 80,
+          totalTokens: 280,
+          inputTokenDetails: { cacheReadTokens: 30, cacheWriteTokens: 0 },
+          outputTokenDetails: { reasoningTokens: 12 },
+        },
+      });
+    }
+  });
+
+  await handleAgentChat({
+    connection: { provider: jest.fn().mockReturnValue({}) },
+    properties: {
+      agent: {
+        tools: [],
+        hooks: { onFinish: ['track-usage'] },
+        properties: { model: 'gpt-4o' },
+      },
+      messages: [],
+    },
+    context: { callEndpoint, getEndpointConfig: jest.fn() },
+  });
+
+  await mockCreateUIMessageStream._lastExecute({ writer: mockWriter });
+
+  expect(callEndpoint).toHaveBeenCalledWith('track-usage', {
+    payload: expect.objectContaining({
+      usage: {
+        inputTokens: 300,
+        outputTokens: 130,
+        totalTokens: 430,
+        reasoningTokens: 17,
+        cacheReadTokens: 50,
+        cacheWriteTokens: 10,
+      },
+    }),
+  });
+
+  // Restore default mock
+  mockCreateAgentUIStream.mockResolvedValue({ type: 'agent-ui-stream' });
+  mockWriter.merge.mockResolvedValue(undefined);
+});
+
+test('usage accumulator handles missing usage gracefully', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
+
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+
+  const callEndpoint = jest.fn().mockResolvedValue({ success: true, response: {} });
+
+  let capturedOnStepFinish;
+  mockCreateAgentUIStream.mockImplementation(async (opts) => {
+    capturedOnStepFinish = opts.onStepFinish;
+    return { type: 'agent-ui-stream' };
+  });
+  mockWriter.merge.mockImplementation(async () => {
+    if (capturedOnStepFinish) {
+      capturedOnStepFinish({ usage: undefined });
+      capturedOnStepFinish({ usage: { inputTokens: 50 } });
+    }
+  });
+
+  await handleAgentChat({
+    connection: { provider: jest.fn().mockReturnValue({}) },
+    properties: {
+      agent: {
+        tools: [],
+        hooks: { onFinish: ['track-usage'] },
+        properties: { model: 'gpt-4o' },
+      },
+      messages: [],
+    },
+    context: { callEndpoint, getEndpointConfig: jest.fn() },
+  });
+
+  await mockCreateUIMessageStream._lastExecute({ writer: mockWriter });
+
+  expect(callEndpoint).toHaveBeenCalledWith('track-usage', {
+    payload: expect.objectContaining({
+      usage: {
+        inputTokens: 50,
+        outputTokens: 0,
+        totalTokens: 0,
+        reasoningTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      },
+    }),
+  });
+
+  // Restore default mocks
+  mockCreateAgentUIStream.mockResolvedValue({ type: 'agent-ui-stream' });
+  mockWriter.merge.mockResolvedValue(undefined);
+});
+
+test('pageContext true prepends context block to instructions', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
+
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+
+  await handleAgentChat({
+    connection: { provider: jest.fn().mockReturnValue({}) },
+    properties: {
+      agent: {
+        tools: [],
+        properties: {
+          model: 'gpt-4o',
+          instructions: 'You are a governance advisor.',
+          pageContext: true,
+        },
+      },
+      messages: [],
+    },
+    context: {
+      callEndpoint: jest.fn(),
+      getEndpointConfig: jest.fn(),
+      agentContext: {
+        pageId: 'principle-view',
+        userId: 'user_abc',
+        conversationId: 'conv_123',
+        urlQuery: { principle_id: 'P3' },
+      },
+    },
+  });
+
+  expect(lastAgentConfig.instructions).toBe(
+    '<context>\n' +
+      '  pageId: principle-view\n' +
+      '  userId: user_abc\n' +
+      '  conversationId: conv_123\n' +
+      '  urlQuery: {"principle_id":"P3"}\n' +
+      '</context>\n' +
+      '\n' +
+      'You are a governance advisor.'
+  );
+});
+
+test('pageContext false does not modify instructions', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
+
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+
+  await handleAgentChat({
+    connection: { provider: jest.fn().mockReturnValue({}) },
+    properties: {
+      agent: {
+        tools: [],
+        properties: {
+          model: 'gpt-4o',
+          instructions: 'Be helpful.',
+        },
+      },
+      messages: [],
+    },
+    context: {
+      callEndpoint: jest.fn(),
+      getEndpointConfig: jest.fn(),
+      agentContext: { pageId: 'some-page', userId: 'user_1' },
+    },
+  });
+
+  expect(lastAgentConfig.instructions).toBe('Be helpful.');
+});
+
+test('pageContext omits empty urlQuery from context block', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
+
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+
+  await handleAgentChat({
+    connection: { provider: jest.fn().mockReturnValue({}) },
+    properties: {
+      agent: {
+        tools: [],
+        properties: {
+          model: 'gpt-4o',
+          instructions: 'Be helpful.',
+          pageContext: true,
+        },
+      },
+      messages: [],
+    },
+    context: {
+      callEndpoint: jest.fn(),
+      getEndpointConfig: jest.fn(),
+      agentContext: { pageId: 'my-page', userId: 'user_1', urlQuery: {} },
+    },
+  });
+
+  expect(lastAgentConfig.instructions).not.toContain('urlQuery');
+  expect(lastAgentConfig.instructions).toContain('<context>');
+  expect(lastAgentConfig.instructions).toContain('pageId: my-page');
 });

--- a/packages/utils/ai-utils/src/handleAgentChat.test.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.test.js
@@ -1002,7 +1002,7 @@ test('onFinish hook dataParts are written to the stream writer', async () => {
     { type: 'data', value: { suggestions: ['How are you?'] } },
     { type: 'data', value: { title: 'Greeting conversation' } },
   ];
-  const callEndpoint = jest.fn().mockResolvedValue({ dataParts });
+  const callEndpoint = jest.fn().mockResolvedValue({ response: { dataParts } });
 
   await handleAgentChat({
     connection: { provider: jest.fn().mockReturnValue({}) },
@@ -1036,7 +1036,7 @@ test('onFinish hook failure logs warning and continues to next hook', async () =
   const callEndpoint = jest
     .fn()
     .mockRejectedValueOnce(new Error('Network timeout'))
-    .mockResolvedValueOnce({ dataParts: [{ type: 'data', value: { ok: true } }] });
+    .mockResolvedValueOnce({ response: { dataParts: [{ type: 'data', value: { ok: true } }] } });
 
   await handleAgentChat({
     connection: { provider: jest.fn().mockReturnValue({}) },


### PR DESCRIPTION
## Summary

Addresses three agent gaps identified. The onFinish hook payload was missing critical context for persistence and cost tracking, agent instructions couldn't use runtime operators, and there was no channel for server-to-client data parts.

## Changes

- **@lowdefy/api**: Construct `agentContext` in `callAgent` (conversationId, pageId, urlQuery, userId), evaluate agent properties with operators using agentContext as payload, thread agentContext to resolver context
- **@lowdefy/ai-utils**: Aggregate token usage across agent steps via `onStepFinish`, enrich onFinish hook payload with agentContext + usage, capture real `finishReason` from AI SDK step results, add `pageContext` instruction prepend, add `pageContext` to agent schema, deserialize hook response before reading `dataParts` (serializer converts arrays to `~arr` objects), read `dataParts` from `hookResponse.response` (not `hookResponse` directly). Merged prune support from `lowdefy-agents` — usage tracking works in both prune and non-prune paths.
- **@lowdefy/blocks-antd-x**: Send `urlQuery` from AgentChat via transport body, add `onData` callback to useChat firing `onDataPart` event, stabilize urlQuery in useMemo deps, fix `useAgentEvents` status check from `'idle'` to `'ready'` (AI SDK v6 renamed the idle status)
- **@lowdefy/server, @lowdefy/server-dev**: Parse `conversationId` from query string and `urlQuery` from request body in agent API routes, validate `urlQuery` type (must be object, rejects strings/arrays/primitives with 400)

## Key Files

- `packages/api/src/routes/agent/callAgent.js` — agentContext construction, operator evaluation of agent properties
- `packages/utils/ai-utils/src/handleAgentChat.js` — Usage accumulator with finishReason tracking, onFinish enrichment, pageContext prepend, prune path integration, hook response deserialization
- `packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js` — urlQuery transport, onDataPart event
- `packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/useAgentEvents.js` — status 'idle' → 'ready' fix
- `packages/servers/server/pages/api/agent/[...path].js` — urlQuery type validation

## Notes

- `pageContext: true` injects urlQuery values into the system prompt via JSON.stringify — developers should be aware of prompt injection considerations when using user-controlled URL parameters
- Merged `lowdefy-agents` into this branch to integrate prune support; resolved conflicts in `handleAgentChat.js` and its tests to ensure usage tracking works across both prune and non-prune code paths
- Data part types must start with `data-` prefix (AI SDK convention) for `onData`/`onDataPart` to fire on the client
- The `useAgentEvents` status fix (`idle` → `ready`) affects all agent events that depend on stream completion (`onMessageComplete`)