### PR TITLE
_js operator: object form with args

### DIFF
--- a/.changeset/feat-js-operator-args.md
+++ b/.changeset/feat-js-operator-args.md
@@ -1,0 +1,23 @@
+---
+'@lowdefy/build': minor
+'@lowdefy/operators-js': minor
+---
+
+feat(\_js): Pass pre-computed values into `_js` via an `args` object.
+
+The `_js` operator now accepts an object form `{ fn, args }` alongside the existing string form. Values in `args` are resolved by the parser — using any Lowdefy operator (`_state`, `_request`, `_user`, nested `_js`, etc.) — before the JavaScript function runs, and are injected as the `args` object inside the function body.
+
+```yaml
+_js:
+  fn: |
+    const { products, target } = args;
+    return products
+      .filter((p) => p.category === target)
+      .reduce((a, p) => a + p.price, 0);
+  args:
+    products:
+      _request: get_products.data.products
+    target: smartphones
+```
+
+This lets you precompute or normalize values in YAML and keep the JavaScript body focused on computation, rather than mixing operator lookups into the function. The string form continues to work unchanged, and identical `fn` bodies still share a single compiled function at build time — only `args` varies per call.

--- a/.changeset/feat-page-sidebar-layout-sticky-sider.md
+++ b/.changeset/feat-page-sidebar-layout-sticky-sider.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/blocks-antd': patch
+---
+
+fix(PageSidebarLayout): Pin the sider to the viewport so the bottom actions stay visible.
+
+The sider is now `position: sticky` with `height: 100vh`, so the menu, notifications, profile avatar, dark-mode toggle, and logo remain on screen as the page content scrolls. The sticky footer container fades from transparent to the container background so content passing behind it doesn't cut off abruptly.

--- a/.changeset/fix-client-empty-slot-content.md
+++ b/.changeset/fix-client-empty-slot-content.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/client': patch
+---
+
+fix(client): Skip rendering content slots that have no blocks.
+
+`Container`, `InputContainer`, and `List` no longer create a `content[slotKey]` function when the slot's blocks array is empty. Blocks that use the `content.X && content.X()` pattern (for optional header, footer, extra, etc.) now correctly render nothing — including no wrapping `Area` element — when the user leaves the slot empty.

--- a/packages/build/src/build/buildJs/jsMapParser.js
+++ b/packages/build/src/build/buildJs/jsMapParser.js
@@ -18,10 +18,10 @@ import { ConfigError } from '@lowdefy/errors';
 import { serializer, type } from '@lowdefy/helpers';
 import crypto from 'crypto';
 
-function makeHash({ jsMap, env, value }) {
+function hashFn({ jsMap, env, value }) {
   const hash = crypto.createHash('sha1').update(value).digest('base64');
   jsMap[env][hash] = value;
-  return { _js: hash };
+  return hash;
 }
 
 function JsMapParser({ input, jsMap, env }) {
@@ -35,13 +35,20 @@ function JsMapParser({ input, jsMap, env }) {
     const key = Object.keys(value)[0];
     if (key !== '_js') return value;
 
-    if (!type.isString(value[key])) {
-      throw new ConfigError(
-        `_js operator expects the JavaScript definition as a string. Received ${JSON.stringify(value[key])}.`,
-        { configKey: value['~k'] }
-      );
+    const inner = value[key];
+
+    if (type.isString(inner)) {
+      return { _js: hashFn({ jsMap, env, value: inner }) };
     }
-    return makeHash({ jsMap, env, value: value[key] });
+
+    if (type.isObject(inner) && type.isString(inner.fn)) {
+      return { _js: { fn: hashFn({ jsMap, env, value: inner.fn }), args: inner.args } };
+    }
+
+    throw new ConfigError(
+      `_js operator expects a JavaScript string or { fn: string, args?: object }. Received ${JSON.stringify(inner)}.`,
+      { configKey: value['~k'] }
+    );
   };
   return serializer.copy(input, { reviver });
 }

--- a/packages/build/src/build/buildJs/jsMapParser.test.js
+++ b/packages/build/src/build/buildJs/jsMapParser.test.js
@@ -1,0 +1,125 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import jsMapParser from './jsMapParser.js';
+
+test('jsMapParser hashes string form and returns _js hash', () => {
+  const jsMap = {};
+  const input = { x: { _js: 'return 1;' } };
+  const result = jsMapParser({ input, jsMap, env: 'client' });
+
+  expect(typeof result.x._js).toBe('string');
+  expect(jsMap.client[result.x._js]).toBe('return 1;');
+});
+
+test('jsMapParser identical string sources share a hash', () => {
+  const jsMap = {};
+  const input = {
+    a: { _js: 'return 2;' },
+    b: { _js: 'return 2;' },
+  };
+  const result = jsMapParser({ input, jsMap, env: 'client' });
+
+  expect(result.a._js).toBe(result.b._js);
+  expect(Object.keys(jsMap.client)).toHaveLength(1);
+});
+
+test('jsMapParser object form hashes fn and preserves args', () => {
+  const jsMap = {};
+  const fnSource = 'return args.a + args.b;';
+  const input = {
+    x: { _js: { fn: fnSource, args: { a: 1, b: 2 } } },
+  };
+  const result = jsMapParser({ input, jsMap, env: 'server' });
+
+  expect(result.x._js.args).toEqual({ a: 1, b: 2 });
+  expect(typeof result.x._js.fn).toBe('string');
+  expect(jsMap.server[result.x._js.fn]).toBe(fnSource);
+});
+
+test('jsMapParser object form without args leaves args undefined', () => {
+  const jsMap = {};
+  const input = { x: { _js: { fn: 'return 1;' } } };
+  const result = jsMapParser({ input, jsMap, env: 'client' });
+
+  expect(result.x._js.args).toBeUndefined();
+  expect(typeof result.x._js.fn).toBe('string');
+});
+
+test('jsMapParser object form and string form with same fn share a hash', () => {
+  const jsMap = {};
+  const input = {
+    a: { _js: 'return 7;' },
+    b: { _js: { fn: 'return 7;', args: { note: 'different args' } } },
+  };
+  const result = jsMapParser({ input, jsMap, env: 'client' });
+
+  expect(result.a._js).toBe(result.b._js.fn);
+  expect(Object.keys(jsMap.client)).toHaveLength(1);
+});
+
+test('jsMapParser throws when _js value is a number', () => {
+  const jsMap = {};
+  const input = { x: { _js: 1 } };
+
+  expect(() => jsMapParser({ input, jsMap, env: 'client' })).toThrow(
+    '_js operator expects a JavaScript string or { fn: string, args?: object }'
+  );
+});
+
+test('jsMapParser throws when object form is missing fn', () => {
+  const jsMap = {};
+  const input = { x: { _js: { args: { a: 1 } } } };
+
+  expect(() => jsMapParser({ input, jsMap, env: 'client' })).toThrow(
+    '_js operator expects a JavaScript string or { fn: string, args?: object }'
+  );
+});
+
+test('jsMapParser throws when object form fn is not a string', () => {
+  const jsMap = {};
+  const input = { x: { _js: { fn: 42, args: {} } } };
+
+  expect(() => jsMapParser({ input, jsMap, env: 'client' })).toThrow(
+    '_js operator expects a JavaScript string or { fn: string, args?: object }'
+  );
+});
+
+test('jsMapParser processes nested _js inside args', () => {
+  const jsMap = {};
+  const input = {
+    x: {
+      _js: {
+        fn: 'return args.inner;',
+        args: { inner: { _js: 'return 99;' } },
+      },
+    },
+  };
+  const result = jsMapParser({ input, jsMap, env: 'client' });
+
+  expect(typeof result.x._js.fn).toBe('string');
+  expect(typeof result.x._js.args.inner._js).toBe('string');
+  expect(jsMap.client[result.x._js.fn]).toBe('return args.inner;');
+  expect(jsMap.client[result.x._js.args.inner._js]).toBe('return 99;');
+});
+
+test('jsMapParser initializes jsMap env bucket when missing', () => {
+  const jsMap = {};
+  jsMapParser({ input: { a: { _js: 'return 1;' } }, jsMap, env: 'client' });
+
+  expect(jsMap.client).toBeDefined();
+  expect(Object.keys(jsMap.client)).toHaveLength(1);
+});

--- a/packages/build/src/build/buildJs/writeJs.js
+++ b/packages/build/src/build/buildJs/writeJs.js
@@ -21,14 +21,14 @@ async function writeJs({ context }) {
     'plugins/operators/clientJsMap.js',
     generateJsFile({
       map: context.jsMap.client,
-      functionPrototype: `{ actions, event, input, location, lowdefyGlobal, request, state, urlQuery, user }`,
+      functionPrototype: `{ actions, args, event, input, location, lowdefyGlobal, request, state, urlQuery, user }`,
     })
   );
   await context.writeBuildArtifact(
     'plugins/operators/serverJsMap.js',
     generateJsFile({
       map: context.jsMap.server,
-      functionPrototype: `{ item, payload, secrets, state, step, user }`,
+      functionPrototype: `{ args, item, payload, secrets, state, step, user }`,
     })
   );
 }

--- a/packages/build/src/build/buildJs/writeJs.test.js
+++ b/packages/build/src/build/buildJs/writeJs.test.js
@@ -44,16 +44,16 @@ test('writeJs', async () => {
       'plugins/operators/clientJsMap.js',
       `
 export default {
-  'A': ({ actions, event, input, location, lowdefyGlobal, request, state, urlQuery, user }) => { return 12; },
-  'B': ({ actions, event, input, location, lowdefyGlobal, request, state, urlQuery, user }) => { return 1; },
+  'A': ({ actions, args, event, input, location, lowdefyGlobal, request, state, urlQuery, user }) => { return 12; },
+  'B': ({ actions, args, event, input, location, lowdefyGlobal, request, state, urlQuery, user }) => { return 1; },
   };`,
     ],
     [
       'plugins/operators/serverJsMap.js',
       `
 export default {
-  'C': ({ item, payload, secrets, state, step, user }) => { return 10; },
-  'D': ({ item, payload, secrets, state, step, user }) => { return 1; },
+  'C': ({ args, item, payload, secrets, state, step, user }) => { return 10; },
+  'D': ({ args, item, payload, secrets, state, step, user }) => { return 1; },
   };`,
     ],
   ]);
@@ -83,7 +83,7 @@ test('writeJs multiline', async () => {
       'plugins/operators/clientJsMap.js',
       `
 export default {
-  'A': ({ actions, event, input, location, lowdefyGlobal, request, state, urlQuery, user }) => { const parts = input.split('-').filter(part => part);
+  'A': ({ actions, args, event, input, location, lowdefyGlobal, request, state, urlQuery, user }) => { const parts = input.split('-').filter(part => part);
       return parts.reduce((acc, current, index) => {
         const prefix = index === 0 ? '-' : acc[index - 1] + '-';
         acc.push(prefix + current);
@@ -95,7 +95,7 @@ export default {
       'plugins/operators/serverJsMap.js',
       `
 export default {
-  'C': ({ item, payload, secrets, state, step, user }) => { let array = [1, 2, 3, 4, 5, 6];
+  'C': ({ args, item, payload, secrets, state, step, user }) => { let array = [1, 2, 3, 4, 5, 6];
       if (array.length > 3) {
         array.splice(3);
       }

--- a/packages/build/src/build/full/buildJs.test.js
+++ b/packages/build/src/build/full/buildJs.test.js
@@ -139,13 +139,35 @@ test('buildJs connection functions', async () => {
   });
 });
 
-test('buildJs throw when _js value is not a string', async () => {
+test('buildJs throw when _js value is not a string or valid object', async () => {
   const context = testContext();
   const components = {
     pages: [{ id: 'a', style: { _js: 1 }, requests: [] }],
   };
 
   expect(() => buildJs({ components, context })).toThrow(
-    '_js operator expects the JavaScript definition as a string'
+    '_js operator expects a JavaScript string or { fn: string, args?: object }'
   );
+});
+
+test('buildJs hashes fn only and preserves args for object form', async () => {
+  const context = testContext();
+  const fnSource = 'return args.a + args.b;';
+  const components = {
+    pages: [
+      {
+        id: 'a',
+        style: { _js: { fn: fnSource, args: { a: 1, b: 2 } } },
+        requests: [],
+      },
+    ],
+  };
+
+  buildJs({ components, context });
+
+  const page = components.pages[0];
+  expect(page.style._js.args).toEqual({ a: 1, b: 2 });
+  expect(typeof page.style._js.fn).toBe('string');
+  expect(context.jsMap.client[page.style._js.fn]).toBe(fnSource);
+  expect(context.jsMap.server).toEqual({});
 });

--- a/packages/client/src/block/Container.js
+++ b/packages/client/src/block/Container.js
@@ -27,6 +27,7 @@ const Container = ({ block, Blocks, Component, context, loading, lowdefy }) => {
   // eslint-disable-next-line prefer-destructuring
   const slots = Blocks.subSlots[block.id][0].slots;
   Object.keys(slots).forEach((slotKey, i) => {
+    if (slots[slotKey].blocks.length === 0) return;
     content[slotKey] = (contentStyle) => (
       <Area
         area={block.eval.slots[slotKey]}

--- a/packages/client/src/block/InputContainer.js
+++ b/packages/client/src/block/InputContainer.js
@@ -27,6 +27,7 @@ const InputContainer = ({ block, Blocks, Component, context, loading, lowdefy })
   // eslint-disable-next-line prefer-destructuring
   const slots = Blocks.subSlots[block.id][0].slots;
   Object.keys(slots).forEach((slotKey, i) => {
+    if (slots[slotKey].blocks.length === 0) return;
     content[slotKey] = (contentStyle) => (
       <Area
         area={block.eval.slots[slotKey]}

--- a/packages/client/src/block/List.js
+++ b/packages/client/src/block/List.js
@@ -27,6 +27,7 @@ const List = ({ block, Blocks, Component, context, loading, lowdefy }) => {
   const contentList = [];
   Blocks.subSlots[block.id].forEach((SBlock) => {
     Object.keys(SBlock.slots).forEach((slotKey) => {
+      if (SBlock.slots[slotKey].blocks.length === 0) return;
       content[slotKey] = (contentStyle) => (
         <Area
           area={block.eval.slots[slotKey]}

--- a/packages/docs/operators/_js.yaml
+++ b/packages/docs/operators/_js.yaml
@@ -23,6 +23,7 @@ _ref:
     types: |
       ```
       (function: string): any
+      (function: { fn: string, args?: object }): any
       ```
     description: |
       The `_js` operator enables the use of custom JavaScript logic within Lowdefy configuration where operators are evaluated. The purpose of this operator is to facilitate quick implementation of fast, synchronous functions. Like other operators, these functions are evaluated during page render, thus slow functions can impact app performance.
@@ -34,13 +35,14 @@ _ref:
       ###### Client JavaScript function prototype:
       _Function parameters passed to the operator method._
       ```js
-      function ({ actions, event, input, location, lowdefyGlobal, request, state, urlQuery, user }) {
+      function ({ actions, args, event, input, location, lowdefyGlobal, request, state, urlQuery, user }) {
         // Your JavaScript code here
       };
       ```
 
       The function arguments available to the JavaScript function are:
         - `actions: function`: Implements the [_actions](/_actions) operator.
+        - `args: object`: Pre-resolved values passed via the object form of `_js` (see below). `undefined` when the string form is used.
         - `event: function`: Implements the [_event](/_event) operator.
         - `input: function`: Implements the [_input](/_input) operator.
         - `location: function`: Implements the [_location](/_location) operator.
@@ -53,19 +55,31 @@ _ref:
       ###### Server JavaScript function prototype:
       _Function parameters passed to the operator method._
       ```js
-      function ({ payload, secrets, user }) {
+      function ({ args, item, payload, secrets, state, step, user }) {
         // Your JavaScript code here
       };
       ```
 
       The function arguments available to the JavaScript function are
+        - `args: object`: Pre-resolved values passed via the object form of `_js` (see below). `undefined` when the string form is used.
+        - `item: function`: Implements the [_item](/_item) operator.
         - `payload: function`: Implements the [_payload](/_payload) operator.
         - `secrets: function`: Implements the [_secret](/_secret) operator.
+        - `state: function`: Implements the [_state](/_state) operator.
+        - `step: function`: Implements the [_step](/_step) operator.
         - `user: function`: Implements the [_user](/_user) operator.
+
+      #### Passing pre-computed values with `args`
+      The object form of `_js` accepts an `args` object whose values are resolved by the parser **before** the JavaScript function runs. This lets you compute values using any Lowdefy operator (`_state`, `_request`, `_user`, etc.) and consume them inside the function without calling operator methods from JavaScript.
 
     arguments: |
       ###### string
       The JavaScript function body, including the function return statement, excluding the function prototype.
+
+      ###### object
+      An object with the following properties:
+        - `fn: string`: The JavaScript function body (same as the string form).
+        - `args: object`: (optional) Values to inject into the function. Each value is evaluated as a normal Lowdefy expression and made available inside `fn` on the `args` object.
     examples: |
       ###### Perform a calculation:
       ```js
@@ -96,4 +110,18 @@ _ref:
             .filter(product => product.category === "smartphones")
             .reduce((acc, product) => acc + product.price, 0);
         return totalPriceOfPhones;
+      ```
+
+      ###### Pass pre-computed values with `args`:
+      ```yaml
+      _js:
+        fn: |
+          const { products, target } = args;
+          return products
+              .filter(p => p.category === target)
+              .reduce((a, p) => a + p.price, 0);
+        args:
+          products:
+            _request: get_products.data.products
+          target: smartphones
       ```

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PageSidebarLayout/PageSidebarLayout.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PageSidebarLayout/PageSidebarLayout.js
@@ -117,7 +117,13 @@ const PageSidebarLayout = ({
               }}
               styles={{
                 element: mergeObjects([
-                  { borderInlineEnd: '1px solid var(--ant-color-border)' },
+                  {
+                    borderInlineEnd: '1px solid var(--ant-color-border)',
+                    position: 'sticky',
+                    top: 0,
+                    height: '100vh',
+                    alignSelf: 'flex-start',
+                  },
                   styles.sider,
                 ]),
               }}
@@ -204,8 +210,9 @@ const PageSidebarLayout = ({
                       style={{
                         position: 'sticky',
                         bottom: 0,
-                        background: 'var(--ant-color-bg-container)',
-                        padding: 8,
+                        background:
+                          'linear-gradient(to bottom, transparent 0%, color-mix(in srgb, var(--ant-color-bg-container) 85%, transparent) 32px, color-mix(in srgb, var(--ant-color-bg-container) 95%, transparent) 100%)',
+                        padding: '40px 8px 8px',
                         display: 'flex',
                         flexDirection: 'column',
                         alignItems: 'center',

--- a/packages/plugins/operators/operators-js/src/operators/client/js.js
+++ b/packages/plugins/operators/operators-js/src/operators/client/js.js
@@ -14,16 +14,21 @@
   limitations under the License.
 */
 
+import { type } from '@lowdefy/helpers';
+
 function js(operatorContext) {
   const { jsMap, operators, params } = operatorContext;
-  if (!jsMap[params]) {
+  const hash = type.isString(params) ? params : params?.fn;
+  const args = type.isObject(params) ? params.args : undefined;
+  if (!jsMap[hash]) {
     throw new Error(
-      `_js function not found. The function may not have been built yet. Received hash: ${params}`
+      `_js function not found. The function may not have been built yet. Received hash: ${hash}`
     );
   }
   try {
-    return jsMap[params]({
+    return jsMap[hash]({
       actions: (p) => operators._actions({ ...operatorContext, params: p }),
+      args,
       event: (p) => operators._event({ ...operatorContext, params: p }),
       input: (p) => operators._input({ ...operatorContext, params: p }),
       location: (p) => operators._location({ ...operatorContext, params: p }),
@@ -34,7 +39,7 @@ function js(operatorContext) {
       user: (p) => operators._user({ ...operatorContext, params: p }),
     });
   } catch (error) {
-    throw new Error(`_js function execution error. Function: ${jsMap[params].toString()}`, {
+    throw new Error(`_js function execution error. Function: ${jsMap[hash].toString()}`, {
       cause: error,
     });
   }

--- a/packages/plugins/operators/operators-js/src/operators/client/js.schema.js
+++ b/packages/plugins/operators/operators-js/src/operators/client/js.schema.js
@@ -17,7 +17,25 @@
 export default {
   type: 'object',
   params: {
-    type: 'string',
-    description: 'Hash identifier of the pre-built JavaScript function to execute.',
+    oneOf: [
+      {
+        type: 'string',
+        description: 'Hash identifier of the pre-built JavaScript function to execute.',
+      },
+      {
+        type: 'object',
+        required: ['fn'],
+        additionalProperties: false,
+        properties: {
+          fn: {
+            type: 'string',
+            description: 'Hash identifier of the pre-built JavaScript function to execute.',
+          },
+          args: {
+            description: 'Pre-resolved values injected into the JavaScript function as `args`.',
+          },
+        },
+      },
+    ],
   },
 };

--- a/packages/plugins/operators/operators-js/src/operators/client/js.test.js
+++ b/packages/plugins/operators/operators-js/src/operators/client/js.test.js
@@ -88,3 +88,51 @@ test('js throw when invalid javascript function', async () => {
     })
   ).toThrow('c1 is not a proper JavaScript function');
 });
+
+test('js passes args through when params is object form', async () => {
+  const receivedArgs = [];
+  const argsMap = {
+    h1: ({ args }) => {
+      receivedArgs.push(args);
+      return args?.a + args?.b;
+    },
+  };
+  const result = js({
+    jsMap: argsMap,
+    operators: {},
+    location: rootLocation,
+    params: { fn: 'h1', args: { a: 2, b: 3 } },
+  });
+  expect(result).toEqual(5);
+  expect(receivedArgs[0]).toEqual({ a: 2, b: 3 });
+});
+
+test('js passes args as undefined when object form omits args', async () => {
+  const receivedArgs = [];
+  const argsMap = {
+    h1: ({ args }) => {
+      receivedArgs.push(args);
+      return 'ok';
+    },
+  };
+  js({
+    jsMap: argsMap,
+    operators: {},
+    location: rootLocation,
+    params: { fn: 'h1' },
+  });
+  expect(receivedArgs[0]).toBeUndefined();
+});
+
+test('js throws when object-form hash is not in map', async () => {
+  expect(() =>
+    js({
+      jsMap: {},
+      operators: {},
+      location: rootLocation,
+      params: { fn: 'missing', args: { a: 1 } },
+    })
+  ).toThrow(
+    '_js function not found. The function may not have been built yet. Received hash: missing'
+  );
+});

--- a/packages/plugins/operators/operators-js/src/operators/server/js.js
+++ b/packages/plugins/operators/operators-js/src/operators/server/js.js
@@ -14,15 +14,20 @@
   limitations under the License.
 */
 
+import { type } from '@lowdefy/helpers';
+
 function js(operatorContext) {
   const { jsMap, operators, location, params } = operatorContext;
-  if (!jsMap[params]) {
+  const hash = type.isString(params) ? params : params?.fn;
+  const args = type.isObject(params) ? params.args : undefined;
+  if (!jsMap[hash]) {
     throw new Error(
-      `_js function not found. The function may not have been built yet. Received hash: ${params}`
+      `_js function not found. The function may not have been built yet. Received hash: ${hash}`
     );
   }
   try {
-    return jsMap[params]({
+    return jsMap[hash]({
+      args,
       payload: (p) => operators._payload({ ...operatorContext, params: p }),
       secret: (p) => operators._secret({ ...operatorContext, params: p }),
       user: (p) => operators._user({ ...operatorContext, params: p }),
@@ -31,7 +36,7 @@ function js(operatorContext) {
       state: (p) => operators._state({ ...operatorContext, params: p }),
     });
   } catch (error) {
-    throw new Error(`_js function execution error. Function: ${jsMap[params].toString()}`, {
+    throw new Error(`_js function execution error. Function: ${jsMap[hash].toString()}`, {
       cause: error,
     });
   }

--- a/packages/plugins/operators/operators-js/src/operators/server/js.schema.js
+++ b/packages/plugins/operators/operators-js/src/operators/server/js.schema.js
@@ -17,7 +17,25 @@
 export default {
   type: 'object',
   params: {
-    type: 'string',
-    description: 'Hash identifier of the pre-built JavaScript function to execute.',
+    oneOf: [
+      {
+        type: 'string',
+        description: 'Hash identifier of the pre-built JavaScript function to execute.',
+      },
+      {
+        type: 'object',
+        required: ['fn'],
+        additionalProperties: false,
+        properties: {
+          fn: {
+            type: 'string',
+            description: 'Hash identifier of the pre-built JavaScript function to execute.',
+          },
+          args: {
+            description: 'Pre-resolved values injected into the JavaScript function as `args`.',
+          },
+        },
+      },
+    ],
   },
 };

--- a/packages/plugins/operators/operators-js/src/operators/server/js.test.js
+++ b/packages/plugins/operators/operators-js/src/operators/server/js.test.js
@@ -63,3 +63,51 @@ test('js throw when invalid javascript function', async () => {
     })
   ).toThrow('c1 is not a proper JavaScript function');
 });
+
+test('js passes args through when params is object form', async () => {
+  const receivedArgs = [];
+  const argsMap = {
+    h1: ({ args }) => {
+      receivedArgs.push(args);
+      return args?.a + args?.b;
+    },
+  };
+  const result = js({
+    jsMap: argsMap,
+    operators: {},
+    location: rootLocation,
+    params: { fn: 'h1', args: { a: 2, b: 3 } },
+  });
+  expect(result).toEqual(5);
+  expect(receivedArgs[0]).toEqual({ a: 2, b: 3 });
+});
+
+test('js passes args as undefined when object form omits args', async () => {
+  const receivedArgs = [];
+  const argsMap = {
+    h1: ({ args }) => {
+      receivedArgs.push(args);
+      return 'ok';
+    },
+  };
+  js({
+    jsMap: argsMap,
+    operators: {},
+    location: rootLocation,
+    params: { fn: 'h1' },
+  });
+  expect(receivedArgs[0]).toBeUndefined();
+});
+
+test('js throws when object-form hash is not in map', async () => {
+  expect(() =>
+    js({
+      jsMap: {},
+      operators: {},
+      location: rootLocation,
+      params: { fn: 'missing', args: { a: 1 } },
+    })
+  ).toThrow(
+    '_js function not found. The function may not have been built yet. Received hash: missing'
+  );
+});


### PR DESCRIPTION
## Summary

Extends the `_js` operator to accept an object form `{ fn, args }` alongside the existing string form. Values inside `args` are resolved by the parser (any Lowdefy operator — `_state`, `_request`, `_global`, nested `_js`) before the JavaScript runs, and are injected as an `args` object inside the function body.

**Motivation.** This was built for enum-driven config patterns — `emap_*` files — where a single JS transform needs to run against many enum shapes. Without `args`, the only way to parameterize the body was to nunjucks-template a `_ref` var into the JS source string:

```yaml
_js: |
  const m = lowdefyGlobal('enums.{{ enum_key }}') || {};
  return Object.fromEntries(
    Object.entries(m).map(([k, v]) => [k.toUpperCase(), v && v.color])
  );
```

Every `emap_X.yaml` file produces a different JS string (because `{{ enum_key }}` is baked into the code), so every file ends up with its own compiled function. With `args`, the body is invariant — only the data changes — so identical `fn` strings share a single compiled function at build time:

```yaml
_js:
  fn: |
    const m = args.enum || {};
    return Object.fromEntries(
      Object.entries(m).map(([k, v]) => [k.toUpperCase(), v && v.color])
    );
  args:
    enum:
      _var: enum
    
```

Bundles two small UI fixes observed while building a test page: client no longer renders empty content slots, and `PageSidebarLayout`'s sider is now pinned so its bottom actions stay visible on long pages.

## Changes

- **@lowdefy/operators-js**: `_js` now accepts `{ fn, args? }` in addition to a raw string. The runtime operator detects the shape, passes `args` through to the built function, and injects it as the `args` parameter on both client and server prototypes. Schemas updated to `oneOf` string/object.
- **@lowdefy/build**: `jsMapParser` accepts the object form and hashes only `fn` (so identical bodies with different `args` share one compiled function — the whole point of the enum use case). `writeJs` adds `args` to the generated client and server function prototypes.
- **@lowdefy/client**: `Container`, `InputContainer`, and `List` skip creating a `content[slotKey]` entry when the slot has no blocks, so the `content.X && content.X()` pattern renders nothing — including no wrapping `Area` — for empty slots.
- **@lowdefy/blocks-antd**: `PageSidebarLayout` sider uses `position: sticky` + `height: 100vh` so the menu, notifications, profile, dark-mode toggle, and logo remain reachable as the content body scrolls. Footer gradient fades into the background so content passes cleanly behind it.

## Key Files

- `packages/build/src/build/buildJs/jsMapParser.js` — accepts object form; only `fn` is hashed
- `packages/build/src/build/buildJs/writeJs.js` — adds `args` to both function prototypes
- `packages/plugins/operators/operators-js/src/operators/{client,server}/js.js` — runtime shape detection + `args` injection
- `packages/client/src/block/{Container,InputContainer,List}.js` — empty-slot guards
- `packages/plugins/blocks/blocks-antd/src/blocks/PageSidebarLayout/PageSidebarLayout.js` — sticky sider

## Test Plan

- [ ] `pnpm --filter=@lowdefy/operators-js test` — new object-form tests pass
- [ ] `pnpm --filter=@lowdefy/build test --testPathPattern='jsMapParser|buildJs|writeJs'` — parser + pipeline tests pass
- [ ] Convert an `emap_*` hydra file to the object form and confirm the compiled JS map contains one function shared across all enum variants
- [ ] Confirm the string form still works unchanged on existing apps
- [ ] On a page with optional empty slots, confirm no stray `Area` wrappers render
- [ ] On a long `PageSidebarLayout` page, scroll and confirm sider bottom actions stay pinned