### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/packages/api/src/context/createReadConfigFile.js
+++ b/packages/api/src/context/createReadConfigFile.js
@@ -15,17 +15,34 @@
 */
 
 import path from 'path';
+import { realpath } from 'fs/promises';
 import { cachedPromises, serializer } from '@lowdefy/helpers';
 import { getFileExtension, readFile } from '@lowdefy/node-utils';
 
 const validPathPattern = /^[A-Za-z0-9\-_/.:]+$/;
 
 function createReadConfigFile({ buildDirectory, fileCache }) {
+  const resolvedBuildDirectory = path.resolve(buildDirectory);
+
   async function readConfigFile(filePath) {
-    if (!validPathPattern.test(filePath) || filePath.includes('..')) {
+    if (!validPathPattern.test(filePath) || filePath.includes('..') || path.isAbsolute(filePath)) {
       return null;
     }
-    const fileContent = await readFile(path.resolve(buildDirectory, filePath));
+
+    const resolvedPath = path.resolve(resolvedBuildDirectory, filePath);
+    const [canonicalBuildDirectory, canonicalPath] = await Promise.all([
+      realpath(resolvedBuildDirectory),
+      realpath(resolvedPath),
+    ]);
+
+    if (
+      canonicalPath !== canonicalBuildDirectory &&
+      !canonicalPath.startsWith(`${canonicalBuildDirectory}${path.sep}`)
+    ) {
+      return null;
+    }
+
+    const fileContent = await readFile(canonicalPath);
     if (getFileExtension(filePath) === 'json') {
       return serializer.deserializeFromString(fileContent);
     }

--- a/packages/api/src/routes/endpoints/callEndpoint.js
+++ b/packages/api/src/routes/endpoints/callEndpoint.js
@@ -45,9 +45,17 @@ async function callEndpoint(context, { blockId, endpointId, pageId, payload }) {
   });
 
   const success = !['error', 'reject'].includes(status);
+  const clientError =
+    success || error == null
+      ? error
+      : { code: 'ENDPOINT_ERROR', message: 'Endpoint request failed.' };
+
+  if (!success && error) {
+    logger.error({ event: 'endpoint_error', blockId, endpointId, pageId, error });
+  }
 
   return {
-    error: serializer.serialize(error),
+    error: serializer.serialize(clientError),
     response: serializer.serialize(response),
     status: success ? 'success' : status,
     success,


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `packages/api/src/context/createReadConfigFile.js:L20`

`createReadConfigFile` validates characters and blocks `..`, but it does not verify that the resolved path stays داخل `buildDirectory`. If an untrusted `filePath` reaches this function, absolute paths (or symlink-based escapes) could allow reading files outside the build artifact directory.

## Solution

After `path.resolve`, enforce a strict prefix check against `buildDirectory` (e.g., `resolvedPath.startsWith(path.resolve(buildDirectory) + path.sep)`). Reject absolute input paths and normalize/canonicalize before checking.

## Changes

- `packages/api/src/context/createReadConfigFile.js` (modified)
- `packages/api/src/routes/endpoints/callEndpoint.js` (modified)