### PR TITLE
Harden build modules map and tighten request path validation

### DIFF
--- a/packages/build/src/build/registerModules.js
+++ b/packages/build/src/build/registerModules.js
@@ -96,13 +96,16 @@ async function resolveLocalManifest({ entry, resolvedPaths, context }) {
         `Use a flat identifier like "team-users".`
     );
   }
+  if (entry.id === '__proto__' || entry.id === 'constructor' || entry.id === 'prototype') {
+    throw new ConfigError(`Module entry id "${entry.id}" is a reserved name.`);
+  }
   if (!entry.source || !type.isString(entry.source)) {
     throw new ConfigError(
       `Module entry "${entry.id}": 'source' is required and must be a string.`
     );
   }
 
-  if (context.modules[entry.id]) {
+  if (Object.hasOwn(context.modules, entry.id)) {
     throw new ConfigError(`Duplicate module entry id "${entry.id}".`);
   }
 

--- a/packages/build/src/createContext.js
+++ b/packages/build/src/createContext.js
@@ -34,7 +34,8 @@ function createContext({ customTypesMap, directories, logger, refResolver, stage
     warnings: [],
     keyMap: {},
     logger,
-    modules: {},  // Map<entryId, ModuleEntry> — populated by buildModuleDefs (Phase 1)
+    // Null prototype prevents pollution via attacker-controlled entry.id.
+    modules: Object.create(null),
     readConfigFile: createReadConfigFile({ directories }),
     refMap: {},
     refResolver,

--- a/packages/servers/server-dev/pages/api/request/[...path].js
+++ b/packages/servers/server-dev/pages/api/request/[...path].js
@@ -23,7 +23,7 @@ async function handler({ context, req, res }) {
     throw new Error('Only POST requests are supported.');
   }
   const segments = req.query.path;
-  if (!segments || segments.length < 2) {
+  if (!Array.isArray(segments) || segments.length < 2) {
     res.status(400).json({ error: 'Invalid request path' });
     return;
   }

--- a/packages/servers/server/pages/api/request/[...path].js
+++ b/packages/servers/server/pages/api/request/[...path].js
@@ -23,7 +23,7 @@ async function handler({ context, req, res }) {
     throw new Error('Only POST requests are supported.');
   }
   const segments = req.query.path;
-  if (!segments || segments.length < 2) {
+  if (!Array.isArray(segments) || segments.length < 2) {
     res.status(400).json({ error: 'Invalid request path' });
     return;
   }


### PR DESCRIPTION
## Summary

Two small defensive hardening changes surfaced during a review of uncommitted work. The build's `context.modules` map is keyed by `entry.id`, which comes from user-controlled YAML, so a plain `{}` map combined with bracket-access assignment leaves a prototype-pollution vector if `entry.id` is `__proto__`. Separately, the request handler's path-segments check was looser than the actual contract — a tighter `Array.isArray` guard makes the expected shape explicit.

## Changes

- **@lowdefy/build**: `context.modules` is now created with `Object.create(null)` to eliminate the prototype-pollution vector, with an explicit reserved-name check (`__proto__`, `constructor`, `prototype`) for defense-in-depth and a clearer `ConfigError`. Duplicate detection switched to `Object.hasOwn` for canonical own-key semantics on the null-prototype map.
- **@lowdefy/server** / **@lowdefy/server-dev**: The request handler now requires `req.query.path` to be an array via `Array.isArray` before length-checking it, instead of relying on truthiness.

## Notes

- No changeset added in this PR — left for follow-up.
- No tests added; the hardened paths are guarded by `ConfigError` / 400 responses respectively. Worth a regression test for `entry.id: __proto__` and for non-array `req.query.path` if reviewers want belt-and-braces coverage.