### PR TITLE
docs: Update pnpx lowdefy@4 references to @5

### DIFF
--- a/packages/docs/concepts/cli.yaml
+++ b/packages/docs/concepts/cli.yaml
@@ -29,7 +29,7 @@ _ref:
             We recommend running the CLI using `pnpx`, to always use the latest version:
 
             ```
-            pnpx lowdefy@4 <command>
+            pnpx lowdefy@5 <command>
             ```
 
             or, to use a specific version:
@@ -112,8 +112,8 @@ _ref:
             It fetches the latest `@lowdefy/codemods` package, resolves the version chain from your current version to the target, and presents migration prompts phase by phase.
 
             ```
-            pnpx lowdefy@4 upgrade
-            pnpx lowdefy@4 upgrade --to 6.0.0
+            pnpx lowdefy@5 upgrade
+            pnpx lowdefy@5 upgrade --to 6.0.0
             ```
 
             - `--to <version>`: Target version to upgrade to. Defaults to the latest stable release.
@@ -149,12 +149,12 @@ _ref:
 
             Run the dev server, watching a relative directory for file changes:
             ```txt
-            pnpx lowdefy@4 dev --watch ../other-project
+            pnpx lowdefy@5 dev --watch ../other-project
             ```
 
             Run the dev server, ignoring the public directory:
             ```txt
-            pnpx lowdefy@4 dev --watch-ignore public/**
+            pnpx lowdefy@5 dev --watch-ignore public/**
             ```
 
 

--- a/packages/docs/deployment/docker.yaml
+++ b/packages/docs/deployment/docker.yaml
@@ -43,7 +43,7 @@ _ref:
             RUN corepack enable
 
             # Build lowdefy app
-            RUN pnpx lowdefy@4 build --log-level=debug
+            RUN pnpx lowdefy@5 build --log-level=debug
 
             FROM node:18-alpine AS runner
 
@@ -158,7 +158,7 @@ _ref:
             RUN corepack enable
 
             # TODO: Change config-directory (./app) as appropriate here
-            RUN pnpx lowdefy@4 build --config-directory ./app --log-level=debug
+            RUN pnpx lowdefy@5 build --config-directory ./app --log-level=debug
 
             RUN pnpm --filter=@lowdefy/server --prod deploy ./deploy
 

--- a/packages/docs/deployment/node-server.yaml
+++ b/packages/docs/deployment/node-server.yaml
@@ -28,11 +28,11 @@ _ref:
 
             To test the production server, it can be run locally. In order to do this, first create the production build output using:
 
-            `pnpx lowdefy@4 build`
+            `pnpx lowdefy@5 build`
 
             The production server can then be run using:
 
-            `pnpx lowdefy@4 start`
+            `pnpx lowdefy@5 start`
 
             ### Create Standalone Folder:
 
@@ -49,7 +49,7 @@ _ref:
 
             The production build output is then created by running:
 
-            `pnpx lowdefy@4 build`
+            `pnpx lowdefy@5 build`
 
             The above creates a Next.js standalone folder at `<config-directory>/.lowdefy/server/.next/standalone`. Read more about this [here](https://nextjs.org/docs/pages/api-reference/next-config-js/output).
 

--- a/packages/docs/introduction.yaml
+++ b/packages/docs/introduction.yaml
@@ -37,7 +37,7 @@ _ref:
           path: templates/cli_command.yaml.njk
           vars:
             id: quickstart
-            command: 'pnpx lowdefy@4 init && pnpx lowdefy@4 dev'
+            command: 'pnpx lowdefy@5 init && pnpx lowdefy@5 dev'
 
       - id: body_features
         type: Markdown

--- a/packages/docs/tutorial/tutorial-start.yaml
+++ b/packages/docs/tutorial/tutorial-start.yaml
@@ -89,7 +89,7 @@ _ref:
           path: templates/cli_command.yaml.njk
           vars:
             id: init
-            command: 'pnpx lowdefy@4 init'
+            command: 'pnpx lowdefy@5 init'
 
       - id: body_init
         type: MarkdownWithCode
@@ -111,7 +111,7 @@ _ref:
           path: templates/cli_command.yaml.njk
           vars:
             id: dev
-            command: 'pnpx lowdefy@4 dev'
+            command: 'pnpx lowdefy@5 dev'
 
       - id: body_open_browser
         type: MarkdownWithCode
@@ -257,9 +257,9 @@ _ref:
 
             The Lowdefy CLI helps you develop a Lowdefy app.
 
-            We used the `pnpx lowdefy@4 init` command to initialize a new project. This created all the essential files.
+            We used the `pnpx lowdefy@5 init` command to initialize a new project. This created all the essential files.
 
-            We also used the `pnpx lowdefy@4 dev` command to start a development server. The development server runs a Lowdefy app locally on your computer, which can be accessed at http://localhost:3000. The development server watches your configuration files, and if any of them changes it "builds" (compiles the configuration together for the server to serve) the configuration again and refreshes the browser to show the changes.
+            We also used the `pnpx lowdefy@5 dev` command to start a development server. The development server runs a Lowdefy app locally on your computer, which can be accessed at http://localhost:3000. The development server watches your configuration files, and if any of them changes it "builds" (compiles the configuration together for the server to serve) the configuration again and refreshes the browser to show the changes.
 
             ### Up next
 


### PR DESCRIPTION
## Summary

The quickstart, tutorial, CLI, and deployment docs still instructed users to install the v4 line via `pnpx lowdefy@4`. The npm `latest` tag is now `5.1.0`, so users following the docs were getting pinned to an outdated major. This PR bumps all doc references to `@5` — consistent with the existing convention of pinning to the current major so copy-pasters aren't auto-upgraded into a future breaking release.

## Changes

- **@lowdefy/docs**: Replaced `pnpx lowdefy@4` → `pnpx lowdefy@5` across the quickstart (`introduction.yaml`), tutorial (`tutorial/tutorial-start.yaml`), CLI concept page (`concepts/cli.yaml`), and the Node/Docker deployment guides.

## Notes

- `packages/docs/CHANGELOG.md` still mentions `@4`, but that's historical and intentionally left alone.
- `tutorial/tutorial-deploy.yaml` uses `npx lowdefy@latest build-netlify` — inconsistent with the new `@5` convention but out of scope for this PR.
- `concepts/cli.yaml` has an illustrative `upgrade --to 6.0.0` example that may want updating when v6 lands.