### PR TITLE
Add default header border to PageHeaderMenu

### DIFF
--- a/.changeset/fix-page-header-menu-border.md
+++ b/.changeset/fix-page-header-menu-border.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/blocks-antd': patch
+---
+
+fix(blocks-antd): Add default header border to PageHeaderMenu.
+
+PageHeaderMenu now has a default `borderBottom` matching the existing default borders on PageSiderMenu and PageSidebarLayout, for visual consistency across the page menu blocks. The default can still be overridden via `styles.header`.

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PageHeaderMenu/PageHeaderMenu.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PageHeaderMenu/PageHeaderMenu.js
@@ -65,6 +65,7 @@ const PageHeaderMenu = ({
                 element: mergeObjects([
                   {
                     background: 'var(--ant-color-bg-container)',
+                    borderBottom: '1px solid var(--ant-color-border)',
                   },
                   styles.header,
                 ]),


### PR DESCRIPTION
## Summary

PageSiderMenu and PageSidebarLayout both have default borders on their sider/header, but PageHeaderMenu's header had none — leaving the three page menu blocks visually inconsistent. This PR adds a matching default `borderBottom` on PageHeaderMenu's header so all three blocks render with the same chrome out of the box.

## Changes

- **@lowdefy/blocks-antd**: Added a default `borderBottom: '1px solid var(--ant-color-border)'` to PageHeaderMenu's header element. The default is theme-token based (so it adapts to dark mode) and remains overridable via `styles.header`.