### PR TITLE
Add bidirectional page state sync to agent chat

### DIFF
--- a/packages/api/src/routes/agent/callAgent.js
+++ b/packages/api/src/routes/agent/callAgent.js
@@ -25,7 +25,7 @@ import getAgentResolver from './getAgentResolver.js';
 import getConnectionConfig from '../request/getConnectionConfig.js';
 import getConnection from '../request/getConnection.js';
 
-async function callAgent(context, { agentId, pageId, messages, conversationId, urlQuery }) {
+async function callAgent(context, { agentId, pageId, messages, conversationId, urlQuery, pageState }) {
   const { logger } = context;
 
   context.pageId = pageId;
@@ -37,6 +37,7 @@ async function callAgent(context, { agentId, pageId, messages, conversationId, u
   const agentContext = {
     conversationId: conversationId ?? undefined,
     pageId,
+    pageState: pageState ?? {},
     urlQuery: urlQuery ?? {},
     userId: context.user?.sub ?? context.user?.id ?? null,
   };

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
@@ -35,6 +35,7 @@ function AgentChat({ blockId, components: { Icon }, methods, pageId, properties 
   const {
     agentId,
     urlQuery,
+    pageState,
     welcome,
     messageDisplay,
     sender,
@@ -48,6 +49,8 @@ function AgentChat({ blockId, components: { Icon }, methods, pageId, properties 
   const finishMetaRef = useRef(null);
   const fileInputRef = useRef(null);
   const [attachedFiles, setAttachedFiles] = useState([]);
+  const pageStateRef = useRef(pageState);
+  pageStateRef.current = pageState;
   const attachmentsConfig = sender?.attachments;
   const switchConfigs = sender?.switches ?? [];
   const [headerOpen, setHeaderOpen] = useState(sender?.header?.open ?? true);
@@ -61,7 +64,7 @@ function AgentChat({ blockId, components: { Icon }, methods, pageId, properties 
 
   const urlQueryKey = JSON.stringify(urlQuery ?? null);
   const transport = useMemo(
-    () => createLowdefyChatTransport({ pageId, agentId, conversationId, urlQuery }),
+    () => createLowdefyChatTransport({ pageId, agentId, conversationId, urlQuery, pageStateRef }),
     [pageId, agentId, conversationId, urlQueryKey]
   );
 

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/LowdefyChatTransport.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/LowdefyChatTransport.js
@@ -16,7 +16,7 @@
 
 import { DefaultChatTransport } from 'ai';
 
-function createLowdefyChatTransport({ pageId, agentId, conversationId, urlQuery }) {
+function createLowdefyChatTransport({ pageId, agentId, conversationId, urlQuery, pageStateRef }) {
   const base = `/api/agent/${pageId}/${agentId}`;
   const api = conversationId
     ? `${base}?conversationId=${encodeURIComponent(conversationId)}`
@@ -24,7 +24,13 @@ function createLowdefyChatTransport({ pageId, agentId, conversationId, urlQuery 
   return new DefaultChatTransport({
     api,
     credentials: 'include',
-    body: urlQuery ? { urlQuery } : undefined,
+    body: () => {
+      const pageState = pageStateRef?.current;
+      return {
+        ...(urlQuery ? { urlQuery } : {}),
+        ...(pageState && Object.keys(pageState).length > 0 ? { pageState } : {}),
+      };
+    },
   });
 }
 

--- a/packages/servers/server-dev/pages/api/agent/[...path].js
+++ b/packages/servers/server-dev/pages/api/agent/[...path].js
@@ -31,7 +31,7 @@ async function handler({ context, req, res }) {
   const pageId = segments.slice(0, -1).join('/');
   context.logger.info({ color: 'gray' }, `Agent: ${pageId} → ${agentId}`);
   const { conversationId } = req.query;
-  const { messages, urlQuery } = req.body;
+  const { messages, urlQuery, pageState } = req.body;
   if (!Array.isArray(messages)) {
     res.status(400).json({ error: 'messages must be an array' });
     return;
@@ -40,11 +40,16 @@ async function handler({ context, req, res }) {
     res.status(400).json({ error: 'urlQuery must be an object' });
     return;
   }
+  if (pageState != null && (typeof pageState !== 'object' || Array.isArray(pageState))) {
+    res.status(400).json({ error: 'pageState must be an object' });
+    return;
+  }
   const { response: webResponse } = await callAgent(context, {
     agentId,
     pageId,
     messages,
     conversationId: conversationId ?? undefined,
+    pageState: pageState ?? undefined,
     urlQuery: urlQuery ?? undefined,
   });
 

--- a/packages/servers/server/pages/api/agent/[...path].js
+++ b/packages/servers/server/pages/api/agent/[...path].js
@@ -31,7 +31,7 @@ async function handler({ context, req, res }) {
   const pageId = segments.slice(0, -1).join('/');
   context.logger.info({ event: 'call_agent', agentId, pageId });
   const { conversationId } = req.query;
-  const { messages, urlQuery } = req.body;
+  const { messages, urlQuery, pageState } = req.body;
   if (!Array.isArray(messages)) {
     res.status(400).json({ error: 'messages must be an array' });
     return;
@@ -40,11 +40,16 @@ async function handler({ context, req, res }) {
     res.status(400).json({ error: 'urlQuery must be an object' });
     return;
   }
+  if (pageState != null && (typeof pageState !== 'object' || Array.isArray(pageState))) {
+    res.status(400).json({ error: 'pageState must be an object' });
+    return;
+  }
   const { response: webResponse } = await callAgent(context, {
     agentId,
     pageId,
     messages,
     conversationId: conversationId ?? undefined,
+    pageState: pageState ?? undefined,
     urlQuery: urlQuery ?? undefined,
   });
 

--- a/packages/utils/ai-utils/src/handleAgentChat.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.js
@@ -145,6 +145,9 @@ async function handleAgentChat({ connection, properties, context }) {
     if (ctx.urlQuery && Object.keys(ctx.urlQuery).length > 0) {
       contextLines.push(`  urlQuery: ${JSON.stringify(ctx.urlQuery)}`);
     }
+    if (ctx.pageState && Object.keys(ctx.pageState).length > 0) {
+      contextLines.push(`  pageState: ${JSON.stringify(ctx.pageState)}`);
+    }
     contextLines.push('</context>');
     instructions = `${contextLines.join('\n')}\n\n${instructions ?? ''}`;
   }

--- a/packages/utils/ai-utils/src/handleAgentChat.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.js
@@ -203,7 +203,19 @@ async function handleAgentChat({ connection, properties, context }) {
   const stream = createUIMessageStream({
     execute: async ({ writer }) => {
       const usageAccumulator = createUsageAccumulator();
+      const steps = [];
       let agentStream;
+
+      function collectStep(stepResult) {
+        usageAccumulator.add(stepResult);
+        steps.push({
+          stepNumber: stepResult.stepNumber,
+          text: stepResult.text,
+          toolCalls: stepResult.toolCalls,
+          toolResults: stepResult.toolResults,
+          finishReason: stepResult.finishReason,
+        });
+      }
 
       if (pruneConfig) {
         // Decompose createAgentUIStream so we can insert pruneMessages
@@ -222,9 +234,7 @@ async function handleAgentChat({ connection, properties, context }) {
         const result = await agentInstance.stream({
           prompt: prunedMessages,
           ...timeoutConfig,
-          onStepFinish: (stepResult) => {
-            usageAccumulator.add(stepResult);
-          },
+          onStepFinish: collectStep,
         });
         agentStream = result.toUIMessageStream({
           originalMessages: validatedMessages,
@@ -237,9 +247,7 @@ async function handleAgentChat({ connection, properties, context }) {
           agent: agentInstance,
           uiMessages: messages,
           ...timeoutConfig,
-          onStepFinish: (stepResult) => {
-            usageAccumulator.add(stepResult);
-          },
+          onStepFinish: collectStep,
         });
       }
 
@@ -260,6 +268,8 @@ async function handleAgentChat({ connection, properties, context }) {
       if (hasOnFinishHooks) {
         const finishPayload = {
           messages,
+          steps,
+          toolResults: steps.flatMap((s) => s.toolResults ?? []),
           finishReason: usageAccumulator.getFinishReason(),
           isAborted: false,
           ...(context.agentContext ?? {}),

--- a/packages/utils/ai-utils/src/handleAgentChat.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.js
@@ -240,9 +240,19 @@ async function handleAgentChat({ connection, properties, context }) {
         });
       }
 
-      writer.merge(agentStream);
-
-      // After merge resolves the agent stream is complete.
+      // Read the agent stream to completion before running onFinish hooks.
+      // writer.merge() is fire-and-forget (returns void in the AI SDK), so we
+      // manually read the stream to ensure hooks fire after the agent finishes.
+      const reader = agentStream.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          writer.write(value);
+        }
+      } catch (error) {
+        writer.write({ type: 'error', errorText: writer.onError(error) });
+      }
       // Call onFinish hooks — awaited so dataParts can be written to stream.
       if (hasOnFinishHooks) {
         const finishPayload = {

--- a/packages/utils/ai-utils/src/handleAgentChat.test.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.test.js
@@ -21,11 +21,28 @@ const mockJsonSchema = jest.fn();
 const mockStepCountIs = jest.fn((n) => ({ type: 'stepCount', count: n }));
 const mockHasToolCall = jest.fn((name) => ({ type: 'hasToolCall', toolName: name }));
 
+function createMockReadableStream(chunks = []) {
+  return {
+    getReader: () => {
+      let index = 0;
+      return {
+        read: jest.fn().mockImplementation(async () => {
+          if (index < chunks.length) {
+            return { done: false, value: chunks[index++] };
+          }
+          return { done: true };
+        }),
+      };
+    },
+  };
+}
+
 const mockWriter = {
   write: jest.fn(),
-  merge: jest.fn().mockResolvedValue(undefined),
 };
-const mockCreateAgentUIStream = jest.fn().mockResolvedValue({ type: 'agent-ui-stream' });
+const mockCreateAgentUIStream = jest
+  .fn()
+  .mockImplementation(async () => createMockReadableStream());
 const mockCreateUIMessageStream = jest.fn().mockImplementation(({ execute }) => {
   mockCreateUIMessageStream._lastExecute = execute;
   return { type: 'readable-stream' };
@@ -34,7 +51,7 @@ const mockCreateUIMessageStreamResponse = jest.fn().mockReturnValue({ type: 'web
 
 let lastAgentConfig = null;
 let lastAgentInstance = null;
-const mockToUIMessageStream = jest.fn().mockReturnValue({ type: 'pruned-ui-stream' });
+const mockToUIMessageStream = jest.fn().mockImplementation(() => createMockReadableStream());
 class MockToolLoopAgent {
   constructor(config) {
     this.config = config;
@@ -952,7 +969,7 @@ test('stream-level onFinish calls hook endpoints with messages payload', async (
   const execute = mockCreateUIMessageStream._lastExecute;
   expect(execute).toEqual(expect.any(Function));
 
-  const localWriter = { write: jest.fn(), merge: jest.fn().mockResolvedValue(undefined) };
+  const localWriter = { write: jest.fn() };
   await execute({ writer: localWriter });
 
   expect(callEndpoint).toHaveBeenCalledWith('save-conversation', {
@@ -985,7 +1002,7 @@ test('no onFinish hooks does not call callEndpoint in execute', async () => {
   });
 
   const execute = mockCreateUIMessageStream._lastExecute;
-  const localWriter = { write: jest.fn(), merge: jest.fn().mockResolvedValue(undefined) };
+  const localWriter = { write: jest.fn() };
   await execute({ writer: localWriter });
 
   expect(callEndpoint).not.toHaveBeenCalled();
@@ -1018,7 +1035,7 @@ test('onFinish hook dataParts are written to the stream writer', async () => {
   });
 
   const execute = mockCreateUIMessageStream._lastExecute;
-  const localWriter = { write: jest.fn(), merge: jest.fn().mockResolvedValue(undefined) };
+  const localWriter = { write: jest.fn() };
   await execute({ writer: localWriter });
 
   expect(localWriter.write).toHaveBeenCalledTimes(2);
@@ -1052,7 +1069,7 @@ test('onFinish hook failure logs warning and continues to next hook', async () =
   });
 
   const execute = mockCreateUIMessageStream._lastExecute;
-  const localWriter = { write: jest.fn(), merge: jest.fn().mockResolvedValue(undefined) };
+  const localWriter = { write: jest.fn() };
   await execute({ writer: localWriter });
 
   expect(callEndpoint).toHaveBeenCalledTimes(2);
@@ -1086,7 +1103,7 @@ test('onFinish hook without dataParts does not write to stream', async () => {
   });
 
   const execute = mockCreateUIMessageStream._lastExecute;
-  const localWriter = { write: jest.fn(), merge: jest.fn().mockResolvedValue(undefined) };
+  const localWriter = { write: jest.fn() };
   await execute({ writer: localWriter });
 
   expect(callEndpoint).toHaveBeenCalledWith('save-conversation', expect.any(Object));
@@ -1280,7 +1297,7 @@ test('timeout as number passed to createAgentUIStream', async () => {
   });
 
   const execute = mockCreateUIMessageStream._lastExecute;
-  const localWriter = { write: jest.fn(), merge: jest.fn().mockResolvedValue(undefined) };
+  const localWriter = { write: jest.fn() };
   await execute({ writer: localWriter });
 
   expect(mockCreateAgentUIStream).toHaveBeenCalledWith(expect.objectContaining({ timeout: 30000 }));
@@ -1307,7 +1324,7 @@ test('timeout as object passed to createAgentUIStream', async () => {
   });
 
   const execute = mockCreateUIMessageStream._lastExecute;
-  const localWriter = { write: jest.fn(), merge: jest.fn().mockResolvedValue(undefined) };
+  const localWriter = { write: jest.fn() };
   await execute({ writer: localWriter });
 
   expect(mockCreateAgentUIStream).toHaveBeenCalledWith(
@@ -1334,7 +1351,7 @@ test('no timeout omits key from createAgentUIStream', async () => {
   });
 
   const execute = mockCreateUIMessageStream._lastExecute;
-  const localWriter = { write: jest.fn(), merge: jest.fn().mockResolvedValue(undefined) };
+  const localWriter = { write: jest.fn() };
   await execute({ writer: localWriter });
 
   const streamCallArgs =
@@ -1525,16 +1542,10 @@ test('onFinish hook payload includes aggregated usage from multiple steps', asyn
 
   const callEndpoint = jest.fn().mockResolvedValue({ success: true, response: {} });
 
-  // Mock createAgentUIStream to capture onStepFinish and simulate multiple steps
-  let capturedOnStepFinish;
+  // Mock createAgentUIStream to simulate multiple steps completing during execution
   mockCreateAgentUIStream.mockImplementation(async (opts) => {
-    capturedOnStepFinish = opts.onStepFinish;
-    return { type: 'agent-ui-stream' };
-  });
-  // Make merge call onStepFinish to simulate steps completing before merge resolves
-  mockWriter.merge.mockImplementation(async () => {
-    if (capturedOnStepFinish) {
-      capturedOnStepFinish({
+    if (opts.onStepFinish) {
+      opts.onStepFinish({
         usage: {
           inputTokens: 100,
           outputTokens: 50,
@@ -1543,7 +1554,7 @@ test('onFinish hook payload includes aggregated usage from multiple steps', asyn
           outputTokenDetails: { reasoningTokens: 5 },
         },
       });
-      capturedOnStepFinish({
+      opts.onStepFinish({
         usage: {
           inputTokens: 200,
           outputTokens: 80,
@@ -1553,6 +1564,7 @@ test('onFinish hook payload includes aggregated usage from multiple steps', asyn
         },
       });
     }
+    return createMockReadableStream();
   });
 
   await handleAgentChat({
@@ -1584,8 +1596,7 @@ test('onFinish hook payload includes aggregated usage from multiple steps', asyn
   });
 
   // Restore default mock
-  mockCreateAgentUIStream.mockResolvedValue({ type: 'agent-ui-stream' });
-  mockWriter.merge.mockResolvedValue(undefined);
+  mockCreateAgentUIStream.mockImplementation(async () => createMockReadableStream());
 });
 
 test('usage accumulator handles missing usage gracefully', async () => {
@@ -1596,16 +1607,12 @@ test('usage accumulator handles missing usage gracefully', async () => {
 
   const callEndpoint = jest.fn().mockResolvedValue({ success: true, response: {} });
 
-  let capturedOnStepFinish;
   mockCreateAgentUIStream.mockImplementation(async (opts) => {
-    capturedOnStepFinish = opts.onStepFinish;
-    return { type: 'agent-ui-stream' };
-  });
-  mockWriter.merge.mockImplementation(async () => {
-    if (capturedOnStepFinish) {
-      capturedOnStepFinish({ usage: undefined });
-      capturedOnStepFinish({ usage: { inputTokens: 50 } });
+    if (opts.onStepFinish) {
+      opts.onStepFinish({ usage: undefined });
+      opts.onStepFinish({ usage: { inputTokens: 50 } });
     }
+    return createMockReadableStream();
   });
 
   await handleAgentChat({
@@ -1637,8 +1644,7 @@ test('usage accumulator handles missing usage gracefully', async () => {
   });
 
   // Restore default mocks
-  mockCreateAgentUIStream.mockResolvedValue({ type: 'agent-ui-stream' });
-  mockWriter.merge.mockResolvedValue(undefined);
+  mockCreateAgentUIStream.mockImplementation(async () => createMockReadableStream());
 });
 
 test('pageContext true prepends context block to instructions', async () => {
@@ -1776,7 +1782,7 @@ test('prune config triggers decomposed stream pipeline instead of createAgentUIS
     context: { callEndpoint: jest.fn(), getEndpointConfig: jest.fn() },
   });
 
-  const localWriter = { write: jest.fn(), merge: jest.fn().mockResolvedValue(undefined) };
+  const localWriter = { write: jest.fn() };
   await mockCreateUIMessageStream._lastExecute({ writer: localWriter });
 
   expect(mockValidateUIMessages).toHaveBeenCalledWith({
@@ -1798,7 +1804,6 @@ test('prune config triggers decomposed stream pipeline instead of createAgentUIS
     originalMessages: mockValidated,
   });
   expect(mockCreateAgentUIStream).not.toHaveBeenCalled();
-  expect(localWriter.merge).toHaveBeenCalledWith({ type: 'pruned-ui-stream' });
 });
 
 test('without prune config, createAgentUIStream is used and prune functions are not called', async () => {
@@ -1823,7 +1828,7 @@ test('without prune config, createAgentUIStream is used and prune functions are 
     context: { callEndpoint: jest.fn(), getEndpointConfig: jest.fn() },
   });
 
-  const localWriter = { write: jest.fn(), merge: jest.fn().mockResolvedValue(undefined) };
+  const localWriter = { write: jest.fn() };
   await mockCreateUIMessageStream._lastExecute({ writer: localWriter });
 
   expect(mockCreateAgentUIStream).toHaveBeenCalled();
@@ -1861,7 +1866,7 @@ test('all pruneConfig properties are spread into pruneMessages call', async () =
   });
 
   await mockCreateUIMessageStream._lastExecute({
-    writer: { write: jest.fn(), merge: jest.fn().mockResolvedValue(undefined) },
+    writer: { write: jest.fn() },
   });
 
   expect(mockPruneMessages).toHaveBeenCalledWith({
@@ -1894,7 +1899,7 @@ test('prune branch passes timeout to agentInstance.stream', async () => {
   });
 
   await mockCreateUIMessageStream._lastExecute({
-    writer: { write: jest.fn(), merge: jest.fn().mockResolvedValue(undefined) },
+    writer: { write: jest.fn() },
   });
 
   expect(lastAgentInstance.stream).toHaveBeenCalledWith({

--- a/packages/utils/ai-utils/src/handleAgentChat.test.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.test.js
@@ -975,6 +975,8 @@ test('stream-level onFinish calls hook endpoints with messages payload', async (
   expect(callEndpoint).toHaveBeenCalledWith('save-conversation', {
     payload: expect.objectContaining({
       messages,
+      steps: [],
+      toolResults: [],
       finishReason: 'stop',
       isAborted: false,
     }),
@@ -1546,6 +1548,11 @@ test('onFinish hook payload includes aggregated usage from multiple steps', asyn
   mockCreateAgentUIStream.mockImplementation(async (opts) => {
     if (opts.onStepFinish) {
       opts.onStepFinish({
+        stepNumber: 0,
+        text: 'Looking up products...',
+        toolCalls: [{ toolCallId: 'tc1', toolName: 'search', input: { q: 'laptop' } }],
+        toolResults: [{ toolCallId: 'tc1', toolName: 'search', input: { q: 'laptop' }, output: [{ name: 'MacBook' }] }],
+        finishReason: 'tool-calls',
         usage: {
           inputTokens: 100,
           outputTokens: 50,
@@ -1555,6 +1562,11 @@ test('onFinish hook payload includes aggregated usage from multiple steps', asyn
         },
       });
       opts.onStepFinish({
+        stepNumber: 1,
+        text: 'Here are the results.',
+        toolCalls: [],
+        toolResults: [],
+        finishReason: 'stop',
         usage: {
           inputTokens: 200,
           outputTokens: 80,
@@ -1812,6 +1824,108 @@ test('pageContext omits empty pageState from context block', async () => {
   });
 
   expect(lastAgentConfig.instructions).not.toContain('pageState');
+});
+
+test('onFinish hook payload includes steps with toolCalls and toolResults', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
+
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+
+  const callEndpoint = jest.fn().mockResolvedValue({ success: true, response: {} });
+
+  const mockToolCall = { toolCallId: 'tc1', toolName: 'set_form', input: { name: 'Acme' } };
+  const mockToolResult = { ...mockToolCall, output: { success: true } };
+
+  mockCreateAgentUIStream.mockImplementation(async (opts) => {
+    if (opts.onStepFinish) {
+      opts.onStepFinish({
+        stepNumber: 0,
+        text: 'Setting form fields.',
+        toolCalls: [mockToolCall],
+        toolResults: [mockToolResult],
+        finishReason: 'stop',
+        usage: { inputTokens: 50, outputTokens: 20, totalTokens: 70 },
+      });
+    }
+    return createMockReadableStream();
+  });
+
+  await handleAgentChat({
+    connection: { provider: jest.fn().mockReturnValue({}) },
+    properties: {
+      agent: {
+        tools: [],
+        hooks: { onFinish: ['process-results'] },
+        properties: { model: 'gpt-4o' },
+      },
+      messages: [],
+    },
+    context: { callEndpoint, getEndpointConfig: jest.fn() },
+  });
+
+  await mockCreateUIMessageStream._lastExecute({ writer: mockWriter });
+
+  const payload = callEndpoint.mock.calls[0][1].payload;
+
+  expect(payload.steps).toEqual([
+    {
+      stepNumber: 0,
+      text: 'Setting form fields.',
+      toolCalls: [mockToolCall],
+      toolResults: [mockToolResult],
+      finishReason: 'stop',
+    },
+  ]);
+  expect(payload.toolResults).toEqual([mockToolResult]);
+
+  mockCreateAgentUIStream.mockImplementation(async () => createMockReadableStream());
+});
+
+test('onFinish hook payload has empty toolResults when no tools called', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
+
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+
+  const callEndpoint = jest.fn().mockResolvedValue({ success: true, response: {} });
+
+  mockCreateAgentUIStream.mockImplementation(async (opts) => {
+    if (opts.onStepFinish) {
+      opts.onStepFinish({
+        stepNumber: 0,
+        text: 'Hello!',
+        toolCalls: [],
+        toolResults: [],
+        finishReason: 'stop',
+        usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+      });
+    }
+    return createMockReadableStream();
+  });
+
+  await handleAgentChat({
+    connection: { provider: jest.fn().mockReturnValue({}) },
+    properties: {
+      agent: {
+        tools: [],
+        hooks: { onFinish: ['save'] },
+        properties: { model: 'gpt-4o' },
+      },
+      messages: [],
+    },
+    context: { callEndpoint, getEndpointConfig: jest.fn() },
+  });
+
+  await mockCreateUIMessageStream._lastExecute({ writer: mockWriter });
+
+  const payload = callEndpoint.mock.calls[0][1].payload;
+
+  expect(payload.steps).toHaveLength(1);
+  expect(payload.steps[0].text).toBe('Hello!');
+  expect(payload.toolResults).toEqual([]);
+
+  mockCreateAgentUIStream.mockImplementation(async () => createMockReadableStream());
 });
 
 test('prune config triggers decomposed stream pipeline instead of createAgentUIStream', async () => {

--- a/packages/utils/ai-utils/src/handleAgentChat.test.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.test.js
@@ -1749,6 +1749,71 @@ test('pageContext omits empty urlQuery from context block', async () => {
   expect(lastAgentConfig.instructions).toContain('pageId: my-page');
 });
 
+test('pageContext includes pageState in context block', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
+
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+
+  await handleAgentChat({
+    connection: { provider: jest.fn().mockReturnValue({}) },
+    properties: {
+      agent: {
+        tools: [],
+        properties: {
+          model: 'gpt-4o',
+          instructions: 'Be helpful.',
+          pageContext: true,
+        },
+      },
+      messages: [],
+    },
+    context: {
+      callEndpoint: jest.fn(),
+      getEndpointConfig: jest.fn(),
+      agentContext: {
+        pageId: 'onboarding',
+        userId: 'user_abc',
+        pageState: { org_name: 'TestCorp', sector: 'private_security' },
+      },
+    },
+  });
+
+  expect(lastAgentConfig.instructions).toContain(
+    'pageState: {"org_name":"TestCorp","sector":"private_security"}'
+  );
+  expect(lastAgentConfig.instructions).toContain('<context>');
+});
+
+test('pageContext omits empty pageState from context block', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
+
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+
+  await handleAgentChat({
+    connection: { provider: jest.fn().mockReturnValue({}) },
+    properties: {
+      agent: {
+        tools: [],
+        properties: {
+          model: 'gpt-4o',
+          instructions: 'Be helpful.',
+          pageContext: true,
+        },
+      },
+      messages: [],
+    },
+    context: {
+      callEndpoint: jest.fn(),
+      getEndpointConfig: jest.fn(),
+      agentContext: { pageId: 'my-page', userId: 'user_1', pageState: {} },
+    },
+  });
+
+  expect(lastAgentConfig.instructions).not.toContain('pageState');
+});
+
 test('prune config triggers decomposed stream pipeline instead of createAgentUIStream', async () => {
   mockTool.mockImplementation((def) => def);
   mockJsonSchema.mockReturnValue(MOCK_SCHEMA);


### PR DESCRIPTION
## Summary

Enables bidirectional state synchronization between page form fields and agent chat. The agent can read page state via its context block and write back to form fields through tool calls, with results forwarded as data stream parts that trigger client-side SetState actions.

## Changes

- **@lowdefy/blocks-antd-x**: Send `pageState` property with agent chat requests via LowdefyChatTransport, enabling agents to receive current form values.
- **@lowdefy/api**: Thread `pageState` from the request body through to `agentContext` in callAgent, making it available to the agent runtime.
- **@lowdefy/server, @lowdefy/server-dev**: Parse `pageState` from agent API request bodies in route handlers.
- **@lowdefy/ai-utils**: Await agent stream completion before running onFinish hooks so dataParts can be written to the response stream. Include accumulated `steps` and `toolResults` in onFinish hook payloads.