### PR TITLE
feat: S3 presigned metadata encoding, TipTap blocks package, skeleton polish

### DIFF
--- a/.changeset/feat-aws-presigned-meta-url-encode.md
+++ b/.changeset/feat-aws-presigned-meta-url-encode.md
@@ -1,0 +1,19 @@
+---
+'@lowdefy/plugin-aws': patch
+---
+
+feat(plugin-aws): Auto URL-encode `x-amz-meta-*` fields on `AwsS3PresignedPostPolicy`.
+
+`AwsS3PresignedPostPolicy` now URL-encodes any field whose name starts with `x-amz-meta-` (case-insensitive) before signing the policy. S3 user metadata must be ASCII, so values containing names, URLs, or other non-ASCII characters previously had to be wrapped with `_uri.encode` in every request config.
+
+With this change, upload policies can pass values through directly:
+
+```yaml
+fields:
+  x-amz-meta-uploaded-by-name:
+    _user: profile.name
+  x-amz-meta-uploaded-by-url:
+    _payload: url
+```
+
+Other protocol fields (`acl`, `Content-Type`, `success_action_redirect`, etc.) continue to pass through literally. Readers of the metadata (e.g., Lambda triggers that ingest S3 events) should URL-decode `x-amz-meta-*` values via `decodeURIComponent` before use.

--- a/.changeset/feat-blocks-tiptap.md
+++ b/.changeset/feat-blocks-tiptap.md
@@ -1,0 +1,28 @@
+---
+'@lowdefy/blocks-tiptap': minor
+'@lowdefy/build': patch
+'@lowdefy/server-dev': patch
+'@lowdefy/server-e2e': patch
+---
+
+feat(blocks-tiptap): Add new default block package with `TiptapInput` and `TiptapMentionInput` rich-text editors.
+
+`@lowdefy/blocks-tiptap` ships two rich-text editor blocks built on [TipTap](https://tiptap.dev):
+
+- **`TiptapInput`** — standard rich-text editor with bold/italic/strike-through, multi-color highlight, headings, lists, tables, links, and a bubble menu.
+- **`TiptapMentionInput`** — everything `TiptapInput` does, plus an @-mention dropdown populated from a static options list or a Lowdefy request. Resolved mentions are returned on the block value as `mentions: [...]`.
+
+Both blocks emit an object value shaped `{ html, text, markdown, fileList, mentions? }` and register `clear`, `setContent`, and `focus` methods.
+
+**Configurable extensions** — defaults preserve the bundled editor; override any of these to trim the editor down or tune it:
+
+- `properties.starterKit` — object forwarded to TipTap [StarterKit](https://tiptap.dev/docs/editor/extensions/functionality/starterkit), e.g. `{ heading: false, codeBlock: false }`.
+- `properties.image` — `{ enabled, maxWidth, zoom }`
+- `properties.table` — `{ enabled, resizable }`
+- `properties.link` — `{ enabled, autolink, linkOnPaste, openOnClick, defaultProtocol }`
+- `properties.highlight` — `{ enabled, multicolor }`
+- `properties.mentions.char` / `properties.mentions.allowSpaces` — change the trigger char (e.g. `#` for hashtags) or disable spaces inside a mention query (`TiptapMentionInput` only).
+
+Image drag/drop and paste are supported by pointing `properties.s3PostPolicyRequestId` at a request that returns an S3 presigned POST policy (e.g. `AwsS3PresignedPostPolicy`). The file handler is optional — omit the request id to disable uploads entirely.
+
+The blocks are registered in the default types map and are available out of the box on `@lowdefy/server-dev`. No private-registry tokens are required: the blocks use the open-source [`@tiptap/extension-file-handler`](https://www.npmjs.com/package/@tiptap/extension-file-handler) instead of `@tiptap-pro/extension-file-handler`, so projects that migrated from a custom TipTap plugin can drop their `TIPTAP_PRO_TOKEN` environment variable and `.npmrc` scoped-registry config.

--- a/.changeset/refactor-blocks-loaders-skeleton.md
+++ b/.changeset/refactor-blocks-loaders-skeleton.md
@@ -1,0 +1,9 @@
+---
+'@lowdefy/blocks-loaders': patch
+---
+
+refactor(blocks-loaders): Modernize skeleton shimmer animation.
+
+The skeleton placeholder now uses a compositor-accelerated `transform: translateX` shimmer on a `::after` pseudo-element, replacing the older `left`-animated `::before` gradient. The shimmer is softer (three-stop gradient over secondary/quaternary fills), the base element uses `isolation: isolate` to scope its stacking context, and `prefers-reduced-motion` disables the animation for accessibility.
+
+`SkeletonInput` and `SkeletonParagraph` also switch to a flex-column layout with gap spacing: tighter rhythm between rows, distinct border radii for the label vs input, and a slightly wider trailing line (60%) in paragraphs for a more readable look. Purely visual — no API changes.

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -79,6 +79,7 @@
     "@lowdefy/blocks-google-maps": "5.0.0",
     "@lowdefy/blocks-markdown": "5.0.0",
     "@lowdefy/blocks-qr": "5.0.0",
+    "@lowdefy/blocks-tiptap": "5.0.0",
     "@lowdefy/connection-axios-http": "5.0.0",
     "@lowdefy/connection-elasticsearch": "5.0.0",
     "@lowdefy/connection-test": "5.0.0",

--- a/packages/build/src/scripts/generateDefaultTypes.js
+++ b/packages/build/src/scripts/generateDefaultTypes.js
@@ -32,6 +32,7 @@ const defaultPackages = [
   '@lowdefy/blocks-loaders',
   '@lowdefy/blocks-markdown',
   '@lowdefy/blocks-qr',
+  '@lowdefy/blocks-tiptap',
   '@lowdefy/connection-axios-http',
   '@lowdefy/connection-elasticsearch',
   '@lowdefy/connection-test',

--- a/packages/docs/blocks/input/TiptapInput.yaml
+++ b/packages/docs/blocks/input/TiptapInput.yaml
@@ -1,0 +1,29 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_ref:
+  path: templates/blocks/gallery.yaml.njk
+  vars:
+    pageId: TiptapInput
+    pageTitle: TiptapInput
+    section: Input Blocks
+    filePath: blocks/input/TiptapInput.yaml
+    block_type: TiptapInput
+    github_path: packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput
+    schema: ../plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/meta.js
+    gallery: ../plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/gallery.yaml
+    description: >
+      Rich-text editor built on TipTap. Supports bold, italic, strike-through,
+      highlights, headings, lists, tables, links, and drag/drop or paste image
+      uploads via a configurable S3 presigned POST policy request.

--- a/packages/docs/blocks/input/TiptapMentionInput.yaml
+++ b/packages/docs/blocks/input/TiptapMentionInput.yaml
@@ -1,0 +1,28 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_ref:
+  path: templates/blocks/gallery.yaml.njk
+  vars:
+    pageId: TiptapMentionInput
+    pageTitle: TiptapMentionInput
+    section: Input Blocks
+    filePath: blocks/input/TiptapMentionInput.yaml
+    block_type: TiptapMentionInput
+    github_path: packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput
+    schema: ../plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/meta.js
+    gallery: ../plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/gallery.yaml
+    description: >
+      Rich-text editor with @-mention support. Same feature set as TiptapInput,
+      plus a mention dropdown populated from a static options list or a request.

--- a/packages/docs/menus.yaml
+++ b/packages/docs/menus.yaml
@@ -412,6 +412,12 @@
         - id: TextInput
           type: MenuLink
           pageId: TextInput
+        - id: TiptapInput
+          type: MenuLink
+          pageId: TiptapInput
+        - id: TiptapMentionInput
+          type: MenuLink
+          pageId: TiptapMentionInput
         - id: TitleInput
           type: MenuLink
           pageId: TitleInput

--- a/packages/docs/pages.yaml
+++ b/packages/docs/pages.yaml
@@ -85,6 +85,8 @@
 - _ref: blocks/input/Switch.yaml
 - _ref: blocks/input/TextArea.yaml
 - _ref: blocks/input/TextInput.yaml
+- _ref: blocks/input/TiptapInput.yaml
+- _ref: blocks/input/TiptapMentionInput.yaml
 - _ref: blocks/input/TitleInput.yaml
 - _ref: blocks/input/TreeSelector.yaml
 - _ref: blocks/input/WeekSelector.yaml

--- a/packages/plugins/blocks/blocks-loaders/src/blocks/Skeleton/style.module.css
+++ b/packages/plugins/blocks/blocks-loaders/src/blocks/Skeleton/style.module.css
@@ -18,34 +18,36 @@
   .skeleton {
     position: relative;
     overflow: hidden;
-    background: var(--ant-color-fill-tertiary);
+    background-color: var(--ant-color-fill-secondary);
+    border-radius: var(--ant-border-radius-sm, 4px);
+    isolation: isolate;
   }
 
-  .skeleton::before {
+  .skeleton::after {
     content: '';
-    display: block;
     position: absolute;
-    left: -100%;
-    max-width: 600px;
-    top: 0;
-    height: 200%;
-    width: 100%;
-    background: linear-gradient(
-      to right,
+    inset: 0;
+    transform: translateX(-100%);
+    background-image: linear-gradient(
+      90deg,
       transparent 0%,
-      var(--ant-color-fill-secondary) 50%,
+      var(--ant-color-fill-quaternary) 20%,
+      var(--ant-color-fill) 60%,
       transparent 100%
     );
-    animation: load 1.8s infinite;
-    /* transform: rotate(45deg); */
+    animation: skeleton-shimmer 1.6s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+    will-change: transform;
   }
 
-  @keyframes load {
-    from {
-      left: -100%;
+  @keyframes skeleton-shimmer {
+    100% {
+      transform: translateX(100%);
     }
-    to {
-      left: 100%;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton::after {
+      animation: none;
     }
   }
 }

--- a/packages/plugins/blocks/blocks-loaders/src/blocks/SkeletonAvatar/SkeletonAvatar.js
+++ b/packages/plugins/blocks/blocks-loaders/src/blocks/SkeletonAvatar/SkeletonAvatar.js
@@ -34,12 +34,14 @@ const SkeletonAvatar = ({ classNames, properties, styles }) => {
         size = 32;
     }
   }
+  const borderRadius =
+    properties.shape === 'square' ? 'var(--ant-border-radius-lg, 8px)' : size / 2;
   return (
     <Skeleton
       classNames={classNames}
       styles={{
         element: {
-          borderRadius: properties.shape === 'square' ? '0' : size / 2,
+          borderRadius,
           ...styles?.element,
         },
       }}

--- a/packages/plugins/blocks/blocks-loaders/src/blocks/SkeletonButton/SkeletonButton.js
+++ b/packages/plugins/blocks/blocks-loaders/src/blocks/SkeletonButton/SkeletonButton.js
@@ -31,12 +31,13 @@ const SkeletonButton = ({ classNames, properties, styles }) => {
     default:
       height = 32;
   }
+  const borderRadius = properties.shape === 'round' ? height / 2 : 'var(--ant-border-radius, 6px)';
   return (
     <Skeleton
       classNames={classNames}
       styles={{
         element: {
-          borderRadius: properties.shape === 'round' && height / 2,
+          borderRadius,
           ...styles?.element,
         },
       }}

--- a/packages/plugins/blocks/blocks-loaders/src/blocks/SkeletonInput/SkeletonInput.js
+++ b/packages/plugins/blocks/blocks-loaders/src/blocks/SkeletonInput/SkeletonInput.js
@@ -32,11 +32,21 @@ const SkeletonInput = ({ classNames, properties, styles }) => {
       inputHeight = 32;
   }
   return (
-    <div className={classNames?.element} style={styles?.element}>
+    <div
+      className={classNames?.element}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 10,
+        ...styles?.element,
+      }}
+    >
       {properties.label !== false && (
         <Skeleton
           styles={{
-            element: { marginBottom: 10 },
+            element: {
+              borderRadius: 'var(--ant-border-radius-sm, 4px)',
+            },
           }}
           properties={{
             width: properties.labelWidth ?? properties.width ?? '30%',
@@ -46,7 +56,10 @@ const SkeletonInput = ({ classNames, properties, styles }) => {
       )}
       <Skeleton
         styles={{
-          element: styles?.input ?? {},
+          element: {
+            borderRadius: 'var(--ant-border-radius, 6px)',
+            ...styles?.input,
+          },
         }}
         properties={{
           width: properties.width ?? '100%',

--- a/packages/plugins/blocks/blocks-loaders/src/blocks/SkeletonParagraph/SkeletonParagraph.js
+++ b/packages/plugins/blocks/blocks-loaders/src/blocks/SkeletonParagraph/SkeletonParagraph.js
@@ -24,15 +24,20 @@ const SkeletonParagraph = ({ classNames, properties, styles }) => {
   return (
     <div
       className={classNames?.element}
-      style={{ width: properties.width ?? '100%', ...styles?.element }}
+      style={{
+        width: properties.width ?? '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.75rem',
+        ...styles?.element,
+      }}
     >
       {lines.map((key) => (
         <Skeleton
           key={key}
-          styles={{ element: { marginBottom: '1rem' } }}
           properties={{
-            height: '1.25rem',
-            width: key === lines.length - 1 && key !== 0 ? '40%' : '100%',
+            height: '0.875rem',
+            width: key === lines.length - 1 && key !== 0 ? '60%' : '100%',
           }}
         />
       ))}

--- a/packages/plugins/blocks/blocks-tiptap/README.md
+++ b/packages/plugins/blocks/blocks-tiptap/README.md
@@ -1,0 +1,1 @@
+# @lowdefy/blocks-tiptap

--- a/packages/plugins/blocks/blocks-tiptap/e2e/app/lowdefy.yaml
+++ b/packages/plugins/blocks/blocks-tiptap/e2e/app/lowdefy.yaml
@@ -1,0 +1,20 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+lowdefy: local
+name: blocks-tiptap E2E Tests
+
+pages:
+  - _ref: ../../src/blocks/TiptapInput/tests/TiptapInput.e2e.yaml
+  - _ref: ../../src/blocks/TiptapMentionInput/tests/TiptapMentionInput.e2e.yaml

--- a/packages/plugins/blocks/blocks-tiptap/e2e/playwright.config.js
+++ b/packages/plugins/blocks/blocks-tiptap/e2e/playwright.config.js
@@ -1,0 +1,26 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createPlaywrightConfig } from '@lowdefy/block-dev-e2e';
+
+const packageDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+export default createPlaywrightConfig({
+  packageDir,
+  port: 3012,
+});

--- a/packages/plugins/blocks/blocks-tiptap/package.json
+++ b/packages/plugins/blocks/blocks-tiptap/package.json
@@ -1,0 +1,88 @@
+{
+  "name": "@lowdefy/blocks-tiptap",
+  "version": "5.0.0",
+  "license": "Apache-2.0",
+  "description": "Lowdefy TipTap rich-text editor blocks.",
+  "homepage": "https://lowdefy.com",
+  "keywords": [
+    "lowdefy",
+    "lowdefy blocks",
+    "tiptap",
+    "rich-text",
+    "wysiwyg",
+    "lowdefy plugin"
+  ],
+  "bugs": {
+    "url": "https://github.com/lowdefy/lowdefy/issues"
+  },
+  "contributors": [
+    {
+      "name": "Sam Tolmay",
+      "url": "https://github.com/SamTolmay"
+    },
+    {
+      "name": "Gerrie van Wyk",
+      "url": "https://github.com/Gervwyk"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lowdefy/lowdefy.git"
+  },
+  "type": "module",
+  "exports": {
+    "./*": "./dist/*",
+    "./blocks": "./dist/blocks.js",
+    "./metas": "./dist/metas.js",
+    "./e2e": "./dist/e2e.js",
+    "./types": "./dist/types.js"
+  },
+  "files": [
+    "dist/*"
+  ],
+  "scripts": {
+    "build": "swc src --out-dir dist --config-file ../../../../.swcrc --cli-config-file ../../../../.swc-cli.json && pnpm copyfiles",
+    "clean": "rm -rf dist",
+    "copyfiles": "copyfiles -u 1 \"./src/**/*\" dist -e \"./src/**/*.js\" -e \"./src/**/*.yaml\" -e \"./src/**/*.snap\"",
+    "e2e": "playwright test --config e2e/playwright.config.js",
+    "e2e:ui": "playwright test --config e2e/playwright.config.js --ui",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {
+    "@lowdefy/block-utils": "5.0.0",
+    "@lowdefy/blocks-antd": "5.0.0",
+    "@lowdefy/helpers": "5.0.0",
+    "@tiptap/core": "2.27.2",
+    "@tiptap/extension-file-handler": "2.27.2",
+    "@tiptap/extension-highlight": "2.27.2",
+    "@tiptap/extension-image": "2.27.2",
+    "@tiptap/extension-link": "2.27.2",
+    "@tiptap/extension-mention": "2.27.2",
+    "@tiptap/extension-placeholder": "2.27.2",
+    "@tiptap/extension-table": "2.27.2",
+    "@tiptap/extension-table-cell": "2.27.2",
+    "@tiptap/extension-table-header": "2.27.2",
+    "@tiptap/extension-table-row": "2.27.2",
+    "@tiptap/pm": "2.27.2",
+    "@tiptap/react": "2.27.2",
+    "@tiptap/starter-kit": "2.27.2",
+    "react-icons": "5.6.0",
+    "tippy.js": "6.3.7",
+    "turndown": "7.2.0"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
+  },
+  "devDependencies": {
+    "@lowdefy/block-dev-e2e": "5.0.0",
+    "@lowdefy/e2e-utils": "5.0.0",
+    "@playwright/test": "1.50.1",
+    "@swc/cli": "0.8.0",
+    "@swc/core": "1.15.18",
+    "copyfiles": "2.4.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks.js
@@ -1,0 +1,18 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+export { default as TiptapInput } from './blocks/TiptapInput/TiptapInput.js';
+export { default as TiptapMentionInput } from './blocks/TiptapMentionInput/TiptapMentionInput.js';

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/TiptapInput.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/TiptapInput.js
@@ -1,0 +1,180 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import React, { useEffect } from 'react';
+import { withBlockDefaults } from '@lowdefy/block-utils';
+import { type } from '@lowdefy/helpers';
+import { useEditor, EditorContent } from '@tiptap/react';
+
+import Label from '@lowdefy/blocks-antd/blocks/Label/Label.js';
+
+import PopoverMenu from '../utils/PopoverMenu.js';
+import buildExtensions from '../utils/buildExtensions.js';
+import computeHeightStyle from '../utils/computeHeightStyle.js';
+import statusClass from '../utils/statusClass.js';
+import useTiptapState from './useTiptapState.js';
+
+import './style.module.css';
+
+const TiptapInput = ({
+  blockId,
+  components: { Icon, Link },
+  events,
+  loading,
+  methods,
+  properties,
+  required,
+  validation,
+  value,
+}) => {
+  const { emit, insertImage } = useTiptapState({ value, methods });
+
+  const disabled = properties.disabled === true || loading;
+  const uploadEnabled = !type.isNone(properties.s3PostPolicyRequestId);
+
+  const extensions = buildExtensions({
+    properties,
+    insertImage,
+    uploadEnabled,
+  });
+
+  const heightStyle = computeHeightStyle({
+    rows: properties.rows,
+    autoSize: properties.autoSize,
+  });
+
+  const editor = useEditor({
+    extensions,
+    content: value?.html || '',
+    editable: () => !disabled,
+    onUpdate({ editor }) {
+      // User-driven change. Emit the full derived value to Lowdefy.
+      emit(editor);
+      methods.triggerEvent({ name: 'onChange' });
+    },
+  });
+
+  // Register upload-policy event once (if configured).
+  useEffect(() => {
+    if (!uploadEnabled) return;
+    methods.registerEvent({
+      name: '__getS3PostPolicy',
+      actions: [
+        {
+          id: '__getS3PostPolicy',
+          type: 'Request',
+          params: [properties.s3PostPolicyRequestId],
+        },
+      ],
+    });
+  }, []);
+
+  // Register methods as soon as the editor is available.
+  useEffect(() => {
+    if (!editor) return;
+    methods.registerMethod('clear', () => {
+      editor.commands.clearContent();
+      emit(editor);
+    });
+    methods.registerMethod('setContent', (args) => {
+      editor.commands.setContent(args?.html ?? '');
+      emit(editor);
+    });
+    methods.registerMethod('focus', () => {
+      editor.commands.focus();
+    });
+  }, [editor]);
+
+  // External value.html → editor sync. One-way only: we read value.html and
+  // push it into the editor with setContent(..., false) so tiptap's onUpdate
+  // does not fire. No write-back via emit() — that would race with concurrent
+  // SetState calls (child effects fire before parent effects, so a sibling's
+  // onMount SetState could be overwritten by our derived emit). Derived
+  // fields (text/markdown/fileList) are populated on user interaction via
+  // onUpdate; downstream consumers of seeded content should read value.html
+  // directly, or include the fields they need in their SetState payload.
+  useEffect(() => {
+    if (!editor) return;
+    const next = value?.html ?? '';
+    const current = editor.getHTML();
+    if (next !== current) {
+      editor.commands.setContent(next, false);
+    }
+  }, [value?.html, editor]);
+
+  useEffect(() => {
+    if (!editor) return;
+    editor.setOptions({ editable: !disabled });
+  }, [editor, disabled]);
+
+  useEffect(() => {
+    if (!editor) return;
+    const placeholderExt = editor.extensionManager.extensions.find(
+      (extension) => extension.name === 'placeholder'
+    );
+    if (placeholderExt) {
+      placeholderExt.options.placeholder = properties.placeholder ?? '';
+      editor.view.dispatch(editor.state.tr);
+    }
+  }, [editor, properties.placeholder]);
+
+  const wrapperClass = [
+    'tiptap-wrapper',
+    properties.bordered === false ? 'tiptap-wrapper-borderless' : '',
+    disabled ? 'tiptap-wrapper-disabled' : '',
+    statusClass(validation?.status),
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const wrapperStyle = {
+    padding: 0,
+    ...heightStyle,
+    ...properties.inputStyle,
+    ...properties.style,
+  };
+
+  return (
+    <Label
+      blockId={blockId}
+      components={{ Icon, Link }}
+      events={events}
+      properties={{ title: properties.title, size: properties.size, ...properties.label }}
+      required={required}
+      validation={validation}
+      content={{
+        content: () => {
+          if (!editor) {
+            return <div />;
+          }
+          return (
+            <>
+              <EditorContent
+                id={`${blockId}_input`}
+                editor={editor}
+                className={wrapperClass}
+                style={wrapperStyle}
+              />
+              {!disabled && <PopoverMenu editor={editor} Icon={Icon} />}
+            </>
+          );
+        },
+      }}
+    />
+  );
+};
+
+export default withBlockDefaults(TiptapInput);

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/e2e.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/e2e.js
@@ -1,0 +1,30 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { createBlockHelper, escapeId } from '@lowdefy/e2e-utils';
+import { expect } from '@playwright/test';
+
+const locator = (page, blockId) => page.locator(`#${escapeId(blockId)}_input .ProseMirror`).first();
+
+export default createBlockHelper({
+  locator,
+  expect: {
+    containsText: (page, blockId, text) => expect(locator(page, blockId)).toContainText(text),
+    containsHtml: (page, blockId, selector) =>
+      expect(locator(page, blockId).locator(selector)).toBeVisible(),
+    isEmpty: (page, blockId) => expect(locator(page, blockId)).toHaveText(''),
+  },
+});

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/gallery.yaml
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/gallery.yaml
@@ -1,0 +1,210 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- title: Default
+  fullWidth: true
+  blocks:
+    - id: tiptap_default
+      type: TiptapInput
+      properties:
+        title: Notes
+        placeholder: 'Start typing here. Try **bold**, *italic*, or headings.'
+
+- title: Pre-populated content
+  fullWidth: true
+  blocks:
+    - id: tiptap_prepopulated
+      type: TiptapInput
+      events:
+        onMount:
+          - id: tiptap_prepopulated_set
+            type: SetState
+            params:
+              tiptap_prepopulated:
+                html: >
+                  <h2>What's new</h2>
+                  <p>Highlights from this release:</p>
+                  <ul>
+                    <li>Rich-text editor built on <a href="https://tiptap.dev">TipTap</a></li>
+                    <li>Drag-and-drop image uploads</li>
+                    <li>Inline <strong>bold</strong>, <em>italic</em>, and <mark>highlights</mark></li>
+                  </ul>
+                  <blockquote><p>Pair it with a TextArea when you need a simple fallback.</p></blockquote>
+      properties:
+        title: Release notes
+
+- title: Disabled (read-only)
+  fullWidth: true
+  blocks:
+    - id: tiptap_disabled
+      type: TiptapInput
+      events:
+        onMount:
+          - id: tiptap_disabled_set
+            type: SetState
+            params:
+              tiptap_disabled:
+                html: '<p>This editor is disabled and cannot be edited.</p>'
+      properties:
+        title: Read only
+        disabled: true
+
+- title: Borderless
+  fullWidth: true
+  blocks:
+    - id: tiptap_borderless
+      type: TiptapInput
+      properties:
+        title: Borderless editor
+        bordered: false
+        placeholder: 'No border, just content.'
+
+- title: Fixed rows — rows = 2
+  fullWidth: true
+  blocks:
+    - id: tiptap_rows_2
+      type: TiptapInput
+      properties:
+        title: Short note
+        placeholder: 'Exactly 2 rows tall.'
+        rows: 2
+
+- title: autoSize — minRows 2, maxRows 5
+  fullWidth: true
+  blocks:
+    - id: tiptap_autosize_range
+      type: TiptapInput
+      properties:
+        title: Grows between 2 and 5 rows
+        placeholder: 'Keep typing — scrolls past 5 rows.'
+        autoSize:
+          minRows: 2
+          maxRows: 5
+
+- title: Validation — required, with error state
+  fullWidth: true
+  blocks:
+    - id: tiptap_validation
+      type: TiptapInput
+      required: true
+      properties:
+        title: Release notes (required)
+        placeholder: 'Type at least 10 characters, then click Validate.'
+        rows: 3
+      validate:
+        - status: error
+          message: 'Release notes must be at least 10 characters.'
+          pass:
+            _gte:
+              - _string.length:
+                  _state: tiptap_validation.text
+              - 10
+    - id: tiptap_validation_button
+      type: Button
+      properties:
+        title: Validate
+      events:
+        onClick:
+          - id: tiptap_validation_run
+            type: Validate
+            params:
+              - tiptap_validation
+
+- title: autoSize = true — grows with content
+  fullWidth: true
+  blocks:
+    - id: tiptap_autosize_true
+      type: TiptapInput
+      properties:
+        title: Unconstrained
+        placeholder: 'No height cap.'
+        autoSize: true
+
+- title: Minimal — tables, images and highlights disabled
+  fullWidth: true
+  blocks:
+    - id: tiptap_minimal
+      type: TiptapInput
+      properties:
+        title: Plain note
+        placeholder: 'Bold/italic/lists only.'
+        image:
+          disabled: true
+        table:
+          disabled: true
+        highlight:
+          disabled: true
+
+- title: StarterKit overrides — disable code block and blockquote
+  fullWidth: true
+  blocks:
+    - id: tiptap_starterkit
+      type: TiptapInput
+      properties:
+        title: Short-form
+        placeholder: 'No code block or blockquote.'
+        starterKit:
+          codeBlock: false
+          blockquote: false
+          horizontalRule: false
+
+- title: With table (tables enabled by default)
+  fullWidth: true
+  blocks:
+    - id: tiptap_with_table
+      type: TiptapInput
+      events:
+        onMount:
+          - id: tiptap_with_table_set
+            type: SetState
+            params:
+              tiptap_with_table:
+                html: >
+                  <h3>Weekly sync</h3>
+                  <p>Schedule for today's meeting:</p>
+                  <table>
+                    <thead>
+                      <tr><th>Time</th><th>Topic</th><th>Owner</th></tr>
+                    </thead>
+                    <tbody>
+                      <tr><td>09:00</td><td>Kickoff</td><td>Alice</td></tr>
+                      <tr><td>09:15</td><td>Review last week</td><td>Bob</td></tr>
+                      <tr><td>09:45</td><td>This week's plan</td><td>Carol</td></tr>
+                      <tr><td>10:00</td><td>Wrap-up</td><td>Alice</td></tr>
+                    </tbody>
+                  </table>
+                  <p>Notes:</p>
+                  <ul>
+                    <li>Bring the latest metrics</li>
+                    <li>Send follow-ups within 24h</li>
+                  </ul>
+      properties:
+        title: Agenda
+
+- title: Link configuration — open in place (not new tab)
+  fullWidth: true
+  blocks:
+    - id: tiptap_links
+      type: TiptapInput
+      events:
+        onMount:
+          - id: tiptap_links_set
+            type: SetState
+            params:
+              tiptap_links:
+                html: '<p>Visit <a href="https://lowdefy.com">lowdefy.com</a> or type a URL and press space.</p>'
+      properties:
+        title: Open links in place
+        link:
+          openOnClick: false

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/meta.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/meta.js
@@ -1,0 +1,207 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+export default {
+  category: 'input',
+  icons: [],
+  valueType: 'object',
+  initValue: {
+    html: null,
+    text: null,
+    markdown: null,
+    fileList: [],
+  },
+  events: {
+    onChange: 'Trigger action when the editor content is changed.',
+  },
+  properties: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      allowedMimeTypes: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Mime-types accepted by the drag/drop and paste file handler. Defaults to common image types (jpeg, png, gif, webp). Only used when s3PostPolicyRequestId is set.',
+      },
+      autoSize: {
+        oneOf: [
+          {
+            type: 'boolean',
+            default: false,
+            description: 'When true the editor grows with its content and has no max height.',
+          },
+          {
+            type: 'object',
+            description: 'Constrain the editor height with a minimum and/or maximum row count.',
+            properties: {
+              minRows: {
+                type: 'integer',
+                minimum: 1,
+                description: 'Minimum visible rows before content overflows.',
+              },
+              maxRows: {
+                type: 'integer',
+                minimum: 1,
+                description: 'Maximum visible rows; beyond this the editor scrolls vertically.',
+              },
+            },
+          },
+        ],
+        description:
+          'Either a boolean (true to auto-grow without a cap) or an object with minRows/maxRows. Ignored when `rows` is set.',
+      },
+      bordered: {
+        type: 'boolean',
+        default: true,
+        description: 'Whether the editor renders with a border.',
+      },
+      disabled: {
+        type: 'boolean',
+        default: false,
+        description: 'Render the editor as read-only.',
+      },
+      highlight: {
+        type: 'object',
+        description: 'Text highlight extension settings.',
+        additionalProperties: false,
+        properties: {
+          disabled: {
+            type: 'boolean',
+            default: false,
+            description: 'Disable the Highlight extension and its bubble-menu color swatches.',
+          },
+          multicolor: {
+            type: 'boolean',
+            default: true,
+            description: 'Allow highlights to carry a color value. Disable for single-color.',
+          },
+        },
+      },
+      image: {
+        type: 'object',
+        description: 'Image extension settings.',
+        additionalProperties: false,
+        properties: {
+          disabled: {
+            type: 'boolean',
+            default: false,
+            description: 'Disable the Image extension.',
+          },
+          maxWidth: {
+            type: 'string',
+            default: '80%',
+            description: 'Inline CSS max-width applied to inserted images.',
+          },
+          zoom: {
+            type: 'number',
+            default: 0.5,
+            description: 'Inline CSS zoom factor applied to inserted images.',
+          },
+        },
+      },
+      inputStyle: {
+        type: 'object',
+        description: 'Inline style applied to the editable area of the editor.',
+        docs: { displayType: 'yaml' },
+      },
+      label: {
+        type: 'object',
+        description: 'Label configuration forwarded to the Lowdefy Label block.',
+        docs: { displayType: 'yaml' },
+      },
+      link: {
+        type: 'object',
+        description: 'Link extension settings.',
+        additionalProperties: false,
+        properties: {
+          disabled: {
+            type: 'boolean',
+            default: false,
+            description: 'Disable the Link extension.',
+          },
+          autolink: {
+            type: 'boolean',
+            default: true,
+            description: 'Auto-convert URLs typed in the editor to links.',
+          },
+          linkOnPaste: {
+            type: 'boolean',
+            default: true,
+            description: 'Convert pasted URLs to links.',
+          },
+          openOnClick: {
+            type: 'boolean',
+            default: true,
+            description: 'Open links in a new tab when clicked in view mode.',
+          },
+          defaultProtocol: {
+            type: 'string',
+            default: 'https',
+            description: 'Protocol prefixed to URLs that omit one (e.g. "https").',
+          },
+        },
+      },
+      placeholder: {
+        type: 'string',
+        description: 'Placeholder shown when the editor is empty.',
+      },
+      rows: {
+        type: 'integer',
+        minimum: 1,
+        description:
+          'Fix the editor height to exactly this many rows. Takes precedence over autoSize.',
+      },
+      s3PostPolicyRequestId: {
+        type: 'string',
+        description:
+          'Id of a request that returns an S3 presigned POST policy. When set, images dragged or pasted into the editor are uploaded via that policy and inserted as <img> nodes. Leave unset to disable image uploads.',
+      },
+      size: {
+        type: 'string',
+        enum: ['small', 'middle', 'large'],
+        description: 'Label size forwarded to the Label block.',
+      },
+      starterKit: {
+        type: 'object',
+        description:
+          'Options forwarded to TipTap StarterKit (https://tiptap.dev/docs/editor/extensions/functionality/starterkit). Use this to disable bundled extensions (e.g. {heading: false, codeBlock: false}).',
+        docs: { displayType: 'yaml' },
+      },
+      table: {
+        type: 'object',
+        description: 'Table extension settings.',
+        additionalProperties: false,
+        properties: {
+          disabled: {
+            type: 'boolean',
+            default: false,
+            description: 'Disable the Table extension and its row/header/cell nodes.',
+          },
+          resizable: {
+            type: 'boolean',
+            default: true,
+            description: 'Allow column resizing with a drag handle.',
+          },
+        },
+      },
+      title: {
+        type: 'string',
+        description: 'Label title shown above the editor.',
+      },
+    },
+  },
+};

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/style.module.css
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/style.module.css
@@ -1,0 +1,60 @@
+@import '../utils/style.module.css';
+
+:global(.tableWrapper),
+:global(.tiptap-table) {
+  display: block;
+  overflow-x: auto;
+  max-width: 80%;
+}
+
+:global(.tableWrapper) :global(table),
+:global(.tiptap-table) :global(table) {
+  border-collapse: collapse;
+  width: 100%;
+  min-width: 75px;
+}
+
+:global(.tableWrapper) :global(colgroup) :global(col),
+:global(.tiptap-table) :global(colgroup) :global(col) {
+  width: auto;
+}
+
+:global(.tableWrapper) :global(table),
+:global(.tableWrapper) :global(th),
+:global(.tableWrapper) :global(td),
+:global(.tiptap-table) :global(table),
+:global(.tiptap-table) :global(th),
+:global(.tiptap-table) :global(td) {
+  border: 1px solid var(--ant-color-border);
+}
+
+:global(.tableWrapper) :global(th),
+:global(.tableWrapper) :global(td),
+:global(.tiptap-table) :global(th),
+:global(.tiptap-table) :global(td) {
+  padding: 2px;
+  text-align: left;
+}
+
+:global(.tableWrapper) :global(th),
+:global(.tiptap-table) :global(th) {
+  background-color: var(--ant-color-fill-tertiary);
+  font-weight: bold;
+}
+
+:global(.tableWrapper) :global(tr):nth-child(even),
+:global(.tiptap-table) :global(tr):nth-child(even) {
+  background-color: var(--ant-color-fill-quaternary);
+}
+
+:global(.tableWrapper) :global(tr):hover,
+:global(.tiptap-table) :global(tr):hover {
+  background-color: var(--ant-color-primary-bg);
+}
+
+:global(.tableWrapper) :global(td) :global(p),
+:global(.tableWrapper) :global(th) :global(p),
+:global(.tiptap-table) :global(td) :global(p),
+:global(.tiptap-table) :global(th) :global(p) {
+  margin: 0;
+}

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/tests.yaml
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/tests.yaml
@@ -1,0 +1,65 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- id: default
+  type: TiptapInput
+- id: properties.placeholder
+  type: TiptapInput
+  properties:
+    placeholder: 'Start typing...'
+- id: properties.title
+  type: TiptapInput
+  properties:
+    title: 'Note'
+- id: properties.disabled
+  type: TiptapInput
+  properties:
+    disabled: true
+- id: properties.bordered = false
+  type: TiptapInput
+  properties:
+    bordered: false
+    placeholder: 'No border.'
+- id: properties.image and table disabled
+  type: TiptapInput
+  properties:
+    image:
+      disabled: true
+    table:
+      disabled: true
+- id: properties.starterKit overrides
+  type: TiptapInput
+  properties:
+    starterKit:
+      codeBlock: false
+      blockquote: false
+- id: properties.rows = 2
+  type: TiptapInput
+  properties:
+    rows: 2
+- id: properties.autoSize = {minRows 2, maxRows 5}
+  type: TiptapInput
+  properties:
+    autoSize:
+      minRows: 2
+      maxRows: 5
+- id: properties.autoSize = true
+  type: TiptapInput
+  properties:
+    autoSize: true
+- id: properties.link.openOnClick = false
+  type: TiptapInput
+  properties:
+    link:
+      openOnClick: false

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/tests/TiptapInput.e2e.spec.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/tests/TiptapInput.e2e.spec.js
@@ -1,0 +1,64 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { test, expect } from '@playwright/test';
+import { getBlock, navigateToTestPage } from '@lowdefy/block-dev-e2e';
+
+const editorLocator = (page, blockId) => page.locator(`#${blockId}_input .ProseMirror`).first();
+
+test.describe('TiptapInput Block', () => {
+  test.beforeEach(async ({ page }) => {
+    await navigateToTestPage(page, 'tiptap-input');
+  });
+
+  test('renders empty editor', async ({ page }) => {
+    const block = getBlock(page, 'tiptap_empty');
+    await expect(block).toBeVisible();
+    const editor = editorLocator(page, 'tiptap_empty');
+    await expect(editor).toBeVisible();
+    await expect(editor).toHaveAttribute('contenteditable', 'true');
+  });
+
+  test('renders placeholder when empty', async ({ page }) => {
+    const editor = editorLocator(page, 'tiptap_placeholder');
+    const placeholderEl = editor.locator('p.is-editor-empty').first();
+    await expect(placeholderEl).toHaveAttribute('data-placeholder', 'Start typing...');
+  });
+
+  test('renders initial html value', async ({ page }) => {
+    const editor = editorLocator(page, 'tiptap_with_value');
+    await expect(editor).toContainText('Hello world.');
+    await expect(editor.locator('strong')).toHaveText('world');
+  });
+
+  test('disabled editor is not editable', async ({ page }) => {
+    const editor = editorLocator(page, 'tiptap_disabled');
+    await expect(editor).toHaveAttribute('contenteditable', 'false');
+    await expect(editor).toContainText('Disabled content.');
+  });
+
+  test('borderless editor applies the borderless wrapper class', async ({ page }) => {
+    const wrapper = page.locator('#tiptap_borderless_input');
+    await expect(wrapper).toHaveClass(/tiptap-wrapper-borderless/);
+  });
+
+  test('typing updates editor content', async ({ page }) => {
+    const editor = editorLocator(page, 'tiptap_typing');
+    await editor.click();
+    await page.keyboard.type('hello from test');
+    await expect(editor).toContainText('hello from test');
+  });
+});

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/tests/TiptapInput.e2e.yaml
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/tests/TiptapInput.e2e.yaml
@@ -1,0 +1,53 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: tiptap-input
+type: Box
+
+events:
+  onMount:
+    - id: seed_content
+      type: SetState
+      params:
+        tiptap_with_value:
+          html: '<p>Hello <strong>world</strong>.</p>'
+        tiptap_disabled:
+          html: '<p>Disabled content.</p>'
+        tiptap_borderless:
+          html: '<p>Borderless.</p>'
+
+blocks:
+  - id: tiptap_empty
+    type: TiptapInput
+
+  - id: tiptap_placeholder
+    type: TiptapInput
+    properties:
+      placeholder: 'Start typing...'
+
+  - id: tiptap_with_value
+    type: TiptapInput
+
+  - id: tiptap_disabled
+    type: TiptapInput
+    properties:
+      disabled: true
+
+  - id: tiptap_borderless
+    type: TiptapInput
+    properties:
+      bordered: false
+
+  - id: tiptap_typing
+    type: TiptapInput

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/useTiptapState.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/useTiptapState.js
@@ -1,0 +1,90 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { useRef } from 'react';
+import TurndownService from 'turndown';
+
+import s3FileUpload from '../utils/s3FileUpload.js';
+
+// Ref-tracked controller for the editor's value. No useState — the only
+// source of truth for `fileList` is the `value` prop from Lowdefy. We mirror
+// it into a ref each render so callbacks (onUpdate, insertImage) captured in
+// closures always read the current value instead of a stale render snapshot.
+function useTiptapState({ value, methods }) {
+  const valueRef = useRef(value);
+  valueRef.current = value;
+
+  const turndownService = new TurndownService();
+  turndownService.addRule('encodeImgUrl', {
+    filter: 'img',
+    replacement: (content, node) => {
+      const src = node.getAttribute('src');
+      return `![${content}](${encodeURI(src)})`;
+    },
+  });
+
+  // Emit a full `{fileList, html, text, markdown}` value to Lowdefy based on
+  // the editor's current document. When appendFile is supplied (an S3 upload
+  // result), it is added to the current fileList before filtering by
+  // in-document image urls.
+  const emit = (editor, appendFile) => {
+    const html = editor.getHTML();
+    const markdown = turndownService.turndown(html);
+    const json = editor.getJSON();
+    const text = editor.getText().trim() === '' ? null : editor.getText();
+    const urls = (json.content ?? []).filter((c) => c.type === 'image').map((c) => c.attrs.src);
+    const base = valueRef.current?.fileList ?? [];
+    const next = appendFile ? [...base, appendFile] : base;
+    const fileList = next.filter((f) => urls.includes(f.url));
+    methods.setValue({ fileList, html, text, markdown });
+  };
+
+  const insertImage = async (editor, file, pos) => {
+    const url = await s3FileUpload({ file, methods });
+    editor
+      .chain()
+      .insertContentAt(pos, [
+        { type: 'image', attrs: { src: url } },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              marks: [{ type: 'link', attrs: { href: url, target: '_blank' } }],
+              text: 'Enlarge Image',
+            },
+          ],
+        },
+      ])
+      .focus()
+      .run();
+    const fileObj = {
+      bucket: file.bucket,
+      key: file.key,
+      lastModified: file.lastModified,
+      name: file.name,
+      size: file.size,
+      status: file.status,
+      type: file.type,
+      url,
+    };
+    emit(editor, fileObj);
+  };
+
+  return { emit, insertImage };
+}
+
+export default useTiptapState;

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/MentionList.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/MentionList.js
@@ -1,0 +1,81 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import React, { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
+import { renderHtml } from '@lowdefy/block-utils';
+
+const MentionList = forwardRef((props, ref) => {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const selectItem = (index) => {
+    const item = props.items[index];
+    if (item) {
+      props.command({ id: item });
+    }
+  };
+
+  const upHandler = () => {
+    setSelectedIndex((selectedIndex + props.items.length - 1) % props.items.length);
+  };
+
+  const downHandler = () => {
+    setSelectedIndex((selectedIndex + 1) % props.items.length);
+  };
+
+  const enterHandler = () => {
+    selectItem(selectedIndex);
+  };
+
+  useEffect(() => setSelectedIndex(0), [props.items]);
+
+  useImperativeHandle(ref, () => ({
+    onKeyDown: ({ event }) => {
+      if (event.key === 'ArrowUp') {
+        upHandler();
+        return true;
+      }
+      if (event.key === 'ArrowDown') {
+        downHandler();
+        return true;
+      }
+      if (event.key === 'Enter') {
+        enterHandler();
+        return true;
+      }
+      return false;
+    },
+  }));
+
+  return (
+    <div className="tiptap-mention-items">
+      {props.items.length ? (
+        props.items.map((item, index) => (
+          <button
+            className={`tiptap-mention-item ${index === selectedIndex ? 'is-selected' : ''}`}
+            key={index}
+            onClick={() => selectItem(index)}
+          >
+            {renderHtml({ html: item?.label ?? item, methods: props.methods })}
+          </button>
+        ))
+      ) : (
+        <div className="tiptap-mention-item secondary">No matching results</div>
+      )}
+    </div>
+  );
+});
+
+export default MentionList;

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/TiptapMentionInput.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/TiptapMentionInput.js
@@ -1,0 +1,238 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import React, { useEffect } from 'react';
+import { withBlockDefaults } from '@lowdefy/block-utils';
+import { type } from '@lowdefy/helpers';
+import { useEditor, EditorContent } from '@tiptap/react';
+import { mergeAttributes } from '@tiptap/core';
+import Mention from '@tiptap/extension-mention';
+
+import Label from '@lowdefy/blocks-antd/blocks/Label/Label.js';
+
+import PopoverMenu from '../utils/PopoverMenu.js';
+import buildExtensions from '../utils/buildExtensions.js';
+import computeHeightStyle from '../utils/computeHeightStyle.js';
+import statusClass from '../utils/statusClass.js';
+import suggestion from './suggestion.js';
+import useTiptapMentionState from './useTiptapMentionState.js';
+
+import './style.module.css';
+
+function mentionLabel(id) {
+  return id?.tag?.title ?? id?.label ?? id;
+}
+
+const TiptapMentionInput = ({
+  blockId,
+  components: { Icon, Link },
+  events,
+  loading,
+  methods,
+  properties,
+  required,
+  validation,
+  value,
+}) => {
+  const { emit, insertImage } = useTiptapMentionState({ value, methods });
+  const disabled = properties.disabled === true || loading;
+  const uploadEnabled = !type.isNone(properties.s3PostPolicyRequestId);
+  const char = properties.mentions?.char ?? '@';
+  const allowSpaces = properties.mentions?.allowSpaces !== false;
+
+  const mentionExtension = Mention.configure({
+    HTMLAttributes: { class: 'tiptap-mention' },
+    renderHTML({ options, node }) {
+      const label = mentionLabel(node.attrs.id);
+      if (type.isFunction(properties.mentions?.getHref)) {
+        return [
+          'a',
+          mergeAttributes(
+            {
+              href: properties.mentions.getHref(node.attrs.id),
+              'data-id': node.attrs.id?._id,
+            },
+            options.HTMLAttributes
+          ),
+          `${char}${label}`,
+        ];
+      }
+      return ['span', mergeAttributes(options.HTMLAttributes), `${char}${label}`];
+    },
+    renderText({ node }) {
+      return `${char}${mentionLabel(node.attrs.id)}`;
+    },
+    suggestion: suggestion({ methods, char, allowSpaces }),
+  });
+
+  const extensions = buildExtensions({
+    properties,
+    insertImage,
+    mentionExtension,
+    uploadEnabled,
+  });
+
+  const heightStyle = computeHeightStyle({
+    rows: properties.rows,
+    autoSize: properties.autoSize,
+  });
+
+  const editor = useEditor({
+    editorProps: {
+      items: type.isArray(properties.mentions?.options) ? properties.mentions.options : [],
+    },
+    extensions,
+    content: value?.html || '',
+    editable: () => !disabled,
+    onUpdate: ({ editor }) => {
+      emit(editor);
+      methods.triggerEvent({ name: 'onChange' });
+    },
+  });
+
+  useEffect(() => {
+    if (editor) {
+      editor.setOptions({
+        editorProps: {
+          items: type.isArray(properties.mentions?.options) ? properties.mentions.options : [],
+        },
+      });
+    }
+  }, [properties.mentions?.options, editor]);
+
+  useEffect(() => {
+    if (uploadEnabled) {
+      methods.registerEvent({
+        name: '__getS3PostPolicy',
+        actions: [
+          {
+            id: '__getS3PostPolicy',
+            type: 'Request',
+            params: [properties.s3PostPolicyRequestId],
+          },
+        ],
+      });
+    }
+    if (!type.isNone(properties.mentionsRequestId)) {
+      methods.registerEvent({
+        name: '__getTipTapMentions',
+        actions: [
+          {
+            id: '__getTipTapMentions',
+            type: 'Request',
+            params: [properties.mentionsRequestId],
+          },
+        ],
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!editor) return;
+    methods.registerMethod('clear', () => {
+      editor.commands.clearContent();
+      emit(editor);
+    });
+    methods.registerMethod('setContent', (args) => {
+      editor.commands.setContent(args?.html ?? '');
+      emit(editor);
+    });
+    methods.registerMethod('focus', () => {
+      editor.commands.focus();
+    });
+  }, [editor]);
+
+  // External value.html → editor sync. One-way only: we read value.html and
+  // push it into the editor with setContent(..., false) so tiptap's onUpdate
+  // does not fire. No write-back via emit() — that would race with concurrent
+  // SetState calls (child effects fire before parent effects, so a sibling's
+  // onMount SetState could be overwritten by our derived emit). Derived
+  // fields (text/markdown/fileList/mentions) are populated on user interaction
+  // via onUpdate; downstream consumers of seeded content should read
+  // value.html directly, or include the fields they need in their SetState
+  // payload.
+  useEffect(() => {
+    if (!editor) return;
+    const next = value?.html ?? '';
+    const current = editor.getHTML();
+    if (next !== current) {
+      editor.commands.setContent(next, false);
+    }
+  }, [value?.html, editor]);
+
+  useEffect(() => {
+    if (!editor) return;
+    editor.setOptions({ editable: !disabled });
+  }, [editor, disabled]);
+
+  useEffect(() => {
+    if (!editor) return;
+    const placeholderExt = editor.extensionManager.extensions.find(
+      (extension) => extension.name === 'placeholder'
+    );
+    if (placeholderExt) {
+      placeholderExt.options.placeholder = properties.placeholder ?? '';
+      editor.view.dispatch(editor.state.tr);
+    }
+  }, [editor, properties.placeholder]);
+
+  const wrapperClass = [
+    'tiptap-wrapper',
+    properties.bordered === false ? 'tiptap-wrapper-borderless' : '',
+    disabled ? 'tiptap-wrapper-disabled' : '',
+    statusClass(validation?.status),
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const wrapperStyle = {
+    padding: 0,
+    ...heightStyle,
+    ...properties.inputStyle,
+    ...properties.style,
+  };
+
+  return (
+    <Label
+      blockId={blockId}
+      components={{ Icon, Link }}
+      events={events}
+      properties={{ title: properties.title, size: properties.size, ...properties.label }}
+      required={required}
+      validation={validation}
+      content={{
+        content: () => {
+          if (!editor) {
+            return <div />;
+          }
+          return (
+            <>
+              <EditorContent
+                id={`${blockId}_input`}
+                editor={editor}
+                className={wrapperClass}
+                style={wrapperStyle}
+              />
+              {!disabled && <PopoverMenu editor={editor} Icon={Icon} />}
+            </>
+          );
+        },
+      }}
+    />
+  );
+};
+
+export default withBlockDefaults(TiptapMentionInput);

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/e2e.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/e2e.js
@@ -1,0 +1,30 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { createBlockHelper, escapeId } from '@lowdefy/e2e-utils';
+import { expect } from '@playwright/test';
+
+const locator = (page, blockId) => page.locator(`#${escapeId(blockId)}_input .ProseMirror`).first();
+
+export default createBlockHelper({
+  locator,
+  expect: {
+    containsText: (page, blockId, text) => expect(locator(page, blockId)).toContainText(text),
+    containsHtml: (page, blockId, selector) =>
+      expect(locator(page, blockId).locator(selector)).toBeVisible(),
+    isEmpty: (page, blockId) => expect(locator(page, blockId)).toHaveText(''),
+  },
+});

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/gallery.yaml
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/gallery.yaml
@@ -1,0 +1,201 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- title: Default with static mentions
+  fullWidth: true
+  blocks:
+    - id: tiptap_mention_default
+      type: TiptapMentionInput
+      properties:
+        title: Ticket note
+        placeholder: 'Type @ to mention someone.'
+        mentions:
+          options:
+            - label: Alice
+              value:
+                _id: user_1
+                name: Alice
+            - label: Bob
+              value:
+                _id: user_2
+                name: Bob
+            - label: Carol
+              value:
+                _id: user_3
+                name: Carol
+
+- title: Pre-populated content via SetState on onMount
+  fullWidth: true
+  blocks:
+    - id: tiptap_mention_prepopulated
+      type: TiptapMentionInput
+      events:
+        onMount:
+          - id: tiptap_mention_prepopulated_set
+            type: SetState
+            params:
+              tiptap_mention_prepopulated:
+                html: >
+                  <p>Thanks <span class="tiptap-mention">@Alice</span> for the review.
+                  Assigning follow-up to <span class="tiptap-mention">@Bob</span>.</p>
+      properties:
+        title: Ticket summary
+        mentions:
+          options:
+            - label: Alice
+              value:
+                _id: user_1
+            - label: Bob
+              value:
+                _id: user_2
+
+- title: Custom trigger character (hashtags)
+  fullWidth: true
+  blocks:
+    - id: tiptap_mention_hashtags
+      type: TiptapMentionInput
+      properties:
+        title: Tag the ticket
+        placeholder: 'Type # to add a tag.'
+        mentions:
+          char: '#'
+          allowSpaces: false
+          options:
+            - label: bug
+              value:
+                _id: tag_bug
+            - label: feature
+              value:
+                _id: tag_feature
+            - label: needs-triage
+              value:
+                _id: tag_triage
+
+- title: Mentions rendered as links
+  fullWidth: true
+  blocks:
+    - id: tiptap_mention_links
+      type: TiptapMentionInput
+      properties:
+        title: Link mentions to profile pages
+        placeholder: 'Type @ — selections render as <a>.'
+        mentions:
+          options:
+            - label: Alice
+              value:
+                _id: user_1
+            - label: Bob
+              value:
+                _id: user_2
+          getHref:
+            _function:
+              __string.concat:
+                - '/users/'
+                - __args: 0.value._id
+
+- title: autoSize — minRows 2, maxRows 5
+  fullWidth: true
+  blocks:
+    - id: tiptap_mention_autosize
+      type: TiptapMentionInput
+      properties:
+        title: Grows between 2 and 5 rows
+        placeholder: 'Type @ to mention. Scrolls past 5 rows.'
+        autoSize:
+          minRows: 2
+          maxRows: 5
+        mentions:
+          options:
+            - label: Alice
+              value:
+                _id: user_1
+            - label: Bob
+              value:
+                _id: user_2
+
+- title: Validation — required, with error state
+  fullWidth: true
+  blocks:
+    - id: tiptap_mention_validation
+      type: TiptapMentionInput
+      required: true
+      properties:
+        title: Mention a teammate (required)
+        placeholder: 'Type @ and pick someone, then click Validate.'
+        rows: 3
+        mentions:
+          options:
+            - label: Alice
+              value:
+                _id: user_1
+            - label: Bob
+              value:
+                _id: user_2
+      validate:
+        - status: error
+          message: 'Please mention at least one teammate.'
+          pass:
+            _gt:
+              - _string.length:
+                  _state: tiptap_mention_validation.text
+              - 0
+    - id: tiptap_mention_validation_button
+      type: Button
+      properties:
+        title: Validate
+      events:
+        onClick:
+          - id: tiptap_mention_validation_run
+            type: Validate
+            params:
+              - tiptap_mention_validation
+
+- title: Disabled (read-only)
+  fullWidth: true
+  blocks:
+    - id: tiptap_mention_disabled
+      type: TiptapMentionInput
+      events:
+        onMount:
+          - id: tiptap_mention_disabled_set
+            type: SetState
+            params:
+              tiptap_mention_disabled:
+                html: '<p>Mentions render inline: <span class="tiptap-mention">@Alice</span>.</p>'
+      properties:
+        title: Read only
+        disabled: true
+
+- title: Minimal — tables and images disabled
+  fullWidth: true
+  blocks:
+    - id: tiptap_mention_minimal
+      type: TiptapMentionInput
+      properties:
+        title: Chat-style
+        placeholder: 'Type @ to mention.'
+        image:
+          disabled: true
+        table:
+          disabled: true
+        highlight:
+          disabled: true
+        mentions:
+          options:
+            - label: Alice
+              value:
+                _id: user_1
+            - label: Bob
+              value:
+                _id: user_2

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/meta.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/meta.js
@@ -1,0 +1,186 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+export default {
+  category: 'input',
+  icons: [],
+  valueType: 'object',
+  initValue: {
+    html: null,
+    text: null,
+    markdown: null,
+    fileList: [],
+    mentions: [],
+  },
+  events: {
+    onChange: 'Trigger action when the editor content is changed.',
+  },
+  properties: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      allowedMimeTypes: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Mime-types accepted by the drag/drop and paste file handler. Defaults to common image types. Only used when s3PostPolicyRequestId is set.',
+      },
+      autoSize: {
+        oneOf: [
+          {
+            type: 'boolean',
+            default: false,
+            description: 'When true the editor grows with its content and has no max height.',
+          },
+          {
+            type: 'object',
+            description: 'Constrain the editor height with a minimum and/or maximum row count.',
+            properties: {
+              minRows: { type: 'integer', minimum: 1 },
+              maxRows: { type: 'integer', minimum: 1 },
+            },
+          },
+        ],
+        description:
+          'Either a boolean (true to auto-grow without a cap) or an object with minRows/maxRows. Ignored when `rows` is set.',
+      },
+      bordered: {
+        type: 'boolean',
+        default: true,
+        description: 'Whether the editor renders with a border.',
+      },
+      disabled: {
+        type: 'boolean',
+        default: false,
+        description: 'Render the editor as read-only.',
+      },
+      highlight: {
+        type: 'object',
+        description: 'Text highlight extension settings.',
+        additionalProperties: false,
+        properties: {
+          disabled: { type: 'boolean', default: false },
+          multicolor: { type: 'boolean', default: true },
+        },
+      },
+      image: {
+        type: 'object',
+        description: 'Image extension settings.',
+        additionalProperties: false,
+        properties: {
+          disabled: { type: 'boolean', default: false },
+          maxWidth: { type: 'string', default: '80%' },
+          zoom: { type: 'number', default: 0.6 },
+        },
+      },
+      inputStyle: {
+        type: 'object',
+        description: 'Inline style applied to the editable area of the editor.',
+        docs: { displayType: 'yaml' },
+      },
+      label: {
+        type: 'object',
+        description: 'Label configuration forwarded to the Lowdefy Label block.',
+        docs: { displayType: 'yaml' },
+      },
+      link: {
+        type: 'object',
+        description: 'Link extension settings.',
+        additionalProperties: false,
+        properties: {
+          disabled: { type: 'boolean', default: false },
+          autolink: { type: 'boolean', default: true },
+          linkOnPaste: { type: 'boolean', default: true },
+          openOnClick: { type: 'boolean', default: true },
+          defaultProtocol: { type: 'string', default: 'https' },
+        },
+      },
+      mentions: {
+        type: 'object',
+        description: 'Configure the set of mention targets and how they render.',
+        additionalProperties: false,
+        properties: {
+          char: {
+            type: 'string',
+            default: '@',
+            description:
+              'Trigger character that opens the mention dropdown. Change to "#" for hashtags, etc.',
+          },
+          allowSpaces: {
+            type: 'boolean',
+            default: true,
+            description: 'Allow spaces inside a mention query before it is committed.',
+          },
+          options: {
+            type: 'array',
+            description:
+              'Array of mention items. Each item may be a string, or an object with a "label" (matched against user input) and a "value" (stored on the node).',
+          },
+          getHref: {
+            type: 'object',
+            description:
+              'Optional function (_function operator) that receives a selected mention id and returns an href. When provided, mentions render as <a> tags.',
+            docs: { displayType: 'yaml' },
+          },
+        },
+      },
+      mentionsRequestId: {
+        type: 'string',
+        description:
+          'Id of a request used to populate mention options. When set, the block registers a __getTipTapMentions event that calls that request.',
+      },
+      placeholder: {
+        type: 'string',
+        description: 'Placeholder shown when the editor is empty.',
+      },
+      rows: {
+        type: 'integer',
+        minimum: 1,
+        description:
+          'Fix the editor height to exactly this many rows. Takes precedence over autoSize.',
+      },
+      s3PostPolicyRequestId: {
+        type: 'string',
+        description:
+          'Id of a request that returns an S3 presigned POST policy. When set, images dragged or pasted into the editor are uploaded via that policy.',
+      },
+      size: {
+        type: 'string',
+        enum: ['small', 'middle', 'large'],
+        description: 'Label size forwarded to the Label block.',
+      },
+      starterKit: {
+        type: 'object',
+        description:
+          'Options forwarded to TipTap StarterKit. Use to disable bundled extensions (e.g. {heading: false}).',
+        docs: { displayType: 'yaml' },
+      },
+      table: {
+        type: 'object',
+        description: 'Table extension settings.',
+        additionalProperties: false,
+        properties: {
+          disabled: { type: 'boolean', default: false },
+          resizable: { type: 'boolean', default: true },
+        },
+      },
+      title: {
+        type: 'string',
+        description: 'Label title shown above the editor.',
+      },
+    },
+  },
+};

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/style.module.css
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/style.module.css
@@ -1,0 +1,96 @@
+@import '../utils/style.module.css';
+
+:global(.tiptap-mention) {
+  box-decoration-break: clone;
+  font-weight: 600;
+  color: var(--ant-color-link);
+}
+
+:global(.tiptap-mention-items) {
+  background: var(--ant-color-bg-container);
+  border-radius: var(--ant-border-radius, 8px);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.05),
+    0px 10px 20px rgba(0, 0, 0, 0.1);
+  color: var(--ant-color-text);
+  font-size: var(--ant-font-size);
+  overflow: hidden;
+  padding: 0.2rem;
+  position: relative;
+}
+
+:global(.tiptap-mention-item) {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--ant-border-radius, 8px);
+  display: block;
+  margin: 0;
+  padding: 0.2rem 0.4rem;
+  text-align: left;
+  line-height: normal;
+  width: 100%;
+}
+
+:global(.tiptap-mention-item.is-selected) {
+  border-color: var(--ant-color-primary);
+  background: var(--ant-control-item-bg-hover);
+}
+
+:global(.tableWrapper),
+:global(.tiptap-table) {
+  display: block;
+  overflow-x: auto;
+  max-width: 80%;
+}
+
+:global(.tableWrapper) :global(table),
+:global(.tiptap-table) :global(table) {
+  border-collapse: collapse;
+  width: 100%;
+  min-width: 75px;
+}
+
+:global(.tableWrapper) :global(colgroup) :global(col),
+:global(.tiptap-table) :global(colgroup) :global(col) {
+  width: auto;
+}
+
+:global(.tableWrapper) :global(table),
+:global(.tableWrapper) :global(th),
+:global(.tableWrapper) :global(td),
+:global(.tiptap-table) :global(table),
+:global(.tiptap-table) :global(th),
+:global(.tiptap-table) :global(td) {
+  border: 1px solid var(--ant-color-border);
+}
+
+:global(.tableWrapper) :global(th),
+:global(.tableWrapper) :global(td),
+:global(.tiptap-table) :global(th),
+:global(.tiptap-table) :global(td) {
+  padding: 2px;
+  text-align: left;
+}
+
+:global(.tableWrapper) :global(th),
+:global(.tiptap-table) :global(th) {
+  background-color: var(--ant-color-fill-tertiary);
+  font-weight: bold;
+}
+
+:global(.tableWrapper) :global(tr):nth-child(even),
+:global(.tiptap-table) :global(tr):nth-child(even) {
+  background-color: var(--ant-color-fill-quaternary);
+}
+
+:global(.tableWrapper) :global(tr):hover,
+:global(.tiptap-table) :global(tr):hover {
+  background-color: var(--ant-color-primary-bg);
+}
+
+:global(.tableWrapper) :global(td) :global(p),
+:global(.tableWrapper) :global(th) :global(p),
+:global(.tiptap-table) :global(td) :global(p),
+:global(.tiptap-table) :global(th) :global(p) {
+  margin: 0;
+}

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/suggestion.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/suggestion.js
@@ -1,0 +1,91 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ReactRenderer } from '@tiptap/react';
+import { type } from '@lowdefy/helpers';
+import tippy from 'tippy.js';
+
+import MentionList from './MentionList.js';
+
+function suggestion({ methods, char = '@', allowSpaces = true }) {
+  return {
+    // `char` must be set explicitly: Mention.configure does a shallow merge
+    // on its options.suggestion, replacing the extension's default `@`.
+    char,
+    allowSpaces,
+    items: ({ query, editor }) => {
+      const itemsList = editor.options.editorProps.items ?? [];
+      return itemsList
+        .filter((item) => {
+          if (type.isString(item)) {
+            return item.toLowerCase().includes(query.toLowerCase());
+          }
+          if (type.isString(item?.label)) {
+            return item.label.toLowerCase().includes(query.toLowerCase());
+          }
+          return false;
+        })
+        .slice(0, 5);
+    },
+
+    render: () => {
+      let component;
+      let popup;
+
+      return {
+        onStart: (props) => {
+          component = new ReactRenderer(MentionList, {
+            props: { ...props, methods },
+            editor: props.editor,
+          });
+
+          if (!props.clientRect) return;
+
+          popup = tippy('body', {
+            getReferenceClientRect: props.clientRect,
+            appendTo: () => document.body,
+            content: component.element,
+            showOnCreate: true,
+            interactive: true,
+            trigger: 'manual',
+            placement: 'bottom-start',
+          });
+        },
+
+        onUpdate(props) {
+          component.updateProps(props);
+          if (!props.clientRect) return;
+          popup[0].setProps({ getReferenceClientRect: props.clientRect });
+        },
+
+        onKeyDown(props) {
+          if (props.event.key === 'Escape') {
+            popup[0].hide();
+            return true;
+          }
+          return component.ref?.onKeyDown(props);
+        },
+
+        onExit() {
+          popup[0].destroy();
+          component.destroy();
+        },
+      };
+    },
+  };
+}
+
+export default suggestion;

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests.yaml
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests.yaml
@@ -1,0 +1,45 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- id: default
+  type: TiptapMentionInput
+- id: properties.placeholder
+  type: TiptapMentionInput
+  properties:
+    placeholder: 'Type @ to mention...'
+- id: properties.disabled
+  type: TiptapMentionInput
+  properties:
+    disabled: true
+- id: properties.mentions.options
+  type: TiptapMentionInput
+  properties:
+    mentions:
+      options:
+        - label: Alice
+          value:
+            _id: user_1
+        - label: Bob
+          value:
+            _id: user_2
+- id: properties.mentions.char = '#'
+  type: TiptapMentionInput
+  properties:
+    placeholder: 'Type # to tag'
+    mentions:
+      char: '#'
+      options:
+        - label: bug
+          value:
+            _id: tag_bug

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests/TiptapMentionInput.e2e.spec.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests/TiptapMentionInput.e2e.spec.js
@@ -1,0 +1,73 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { test, expect } from '@playwright/test';
+import { getBlock, navigateToTestPage } from '@lowdefy/block-dev-e2e';
+
+const editorLocator = (page, blockId) => page.locator(`#${blockId}_input .ProseMirror`).first();
+
+test.describe('TiptapMentionInput Block', () => {
+  test.beforeEach(async ({ page }) => {
+    await navigateToTestPage(page, 'tiptap-mention-input');
+  });
+
+  test('renders empty editor', async ({ page }) => {
+    const block = getBlock(page, 'tiptap_mention_empty');
+    await expect(block).toBeVisible();
+    const editor = editorLocator(page, 'tiptap_mention_empty');
+    await expect(editor).toBeVisible();
+    await expect(editor).toHaveAttribute('contenteditable', 'true');
+  });
+
+  test('renders placeholder when empty', async ({ page }) => {
+    const editor = editorLocator(page, 'tiptap_mention_placeholder');
+    const placeholderEl = editor.locator('p.is-editor-empty').first();
+    await expect(placeholderEl).toHaveAttribute('data-placeholder', 'Type @ to mention...');
+  });
+
+  test('renders initial html value with mention node', async ({ page }) => {
+    const editor = editorLocator(page, 'tiptap_mention_with_value');
+    await expect(editor).toContainText('@Alice');
+    await expect(editor.locator('.tiptap-mention')).toBeVisible();
+  });
+
+  test('disabled editor is not editable', async ({ page }) => {
+    const editor = editorLocator(page, 'tiptap_mention_disabled');
+    await expect(editor).toHaveAttribute('contenteditable', 'false');
+  });
+
+  test('typing @ opens mention dropdown with filtered options', async ({ page }) => {
+    const editor = editorLocator(page, 'tiptap_mention_options');
+    await editor.click();
+    await page.keyboard.type('@A');
+    const dropdown = page.locator('.tiptap-mention-items');
+    await expect(dropdown).toBeVisible();
+    await expect(dropdown.locator('.tiptap-mention-item', { hasText: 'Alice' })).toBeVisible();
+  });
+
+  test('selecting a mention renders the trigger char and label (not undefined)', async ({
+    page,
+  }) => {
+    const editor = editorLocator(page, 'tiptap_mention_options');
+    await editor.click();
+    await page.keyboard.type('@B');
+    await page.locator('.tiptap-mention-items .tiptap-mention-item', { hasText: 'Bob' }).click();
+    const mention = editor.locator('.tiptap-mention');
+    await expect(mention).toBeVisible();
+    await expect(mention).toHaveText('@Bob');
+    await expect(editor).not.toContainText('undefined');
+  });
+});

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests/TiptapMentionInput.e2e.yaml
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests/TiptapMentionInput.e2e.yaml
@@ -1,0 +1,56 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: tiptap-mention-input
+type: Box
+
+events:
+  onMount:
+    - id: seed_content
+      type: SetState
+      params:
+        tiptap_mention_with_value:
+          html: '<p>Hi <span class="tiptap-mention">@Alice</span>.</p>'
+        tiptap_mention_disabled:
+          html: '<p>Disabled mention editor.</p>'
+
+blocks:
+  - id: tiptap_mention_empty
+    type: TiptapMentionInput
+
+  - id: tiptap_mention_placeholder
+    type: TiptapMentionInput
+    properties:
+      placeholder: 'Type @ to mention...'
+
+  - id: tiptap_mention_with_value
+    type: TiptapMentionInput
+
+  - id: tiptap_mention_disabled
+    type: TiptapMentionInput
+    properties:
+      disabled: true
+
+  - id: tiptap_mention_options
+    type: TiptapMentionInput
+    properties:
+      placeholder: 'Try @A'
+      mentions:
+        options:
+          - label: Alice
+            value:
+              _id: user_1
+          - label: Bob
+            value:
+              _id: user_2

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/useTiptapMentionState.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/useTiptapMentionState.js
@@ -1,0 +1,97 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { useRef } from 'react';
+import TurndownService from 'turndown';
+
+import s3FileUpload from '../utils/s3FileUpload.js';
+
+// Ref-tracked controller for the mention editor's value. Mirrors TiptapInput's
+// useTiptapState but also extracts mentions from the document.
+function useTiptapMentionState({ value, methods }) {
+  const valueRef = useRef(value);
+  valueRef.current = value;
+
+  const turndownService = new TurndownService();
+  turndownService.addRule('encodeImgUrl', {
+    filter: 'img',
+    replacement: (content, node) => {
+      const src = node.getAttribute('src');
+      return `![${content}](${encodeURI(src)})`;
+    },
+  });
+
+  const emit = (editor, appendFile) => {
+    const html = editor.getHTML();
+    const markdown = turndownService.turndown(html);
+    const json = editor.getJSON();
+    const text = editor.getText().trim() === '' ? null : editor.getText();
+    const urls = (json.content ?? []).filter((c) => c.type === 'image').map((c) => c.attrs.src);
+    const base = valueRef.current?.fileList ?? [];
+    const next = appendFile ? [...base, appendFile] : base;
+    const fileList = next.filter((f) => urls.includes(f.url));
+
+    const mentionsMap = new Map();
+    (json.content ?? [])
+      .filter((c) => c.type === 'paragraph')
+      .forEach((c) => {
+        c.content?.forEach((cc) => {
+          if (cc.type === 'mention') {
+            mentionsMap.set(JSON.stringify(cc.attrs.id.value), cc.attrs.id.value);
+          }
+        });
+      });
+    const mentions = Array.from(mentionsMap.values());
+
+    methods.setValue({ fileList, html, mentions, text, markdown });
+  };
+
+  const insertImage = async (editor, file, pos) => {
+    const url = await s3FileUpload({ file, methods });
+    editor
+      .chain()
+      .insertContentAt(pos, [
+        { type: 'image', attrs: { src: url } },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              marks: [{ type: 'link', attrs: { href: url, target: '_blank' } }],
+              text: 'Enlarge Image',
+            },
+          ],
+        },
+      ])
+      .focus()
+      .run();
+    const fileObj = {
+      bucket: file.bucket,
+      key: file.key,
+      lastModified: file.lastModified,
+      name: file.name,
+      size: file.size,
+      status: file.status,
+      type: file.type,
+      url,
+    };
+    emit(editor, fileObj);
+  };
+
+  return { emit, insertImage };
+}
+
+export default useTiptapMentionState;

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/PopoverMenu.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/PopoverMenu.js
@@ -1,0 +1,96 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import React from 'react';
+import { BubbleMenu } from '@tiptap/react';
+import {
+  AiOutlineBold,
+  AiOutlineItalic,
+  AiOutlineStrikethrough,
+  AiOutlineHighlight,
+} from 'react-icons/ai';
+import { isTextSelection } from '@tiptap/core';
+
+const HIGHLIGHT_SWATCHES = [
+  { color: 'rgba(170, 255, 0, 1)', fill: 'rgba(170, 255, 0, 0.5)' },
+  { color: 'rgba(255, 170, 0, 1)', fill: 'rgba(255, 170, 0, 0.5)' },
+  { color: 'rgba(255, 0, 170, 1)', fill: 'rgba(255, 0, 170, 0.5)' },
+  { color: 'rgba(170, 0, 255, 1)', fill: 'rgba(170, 0, 255, 0.5)' },
+];
+
+function hasExt(editor, name) {
+  return editor.extensionManager.extensions.some((ext) => ext.name === name);
+}
+
+const PopoverMenu = ({ editor }) => {
+  const showBold = hasExt(editor, 'bold');
+  const showItalic = hasExt(editor, 'italic');
+  const showStrike = hasExt(editor, 'strike');
+  const showHighlight = hasExt(editor, 'highlight');
+
+  if (!showBold && !showItalic && !showStrike && !showHighlight) {
+    return null;
+  }
+
+  return (
+    <BubbleMenu
+      className="tiptap-popover"
+      editor={editor}
+      shouldShow={({ editor, view, state, from, to }) => {
+        if (editor.isActive('image')) return false;
+        const { doc, selection } = state;
+        const { empty } = selection;
+        const isEmptyTextBlock =
+          !doc.textBetween(from, to).length && isTextSelection(state.selection);
+        const hasEditorFocus = view.hasFocus();
+        if (!hasEditorFocus || empty || isEmptyTextBlock || !editor.isEditable) {
+          return false;
+        }
+        return true;
+      }}
+    >
+      {showBold && (
+        <AiOutlineBold
+          className="tiptap-icon"
+          onClick={() => editor.chain().focus().toggleBold().run()}
+        />
+      )}
+      {showItalic && (
+        <AiOutlineItalic
+          className="tiptap-icon"
+          onClick={() => editor.chain().focus().toggleItalic().run()}
+        />
+      )}
+      {showStrike && (
+        <AiOutlineStrikethrough
+          className="tiptap-icon"
+          onClick={() => editor.chain().focus().toggleStrike().run()}
+        />
+      )}
+      {showHighlight &&
+        HIGHLIGHT_SWATCHES.map(({ color, fill }) => (
+          <AiOutlineHighlight
+            key={color}
+            className="tiptap-icon"
+            style={{ color }}
+            onClick={() => editor.chain().focus().toggleHighlight({ color: fill }).run()}
+          />
+        ))}
+    </BubbleMenu>
+  );
+};
+
+export default PopoverMenu;

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/buildExtensions.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/buildExtensions.js
@@ -1,0 +1,136 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import FileHandler from '@tiptap/extension-file-handler';
+import Highlight from '@tiptap/extension-highlight';
+import Image from '@tiptap/extension-image';
+import Placeholder from '@tiptap/extension-placeholder';
+import StarterKit from '@tiptap/starter-kit';
+import LinkExtension from '@tiptap/extension-link';
+import Table from '@tiptap/extension-table';
+import TableCell from '@tiptap/extension-table-cell';
+import TableHeader from '@tiptap/extension-table-header';
+import TableRow from '@tiptap/extension-table-row';
+import { type } from '@lowdefy/helpers';
+
+const DEFAULT_IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+
+const DEFAULTS = {
+  image: { disabled: false, maxWidth: '80%', zoom: 0.5 },
+  table: { disabled: false, resizable: true },
+  link: {
+    disabled: false,
+    openOnClick: true,
+    autolink: true,
+    linkOnPaste: true,
+    defaultProtocol: 'https',
+  },
+  highlight: { disabled: false, multicolor: true },
+};
+
+function merge(defaults, overrides) {
+  if (!type.isObject(overrides)) return defaults;
+  return { ...defaults, ...overrides };
+}
+
+function buildExtensions({ properties, insertImage, mentionExtension, uploadEnabled }) {
+  const image = merge(DEFAULTS.image, properties.image);
+  const table = merge(DEFAULTS.table, properties.table);
+  const link = merge(DEFAULTS.link, properties.link);
+  const highlight = merge(DEFAULTS.highlight, properties.highlight);
+  const starterKitOptions = type.isObject(properties.starterKit) ? properties.starterKit : {};
+  const allowedMimeTypes = type.isArray(properties.allowedMimeTypes)
+    ? properties.allowedMimeTypes
+    : DEFAULT_IMAGE_MIME_TYPES;
+
+  const extensions = [StarterKit.configure(starterKitOptions)];
+
+  if (!table.disabled) {
+    extensions.push(
+      Table.configure({
+        HTMLAttributes: { class: 'tiptap-table' },
+        resizable: table.resizable,
+      }),
+      TableRow,
+      TableHeader,
+      TableCell
+    );
+  }
+
+  if (!image.disabled) {
+    extensions.push(
+      Image.configure({
+        HTMLAttributes: {
+          style: `max-width: ${image.maxWidth}; display: block; zoom: ${image.zoom};`,
+        },
+      })
+    );
+  }
+
+  extensions.push(
+    Placeholder.configure({
+      placeholder: () => properties.placeholder ?? '',
+      showOnlyWhenEditable: false,
+      considerAnyAsEmpty: true,
+    })
+  );
+
+  if (!highlight.disabled) {
+    extensions.push(
+      Highlight.configure({
+        multicolor: highlight.multicolor,
+        HTMLAttributes: { style: 'padding: 0;' },
+      })
+    );
+  }
+
+  if (!link.disabled) {
+    extensions.push(
+      LinkExtension.configure({
+        autolink: link.autolink,
+        linkOnPaste: link.linkOnPaste,
+        openOnClick: link.openOnClick,
+        defaultProtocol: link.defaultProtocol,
+      })
+    );
+  }
+
+  if (mentionExtension) {
+    extensions.push(mentionExtension);
+  }
+
+  if (uploadEnabled) {
+    extensions.push(
+      FileHandler.configure({
+        onDrop: (editor, files, pos) => {
+          files.forEach((file) => insertImage(editor, file, pos));
+        },
+        onPaste: (editor, files, htmlContent) => {
+          if (htmlContent) return false;
+          files.forEach((file) => {
+            const pos = editor.state.selection.anchor;
+            insertImage(editor, file, pos);
+          });
+        },
+        allowedMimeTypes,
+      })
+    );
+  }
+
+  return extensions;
+}
+
+export default buildExtensions;

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/computeHeightStyle.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/computeHeightStyle.js
@@ -1,0 +1,55 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { type } from '@lowdefy/helpers';
+
+// Matches ant-design Input's line-height ratio at the default font size,
+// plus the 8px top/bottom padding on the ProseMirror editable area.
+const LINE_HEIGHT = '1.5714em';
+const VERTICAL_PADDING = 16;
+
+function calcRows(n) {
+  return `calc(${n} * ${LINE_HEIGHT} + ${VERTICAL_PADDING}px)`;
+}
+
+const DEFAULT_MIN_ROWS = 5;
+
+// Translate TextArea-style rows/autoSize props into React inline CSS applied
+// to the EditorContent wrapper. The wrapper becomes the scroll container;
+// ProseMirror's editable inside grows naturally.
+function computeHeightStyle({ rows, autoSize }) {
+  if (type.isInt(rows) && rows >= 1) {
+    const h = calcRows(rows);
+    return { minHeight: h, maxHeight: h, overflowY: 'auto' };
+  }
+  if (autoSize === true) {
+    return { minHeight: calcRows(1), maxHeight: 'none' };
+  }
+  if (type.isObject(autoSize)) {
+    const style = {};
+    if (type.isInt(autoSize.minRows) && autoSize.minRows >= 1) {
+      style.minHeight = calcRows(autoSize.minRows);
+    }
+    if (type.isInt(autoSize.maxRows) && autoSize.maxRows >= 1) {
+      style.maxHeight = calcRows(autoSize.maxRows);
+      style.overflowY = 'auto';
+    }
+    if (Object.keys(style).length > 0) return style;
+  }
+  return { minHeight: calcRows(DEFAULT_MIN_ROWS) };
+}
+
+export default computeHeightStyle;

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/s3FileUpload.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/s3FileUpload.js
@@ -1,0 +1,47 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+async function s3FileUpload({ file, methods }) {
+  if (!file) {
+    return;
+  }
+  const { lastModified, name, size, type, uid } = file;
+  const s3PostPolicyResponse = await methods.triggerEvent({
+    name: '__getS3PostPolicy',
+    event: { file: { name, lastModified, size, type, uid } },
+  });
+
+  if (s3PostPolicyResponse.success !== true) {
+    throw new Error('S3 post policy request error.');
+  }
+
+  const { url, fields } = s3PostPolicyResponse.responses.__getS3PostPolicy.response[0];
+  const { bucket, key } = fields;
+  file.bucket = bucket;
+  file.key = key;
+
+  const formData = new FormData();
+  Object.keys(fields).forEach((field) => {
+    formData.append(field, fields[field]);
+  });
+  formData.append('file', file);
+
+  await fetch(url, { method: 'POST', body: formData });
+  file.url = `${url}/${key}`;
+  return file.url;
+}
+
+export default s3FileUpload;

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/statusClass.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/statusClass.js
@@ -1,0 +1,27 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Map validation.status → wrapper class. Matches the visual behavior of
+// passing status="error" | "warning" to an antd <Input />, but rendered
+// with our own CSS (see utils/style.module.css) because antd v6 uses
+// CSS-in-JS, so the .ant-input-status-* classes are not global.
+function statusClass(status) {
+  if (status === 'error') return 'tiptap-wrapper-error';
+  if (status === 'warning') return 'tiptap-wrapper-warning';
+  return '';
+}
+
+export default statusClass;

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/style.module.css
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/style.module.css
@@ -1,0 +1,128 @@
+/* Wrapper: the EditorContent div with border/background/focus styling.
+   Antd v6 uses CSS-in-JS so the `.ant-input` class is not a global
+   stylesheet class — we replicate the input look using antd's theme
+   CSS variables (--ant-color-*, --ant-border-radius) so the block
+   tracks the active theme without depending on cssinjs. */
+:global(.tiptap-wrapper) {
+  border: 1px solid var(--ant-color-border, #d9d9d9);
+  border-radius: var(--ant-border-radius, 6px);
+  background: var(--ant-color-bg-container, #fff);
+  color: var(--ant-color-text, rgba(0, 0, 0, 0.88));
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s,
+    background 0.2s;
+  padding: 0;
+}
+
+:global(.tiptap-wrapper):hover {
+  border-color: var(--ant-color-primary-hover, #4096ff);
+}
+
+:global(.tiptap-wrapper):focus-within {
+  border-color: var(--ant-color-primary, #1677ff);
+  box-shadow: 0 0 0 2px var(--ant-color-primary-bg, rgba(22, 119, 255, 0.1));
+  outline: none;
+}
+
+:global(.tiptap-wrapper-borderless) {
+  border-color: transparent;
+  background: transparent;
+}
+
+:global(.tiptap-wrapper-borderless):hover,
+:global(.tiptap-wrapper-borderless):focus-within {
+  border-color: transparent;
+  box-shadow: none;
+}
+
+:global(.tiptap-wrapper-error) {
+  border-color: var(--ant-color-error, #ff4d4f);
+}
+
+:global(.tiptap-wrapper-error):hover {
+  border-color: var(--ant-color-error-hover, var(--ant-color-error, #ff4d4f));
+}
+
+:global(.tiptap-wrapper-error):focus-within {
+  border-color: var(--ant-color-error, #ff4d4f);
+  box-shadow: 0 0 0 2px var(--ant-color-error-bg, rgba(255, 77, 79, 0.1));
+}
+
+:global(.tiptap-wrapper-warning) {
+  border-color: var(--ant-color-warning, #faad14);
+}
+
+:global(.tiptap-wrapper-warning):hover {
+  border-color: var(--ant-color-warning-hover, var(--ant-color-warning, #faad14));
+}
+
+:global(.tiptap-wrapper-warning):focus-within {
+  border-color: var(--ant-color-warning, #faad14);
+  box-shadow: 0 0 0 2px var(--ant-color-warning-bg, rgba(250, 173, 20, 0.1));
+}
+
+:global(.tiptap-wrapper-disabled) {
+  background: var(--ant-color-bg-container-disabled, rgba(0, 0, 0, 0.04));
+  color: var(--ant-color-text-disabled, rgba(0, 0, 0, 0.25));
+  cursor: not-allowed;
+}
+
+:global(.tiptap-wrapper-disabled):hover {
+  border-color: var(--ant-color-border, #d9d9d9);
+}
+
+:global(.tiptap-wrapper-disabled) :global(.tiptap.ProseMirror) {
+  cursor: not-allowed;
+}
+
+/* ProseMirror editable — sits inside the wrapper. */
+:global(.tiptap.ProseMirror) {
+  padding: 8px;
+  outline: none;
+}
+
+:global(.tiptap) :global(p) {
+  margin: 0;
+}
+
+:global(.tiptap) :global(p.is-editor-empty):first-child::before {
+  color: var(--ant-color-text-placeholder, rgba(0, 0, 0, 0.25));
+  content: attr(data-placeholder);
+  float: left;
+  height: 0;
+  pointer-events: none;
+}
+
+:global(.tiptap-popover) {
+  background: rgba(0, 0, 0, 0.85);
+  color: var(--ant-color-text-light-solid, #fff);
+  border-radius: var(--ant-border-radius, 8px);
+  padding: 4px;
+  margin: -4px;
+  display: flex;
+}
+
+:global(.tiptap-icon) {
+  border-radius: var(--ant-border-radius-sm, 4px);
+  display: flex;
+  width: 16px;
+  height: 16px;
+  justify-content: center;
+  align-items: center;
+  color: var(--ant-color-text-light-solid, #fff);
+}
+
+:global(.tiptap-icon.disabled) {
+  pointer-events: none;
+}
+
+:global(.tiptap-icon):hover {
+  background: var(--ant-color-icon-hover, rgba(0, 0, 0, 0.75));
+  color: var(--ant-color-text-light-solid, #fff);
+  cursor: pointer;
+}
+
+:global(.tiptap-icon) + :global(.tiptap-icon) {
+  margin-left: 4px;
+}

--- a/packages/plugins/blocks/blocks-tiptap/src/e2e.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/e2e.js
@@ -1,0 +1,18 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+export { default as TiptapInput } from './blocks/TiptapInput/e2e.js';
+export { default as TiptapMentionInput } from './blocks/TiptapMentionInput/e2e.js';

--- a/packages/plugins/blocks/blocks-tiptap/src/metas.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/metas.js
@@ -1,0 +1,18 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+export { default as TiptapInput } from './blocks/TiptapInput/meta.js';
+export { default as TiptapMentionInput } from './blocks/TiptapMentionInput/meta.js';

--- a/packages/plugins/blocks/blocks-tiptap/src/types.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/types.js
@@ -1,0 +1,21 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { extractBlockTypes } from '@lowdefy/block-utils';
+
+import * as metas from './metas.js';
+
+export default extractBlockTypes(metas);

--- a/packages/plugins/plugins/plugin-aws/src/connections/AwsS3Bucket/AwsS3PresignedPostPolicy/AwsS3PresignedPostPolicy.js
+++ b/packages/plugins/plugins/plugin-aws/src/connections/AwsS3Bucket/AwsS3PresignedPostPolicy/AwsS3PresignedPostPolicy.js
@@ -41,7 +41,12 @@ async function AwsS3PresignedPostPolicy({ request, connection }) {
   }
   Object.keys(fields).forEach((field) => {
     if (fields[field]) {
-      params.Fields[field] = fields[field];
+      // S3 user metadata values must be ASCII. URL-encode x-amz-meta-* values so
+      // non-ASCII characters (names, URLs, etc.) survive the round trip. Other
+      // protocol fields (acl, Content-Type, ...) must be passed through literally.
+      params.Fields[field] = field.toLowerCase().startsWith('x-amz-meta-')
+        ? encodeURIComponent(fields[field])
+        : fields[field];
     }
   });
   const s3 = new S3Client({

--- a/packages/plugins/plugins/plugin-aws/src/connections/AwsS3Bucket/AwsS3PresignedPostPolicy/AwsS3PresignedPostPolicy.test.js
+++ b/packages/plugins/plugins/plugin-aws/src/connections/AwsS3Bucket/AwsS3PresignedPostPolicy/AwsS3PresignedPostPolicy.test.js
@@ -120,6 +120,36 @@ test('AwsS3PresignedPostPolicy options', async () => {
   expect(res).toEqual('res');
 });
 
+test('AwsS3PresignedPostPolicy URL-encodes x-amz-meta-* fields but passes other fields through', async () => {
+  const request = {
+    key: 'key',
+    acl: 'private',
+  };
+  const connection = {
+    accessKeyId: 'accessKeyId',
+    secretAccessKey: 'secretAccessKey',
+    region: 'region',
+    write: true,
+    bucket: 'bucket',
+  };
+  // Fields are normally injected via request.properties.fields in the engine;
+  // simulate that shape here by attaching fields directly to the request.
+  request.fields = {
+    'x-amz-meta-uploaded-by-name': 'Zoë Güven',
+    'x-amz-meta-uploaded-by-url': 'https://example.com/page?q=hello world',
+    'X-Amz-Meta-Mixed-Case': 'a b',
+    'Content-Type': 'application/pdf',
+  };
+  await AwsS3PresignedPostPolicy({ request, connection });
+  expect(mockCreatePresignedPost.mock.calls[0][1].Fields).toEqual({
+    acl: 'private',
+    'x-amz-meta-uploaded-by-name': 'Zo%C3%AB%20G%C3%BCven',
+    'x-amz-meta-uploaded-by-url': 'https%3A%2F%2Fexample.com%2Fpage%3Fq%3Dhello%20world',
+    'X-Amz-Meta-Mixed-Case': 'a%20b',
+    'Content-Type': 'application/pdf',
+  });
+});
+
 test('Error from s3 client', async () => {
   mockCreatePresignedPost.mockImplementation(() => {
     throw new Error('Test S3 client error.');

--- a/packages/servers/server-dev/package.json
+++ b/packages/servers/server-dev/package.json
@@ -53,6 +53,7 @@
     "@lowdefy/blocks-echarts": "5.0.0",
     "@lowdefy/blocks-loaders": "5.0.0",
     "@lowdefy/blocks-markdown": "5.0.0",
+    "@lowdefy/blocks-tiptap": "5.0.0",
     "@lowdefy/build": "5.0.0",
     "@lowdefy/client": "5.0.0",
     "@lowdefy/connection-axios-http": "5.0.0",

--- a/packages/servers/server-e2e/next.config.js
+++ b/packages/servers/server-e2e/next.config.js
@@ -3,7 +3,12 @@ const lowdefyConfig = require('./build/config.json');
 const nextConfig = {
   basePath: lowdefyConfig.basePath,
   reactStrictMode: true,
-  transpilePackages: ['@lowdefy/client', '@lowdefy/blocks-loaders', '@lowdefy/blocks-markdown'],
+  transpilePackages: [
+    '@lowdefy/client',
+    '@lowdefy/blocks-loaders',
+    '@lowdefy/blocks-markdown',
+    '@lowdefy/blocks-tiptap',
+  ],
   webpack: (config, { isServer }) => {
     if (!isServer) {
       config.resolve.fallback = {

--- a/packages/servers/server-e2e/package.json
+++ b/packages/servers/server-e2e/package.json
@@ -56,6 +56,7 @@
     "@lowdefy/blocks-basic": "5.0.0",
     "@lowdefy/blocks-loaders": "5.0.0",
     "@lowdefy/blocks-markdown": "5.0.0",
+    "@lowdefy/blocks-tiptap": "5.0.0",
     "@lowdefy/client": "5.0.0",
     "@lowdefy/connection-axios-http": "5.0.0",
     "@lowdefy/connection-mongodb": "5.0.0",

--- a/packages/servers/server/package.json
+++ b/packages/servers/server/package.json
@@ -54,6 +54,7 @@
     "@lowdefy/blocks-antd": "5.0.0",
     "@lowdefy/blocks-basic": "5.0.0",
     "@lowdefy/blocks-loaders": "5.0.0",
+    "@lowdefy/blocks-tiptap": "5.0.0",
     "@lowdefy/client": "5.0.0",
     "@lowdefy/errors": "5.0.0",
     "@lowdefy/helpers": "5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       '@lowdefy/blocks-qr':
         specifier: 5.0.0
         version: link:../plugins/blocks/blocks-qr
+      '@lowdefy/blocks-tiptap':
+        specifier: 5.0.0
+        version: link:../plugins/blocks/blocks-tiptap
       '@lowdefy/connection-axios-http':
         specifier: 5.0.0
         version: link:../plugins/connections/connection-axios-http
@@ -1027,6 +1030,94 @@ importers:
         specifier: 2.4.1
         version: 2.4.1
 
+  packages/plugins/blocks/blocks-tiptap:
+    dependencies:
+      '@lowdefy/block-utils':
+        specifier: 5.0.0
+        version: link:../../../utils/block-utils
+      '@lowdefy/blocks-antd':
+        specifier: 5.0.0
+        version: link:../blocks-antd
+      '@lowdefy/helpers':
+        specifier: 5.0.0
+        version: link:../../../utils/helpers
+      '@tiptap/core':
+        specifier: 2.27.2
+        version: 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/extension-file-handler':
+        specifier: 2.27.2
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/extension-text-style@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2)))
+      '@tiptap/extension-highlight':
+        specifier: 2.27.2
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-image':
+        specifier: 2.27.2
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-link':
+        specifier: 2.27.2
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+      '@tiptap/extension-mention':
+        specifier: 2.27.2
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(@tiptap/suggestion@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2))
+      '@tiptap/extension-placeholder':
+        specifier: 2.27.2
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+      '@tiptap/extension-table':
+        specifier: 2.27.2
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+      '@tiptap/extension-table-cell':
+        specifier: 2.27.2
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-table-header':
+        specifier: 2.27.2
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-table-row':
+        specifier: 2.27.2
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/pm':
+        specifier: 2.27.2
+        version: 2.27.2
+      '@tiptap/react':
+        specifier: 2.27.2
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tiptap/starter-kit':
+        specifier: 2.27.2
+        version: 2.27.2
+      react:
+        specifier: '>=18'
+        version: 18.2.0
+      react-dom:
+        specifier: '>=18'
+        version: 18.2.0(react@18.2.0)
+      react-icons:
+        specifier: 5.6.0
+        version: 5.6.0(react@18.2.0)
+      tippy.js:
+        specifier: 6.3.7
+        version: 6.3.7
+      turndown:
+        specifier: 7.2.0
+        version: 7.2.0
+    devDependencies:
+      '@lowdefy/block-dev-e2e':
+        specifier: 5.0.0
+        version: link:../../../utils/block-dev-e2e
+      '@lowdefy/e2e-utils':
+        specifier: 5.0.0
+        version: link:../../../utils/e2e-utils
+      '@playwright/test':
+        specifier: 1.50.1
+        version: 1.50.1
+      '@swc/cli':
+        specifier: 0.8.0
+        version: 0.8.0(@swc/core@1.15.18)
+      '@swc/core':
+        specifier: 1.15.18
+        version: 1.15.18
+      copyfiles:
+        specifier: 2.4.1
+        version: 2.4.1
+
   packages/plugins/connections/connection-axios-http:
     dependencies:
       '@lowdefy/helpers':
@@ -1748,6 +1839,9 @@ importers:
       '@lowdefy/blocks-loaders':
         specifier: 5.0.0
         version: link:../../plugins/blocks/blocks-loaders
+      '@lowdefy/blocks-tiptap':
+        specifier: 5.0.0
+        version: link:../../plugins/blocks/blocks-tiptap
       '@lowdefy/client':
         specifier: 5.0.0
         version: link:../../client
@@ -1857,6 +1951,9 @@ importers:
       '@lowdefy/blocks-markdown':
         specifier: 5.0.0
         version: link:../../plugins/blocks/blocks-markdown
+      '@lowdefy/blocks-tiptap':
+        specifier: 5.0.0
+        version: link:../../plugins/blocks/blocks-tiptap
       '@lowdefy/build':
         specifier: 5.0.0
         version: link:../../build
@@ -2005,6 +2102,9 @@ importers:
       '@lowdefy/blocks-markdown':
         specifier: 5.0.0
         version: link:../../plugins/blocks/blocks-markdown
+      '@lowdefy/blocks-tiptap':
+        specifier: 5.0.0
+        version: link:../../plugins/blocks/blocks-tiptap
       '@lowdefy/client':
         specifier: 5.0.0
         version: link:../../client
@@ -3731,6 +3831,9 @@ packages:
     resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
     hasBin: true
 
+  '@mixmark-io/domino@2.2.0':
+    resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+
   '@mongodb-js/saslprep@1.1.0':
     resolution: {integrity: sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==}
 
@@ -4360,6 +4463,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@popperjs/core@2.11.8':
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
   '@posthog/core@1.20.2':
     resolution: {integrity: sha512-aQhrUzOHYr0z/bkwDsJ5hXahdh6oyeWdx2/CHwR6vFG3eK07J69lbuGOj+HGOOxJP1eAdNnsk8J0fj1vqRA9+A==}
 
@@ -4722,6 +4828,9 @@ packages:
     resolution: {integrity: sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==}
     peerDependencies:
       '@redis/client': ^1.0.0
+
+  '@remirror/core-constants@3.0.0':
+    resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
   '@rollup/plugin-commonjs@28.0.1':
     resolution: {integrity: sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==}
@@ -5465,6 +5574,199 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@tiptap/core@2.27.2':
+    resolution: {integrity: sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==}
+    peerDependencies:
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-blockquote@2.27.2':
+    resolution: {integrity: sha512-oIGZgiAeA4tG3YxbTDfrmENL4/CIwGuP3THtHsNhwRqwsl9SfMk58Ucopi2GXTQSdYXpRJ0ahE6nPqB5D6j/Zw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-bold@2.27.2':
+    resolution: {integrity: sha512-bR7J5IwjCGQ0s3CIxyMvOCnMFMzIvsc5OVZKscTN5UkXzFsaY6muUAIqtKxayBUucjtUskm5qZowJITCeCb1/A==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-bubble-menu@2.27.2':
+    resolution: {integrity: sha512-VkwlCOcr0abTBGzjPXklJ92FCowG7InU8+Od9FyApdLNmn0utRYGRhw0Zno6VgE9EYr1JY4BRnuSa5f9wlR72w==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-bullet-list@2.27.2':
+    resolution: {integrity: sha512-gmFuKi97u5f8uFc/GQs+zmezjiulZmFiDYTh3trVoLRoc2SAHOjGEB7qxdx7dsqmMN7gwiAWAEVurLKIi1lnnw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-code-block@2.27.2':
+    resolution: {integrity: sha512-KgvdQHS4jXr79aU3wZOGBIZYYl9vCB7uDEuRFV4so2rYrfmiYMw3T8bTnlNEEGe4RUeAms1i4fdwwvQp9nR1Dw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-code@2.27.2':
+    resolution: {integrity: sha512-7X9AgwqiIGXoZX7uvdHQsGsjILnN/JaEVtqfXZnPECzKGaWHeK/Ao4sYvIIIffsyZJA8k5DC7ny2/0sAgr2TuA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-document@2.27.2':
+    resolution: {integrity: sha512-CFhAYsPnyYnosDC4639sCJnBUnYH4Cat9qH5NZWHVvdgtDwu8GZgZn2eSzaKSYXWH1vJ9DSlCK+7UyC3SNXIBA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-dropcursor@2.27.2':
+    resolution: {integrity: sha512-oEu/OrktNoQXq1x29NnH/GOIzQZm8ieTQl3FK27nxfBPA89cNoH4mFEUmBL5/OFIENIjiYG3qWpg6voIqzswNw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-file-handler@2.27.2':
+    resolution: {integrity: sha512-RaGBOp/2eH0DonCD0xouk9o+3z5TuYuyZTxHvh1CA3H8pH3gFufRbkI+D9Lu3Uhb149isM5L01FpgX1f6BYkFg==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/extension-text-style': ^2.7.0
+
+  '@tiptap/extension-floating-menu@2.27.2':
+    resolution: {integrity: sha512-GUN6gPIGXS7ngRJOwdSmtBRBDt9Kt9CM/9pSwKebhLJ+honFoNA+Y6IpVyDvvDMdVNgBchiJLs6qA5H97gAePQ==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-gapcursor@2.27.2':
+    resolution: {integrity: sha512-/c9VF1HBxj+AP54XGVgCmD9bEGYc5w5OofYCFQgM7l7PB1J00A4vOke0oPkHJnqnOOyPlFaxO/7N6l3XwFcnKA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-hard-break@2.27.2':
+    resolution: {integrity: sha512-kSRVGKlCYK6AGR0h8xRkk0WOFGXHIIndod3GKgWU49APuIGDiXd8sziXsSlniUsWmqgDmDXcNnSzPcV7AQ8YNg==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-heading@2.27.2':
+    resolution: {integrity: sha512-iM3yeRWuuQR/IRQ1djwNooJGfn9Jts9zF43qZIUf+U2NY8IlvdNsk2wTOdBgh6E0CamrStPxYGuln3ZS4fuglw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-highlight@2.27.2':
+    resolution: {integrity: sha512-ZjlktDdMjruMJFAVz0TbQf0v92Jqkc7Ri1iZJqBXuLid+r+GxUzl2CVAV7qq5yagkGQgvAG+WGsMk880HgR3MA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-history@2.27.2':
+    resolution: {integrity: sha512-+hSyqERoFNTWPiZx4/FCyZ/0eFqB9fuMdTB4AC/q9iwu3RNWAQtlsJg5230bf/qmyO6bZxRUc0k8p4hrV6ybAw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-horizontal-rule@2.27.2':
+    resolution: {integrity: sha512-WGWUSgX+jCsbtf9Y9OCUUgRZYuwjVoieW5n6mAUohJ9/6gc6sGIOrUpBShf+HHo6WD+gtQjRd+PssmX3NPWMpg==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-image@2.27.2':
+    resolution: {integrity: sha512-5zL/BY41FIt72azVrCrv3n+2YJ/JyO8wxCcA4Dk1eXIobcgVyIdo4rG39gCqIOiqziAsqnqoj12QHTBtHsJ6mQ==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-italic@2.27.2':
+    resolution: {integrity: sha512-1OFsw2SZqfaqx5Fa5v90iNlPRcqyt+lVSjBwTDzuPxTPFY4Q0mL89mKgkq2gVHYNCiaRkXvFLDxaSvBWbmthgg==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-link@2.27.2':
+    resolution: {integrity: sha512-bnP61qkr0Kj9Cgnop1hxn2zbOCBzNtmawxr92bVTOE31fJv6FhtCnQiD6tuPQVGMYhcmAj7eihtvuEMFfqEPcQ==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-list-item@2.27.2':
+    resolution: {integrity: sha512-eJNee7IEGXMnmygM5SdMGDC8m/lMWmwNGf9fPCK6xk0NxuQRgmZHL6uApKcdH6gyNcRPHCqvTTkhEP7pbny/fg==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-mention@2.27.2':
+    resolution: {integrity: sha512-uHxVf8RISscb4xgCEJmDSNcFQmzlBTKJh7fp2QAXWIF4Xtrg3zD08PIXUvvHapoluGD9OdBugW4YCu1PJ3xWNw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+      '@tiptap/suggestion': ^2.7.0
+
+  '@tiptap/extension-ordered-list@2.27.2':
+    resolution: {integrity: sha512-M7A4tLGJcLPYdLC4CI2Gwl8LOrENQW59u3cMVa+KkwG1hzSJyPsbDpa1DI6oXPC2WtYiTf22zrbq3gVvH+KA2w==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-paragraph@2.27.2':
+    resolution: {integrity: sha512-elYVn2wHJJ+zB9LESENWOAfI4TNT0jqEN34sMA/hCtA4im1ZG2DdLHwkHIshj/c4H0dzQhmsS/YmNC5Vbqab/A==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-placeholder@2.27.2':
+    resolution: {integrity: sha512-IjsgSVYJRjpAKmIoapU0E2R4E2FPY3kpvU7/1i7PUYisylqejSJxmtJPGYw0FOMQY9oxnEEvfZHMBA610tqKpg==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-strike@2.27.2':
+    resolution: {integrity: sha512-HHIjhafLhS2lHgfAsCwC1okqMsQzR4/mkGDm4M583Yftyjri1TNA7lzhzXWRFWiiMfJxKtdjHjUAQaHuteRTZw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-table-cell@2.27.2':
+    resolution: {integrity: sha512-9Lk46MjZMFzVZfOj9Kd7VgC6Odt6vmEhlCYVumErShUY7EkFqCw3b2IYoUtQkntfOEx/Afnhff/okNQwPsJeUA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-table-header@2.27.2':
+    resolution: {integrity: sha512-ZEb6lbG0NbbodWLV0b4BS/QrDIPlUbCcuOsUxzqVvlMUY1Vg6Fj6fKwLaBcsIUDHi8sxZDBEgYEDw3BR/zcO6A==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-table-row@2.27.2':
+    resolution: {integrity: sha512-Nw9+tA56Y5HtLVP01NGCZSUuTQhJPtfK9OfmDgGgcxynn2cRVdEtj+9FNZqRhQ1iRVaAI+Rd4xRvX9qYePMOxw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-table@2.27.2':
+    resolution: {integrity: sha512-pDbhOpT5phZkcsyPjGBQlXv0+0hmdrvqHJ+dJjkGcCtlfy2pHiEIhmIItOFagc7wXy8G9iUFZ9Jie4zvDf+brg==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-text-style@2.27.2':
+    resolution: {integrity: sha512-Omk+uxjJLyEY69KStpCw5fA9asvV+MGcAX2HOxyISDFoLaL49TMrNjhGAuz09P1L1b0KGXo4ml7Q3v/Lfy4WPA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-text@2.27.2':
+    resolution: {integrity: sha512-Xk7nYcigljAY0GO9hAQpZ65ZCxqOqaAlTPDFcKerXmlkQZP/8ndx95OgUb1Xf63kmPOh3xypurGS2is3v0MXSA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/pm@2.27.2':
+    resolution: {integrity: sha512-kaEg7BfiJPDQMKbjVIzEPO3wlcA+pZb2tlcK9gPrdDnEFaec2QTF1sXz2ak2IIb2curvnIrQ4yrfHgLlVA72wA==}
+
+  '@tiptap/react@2.27.2':
+    resolution: {integrity: sha512-0EAs8Cpkfbvben1PZ34JN2Nd79Dhioynm2jML27DBbf1VWPk+FFWFGTMLUT0bu+Np5iVxio8fqV9t0mc4D6thA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tiptap/starter-kit@2.27.2':
+    resolution: {integrity: sha512-bb0gJvPoDuyRUQ/iuN52j1//EtWWttw+RXAv1uJxfR0uKf8X7uAqzaOOgwjknoCIDC97+1YHwpGdnRjpDkOBxw==}
+
+  '@tiptap/suggestion@2.27.2':
+    resolution: {integrity: sha512-dQyvCIg0hcAVeh4fCIVCxogvbp+bF+GpbUb8sNlgnGrmHXnapGxzkvrlHnvneXZxLk/j7CxmBPKJNnm4Pbx4zw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
     engines: {node: '>=18'}
@@ -5588,8 +5890,17 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
   '@types/mdast@3.0.13':
     resolution: {integrity: sha512-HjiGiWedR0DVFkeNljpa6Lv4/IZU1+30VY5d747K7lBudFc3R0Ibr6yJ9lN3BE28VnZyDfLF/VB1Ql1ZIbKrmg==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/minimatch@5.1.2':
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
@@ -5671,6 +5982,9 @@ packages:
 
   '@types/unist@3.0.0':
     resolution: {integrity: sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/vscode@1.74.0':
     resolution: {integrity: sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==}
@@ -6889,6 +7203,9 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   cross-spawn@5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
@@ -9161,6 +9478,12 @@ packages:
   linkify-it@3.0.3:
     resolution: {integrity: sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
+  linkifyjs@4.3.2:
+    resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
+
   listenercount@1.0.1:
     resolution: {integrity: sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==}
 
@@ -9299,6 +9622,10 @@ packages:
     resolution: {integrity: sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==}
     hasBin: true
 
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
   markdown-table@3.0.3:
     resolution: {integrity: sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==}
 
@@ -9347,6 +9674,9 @@ packages:
 
   mdurl@1.0.1:
     resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
@@ -10028,6 +10358,9 @@ packages:
     resolution: {integrity: sha512-0TUxTiFJWv+JnjWm4o9yvuskpEJLXTcng8MJuKd+SzAzp2o+OP3HWqNhB4OdJRt1Vsd9/mR0oyaEYlOnL7XIRw==}
     engines: {node: '>=16'}
 
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
@@ -10424,6 +10757,64 @@ packages:
   property-information@6.3.0:
     resolution: {integrity: sha512-gVNZ74nqhRMiIUYWGQdosYetaKc83x8oT41a0LlV3AAFCAZwCpg4vmGkq8t34+cUhp3cnM4XDiU/7xlgK7HGrg==}
 
+  prosemirror-changeset@2.4.1:
+    resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
+
+  prosemirror-collab@1.3.1:
+    resolution: {integrity: sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==}
+
+  prosemirror-commands@1.7.1:
+    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
+
+  prosemirror-dropcursor@1.8.2:
+    resolution: {integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==}
+
+  prosemirror-gapcursor@1.4.1:
+    resolution: {integrity: sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==}
+
+  prosemirror-history@1.5.0:
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
+
+  prosemirror-inputrules@1.5.1:
+    resolution: {integrity: sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==}
+
+  prosemirror-keymap@1.2.3:
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
+
+  prosemirror-markdown@1.13.4:
+    resolution: {integrity: sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==}
+
+  prosemirror-menu@1.3.2:
+    resolution: {integrity: sha512-6VgUJTYod0nMBlCaYJGhXGLu7Gt4AvcwcOq0YfJCY/6Uh+3S7UsWhpy6rJFCBFOmonq1hD8KyWOtZhkppd4YPg==}
+
+  prosemirror-model@1.25.4:
+    resolution: {integrity: sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==}
+
+  prosemirror-schema-basic@1.2.4:
+    resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
+
+  prosemirror-schema-list@1.5.1:
+    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
+
+  prosemirror-state@1.4.4:
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
+
+  prosemirror-tables@1.8.5:
+    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
+
+  prosemirror-trailing-node@3.0.0:
+    resolution: {integrity: sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==}
+    peerDependencies:
+      prosemirror-model: ^1.22.1
+      prosemirror-state: ^1.4.2
+      prosemirror-view: ^1.33.8
+
+  prosemirror-transform@1.12.0:
+    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
+
+  prosemirror-view@1.41.8:
+    resolution: {integrity: sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==}
+
   protobufjs@7.5.4:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
@@ -10442,6 +10833,10 @@ packages:
 
   pump@3.0.0:
     resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.1.1:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
@@ -10719,6 +11114,9 @@ packages:
     resolution: {integrity: sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
   run-applescript@5.0.0:
     resolution: {integrity: sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==}
@@ -11408,6 +11806,9 @@ packages:
   tinykeys@3.0.0:
     resolution: {integrity: sha512-nazawuGv5zx6MuDfDY0rmfXjuOGhD5XU2z0GLURQ1nzl0RUe9OuCJq+0u8xxJZINHe+mr7nw8PWYYZ9WhMFujw==}
 
+  tippy.js@6.3.7:
+    resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
+
   titleize@3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
     engines: {node: '>=12'}
@@ -11519,6 +11920,9 @@ packages:
     resolution: {integrity: sha512-9NTKvQZ/02XnJCSU4mF5gvAPK+nuLbvCtft/NE8dJeOwaup0bJ14rYx7TxmSXp8JJuAN8nAjqfXWFsWwoQSFHg==}
     hasBin: true
 
+  turndown@7.2.0:
+    resolution: {integrity: sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==}
+
   type-check@0.3.2:
     resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}
     engines: {node: '>= 0.8.0'}
@@ -11617,6 +12021,9 @@ packages:
 
   uc.micro@1.0.6:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   uint8array-extras@1.5.0:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
@@ -11767,6 +12174,9 @@ packages:
   w3c-hr-time@1.0.2:
     resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}
     deprecated: Use your platform's native performance.now() and performance.timeOrigin.
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   w3c-xmlserializer@3.0.0:
     resolution: {integrity: sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==}
@@ -14190,6 +14600,8 @@ snapshots:
       - encoding
       - supports-color
 
+  '@mixmark-io/domino@2.2.0': {}
+
   '@mongodb-js/saslprep@1.1.0':
     dependencies:
       sparse-bitfield: 3.0.3
@@ -14764,6 +15176,8 @@ snapshots:
     dependencies:
       playwright: 1.50.1
 
+  '@popperjs/core@2.11.8': {}
+
   '@posthog/core@1.20.2':
     dependencies:
       cross-spawn: 7.0.6
@@ -15189,6 +15603,8 @@ snapshots:
   '@redis/time-series@1.0.5(@redis/client@1.5.12)':
     dependencies:
       '@redis/client': 1.5.12
+
+  '@remirror/core-constants@3.0.0': {}
 
   '@rollup/plugin-commonjs@28.0.1(rollup@3.29.5)':
     dependencies:
@@ -16228,6 +16644,212 @@ snapshots:
     dependencies:
       '@testing-library/dom': 8.19.1
 
+  '@tiptap/core@2.27.2(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/pm': 2.27.2
+
+  '@tiptap/extension-blockquote@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-bold@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-bubble-menu@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+      tippy.js: 6.3.7
+
+  '@tiptap/extension-bullet-list@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-code-block@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+
+  '@tiptap/extension-code@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-document@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-dropcursor@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+
+  '@tiptap/extension-file-handler@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/extension-text-style@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2)))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/extension-text-style': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+
+  '@tiptap/extension-floating-menu@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+      tippy.js: 6.3.7
+
+  '@tiptap/extension-gapcursor@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+
+  '@tiptap/extension-hard-break@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-heading@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-highlight@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-history@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+
+  '@tiptap/extension-horizontal-rule@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+
+  '@tiptap/extension-image@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-italic@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-link@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+      linkifyjs: 4.3.2
+
+  '@tiptap/extension-list-item@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-mention@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(@tiptap/suggestion@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+      '@tiptap/suggestion': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-ordered-list@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-paragraph@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-placeholder@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+
+  '@tiptap/extension-strike@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-table-cell@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-table-header@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-table-row@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-table@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+
+  '@tiptap/extension-text-style@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-text@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/pm@2.27.2':
+    dependencies:
+      prosemirror-changeset: 2.4.1
+      prosemirror-collab: 1.3.1
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-gapcursor: 1.4.1
+      prosemirror-history: 1.5.0
+      prosemirror-inputrules: 1.5.1
+      prosemirror-keymap: 1.2.3
+      prosemirror-markdown: 1.13.4
+      prosemirror-menu: 1.3.2
+      prosemirror-model: 1.25.4
+      prosemirror-schema-basic: 1.2.4
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  '@tiptap/react@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/extension-bubble-menu': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+      '@tiptap/extension-floating-menu': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+      '@types/use-sync-external-store': 0.0.6
+      fast-deep-equal: 3.1.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      use-sync-external-store: 1.2.0(react@18.2.0)
+
+  '@tiptap/starter-kit@2.27.2':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/extension-blockquote': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-bold': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-bullet-list': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-code': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-code-block': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+      '@tiptap/extension-document': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-dropcursor': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+      '@tiptap/extension-gapcursor': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+      '@tiptap/extension-hard-break': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-heading': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-history': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+      '@tiptap/extension-horizontal-rule': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+      '@tiptap/extension-italic': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-list-item': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-ordered-list': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-paragraph': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-strike': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-text': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-text-style': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/pm': 2.27.2
+
+  '@tiptap/suggestion@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+
   '@tokenizer/inflate@0.2.7':
     dependencies:
       debug: 4.4.3
@@ -16358,9 +16980,18 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
   '@types/mdast@3.0.13':
     dependencies:
       '@types/unist': 2.0.6
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/minimatch@5.1.2': {}
 
@@ -16435,6 +17066,8 @@ snapshots:
   '@types/unist@2.0.6': {}
 
   '@types/unist@3.0.0': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/vscode@1.74.0': {}
 
@@ -17842,6 +18475,8 @@ snapshots:
   core-js@3.48.0: {}
 
   core-util-is@1.0.3: {}
+
+  crelt@1.0.6: {}
 
   cross-spawn@5.1.0:
     dependencies:
@@ -20757,6 +21392,12 @@ snapshots:
     dependencies:
       uc.micro: 1.0.6
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
+  linkifyjs@4.3.2: {}
+
   listenercount@1.0.1: {}
 
   load-yaml-file@0.2.0:
@@ -20907,6 +21548,15 @@ snapshots:
       mdurl: 1.0.1
       uc.micro: 1.0.6
 
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   markdown-table@3.0.3: {}
 
   math-intrinsics@1.1.0: {}
@@ -21017,6 +21667,8 @@ snapshots:
       '@types/mdast': 3.0.13
 
   mdurl@1.0.1: {}
+
+  mdurl@2.0.0: {}
 
   memory-pager@1.5.0: {}
 
@@ -21889,6 +22541,8 @@ snapshots:
       string-width: 6.1.0
       strip-ansi: 7.1.0
 
+  orderedmap@2.1.1: {}
+
   os-tmpdir@1.0.2: {}
 
   outdent@0.5.0: {}
@@ -22271,6 +22925,109 @@ snapshots:
 
   property-information@6.3.0: {}
 
+  prosemirror-changeset@2.4.1:
+    dependencies:
+      prosemirror-transform: 1.12.0
+
+  prosemirror-collab@1.3.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+
+  prosemirror-commands@1.7.1:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-dropcursor@1.8.2:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-gapcursor@1.4.1:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.8
+
+  prosemirror-history@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+      rope-sequence: 1.3.4
+
+  prosemirror-inputrules@1.5.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-keymap@1.2.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      w3c-keyname: 2.2.8
+
+  prosemirror-markdown@1.13.4:
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.1.1
+      prosemirror-model: 1.25.4
+
+  prosemirror-menu@1.3.2:
+    dependencies:
+      crelt: 1.0.6
+      prosemirror-commands: 1.7.1
+      prosemirror-history: 1.5.0
+      prosemirror-state: 1.4.4
+
+  prosemirror-model@1.25.4:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-schema-basic@1.2.4:
+    dependencies:
+      prosemirror-model: 1.25.4
+
+  prosemirror-schema-list@1.5.1:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-state@1.4.4:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-tables@1.8.5:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8):
+    dependencies:
+      '@remirror/core-constants': 3.0.0
+      escape-string-regexp: 4.0.0
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.8
+
+  prosemirror-transform@1.12.0:
+    dependencies:
+      prosemirror-model: 1.25.4
+
+  prosemirror-view@1.41.8:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
   protobufjs@7.5.4:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -22298,6 +23055,8 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
+
+  punycode.js@2.3.1: {}
 
   punycode@2.1.1: {}
 
@@ -22652,6 +23411,8 @@ snapshots:
   rollup@3.29.5:
     optionalDependencies:
       fsevents: 2.3.3
+
+  rope-sequence@1.3.4: {}
 
   run-applescript@5.0.0:
     dependencies:
@@ -23505,6 +24266,10 @@ snapshots:
 
   tinykeys@3.0.0: {}
 
+  tippy.js@6.3.7:
+    dependencies:
+      '@popperjs/core': 2.11.8
+
   titleize@3.0.0: {}
 
   tmp@0.0.33:
@@ -23616,6 +24381,10 @@ snapshots:
       '@turbo/windows-64': 2.8.19
       '@turbo/windows-arm64': 2.8.19
 
+  turndown@7.2.0:
+    dependencies:
+      '@mixmark-io/domino': 2.2.0
+
   type-check@0.3.2:
     dependencies:
       prelude-ls: 1.1.2
@@ -23726,6 +24495,8 @@ snapshots:
   typescript@5.9.3: {}
 
   uc.micro@1.0.6: {}
+
+  uc.micro@2.1.0: {}
 
   uint8array-extras@1.5.0: {}
 
@@ -23955,6 +24726,8 @@ snapshots:
   w3c-hr-time@1.0.2:
     dependencies:
       browser-process-hrtime: 1.0.0
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@3.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

This branch bundles three independent improvements that accumulated under the `s3-encode` work:

- **`@lowdefy/plugin-aws`** auto URL-encodes `x-amz-meta-*` fields on `AwsS3PresignedPostPolicy`, removing the need to wrap every metadata value with `_uri.encode` and avoiding the ASCII-only limitation on S3 user metadata.
- **`@lowdefy/blocks-tiptap`** ships two new default-registered rich-text editor blocks (`TiptapInput`, `TiptapMentionInput`) built on open-source TipTap — no private-registry `TIPTAP_PRO_TOKEN` required.
- **`@lowdefy/blocks-loaders`** modernizes the skeleton shimmer animation (compositor-accelerated `translateX`, reduced-motion guard, flex-column layouts).

## Changes

- **`@lowdefy/plugin-aws`** — `AwsS3PresignedPostPolicy` detects `x-amz-meta-*` (case-insensitive) fields and URL-encodes their values before signing. Other protocol fields pass through literally. Consumers reading metadata (Lambda triggers etc.) should `decodeURIComponent` the values.
- **`@lowdefy/blocks-tiptap`** — new package with `TiptapInput` and `TiptapMentionInput`. Bold / italic / strike / highlight bubble menu, tables, images, links, drag-and-drop / paste image uploads via an optional S3 presigned-POST request, @-mention dropdown with custom trigger char. Both blocks emit `{ html, text, markdown, fileList, mentions? }` via `methods.setValue` and expose `clear` / `setContent` / `focus` registered methods. Configurable via `starterKit`, `image`, `table`, `link`, `highlight`, `mentions`, `rows` / `autoSize`.
- **`@lowdefy/build`** — registers `@lowdefy/blocks-tiptap` in `defaultTypesMap` so the block types resolve without explicit `plugins:` config.
- **`@lowdefy/server`, `@lowdefy/server-dev`, `@lowdefy/server-e2e`** — add `@lowdefy/blocks-tiptap` as a dependency so the default types resolve across the Next.js build. server-e2e also includes it in `transpilePackages`.
- **`@lowdefy/docs`** — input-blocks pages for `TiptapInput` and `TiptapMentionInput` plus menu/page registrations.
- **`@lowdefy/blocks-loaders`** — skeleton blocks use a `::after` + `translateX` shimmer instead of `::before` + `left`, softer gradient, `isolation: isolate`, and a `prefers-reduced-motion` guard. `SkeletonInput` / `SkeletonParagraph` switch to a flex-column layout with gap spacing for tighter rhythm.

## Key Files

- `packages/plugins/plugins/plugin-aws/src/connections/AwsS3Bucket/AwsS3PresignedPostPolicy/AwsS3PresignedPostPolicy.js` — `x-amz-meta-*` URL-encoding logic.
- `packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/TiptapInput.js` — ref-tracked controlled pattern with one-way `value.html → setContent(next, false)` external sync; no feedback loop with SetState.
- `packages/plugins/blocks/blocks-tiptap/src/blocks/utils/buildExtensions.js` — shared TipTap extension builder honouring `starterKit`, `image`, `table`, `link`, `highlight` disable toggles and MIME allowlist for the file handler.
- `packages/plugins/blocks/blocks-tiptap/src/blocks/utils/style.module.css` — `.tiptap-wrapper` / `-borderless` / `-error` / `-warning` / `-disabled` classes built from antd theme variables (antd v6 cssinjs classes cannot be reused on custom divs).
- `packages/build/src/scripts/generateDefaultTypes.js` — adds `@lowdefy/blocks-tiptap` to the default package list.
- `packages/plugins/blocks/blocks-loaders/src/blocks/Skeleton/style.module.css` — new shimmer animation and reduced-motion guard.

## Notes

- `TIPTAP_PRO_TOKEN` and any `@tiptap-pro` scoped-registry entry in `.npmrc` can be removed by apps migrating away from a custom TipTap plugin — the new blocks use `@tiptap/extension-file-handler` (the open-sourced successor to `@tiptap-pro/extension-file-handler@2.7.7`).
- `TiptapInput` / `TiptapMentionInput` seed content through `SetState` on `onMount`, not via a `value:` field on the block config (which Lowdefy does not recognise on block configs). The gallery demonstrates the pattern.
- External `SetState` updates only seed `value.html`; derived fields (`text`, `markdown`, `fileList`, `mentions`) populate on first user interaction.