### PR TITLE
Expand PageSidebarLayout header actions when sider is open

### DIFF
--- a/.changeset/fix-page-sidebar-layout-expanded-header-actions.md
+++ b/.changeset/fix-page-sidebar-layout-expanded-header-actions.md
@@ -1,0 +1,11 @@
+---
+'@lowdefy/blocks-antd': patch
+---
+
+fix(PageSidebarLayout): Render notifications, profile, and dark-mode toggle as labeled, left-aligned rows when the sider is expanded.
+
+When the sider is open, the bottom actions now render as `[icon] [label]` rows that match the visual style of the menu items above (e.g. "Notifications", "Profile", "Light mode"). When the sider is collapsed, the actions remain as a centered icon stack. Two new optional schema fields — `notifications.title` (default `Notifications`) and `profile.title` (default `Profile`) — let consumers customise the expanded labels; consumers can also bind `_user: name` to `profile.title` to show the authenticated user's name.
+
+The profile dropdown's default `trigger` now depends on whether the sider is expanded: `click` when expanded (the labeled row invites click), `hover` when collapsed (original small-avatar behavior). Consumers passing `profile.trigger` explicitly are unaffected.
+
+No change to `PageSiderMenu` or `PageHeaderMenu` — their header-bar rendering still uses the icon-only layout and `hover` trigger.

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PageSidebarLayout/PageSidebarLayout.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PageSidebarLayout/PageSidebarLayout.js
@@ -216,6 +216,7 @@ const PageSidebarLayout = ({
                         display: 'flex',
                         flexDirection: 'column',
                         alignItems: 'center',
+                        gap: 8,
                       }}
                     >
                       {renderHeaderActions({
@@ -223,7 +224,10 @@ const PageSidebarLayout = ({
                         classNames: {
                           ...classNames,
                           headerActions:
-                            classNames.headerActions ?? 'flex flex-col items-center gap-4 py-4',
+                            classNames.headerActions ??
+                            (openSiderState
+                              ? 'flex flex-col items-stretch gap-1 w-full'
+                              : 'flex flex-col items-center gap-4 py-4'),
                         },
                         styles,
                         properties,
@@ -231,6 +235,7 @@ const PageSidebarLayout = ({
                         events,
                         components: { Icon, Link, ShortcutBadge },
                         iconsColor: properties.iconsColor,
+                        expanded: openSiderState,
                       })}
                       <Link home={true}>
                         <img

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PageSidebarLayout/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PageSidebarLayout/meta.js
@@ -261,6 +261,12 @@ export default {
           'Notification bell icon with badge. Shown in the sider on desktop and the mobile header on small screens. Renders when configured. Use the link property to navigate when clicked.',
         additionalProperties: false,
         properties: {
+          title: {
+            type: 'string',
+            default: 'Notifications',
+            description:
+              'Label shown next to the bell icon when the sider is expanded. Hidden on mobile header and collapsed sider.',
+          },
           link: {
             type: 'object',
             description: 'Link to navigate to when the notification bell is clicked.',
@@ -325,6 +331,12 @@ export default {
           'Profile avatar with optional dropdown menu. Shown in the sider on desktop and the mobile header on small screens. Renders when configured. Use with the _user operator to populate from the authenticated user.',
         additionalProperties: false,
         properties: {
+          title: {
+            type: 'string',
+            default: 'Profile',
+            description:
+              'Label shown next to the avatar when the sider is expanded. Hidden on mobile header and collapsed sider.',
+          },
           avatar: {
             type: 'object',
             description: 'Avatar display properties.',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/headerActions.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/headerActions.js
@@ -35,6 +35,78 @@ function getDarkModeIcon() {
   return 'AiOutlineLaptop';
 }
 
+function getDarkModeLabel() {
+  const pref = getDarkModePreference();
+  if (pref === 'dark') return 'Dark mode';
+  if (pref === 'light') return 'Light mode';
+  return 'System';
+}
+
+// Wraps a header action row for the expanded sider. Icon cell has a fixed
+// basis so bell / avatar / sun share a vertical line regardless of their
+// own intrinsic size; label fills the remaining width. Row gets a subtle
+// hover background so it reads as interactive (matches menu items above).
+const EXPANDED_ROW_BASE = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 12,
+  padding: '8px 12px',
+  width: '100%',
+  borderRadius: 6,
+  transition: 'background 0.15s',
+};
+
+const EXPANDED_ROW_BUTTON_RESET = {
+  background: 'transparent',
+  border: 'none',
+  textAlign: 'left',
+  font: 'inherit',
+  color: 'inherit',
+};
+
+function ExpandedRow({ children, label, className, style, onClick }) {
+  // `onClick` is only used when the row stands alone as the click target
+  // (e.g., dark-mode toggle). Notifications wraps this in a <Link> and
+  // profile wraps it in a <Dropdown> — in those cases interactivity comes
+  // from the parent, but the row should still hover-highlight.
+  const Tag = onClick ? 'button' : 'div';
+  const [hover, setHover] = React.useState(false);
+  const rowStyle = {
+    ...EXPANDED_ROW_BASE,
+    cursor: 'pointer',
+    ...(onClick ? EXPANDED_ROW_BUTTON_RESET : null),
+    ...(hover
+      ? { background: 'color-mix(in srgb, var(--ant-color-text) 6%, transparent)' }
+      : null),
+    ...style,
+  };
+  return (
+    <Tag
+      type={onClick ? 'button' : undefined}
+      className={className}
+      style={rowStyle}
+      onClick={onClick}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flex: '0 0 24px',
+          lineHeight: 1,
+        }}
+      >
+        {children}
+      </span>
+      <span style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+        {label}
+      </span>
+    </Tag>
+  );
+}
+
 function renderNotifications({
   blockId,
   classNames,
@@ -44,6 +116,7 @@ function renderNotifications({
   Icon,
   Link,
   iconsColor,
+  expanded,
 }) {
   if (type.isNone(properties.notifications)) return null;
   const notif = properties.notifications;
@@ -67,6 +140,31 @@ function renderNotifications({
     </Badge>
   );
   const link = notif.link;
+  if (expanded) {
+    const row = (
+      <ExpandedRow
+        className={classNames.notifications}
+        style={styles.notifications}
+        label={notif.title ?? 'Notifications'}
+      >
+        {badge}
+      </ExpandedRow>
+    );
+    if (link) {
+      return (
+        <Link
+          id={`${blockId}_notifications_link`}
+          pageId={link.pageId}
+          url={link.url}
+          newTab={link.newTab}
+          style={{ display: 'block', color: 'inherit' }}
+        >
+          {row}
+        </Link>
+      );
+    }
+    return row;
+  }
   if (link) {
     return (
       <Link
@@ -98,6 +196,7 @@ function renderProfile({
   Icon,
   Link,
   ShortcutBadge,
+  expanded,
 }) {
   if (type.isNone(properties.profile)) return null;
   const prof = properties.profile;
@@ -130,13 +229,23 @@ function renderProfile({
     </Avatar>
   );
 
+  const trigger = expanded ? (
+    <ExpandedRow
+      className={classNames.profile}
+      style={styles.profile}
+      label={prof.title ?? 'Profile'}
+    >
+      {avatar}
+    </ExpandedRow>
+  ) : (
+    <div className={classNames.profile} style={styles.profile}>
+      {avatar}
+    </div>
+  );
+
   const links = prof.links ?? [];
   if (links.length === 0) {
-    return (
-      <div className={classNames.profile} style={styles.profile}>
-        {avatar}
-      </div>
-    );
+    return trigger;
   }
 
   const items = buildMenuItems({
@@ -150,8 +259,7 @@ function renderProfile({
 
   return (
     <Dropdown
-      className={classNames.profile}
-      style={{ cursor: 'pointer', ...styles.profile }}
+      style={{ cursor: 'pointer' }}
       menu={{
         items,
         onClick: ({ key, keyPath }) => {
@@ -162,8 +270,9 @@ function renderProfile({
           });
         },
       }}
-      trigger={[prof.trigger ?? 'hover']}
-      placement={prof.placement ?? 'bottomRight'}
+      // Row-style trigger (expanded) expects click; small avatar (collapsed) uses hover.
+      trigger={[prof.trigger ?? (expanded ? 'click' : 'hover')]}
+      placement={prof.placement ?? (expanded ? 'topRight' : 'bottomRight')}
       arrow={prof.arrow}
       popupClassName={classNames.profileMenu}
       popupStyle={styles.profileMenu}
@@ -174,24 +283,51 @@ function renderProfile({
         })
       }
     >
-      <div>{avatar}</div>
+      {/* Antd Dropdown attaches its trigger handlers to the immediate child
+          DOM element; wrapping in a div (instead of passing the ExpandedRow
+          function component directly) ensures click/hover listeners land. */}
+      <div>{trigger}</div>
     </Dropdown>
   );
 }
 
-function renderDarkModeToggle({ blockId, classNames, styles, methods, events, Icon, iconsColor }) {
+function renderDarkModeToggle({
+  blockId,
+  classNames,
+  styles,
+  methods,
+  events,
+  Icon,
+  iconsColor,
+  expanded,
+}) {
+  const icon = (
+    <Icon
+      blockId={`${blockId}_dark_mode_toggle_icon`}
+      events={events}
+      properties={{ name: getDarkModeIcon() }}
+      styles={{ element: { fontSize: 16, color: iconsColor } }}
+    />
+  );
+  if (expanded) {
+    return (
+      <ExpandedRow
+        className={classNames.darkModeToggle}
+        style={styles.darkModeToggle}
+        label={getDarkModeLabel()}
+        onClick={() => methods.triggerEvent({ name: '__toggleDarkMode' })}
+      >
+        {icon}
+      </ExpandedRow>
+    );
+  }
   return (
     <div
       className={classNames.darkModeToggle}
       style={{ cursor: 'pointer', lineHeight: 1, ...styles.darkModeToggle }}
       onClick={() => methods.triggerEvent({ name: '__toggleDarkMode' })}
     >
-      <Icon
-        blockId={`${blockId}_dark_mode_toggle_icon`}
-        events={events}
-        properties={{ name: getDarkModeIcon() }}
-        styles={{ element: { fontSize: 16, color: iconsColor } }}
-      />
+      {icon}
     </div>
   );
 }
@@ -205,6 +341,7 @@ function renderHeaderActions({
   events,
   components: { Icon, Link, ShortcutBadge },
   iconsColor,
+  expanded = false,
 }) {
   const hasNotifications = !type.isNone(properties.notifications);
   const hasProfile = !type.isNone(properties.profile);
@@ -223,11 +360,16 @@ function renderHeaderActions({
     Link,
     ShortcutBadge,
     iconsColor,
+    expanded,
   };
+
+  const defaultClassName = expanded
+    ? 'flex flex-col items-stretch gap-1 w-full'
+    : 'flex items-center gap-4 ml-4';
 
   return (
     <div
-      className={classNames.headerActions ?? 'flex items-center gap-4 ml-4'}
+      className={classNames.headerActions ?? defaultClassName}
       style={styles.headerActions}
     >
       {hasNotifications && renderNotifications(ctx)}


### PR DESCRIPTION
## Summary

When a `PageSidebarLayout` sider is open, the menu items render as labeled rows (icon + title + chevron). The bottom actions — notifications, profile, dark-mode toggle — stayed as centered, icon-only widgets, which looked inconsistent in the now-wide column. This PR renders them as left-aligned `[icon] [label]` rows when the sider is expanded, matching the menu style above. Collapsed sider, `PageSiderMenu`, `PageHeaderMenu`, and the mobile header are unchanged.

## Changes

- **@lowdefy/blocks-antd**: New `expanded` runtime flag on `renderHeaderActions` (default `false`); `PageSidebarLayout` passes `expanded: openSiderState` so the bottom actions flip between icon-only (collapsed) and labeled-row (expanded) layouts. A new `ExpandedRow` helper uses a fixed 24px icon basis so bell / avatar / sun share a vertical line regardless of their intrinsic size, with a theme-aware hover background. Two new optional schema fields (`notifications.title`, `profile.title`) let consumers override the expanded labels; the dark-mode label is computed live from the current preference (`Light mode` / `Dark mode` / `System`). The profile dropdown's default `trigger` now depends on sider state: `click` when expanded (the labeled row invites click), `hover` when collapsed (original small-avatar behavior); consumer-supplied `profile.trigger` still wins either way. Sticky footer gains an 8px gap so action rows don't butt up against the Lowdefy logo. `PageSiderMenu`, `PageHeaderMenu`, and the mobile header default `expanded` to `false` and are unchanged.

## Notes

- Schema additions are opt-in: `notifications.title` defaults to `"Notifications"` and `profile.title` to `"Profile"`. Consumers can bind e.g. `profile.title: { _user: name }` to show the authenticated user's name when the sider is expanded.
- Labels only render when the sider is wide. They have no effect on the compact header bar used by `PageSiderMenu` / `PageHeaderMenu` or on the mobile header.
- Patch changeset included.

<img width="237" height="741" alt="Screenshot 2026-04-23 at 15 25 44" src="https://github.com/user-attachments/assets/581379ea-c7ea-4fee-8ccd-ad8228935950" />
