### PR TITLE
fix(client): Forward style prop to all Link variants

### DIFF
--- a/.changeset/fix-link-style-prop-forwarding.md
+++ b/.changeset/fix-link-style-prop-forwarding.md
@@ -1,0 +1,9 @@
+---
+'@lowdefy/client': patch
+---
+
+fix(client): Forward `style` prop to all Link variants.
+
+`createLinkComponent` previously destructured every prop except `style`, so any `<Link style={...}>` passed by a block was silently dropped. Inline style overrides only worked via `className` + CSS. All four link variants (`backLink`, `newOriginLink`, `sameOriginLink` — both newTab and same-origin branches — and `noLink`) now thread `style` through to the rendered `<a>` (or `<span>` for `noLink`).
+
+Surfaces fixes in three places that were already passing `style` and silently broken: `headerActions.js` notifications/profile/dark-mode rows had `color: 'inherit'` that didn't reach the `<a>` (label rendered as antd link blue); `Anchor.js` disabled state set `color: '#BEBEBE'` that never applied; `buildMenuItems.js` per-link `style:` config was discarded.

--- a/packages/client/src/createLinkComponent.js
+++ b/packages/client/src/createLinkComponent.js
@@ -4,10 +4,11 @@ import { type } from '@lowdefy/helpers';
 
 const createLinkComponent = (lowdefy, Link) => {
   const { window } = lowdefy._internal.globals;
-  const backLink = ({ ariaLabel, children, className, id, onClick = () => {}, rel }) => (
+  const backLink = ({ ariaLabel, children, className, id, onClick = () => {}, rel, style }) => (
     <a
       id={id}
       className={className}
+      style={style}
       rel={rel}
       aria-label={ariaLabel ?? 'back'}
       onClick={(...params) => {
@@ -29,6 +30,7 @@ const createLinkComponent = (lowdefy, Link) => {
     pageId,
     query,
     rel,
+    style,
     url,
   }) => {
     return (
@@ -36,6 +38,7 @@ const createLinkComponent = (lowdefy, Link) => {
         id={id}
         aria-label={ariaLabel}
         className={className}
+        style={style}
         href={href ?? `${url}${query ? `?${query}` : ''}`}
         rel={rel ?? (newTab && 'noopener noreferrer')}
         target={newTab && '_blank'}
@@ -62,6 +65,7 @@ const createLinkComponent = (lowdefy, Link) => {
     replace,
     scroll,
     setInput,
+    style,
     url,
   }) => {
     if (newTab) {
@@ -71,6 +75,7 @@ const createLinkComponent = (lowdefy, Link) => {
           id={id}
           aria-label={ariaLabel}
           className={className}
+          style={style}
           href={`${window.location.origin}${lowdefy.basePath}${pathname}${
             query ? `?${query}` : ''
           }`}
@@ -94,6 +99,7 @@ const createLinkComponent = (lowdefy, Link) => {
         id={id}
         aria-label={ariaLabel}
         className={className}
+        style={style}
         rel={rel}
         onClick={(...params) => {
           setInput();
@@ -104,8 +110,8 @@ const createLinkComponent = (lowdefy, Link) => {
       </Link>
     );
   };
-  const noLink = ({ className, children, id, onClick = () => {} }) => (
-    <span id={id} className={className} onClick={onClick}>
+  const noLink = ({ className, children, id, onClick = () => {}, style }) => (
+    <span id={id} className={className} style={style} onClick={onClick}>
       {type.isFunction(children) ? children(id) : children}
     </span>
   );


### PR DESCRIPTION
## Summary

`createLinkComponent` destructured every prop except `style`, so any block passing `<Link style={...}>` had its inline style silently dropped — only `className` overrides reached the rendered `<a>`. This PR threads `style` through all four link variants. The notifications row label in `PageSidebarLayout`'s expanded sider rendered as antd link blue despite `headerActions.js` explicitly setting `color: 'inherit'` on the wrapping Link; same shape of bug also invalidated `Anchor`'s disabled color and `buildMenuItems`' per-link `style:` config.

## Changes

- **@lowdefy/client**: Thread `style` through `backLink`, `newOriginLink`, `sameOriginLink` (both newTab and same-origin Next.js Link branches), and `noLink`. `disabledLink` aliases `noLink` so it inherits the fix. Default behaviour preserved — a bare `<Link>` still picks up antd's link color via CSS-in-JS; only consumers who explicitly pass `style.color` get the override, which matches what every React dev expects when they pass `style`.