### PR TITLE
fix(blocks-aggrid): Suppress cell focus and clip overflowing cell content

### DIFF
--- a/.changeset/fix-blocks-aggrid-cell-focus-overflow.md
+++ b/.changeset/fix-blocks-aggrid-cell-focus-overflow.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/blocks-aggrid': patch
+---
+
+fix(blocks-aggrid): Suppress cell focus by default and clip overflowing cell content.
+
+The ag-grid cell focus outline visually competed with built-in cell renderers (buttons, links, tags), so `suppressCellFocus` now defaults to `true` and can still be overridden per grid. The antd cell wrapper also clips overflowing flex children so long text and inline cell components no longer blow out the cell width.

--- a/packages/plugins/blocks/blocks-aggrid/src/AgGrid.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/AgGrid.js
@@ -29,6 +29,7 @@ const AgGrid = ({ properties, methods, loading, events }) => {
     columnDefs,
     defaultColDef,
     rowData: newRowData,
+    suppressCellFocus = true,
     ...someProperties
   } = properties;
   const [rowData, setRowData] = useState(newRowData ?? []);
@@ -148,6 +149,7 @@ const AgGrid = ({ properties, methods, loading, events }) => {
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
       <AgGridReact
         {...someProperties}
+        suppressCellFocus={suppressCellFocus}
         rowData={rowData}
         defaultColDef={memoDefaultColDef}
         onFilterChanged={onFilterChanged}

--- a/packages/plugins/blocks/blocks-aggrid/src/ag-grid-antd.module.css
+++ b/packages/plugins/blocks/blocks-aggrid/src/ag-grid-antd.module.css
@@ -73,6 +73,8 @@
   display: flex;
   align-items: center;
   line-height: var(--ant-line-height, 1.5);
+  overflow: hidden;
+  min-width: 0;
 }
 
 .antdTheme :global(.lf-ellipsis-1),


### PR DESCRIPTION
## Summary

The default ag-grid cell focus outline visually competed with built-in cell renderers (buttons, links, tags). This PR makes `suppressCellFocus` default to `true` and clips overflowing flex children in the antd cell wrapper so long text and inline cell components no longer blow out the cell width.

## Changes

- **@lowdefy/blocks-aggrid**: Destructure `suppressCellFocus` with default `true` and forward it to `AgGridReact`, so the focus outline is hidden by default but can still be overridden per grid instance. Add `overflow: hidden` and `min-width: 0` to the antd cell wrapper so flex children clip correctly.