### PR TITLE
Add role-check methods to _user operator

### DIFF
--- a/.changeset/user-has-roles.md
+++ b/.changeset/user-has-roles.md
@@ -1,0 +1,6 @@
+---
+'@lowdefy/operators-js': patch
+'@lowdefy/docs': patch
+---
+
+feat(operators-js): Add `_user.hasRole`, `_user.hasSomeRoles`, and `_user.hasAllRoles` methods to check user roles against the `user.roles` array. `hasRole` takes a single role string; `hasSomeRoles` and `hasAllRoles` take an array of role strings. All return a boolean.

--- a/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
+++ b/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
@@ -8777,7 +8777,7 @@
         "oneOf": [
           {
             "type": "string",
-            "description": "Dot-notation path to value in user object."
+            "description": "Dot-notation path to value in user object, or a role name when used with a role method."
           },
           {
             "type": "integer",
@@ -8789,6 +8789,13 @@
               true
             ],
             "description": "Return all user data."
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Array of role names when used with a role method."
           },
           {
             "type": "object",

--- a/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
+++ b/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
@@ -16833,7 +16833,7 @@
         "oneOf": [
           {
             "type": "string",
-            "description": "Dot-notation path to value in user object."
+            "description": "Dot-notation path to value in user object, or a role name when used with a role method."
           },
           {
             "type": "integer",
@@ -16845,6 +16845,13 @@
               true
             ],
             "description": "Return all user data."
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Array of role names when used with a role method."
           },
           {
             "type": "object",

--- a/packages/docs/operators/_user.yaml
+++ b/packages/docs/operators/_user.yaml
@@ -43,6 +43,60 @@ _ref:
         - `all: boolean`: If `all` is set to `true`, the entire `user` object is returned. One of `all` or `key` are required.
         - `key: string`: The value of the key in the `user` object is returned. If the value is not found, `null`, or the specified default value is returned. Dot notation and [block list indexes](/lists) are supported. One of `all` or `key` are required.
         - `default: any`: A value to return if the `key` is not found in `user`. By default, `null` is returned if a value is not found.
+    methods:
+      - name: hasRole
+        types: |
+          ```
+          (role: string): boolean
+          ```
+        description: |
+          The `_user.hasRole` method returns `true` if the `user.roles` array contains the given role. It returns `false` when the user is not logged in, when `user.roles` is missing, or when the role is not present.
+
+          The `user.roles` value is read directly from the `user` object and must be an array of strings. An error is thrown if `user.roles` is defined but is not an array, or if the argument is not a string.
+        examples: |
+          ###### Check for a single role:
+          ```yaml
+          _user.hasRole: admin
+          ```
+          Returns: `true` if `user.roles` includes `"admin"`.
+      - name: hasSomeRoles
+        types: |
+          ```
+          (roles: string[]): boolean
+          ```
+        description: |
+          The `_user.hasSomeRoles` method returns `true` if the `user.roles` array contains at least one of the given roles. It returns `false` when the user is not logged in, when `user.roles` is missing, or when none of the roles match.
+
+          The `user.roles` value is read directly from the `user` object and must be an array of strings. An error is thrown if `user.roles` is defined but is not an array, or if the argument is not an array of strings.
+
+          For checking a single role, use [`_user.hasRole`](#hasRole).
+        examples: |
+          ###### Check for any of several roles:
+          ```yaml
+          _user.hasSomeRoles:
+            - admin
+            - support
+          ```
+          Returns: `true` if `user.roles` includes `"admin"` or `"support"`.
+      - name: hasAllRoles
+        types: |
+          ```
+          (roles: string[]): boolean
+          ```
+        description: |
+          The `_user.hasAllRoles` method returns `true` if the `user.roles` array contains every one of the given roles. It returns `false` when the user is not logged in, when `user.roles` is missing, or when any required role is not present.
+
+          The `user.roles` value is read directly from the `user` object and must be an array of strings. An error is thrown if `user.roles` is defined but is not an array, or if the argument is not an array of strings.
+
+          For checking a single role, use [`_user.hasRole`](#hasRole).
+        examples: |
+          ###### Require all of several roles:
+          ```yaml
+          _user.hasAllRoles:
+            - admin
+            - support
+          ```
+          Returns: `true` only if `user.roles` includes both `"admin"` and `"support"`.
     examples: |
       ###### Get the value of `name` from `user`:
       ```yaml

--- a/packages/plugins/operators/operators-js/src/operators/shared/user.js
+++ b/packages/plugins/operators/operators-js/src/operators/shared/user.js
@@ -14,9 +14,61 @@
   limitations under the License.
 */
 
+import { type } from '@lowdefy/helpers';
 import { getFromObject } from '@lowdefy/operators';
 
-function _user({ arrayIndices, location, params, user }) {
+const roleMethods = ['hasRole', 'hasSomeRoles', 'hasAllRoles'];
+
+function getUserRoles({ user, methodName }) {
+  const roles = user?.roles;
+  if (type.isNone(roles)) return [];
+  if (!type.isArray(roles)) {
+    throw new Error(
+      `_user.${methodName} expects "user.roles" to be an array of strings. Received ${JSON.stringify(
+        roles
+      )}.`
+    );
+  }
+  return roles;
+}
+
+function validateRoleString({ params, methodName }) {
+  if (!type.isString(params)) {
+    throw new Error(`_user.${methodName} accepts a string. Received ${JSON.stringify(params)}.`);
+  }
+  return params;
+}
+
+function validateRoleArray({ params, methodName }) {
+  if (!type.isArray(params) || !params.every((role) => type.isString(role))) {
+    throw new Error(
+      `_user.${methodName} accepts an array of strings. Received ${JSON.stringify(params)}.`
+    );
+  }
+  return params;
+}
+
+function _user({ arrayIndices, location, methodName, params, user }) {
+  if (methodName === 'hasRole') {
+    const role = validateRoleString({ params, methodName });
+    const userRoles = getUserRoles({ user, methodName });
+    return userRoles.includes(role);
+  }
+  if (methodName === 'hasSomeRoles') {
+    const required = validateRoleArray({ params, methodName });
+    const userRoles = getUserRoles({ user, methodName });
+    return required.some((role) => userRoles.includes(role));
+  }
+  if (methodName === 'hasAllRoles') {
+    const required = validateRoleArray({ params, methodName });
+    const userRoles = getUserRoles({ user, methodName });
+    return required.every((role) => userRoles.includes(role));
+  }
+  if (!type.isUndefined(methodName)) {
+    throw new Error(
+      `_user.${methodName} is not supported, use one of the following: ${roleMethods.join(', ')}.`
+    );
+  }
   return getFromObject({
     arrayIndices,
     location,

--- a/packages/plugins/operators/operators-js/src/operators/shared/user.schema.js
+++ b/packages/plugins/operators/operators-js/src/operators/shared/user.schema.js
@@ -18,9 +18,18 @@ export default {
   type: 'object',
   params: {
     oneOf: [
-      { type: 'string', description: 'Dot-notation path to value in user object.' },
+      {
+        type: 'string',
+        description:
+          'Dot-notation path to value in user object, or a role name when used with a role method.',
+      },
       { type: 'integer', description: 'Index to access in user object.' },
       { type: 'boolean', enum: [true], description: 'Return all user data.' },
+      {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Array of role names when used with a role method.',
+      },
       {
         type: 'object',
         properties: {

--- a/packages/plugins/operators/operators-js/src/operators/shared/user.test.js
+++ b/packages/plugins/operators/operators-js/src/operators/shared/user.test.js
@@ -20,7 +20,7 @@ jest.unstable_mockModule('@lowdefy/operators', () => ({
   getFromObject: jest.fn(),
 }));
 
-test('user calls getFromObject', async () => {
+test('user calls getFromObject when no method is used', async () => {
   const lowdefyOperators = await import('@lowdefy/operators');
   const user = (await import('./user.js')).default;
 
@@ -43,4 +43,167 @@ test('user calls getFromObject', async () => {
       },
     ],
   ]);
+});
+
+test('_user.hasRole returns true when user has the role', async () => {
+  const user = (await import('./user.js')).default;
+  expect(
+    user({
+      methodName: 'hasRole',
+      params: 'admin',
+      user: { roles: ['admin', 'support'] },
+    })
+  ).toBe(true);
+});
+
+test('_user.hasRole returns false when user does not have the role', async () => {
+  const user = (await import('./user.js')).default;
+  expect(
+    user({
+      methodName: 'hasRole',
+      params: 'admin',
+      user: { roles: ['viewer'] },
+    })
+  ).toBe(false);
+});
+
+test('_user.hasRole returns false when user has no roles', async () => {
+  const user = (await import('./user.js')).default;
+  expect(
+    user({
+      methodName: 'hasRole',
+      params: 'admin',
+      user: {},
+    })
+  ).toBe(false);
+});
+
+test('_user.hasRole returns false when user is not logged in', async () => {
+  const user = (await import('./user.js')).default;
+  expect(
+    user({
+      methodName: 'hasRole',
+      params: 'admin',
+      user: undefined,
+    })
+  ).toBe(false);
+});
+
+test('_user.hasRole throws when params is not a string', async () => {
+  const user = (await import('./user.js')).default;
+  expect(() =>
+    user({
+      methodName: 'hasRole',
+      params: ['admin'],
+      user: { roles: ['admin'] },
+    })
+  ).toThrow('_user.hasRole accepts a string. Received ["admin"].');
+});
+
+test('_user.hasSomeRoles returns true when user has at least one of the required roles', async () => {
+  const user = (await import('./user.js')).default;
+  expect(
+    user({
+      methodName: 'hasSomeRoles',
+      params: ['admin', 'support'],
+      user: { roles: ['support'] },
+    })
+  ).toBe(true);
+});
+
+test('_user.hasSomeRoles returns false when user has none of the required roles', async () => {
+  const user = (await import('./user.js')).default;
+  expect(
+    user({
+      methodName: 'hasSomeRoles',
+      params: ['admin', 'support'],
+      user: { roles: ['viewer'] },
+    })
+  ).toBe(false);
+});
+
+test('_user.hasSomeRoles returns false when user has no roles', async () => {
+  const user = (await import('./user.js')).default;
+  expect(
+    user({
+      methodName: 'hasSomeRoles',
+      params: ['admin'],
+      user: {},
+    })
+  ).toBe(false);
+});
+
+test('_user.hasSomeRoles returns false when user is not logged in', async () => {
+  const user = (await import('./user.js')).default;
+  expect(
+    user({
+      methodName: 'hasSomeRoles',
+      params: ['admin'],
+      user: undefined,
+    })
+  ).toBe(false);
+});
+
+test('_user.hasAllRoles returns true when user has every required role', async () => {
+  const user = (await import('./user.js')).default;
+  expect(
+    user({
+      methodName: 'hasAllRoles',
+      params: ['admin', 'support'],
+      user: { roles: ['admin', 'support', 'viewer'] },
+    })
+  ).toBe(true);
+});
+
+test('_user.hasAllRoles returns false when user is missing any required role', async () => {
+  const user = (await import('./user.js')).default;
+  expect(
+    user({
+      methodName: 'hasAllRoles',
+      params: ['admin', 'support'],
+      user: { roles: ['admin'] },
+    })
+  ).toBe(false);
+});
+
+test('_user.hasSomeRoles and _user.hasAllRoles throw when params is not an array of strings', async () => {
+  const user = (await import('./user.js')).default;
+  expect(() =>
+    user({
+      methodName: 'hasSomeRoles',
+      params: 'admin',
+      user: { roles: ['admin'] },
+    })
+  ).toThrow('_user.hasSomeRoles accepts an array of strings. Received "admin".');
+  expect(() =>
+    user({
+      methodName: 'hasAllRoles',
+      params: ['admin', 3],
+      user: { roles: ['admin'] },
+    })
+  ).toThrow('_user.hasAllRoles accepts an array of strings. Received ["admin",3].');
+});
+
+test('_user role methods throw when user.roles is not an array', async () => {
+  const user = (await import('./user.js')).default;
+  expect(() =>
+    user({
+      methodName: 'hasRole',
+      params: 'admin',
+      user: { roles: 'admin' },
+    })
+  ).toThrow('_user.hasRole expects "user.roles" to be an array of strings. Received "admin".');
+});
+
+test('_user throws when an unknown method is used', async () => {
+  const user = (await import('./user.js')).default;
+  expect(() =>
+    user({
+      methodName: 'isAdmin',
+      params: 'admin',
+      user: { roles: ['admin'] },
+    })
+  ).toThrow(
+    '_user.isAdmin is not supported, use one of the following: hasRole, hasSomeRoles, hasAllRoles.'
+  );
 });


### PR DESCRIPTION
## Summary

Adds `_user.hasRole`, `_user.hasSomeRoles`, and `_user.hasAllRoles` as first-class methods on the `_user` operator so Lowdefy apps can check user roles inline instead of maintaining ad-hoc `user_has_role.yaml` `_ref` helpers that wrap `_array.some` / `_array.includes` against `_user: roles`. The method-style surface mirrors how `_array.some`, `_string.includes`, and similar built-ins are exposed.

## Changes

- **@lowdefy/operators-js**: The `_user` operator now branches on `methodName` for `hasRole` (accepts a single role string), `hasSomeRoles` (array of roles, returns true if any match), and `hasAllRoles` (array of roles, returns true if all match). All three read `user.roles`, validate input shape, and return `false` when the user is absent or has no roles. Schema loosened to accept an array of strings for the array-form methods. 15 unit tests cover hit/miss, empty roles, missing user, param-shape errors, non-array `user.roles`, and unknown method.
- **@lowdefy/docs**: Added a `methods:` section to `operators/_user.yaml` documenting all three methods with type signatures and examples; `hasSomeRoles` / `hasAllRoles` cross-link to `hasRole` for single-role checks.

## Usage

```yaml
_user.hasRole: admin

_user.hasSomeRoles:
  - admin
  - support

_user.hasAllRoles:
  - admin
  - billing
```