### PR TITLE
AgentChat: typing dots on hidden-tool turns, optional thinking label

### DIFF
--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js
@@ -29,6 +29,7 @@ import { DeleteOutlined, ReloadOutlined, RobotOutlined } from '@ant-design/icons
 
 import { getFileCardType, getFileCardIcon, getFileName } from './fileCardUtils.js';
 import formatToolResult from './formatToolResult.js';
+import { getToolInfo, partCategory } from './messageParts.js';
 import ToolApproval from './ToolApproval.js';
 
 // Module-level singleton for the LaTeX marked extension.
@@ -85,19 +86,6 @@ function RichCodeBlock({ renderMermaid, codeHighlighter }) {
         <code className={lang ? `language-${lang}` : undefined}>{children}</code>
       </pre>
     );
-  };
-}
-
-// Detects tool-call parts from AI SDK v6's dynamic part types.
-// Tool parts have type `tool-${toolName}` or `dynamic-tool`, not a generic `tool-invocation`.
-function getToolInfo(part) {
-  if (!part.type?.startsWith?.('tool-') && part.type !== 'dynamic-tool') return null;
-  return {
-    toolCallId: part.toolCallId,
-    toolName: part.toolName ?? part.type?.replace('tool-', ''),
-    state: part.state,
-    input: part.input,
-    output: part.output,
   };
 }
 
@@ -252,26 +240,6 @@ function MessageBubble({
         )}
       </div>
     );
-  }
-
-  // OpenAI Responses API models (e.g. GPT-5.x) emit text parts with a 'commentary'
-  // phase (preambles before tool calls) and a 'final_answer' phase (the actual response).
-  // Commentary is intermediate output — treat it as reasoning so it renders in the
-  // collapsible reasoning section rather than duplicating the final answer text.
-  function isCommentary(part) {
-    return part.providerMetadata?.openai?.phase === 'commentary';
-  }
-
-  function partCategory(part) {
-    if (part.type === 'step-start') return null;
-    if (part.type === 'reasoning' || (part.type === 'text' && isCommentary(part))) {
-      return 'reasoning';
-    }
-    if (part.type === 'text') return 'text';
-    if (getToolInfo(part)) return 'tool';
-    if (part.type === 'file') return 'file';
-    if (part.type === 'data-status') return 'status';
-    return null;
   }
 
   // Build segments of consecutive same-type parts.

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageList.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageList.js
@@ -20,7 +20,10 @@ import { Avatar } from 'antd';
 import { RobotOutlined, UserOutlined } from '@ant-design/icons';
 
 import { getFileCardType, getFileCardIcon, getFileName } from './fileCardUtils.js';
+import { hasVisibleContent } from './messageParts.js';
 import MessageBubble from './MessageBubble.js';
+import ThinkingIndicator from './ThinkingIndicator.js';
+import useThinkingMessage from './useThinkingMessage.js';
 
 function roleAvatar(roleConfig, fallbackIcon) {
   if (roleConfig?.avatar) {
@@ -32,6 +35,21 @@ function roleAvatar(roleConfig, fallbackIcon) {
 function roleHeader(roleConfig, fallback) {
   const name = roleConfig?.name ?? fallback;
   return <h5 style={{ margin: 0 }}>{name}</h5>;
+}
+
+// Rendered inside a bubble's loadingRender while it shows dots. Lives in its own
+// component so useThinkingMessage's timers mount/unmount with the loading state:
+// when a visible part arrives → loading flips false → this component unmounts →
+// effect cleanup clears the delay timeout and rotation interval.
+function ThinkingBubbleContent({ bubbleId, config }) {
+  const label = useThinkingMessage({
+    active: true,
+    messages: config?.thinkingMessages,
+    delay: config?.thinkingMessageDelay,
+    interval: config?.thinkingMessageRotationInterval,
+    resetKey: bubbleId,
+  });
+  return <ThinkingIndicator label={label} />;
 }
 
 const MessageList = React.forwardRef(function MessageList(
@@ -75,17 +93,20 @@ const MessageList = React.forwardRef(function MessageList(
       }
     }
 
+    // Show loading dots while the agent is working on the last assistant bubble and
+    // nothing visible has rendered yet. `hasVisibleContent` mirrors what MessageBubble
+    // paints, so tool-only messages with showThoughtChain: false also keep dots.
+    const showLoading =
+      isStreaming && isLastAssistant && !hasVisibleContent(msg, config);
+
     items.push({
       key: msg.id,
       content: textContent,
       role: msg.role === 'user' ? 'user' : 'ai',
-      // Only show loading dots when streaming has started but no content has arrived yet.
-      // Once the first token or tool part appears, loading flips to false and content renders.
-      loading:
-        isStreaming &&
-        isLastAssistant &&
-        textContent.length === 0 &&
-        !msg.parts?.some((part) => part.type !== 'text' && part.type !== 'step-start'),
+      loading: showLoading,
+      loadingRender: showLoading
+        ? () => <ThinkingBubbleContent bubbleId={msg.id} config={config} />
+        : undefined,
       streaming: isStreaming && isLastAssistant,
     });
   }
@@ -93,7 +114,14 @@ const MessageList = React.forwardRef(function MessageList(
   // When busy but no assistant message exists yet (submitted, waiting for first chunk),
   // append a placeholder so loading dots are visible immediately.
   if (isStreaming && lastMessage?.role !== 'assistant') {
-    items.push({ key: '__loading', content: '', role: 'ai', loading: true, streaming: true });
+    items.push({
+      key: '__loading',
+      content: '',
+      role: 'ai',
+      loading: true,
+      loadingRender: () => <ThinkingBubbleContent bubbleId="__loading" config={config} />,
+      streaming: true,
+    });
   }
 
   return (

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageList.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageList.js
@@ -113,6 +113,14 @@ const MessageList = React.forwardRef(function MessageList(
 
   // When busy but no assistant message exists yet (submitted, waiting for first chunk),
   // append a placeholder so loading dots are visible immediately.
+  //
+  // Known cosmetic issue: the ThinkingBubbleContent here uses bubbleId="__loading",
+  // while the real assistant bubble (once its first chunk lands) uses msg.id. If the
+  // first chunk arrives after thinkingMessageDelay has already elapsed but brings
+  // only invisible parts (e.g. a tool call with showThoughtChain: false), the
+  // rotation timer resets and the label briefly disappears before the new bubble's
+  // delay elapses again. Accepted for v1 — a turn-stable resetKey (e.g. last user
+  // message id) would smooth this over but needs plumbing.
   if (isStreaming && lastMessage?.role !== 'assistant') {
     items.push({
       key: '__loading',

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/ThinkingIndicator.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/ThinkingIndicator.js
@@ -14,8 +14,8 @@
   limitations under the License.
 */
 
-import React from 'react';
-import { useXProviderContext } from '@ant-design/x';
+import React, { useContext } from 'react';
+import { ConfigProvider } from 'antd';
 
 // Renders the three CSS-animated loading dots that @ant-design/x's Bubble shows by
 // default (same DOM structure as @ant-design/x/lib/bubble/loading.js so the existing
@@ -23,8 +23,12 @@ import { useXProviderContext } from '@ant-design/x';
 // in an aria-live region so screen readers announce rotations without interrupting.
 //
 // The dots are aria-hidden — they're decorative. Only the label is announced.
+//
+// We pull the bubble prefix class from antd's ConfigProvider directly (same route
+// @ant-design/x's internal useXProviderContext uses) so the CSS selectors line up
+// with whatever prefix the host app configures.
 function ThinkingIndicator({ label }) {
-  const { getPrefixCls } = useXProviderContext();
+  const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
   const prefixCls = getPrefixCls('bubble');
   return (
     <span

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/ThinkingIndicator.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/ThinkingIndicator.js
@@ -1,0 +1,51 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import React from 'react';
+import { useXProviderContext } from '@ant-design/x';
+
+// Renders the three CSS-animated loading dots that @ant-design/x's Bubble shows by
+// default (same DOM structure as @ant-design/x/lib/bubble/loading.js so the existing
+// stylesheet animates them), optionally followed by a soft "thinking…" label wrapped
+// in an aria-live region so screen readers announce rotations without interrupting.
+//
+// The dots are aria-hidden — they're decorative. Only the label is announced.
+function ThinkingIndicator({ label }) {
+  const { getPrefixCls } = useXProviderContext();
+  const prefixCls = getPrefixCls('bubble');
+  return (
+    <span
+      style={{ display: 'inline-flex', alignItems: 'center', gap: 8, verticalAlign: 'middle' }}
+    >
+      <span className={`${prefixCls}-dot`} aria-hidden="true">
+        <i className={`${prefixCls}-dot-item`} key="item-1" />
+        <i className={`${prefixCls}-dot-item`} key="item-2" />
+        <i className={`${prefixCls}-dot-item`} key="item-3" />
+      </span>
+      {label != null && label !== '' && (
+        <span
+          aria-live="polite"
+          aria-atomic="true"
+          style={{ color: '#8c8c8c', fontSize: '0.9em' }}
+        >
+          {label}
+        </span>
+      )}
+    </span>
+  );
+}
+
+export default ThinkingIndicator;

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/messageParts.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/messageParts.js
@@ -1,0 +1,82 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Detects tool-call parts from AI SDK v6's dynamic part types.
+// Tool parts have type `tool-${toolName}` or `dynamic-tool`, not a generic `tool-invocation`.
+export function getToolInfo(part) {
+  if (!part.type?.startsWith?.('tool-') && part.type !== 'dynamic-tool') return null;
+  return {
+    toolCallId: part.toolCallId,
+    toolName: part.toolName ?? part.type?.replace('tool-', ''),
+    state: part.state,
+    input: part.input,
+    output: part.output,
+  };
+}
+
+// OpenAI Responses API models (e.g. GPT-5.x) emit text parts with a 'commentary'
+// phase (preambles before tool calls) and a 'final_answer' phase (the actual response).
+// Commentary is intermediate output — treat it as reasoning so it renders in the
+// collapsible reasoning section rather than duplicating the final answer text.
+export function isCommentaryPart(part) {
+  return part.providerMetadata?.openai?.phase === 'commentary';
+}
+
+// Classify a message part for inline rendering in MessageBubble's segment loop.
+// Returns 'reasoning' | 'text' | 'tool' | 'file' | 'status' | null.
+// Parts that return null are either never-rendered (e.g. step-start) or rendered
+// via separate paths (source-url/source-document via SourcesDisplay, custom data-*
+// parts not handled inline). MessageBubble's interleaved loop skips null categories
+// so they don't fragment consecutive same-type segments.
+export function partCategory(part) {
+  if (part.type === 'step-start') return null;
+  if (part.type === 'reasoning' || (part.type === 'text' && isCommentaryPart(part))) {
+    return 'reasoning';
+  }
+  if (part.type === 'text') return 'text';
+  if (getToolInfo(part)) return 'tool';
+  if (part.type === 'file') return 'file';
+  if (part.type === 'data-status') return 'status';
+  return null;
+}
+
+// Returns true if `part` produces visible UI given the current messageDisplay config.
+// Covers both inline rendering (mirrors partCategory + config) and out-of-segment
+// paths (SourcesDisplay for source-url/source-document). Unknown part types default
+// to visible — fail-safe so dots don't flash on top of something we can't classify
+// but the bubble may actually be rendering (future SDK additions, custom data-*).
+export function isPartVisible(part, config) {
+  if (part.type === 'step-start') return false;
+  const category = partCategory(part);
+  if (category === 'text') return (part.text ?? '').length > 0;
+  if (category === 'reasoning') return config?.showReasoning !== false;
+  if (category === 'tool') return config?.showThoughtChain !== false;
+  if (category === 'file') return true;
+  if (category === 'status') return config?.showStatusUpdates !== false;
+  if (part.type === 'source-url' || part.type === 'source-document') {
+    return config?.showSources === true;
+  }
+  // Unknown part type — fail-safe to visible.
+  return true;
+}
+
+// Returns true if `message` has at least one part that renders visible UI.
+// Used to decide whether the last assistant bubble should show typing dots
+// while the agent is still working.
+export function hasVisibleContent(message, config) {
+  if (!message?.parts || message.parts.length === 0) return false;
+  return message.parts.some((part) => isPartVisible(part, config));
+}

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/messageParts.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/messageParts.js
@@ -62,7 +62,15 @@ export function isPartVisible(part, config) {
   if (part.type === 'step-start') return false;
   const category = partCategory(part);
   if (category === 'text') return (part.text ?? '').length > 0;
-  if (category === 'reasoning') return config?.showReasoning !== false;
+  if (category === 'reasoning') {
+    if (config?.showReasoning === false) return false;
+    // Commentary-phase text parts are bucketed as 'reasoning' but still need the
+    // same empty-text guard: the AI SDK pushes text parts with text='' on text-start
+    // before any text-delta chunks arrive, so an empty commentary part shouldn't
+    // count as visible content — dots should keep showing until real text streams.
+    if (part.type === 'text') return (part.text ?? '').length > 0;
+    return true;
+  }
   if (category === 'tool') return config?.showThoughtChain !== false;
   if (category === 'file') return true;
   if (category === 'status') return config?.showStatusUpdates !== false;

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/schema.json
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/schema.json
@@ -68,6 +68,23 @@
         "showStatusUpdates": { "type": "boolean", "default": true },
         "showStepSeparators": { "type": "boolean", "default": false },
         "showToolInputStreaming": { "type": "boolean", "default": true },
+        "thinkingMessages": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+          ],
+          "description": "Optional label shown next to the typing dots on a loading assistant bubble, after a short delay. Pass a string for a single label, or an array to rotate through several. Leave unset (default) to show dots only."
+        },
+        "thinkingMessageDelay": {
+          "type": "number",
+          "default": 3000,
+          "description": "Milliseconds of continuous loading state before the first thinkingMessages entry appears. Ignored when thinkingMessages is unset."
+        },
+        "thinkingMessageRotationInterval": {
+          "type": "number",
+          "default": 8000,
+          "description": "Milliseconds between label rotations when thinkingMessages is an array with 2 or more entries. Ignored for a single string."
+        },
         "editableMessages": {
           "type": "boolean",
           "default": true,

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/schema.json
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/schema.json
@@ -78,11 +78,13 @@
         "thinkingMessageDelay": {
           "type": "number",
           "default": 3000,
-          "description": "Milliseconds of continuous loading state before the first thinkingMessages entry appears. Ignored when thinkingMessages is unset."
+          "minimum": 500,
+          "description": "Milliseconds of continuous loading state before the first thinkingMessages entry appears. Clamped to a 500 ms minimum at runtime to prevent flash-of-label on near-instant responses. Ignored when thinkingMessages is unset."
         },
         "thinkingMessageRotationInterval": {
           "type": "number",
           "default": 8000,
+          "minimum": 500,
           "description": "Milliseconds between label rotations when thinkingMessages is an array with 2 or more entries. Ignored for a single string."
         },
         "editableMessages": {

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/useThinkingMessage.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/useThinkingMessage.js
@@ -1,0 +1,81 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { useEffect, useState } from 'react';
+
+const MIN_DELAY = 500;
+const DEFAULT_DELAY = 3000;
+const DEFAULT_INTERVAL = 8000;
+
+function toList(messages) {
+  if (typeof messages === 'string' && messages.length > 0) return [messages];
+  if (Array.isArray(messages)) {
+    const filtered = messages.filter((m) => typeof m === 'string' && m.length > 0);
+    return filtered.length > 0 ? filtered : null;
+  }
+  return null;
+}
+
+// React hook: returns the current thinking-message label string, or null.
+// - `active`: true while the loading state is visible (bubble has `loading: true`).
+// - `messages`: string or string[] to show / rotate through. Falsy = feature off.
+// - `delay`: ms before the first label appears after `active` becomes true.
+// - `interval`: ms between rotations when `messages` has 2+ entries.
+// - `resetKey`: stable identifier (usually the loading bubble's id). Changing it restarts timers.
+//
+// The hook keeps all timer lifecycle inside a single useEffect. When `active` flips
+// false (or `resetKey`/`messages` change, or the component unmounts) cleanup fires
+// and clears both the delay timeout and the rotation interval — no leaks.
+export default function useThinkingMessage({ active, messages, delay, interval, resetKey }) {
+  const list = toList(messages);
+  const listSize = list?.length ?? 0;
+  // Serialize for useEffect dependency — array identity changes on every render
+  // for YAML-sourced config, but only content changes matter.
+  const listKey = list ? list.join('\u0000') : '';
+
+  const effectiveDelay = Math.max(
+    MIN_DELAY,
+    typeof delay === 'number' && delay >= 0 ? delay : DEFAULT_DELAY
+  );
+  const effectiveInterval =
+    typeof interval === 'number' && interval > 0 ? interval : DEFAULT_INTERVAL;
+
+  // -1 means "delay not yet elapsed, no label to show"
+  const [index, setIndex] = useState(-1);
+
+  useEffect(() => {
+    setIndex(-1);
+    if (!active || listSize === 0) return undefined;
+
+    let rotationId = null;
+    const delayId = setTimeout(() => {
+      setIndex(0);
+      if (listSize >= 2) {
+        rotationId = setInterval(() => {
+          setIndex((i) => (i + 1) % listSize);
+        }, effectiveInterval);
+      }
+    }, effectiveDelay);
+
+    return () => {
+      clearTimeout(delayId);
+      if (rotationId !== null) clearInterval(rotationId);
+    };
+  }, [active, listSize, listKey, effectiveDelay, effectiveInterval, resetKey]);
+
+  if (!active || listSize === 0 || index < 0) return null;
+  return list[index];
+}


### PR DESCRIPTION
## Summary

Consumers of `AgentChat` that hide tool calls (`messageDisplay.showThoughtChain: false`) hit a UX bug: once the first assistant bubble printed, subsequent silent tool calls rendered nothing and the UI looked frozen. This PR keeps typing dots visible on the last assistant bubble whenever the agent is working but hasn't produced any visible content yet, and adds an opt-in rotating "thinking…" label for longer waits.

The `loading` check on the last assistant bubble (`MessageList.js`) now consults a visibility-aware helper that mirrors what `MessageBubble` actually renders, so tool-only messages with `showThoughtChain: false` keep `loading: true` until real visible content arrives. `@ant-design/x`'s `Bubble` ignores `content` while loading, so the thinking label ships via per-item `loadingRender` (dots + label in one span) rather than competing for the content slot.

## Changes

- **@lowdefy/blocks-antd-x**:
  - New `messageParts.js` exports `getToolInfo`, `isCommentaryPart`, `partCategory`, `isPartVisible`, `hasVisibleContent`. The classifier is single-sourced so `MessageBubble`'s rendering rule and `MessageList`'s visibility rule can't drift. Unknown/future SDK part types fall through as visible (fail-safe).
  - `MessageList.js` swaps the old `parts?.some(...)` loading check for `isStreaming && isLastAssistant && !hasVisibleContent(msg, config)`. The `__loading` placeholder stays as-is for the "no assistant message yet" case.
  - New `useThinkingMessage.js` hook handles delay + round-robin rotation with automatic cleanup when `loading` flips false. Delay is clamped to a 500 ms minimum to prevent flash-of-label on near-instant responses.
  - New `ThinkingIndicator.js` renders three CSS-animated dots (same DOM as `@ant-design/x`'s default loading component) plus an `aria-live="polite"` label. Prefix class resolved via antd's `ConfigProvider.ConfigContext` so it matches whatever the host app configures.
  - `schema.json` adds `thinkingMessages` (string or array), `thinkingMessageDelay` (default 3000, min 500), `thinkingMessageRotationInterval` (default 8000) under `messageDisplay`. Unset = dots only.

## Key Files

- `packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/messageParts.js` — shared classifier + `hasVisibleContent`.
- `packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageList.js` — visibility-aware loading check + per-bubble `loadingRender`.
- `packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/useThinkingMessage.js` — delay + round-robin timer hook.
- `packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/ThinkingIndicator.js` — dots + optional label in a single element.
- `packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js` — imports the now-shared classifier; no rendering change.

## SDK research notes (pushbacks on the originating spec)

- `ChatStatus` is `'submitted' | 'streaming' | 'ready' | 'error'` in `ai@6.0.116` — no `'idle'`. `isBusy = submitted || streaming` is correct. (`ai/src/ui/chat.ts:86`)
- The spec's `partCategory` table missed `source-url`, `source-document`, and custom `data-*` parts. Ignoring them would show dots over visible sources. Fixed by extending `isPartVisible` to treat source parts as visible when `showSources: true`, and falling unknown parts through as visible.
- The spec assumed Bubble could render `content` + `loading: true` side-by-side. It can't — `content` is dropped when loading. We use `loadingRender` per item to render dots and label together.
- No idiomatic SDK primitive for "thinking" / "pending" per-message — the only lifecycle signal is `ChatStatus`, which is what we consume.

## Change 2 — follow-up design opinion (not built)

Mid-stream `data-status` parts from tool handlers need their own spec. Short recommendation for the follow-up brainstorm:

- **API shape:** inject an `onStatus` (and optional `onDataPart`) writer into `request.context`, same pattern as `client` / `logger`. Not an operator — operators are pure projection and don't fit a side-effect-during-execution model. Not a new request type — fragments the surface for no gain.
- **Scope:** tool-only for v1. Widening to any long-running `Api` / `InternalApi` call is tempting but only tools have a guaranteed caller on the stream writer.
- **Part schema:** both. `onStatus("…")` writes a `data-status` part (ergonomic). `onDataPart({ type, data })` writes arbitrary `data-*` for richer updates.
- **Timing:** writes flow into the same `UIMessageWriter` the model streams to — interleave naturally. Fire-and-forget from the tool's side, independent of `onStepFinish` / `maxSteps`.
- **Errors:** silently drop (log server-side). A failed status write must never abort the tool call.
- **Open question for the follow-up spec:** whether persisted status parts survive refresh or should be pruneable via a config flag. If a tool emits 20 statuses during a 30 s run, do we want the full trail in the message transcript?

## Opt-out

Change 1 (dots) is always-on — no opt-out today. If consumers need to suppress dots entirely (e.g. they render their own progress UI elsewhere), the consistent shape would be a `messageDisplay.showLoadingIndicator: true` (default). Not added in this PR; easy to layer on later.

## Testing

Smoke-tested locally via a test app page with three side-by-side chats (dots only, single label, rotating labels) against `product_bot` (which hits `search-products` / `get-product-details`). Block components aren't unit tested per repo convention (CLAUDE.md).

## Notes

- No changeset in this PR — per request.
- Default behaviour (`showThoughtChain: true`) is unchanged — `ThoughtChain` remains the primary activity indicator; dots don't compete.
- The `__loading` placeholder at `MessageList.js` is untouched — it covers the "no assistant message yet" case and now also respects `thinkingMessages` via the same `ThinkingBubbleContent`.