### PR TITLE
fix(blocks-markdown): Declare antd as a peer dependency

### DIFF
--- a/.changeset/fix-blocks-markdown-antd-peer-dep.md
+++ b/.changeset/fix-blocks-markdown-antd-peer-dep.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/blocks-markdown': patch
+---
+
+fix(blocks-markdown): Declare `antd` as a peer dependency.
+
+`MarkdownWithCode` imports `antd` for theme-aware syntax highlighting but the package did not declare `antd` in its `peerDependencies`, causing module resolution failures (e.g., when bundling apps that include `@lowdefy/blocks-markdown` without already pulling in `antd`). Added `antd` (`>=6`) as a peer dependency to match the version range used by `@lowdefy/blocks-antd`.

--- a/packages/plugins/blocks/blocks-markdown/package.json
+++ b/packages/plugins/blocks/blocks-markdown/package.json
@@ -56,6 +56,7 @@
     "remark-gfm": "3.0.0"
   },
   "peerDependencies": {
+    "antd": ">=6",
     "react": ">=18",
     "react-dom": ">=18"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,7 +83,7 @@ importers:
         version: 0.2.39(@swc/core@1.15.18)
       jest:
         specifier: 28.1.3
-        version: 28.1.3(@types/node@20.6.2)
+        version: 28.1.3(@types/node@16.18.101)
 
   packages/build:
     dependencies:
@@ -249,7 +249,7 @@ importers:
         version: 0.2.39(@swc/core@1.15.18)
       jest:
         specifier: 28.1.3
-        version: 28.1.3(@types/node@16.18.101)
+        version: 28.1.3(@types/node@20.6.2)
       pino:
         specifier: 8.16.2
         version: 8.16.2
@@ -964,6 +964,9 @@ importers:
       '@lowdefy/block-utils':
         specifier: 5.2.0
         version: link:../../../utils/block-utils
+      antd:
+        specifier: '>=6'
+        version: 6.3.1(date-fns@2.29.3)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       dompurify:
         specifier: 3.2.4
         version: 3.2.4


### PR DESCRIPTION
## Summary

`@lowdefy/blocks-markdown`'s `MarkdownWithCode` imports `antd` for theme-aware syntax highlighting, but the package didn't declare `antd` in its `package.json`. Bundlers that didn't already have `antd` in their tree (notably `pnpm docs:dev` under Turbopack) failed with `Module not found: Can't resolve 'antd'`. Adding it as a peer dependency resolves the build error and matches how `@lowdefy/blocks-antd` declares the same package.

## Changes

- **@lowdefy/blocks-markdown**: Added `"antd": ">=6"` to `peerDependencies` so consuming apps know to install it. Lockfile regenerated. Range matches `@lowdefy/blocks-antd` for consistency.

## Notes

- The `antd` import in `MarkdownWithCode.js` was introduced in commit `d40256621` ("refactor(docs): Add dark mode toggle...") which added theme-token-based dark mode handling but missed updating the package's dependencies.
- Peer dependency (rather than a direct dependency) avoids duplicating `antd` in apps that already pull it in via `@lowdefy/blocks-antd`.