### PR TITLE
AgGrid tag cell: array values + default auto-colouring

### DIFF
--- a/.changeset/feat-blocks-aggrid-tag-array.md
+++ b/.changeset/feat-blocks-aggrid-tag-array.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/blocks-aggrid': minor
+---
+
+feat(blocks-aggrid): Tag cell renders one tag per item for array-valued fields.
+
+The `cell.type: tag` renderer now accepts an array of strings in addition to a single string. Each item is rendered as its own styled tag and resolves its colour through the existing `colorMap` / `colorFrom` / `default` configuration. Empty arrays and arrays containing only null/empty entries render the em-dash placeholder, matching the existing null-value behaviour. Single-string values are unchanged.

--- a/.changeset/feat-blocks-aggrid-tag-seed-colors.md
+++ b/.changeset/feat-blocks-aggrid-tag-seed-colors.md
@@ -1,0 +1,9 @@
+---
+'@lowdefy/blocks-aggrid': minor
+---
+
+feat(blocks-aggrid): Auto-colour tag cells by default for consistent per-value colouring.
+
+When a `cell.type: tag` column is used with no `colorMap`, no `colorFrom`, and no `default`, tag values are now coloured from a stable hash so the same value always gets the same colour across rows, columns, and tables. The palette uses 12 antd named hues (red, volcano, orange, gold, yellow, lime, green, cyan, blue, geekblue, purple, magenta) and respects the active theme.
+
+The grey fallback is still available — set `cell: { type: tag, default: default }` on any column to opt out. When `colorMap`, `colorFrom`, or `default` is set, behaviour is unchanged.

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridAlpine/gallery.yaml
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridAlpine/gallery.yaml
@@ -833,6 +833,51 @@
           - name: Chan Maarten
             roles: null
 
+- title: Auto-coloured tags
+  fullWidth: true
+  blocks:
+    - id: tag_seeded_demo
+      type: AgGridAlpine
+      properties:
+        height: 300
+        defaultColDef:
+          resizable: true
+          flex: 1
+        columnDefs:
+          - headerName: Project
+            field: project
+            minWidth: 160
+          - headerName: Tags
+            field: tags
+            minWidth: 320
+            cell:
+              type: tag
+        rowData:
+          - project: Storefront
+            tags:
+              - frontend
+              - react
+              - typescript
+          - project: API gateway
+            tags:
+              - backend
+              - node
+              - typescript
+          - project: ML pipeline
+            tags:
+              - python
+              - airflow
+              - backend
+          - project: Mobile app
+            tags:
+              - frontend
+              - react
+              - mobile
+          - project: Design system
+            tags:
+              - frontend
+              - design
+
 - title: Linked cells (onCellLink)
   fullWidth: true
   blocks:

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridAlpine/gallery.yaml
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridAlpine/gallery.yaml
@@ -790,6 +790,49 @@
             verified: null
             completion: null
 
+- title: Tag cells with array values
+  fullWidth: true
+  blocks:
+    - id: tag_array_demo
+      type: AgGridAlpine
+      properties:
+        height: 240
+        defaultColDef:
+          resizable: true
+          flex: 1
+        columnDefs:
+          - headerName: User
+            field: name
+            minWidth: 180
+          - headerName: Roles
+            field: roles
+            minWidth: 260
+            cell:
+              type: tag
+              colorMap:
+                admin: red
+                editor: blue
+                viewer: green
+                billing: orange
+              default: default
+        rowData:
+          - name: Alice Johnson
+            roles:
+              - admin
+              - editor
+          - name: Bob Smith
+            roles:
+              - viewer
+          - name: Charlie Lee
+            roles:
+              - editor
+              - billing
+              - viewer
+          - name: Diana Patel
+            roles: []
+          - name: Chan Maarten
+            roles: null
+
 - title: Linked cells (onCellLink)
   fullWidth: true
   blocks:
@@ -868,13 +911,19 @@
         rowData:
           - code: A-01
             title: Main switchboard
-            description: Drafted the main switchboard layout and circuit schedule across three floors. Awaiting sign-off from the project engineer before ordering long-lead parts.
+            description: Drafted the main switchboard layout and circuit schedule across
+              three floors. Awaiting sign-off from the project engineer before
+              ordering long-lead parts.
           - code: A-02
             title: East wing HVAC
-            description: Balancing HVAC loads across the east wing. Waiting on updated ductwork drawings from the architect and a revised thermal model from the mechanical team.
+            description: Balancing HVAC loads across the east wing. Waiting on updated
+              ductwork drawings from the architect and a revised thermal model
+              from the mechanical team.
           - code: A-03
             title: Utility connections
-            description: Blocked on the utility connection survey — main was not where the drawings said it would be, which has cascaded to the trenching schedule.
+            description: Blocked on the utility connection survey — main was not where the
+              drawings said it would be, which has cascaded to the trenching
+              schedule.
 
 - title: Number formatting (currency, percent, compact, accounting)
   fullWidth: true

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridAlpine/meta.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridAlpine/meta.js
@@ -203,7 +203,7 @@ export default {
                 colorMap: {
                   type: 'object',
                   description:
-                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`.',
+                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item.',
                 },
                 colorFrom: {
                   type: 'string',

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridAlpine/meta.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridAlpine/meta.js
@@ -203,7 +203,7 @@ export default {
                 colorMap: {
                   type: 'object',
                   description:
-                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item.',
+                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item. If neither `colorMap`, `colorFrom`, nor `default` is set, tag values are auto-coloured from a stable hash for consistency across rows.',
                 },
                 colorFrom: {
                   type: 'string',

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridBalham/meta.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridBalham/meta.js
@@ -203,7 +203,7 @@ export default {
                 colorMap: {
                   type: 'object',
                   description:
-                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`.',
+                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item.',
                 },
                 colorFrom: {
                   type: 'string',

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridBalham/meta.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridBalham/meta.js
@@ -203,7 +203,7 @@ export default {
                 colorMap: {
                   type: 'object',
                   description:
-                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item.',
+                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item. If neither `colorMap`, `colorFrom`, nor `default` is set, tag values are auto-coloured from a stable hash for consistency across rows.',
                 },
                 colorFrom: {
                   type: 'string',

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridBalham/tests/AgGridBalham.e2e.spec.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridBalham/tests/AgGridBalham.e2e.spec.js
@@ -222,6 +222,32 @@ test.describe('AgGridBalham Block', () => {
     await expect(fourthRowCell).toContainText('—');
   });
 
+  test('cell.type: tag auto-colours unmapped values with the seeded styled-tag pattern', async ({
+    page,
+  }) => {
+    const block = getBlock(page, 'aggridbalham_cell_tag_seeded');
+    const firstRowSpan = block.locator('.ag-row[row-index="0"] .ag-cell span').first();
+    await expect(firstRowSpan).toHaveText('frontend');
+    const style = await firstRowSpan.getAttribute('style');
+    expect(style).toContain('color-mix');
+    expect(style).toContain('12%');
+    expect(style).toContain('30%');
+  });
+
+  test('cell.type: tag seeded colour is consistent across rows for the same value', async ({
+    page,
+  }) => {
+    const block = getBlock(page, 'aggridbalham_cell_tag_seeded');
+    const row0 = block.locator('.ag-row[row-index="0"] .ag-cell span').first();
+    const row1 = block.locator('.ag-row[row-index="1"] .ag-cell span').first();
+    const row2 = block.locator('.ag-row[row-index="2"] .ag-cell span').first();
+    const style0 = await row0.getAttribute('style');
+    const style1 = await row1.getAttribute('style');
+    const style2 = await row2.getAttribute('style');
+    expect(style0).toBe(style1);
+    expect(style0).not.toBe(style2);
+  });
+
   test('cell.type: avatar renders picture when srcField is present', async ({ page }) => {
     const block = getBlock(page, 'aggridbalham_cell_avatar');
     const firstRow = block.locator('.ag-row[row-index="0"]');

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridBalham/tests/AgGridBalham.e2e.spec.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridBalham/tests/AgGridBalham.e2e.spec.js
@@ -189,6 +189,39 @@ test.describe('AgGridBalham Block', () => {
     expect(firstStyle).toContain('color-mix');
   });
 
+  test('cell.type: tag renders one styled span per array item', async ({ page }) => {
+    const block = getBlock(page, 'aggridbalham_cell_tag_array');
+    const firstRowCell = block.locator('.ag-row[row-index="0"] .ag-cell').first();
+    const tagSpans = firstRowCell.locator('span > span');
+    await expect(tagSpans).toHaveCount(2);
+    await expect(tagSpans.nth(0)).toHaveText('admin');
+    await expect(tagSpans.nth(1)).toHaveText('editor');
+    const firstStyle = await tagSpans.nth(0).getAttribute('style');
+    expect(firstStyle).toContain('color-mix');
+    expect(firstStyle).toContain('12%');
+    expect(firstStyle).toContain('30%');
+  });
+
+  test('cell.type: tag renders single tag for a one-element array', async ({ page }) => {
+    const block = getBlock(page, 'aggridbalham_cell_tag_array');
+    const secondRowCell = block.locator('.ag-row[row-index="1"] .ag-cell').first();
+    const tagSpans = secondRowCell.locator('span > span');
+    await expect(tagSpans).toHaveCount(1);
+    await expect(tagSpans.nth(0)).toHaveText('viewer');
+  });
+
+  test('cell.type: tag renders em-dash for empty array', async ({ page }) => {
+    const block = getBlock(page, 'aggridbalham_cell_tag_array');
+    const thirdRowCell = block.locator('.ag-row[row-index="2"] .ag-cell').first();
+    await expect(thirdRowCell).toContainText('—');
+  });
+
+  test('cell.type: tag renders em-dash for null array', async ({ page }) => {
+    const block = getBlock(page, 'aggridbalham_cell_tag_array');
+    const fourthRowCell = block.locator('.ag-row[row-index="3"] .ag-cell').first();
+    await expect(fourthRowCell).toContainText('—');
+  });
+
   test('cell.type: avatar renders picture when srcField is present', async ({ page }) => {
     const block = getBlock(page, 'aggridbalham_cell_avatar');
     const firstRow = block.locator('.ag-row[row-index="0"]');

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridBalham/tests/AgGridBalham.e2e.yaml
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridBalham/tests/AgGridBalham.e2e.yaml
@@ -327,6 +327,19 @@ blocks:
         - roles: []
         - roles: null
 
+  - id: aggridbalham_cell_tag_seeded
+    type: AgGridBalham
+    properties:
+      columnDefs:
+        - headerName: Tag
+          field: tag
+          cell:
+            type: tag
+      rowData:
+        - tag: frontend
+        - tag: frontend
+        - tag: backend
+
   - id: aggridbalham_cell_avatar
     type: AgGridBalham
     properties:

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridBalham/tests/AgGridBalham.e2e.yaml
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridBalham/tests/AgGridBalham.e2e.yaml
@@ -306,6 +306,27 @@ blocks:
         - label: B
           color: '#ff4d4f'
 
+  - id: aggridbalham_cell_tag_array
+    type: AgGridBalham
+    properties:
+      columnDefs:
+        - headerName: Roles
+          field: roles
+          cell:
+            type: tag
+            colorMap:
+              admin: red
+              editor: blue
+              viewer: green
+      rowData:
+        - roles:
+            - admin
+            - editor
+        - roles:
+            - viewer
+        - roles: []
+        - roles: null
+
   - id: aggridbalham_cell_avatar
     type: AgGridBalham
     properties:

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridInputAlpine/meta.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridInputAlpine/meta.js
@@ -218,7 +218,7 @@ export default {
                 colorMap: {
                   type: 'object',
                   description:
-                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item.',
+                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item. If neither `colorMap`, `colorFrom`, nor `default` is set, tag values are auto-coloured from a stable hash for consistency across rows.',
                 },
                 colorFrom: {
                   type: 'string',

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridInputAlpine/meta.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridInputAlpine/meta.js
@@ -218,7 +218,7 @@ export default {
                 colorMap: {
                   type: 'object',
                   description:
-                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`.',
+                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item.',
                 },
                 colorFrom: {
                   type: 'string',

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridInputBalham/meta.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridInputBalham/meta.js
@@ -218,7 +218,7 @@ export default {
                 colorMap: {
                   type: 'object',
                   description:
-                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item.',
+                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item. If neither `colorMap`, `colorFrom`, nor `default` is set, tag values are auto-coloured from a stable hash for consistency across rows.',
                 },
                 colorFrom: {
                   type: 'string',

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridInputBalham/meta.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridInputBalham/meta.js
@@ -218,7 +218,7 @@ export default {
                 colorMap: {
                   type: 'object',
                   description:
-                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`.',
+                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item.',
                 },
                 colorFrom: {
                   type: 'string',

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridInputMaterial/meta.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridInputMaterial/meta.js
@@ -218,7 +218,7 @@ export default {
                 colorMap: {
                   type: 'object',
                   description:
-                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item.',
+                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item. If neither `colorMap`, `colorFrom`, nor `default` is set, tag values are auto-coloured from a stable hash for consistency across rows.',
                 },
                 colorFrom: {
                   type: 'string',

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridInputMaterial/meta.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridInputMaterial/meta.js
@@ -218,7 +218,7 @@ export default {
                 colorMap: {
                   type: 'object',
                   description:
-                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`.',
+                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item.',
                 },
                 colorFrom: {
                   type: 'string',

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridMaterial/meta.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridMaterial/meta.js
@@ -203,7 +203,7 @@ export default {
                 colorMap: {
                   type: 'object',
                   description:
-                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`.',
+                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item.',
                 },
                 colorFrom: {
                   type: 'string',

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridMaterial/meta.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridMaterial/meta.js
@@ -203,7 +203,7 @@ export default {
                 colorMap: {
                   type: 'object',
                   description:
-                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item.',
+                    'Tag: map of cell value → color (antd tag color name or hex). Used when `cell.type: tag`. The cell value may be a single string or an array of strings; arrays render one tag per item. If neither `colorMap`, `colorFrom`, nor `default` is set, tag values are auto-coloured from a stable hash for consistency across rows.',
                 },
                 colorFrom: {
                   type: 'string',

--- a/packages/plugins/blocks/blocks-aggrid/src/cellRenderers/TagCell.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/cellRenderers/TagCell.js
@@ -35,6 +35,33 @@ const ANTD_TAG_COLOR_TOKENS = {
   default: 'var(--ant-color-text-secondary)',
 };
 
+const SEED_PALETTE = [
+  'red',
+  'volcano',
+  'orange',
+  'gold',
+  'yellow',
+  'lime',
+  'green',
+  'cyan',
+  'blue',
+  'geekblue',
+  'purple',
+  'magenta',
+];
+
+function colorSeed(s) {
+  if (type.isNone(s)) return 0;
+  const str = String(s);
+  let hash = 0;
+  for (let i = 0; i < str.length; i += 1) hash = (hash * 31 + str.charCodeAt(i)) >>> 0;
+  return hash;
+}
+
+function seededColor(item) {
+  return SEED_PALETTE[colorSeed(item) % SEED_PALETTE.length];
+}
+
 function resolveColor(value) {
   if (type.isNone(value)) return ANTD_TAG_COLOR_TOKENS.default;
   return ANTD_TAG_COLOR_TOKENS[value] ?? value;
@@ -63,12 +90,18 @@ function TagCell(params) {
 
   const { colorMap, colorFrom, default: defaultColor } = cellConfig ?? {};
   const useColorFrom = type.isString(colorFrom);
+  const useColorMap = type.isObject(colorMap);
   const fromColor = useColorFrom ? resolvePath(colorFrom, data) : undefined;
+  const seedingActive = !useColorFrom && !useColorMap && type.isNone(defaultColor);
 
   function colorFor(item) {
     if (useColorFrom) return fromColor;
-    if (type.isObject(colorMap)) return colorMap[item];
+    if (useColorMap) return colorMap[item];
     return undefined;
+  }
+
+  function pickColor(item) {
+    return colorFor(item) ?? defaultColor ?? (seedingActive ? seededColor(item) : undefined);
   }
 
   if (type.isArray(value)) {
@@ -80,7 +113,7 @@ function TagCell(params) {
     return (
       <span style={containerStyle}>
         {items.map((item, index) => {
-          const resolved = resolveColor(colorFor(item) ?? defaultColor);
+          const resolved = resolveColor(pickColor(item));
           return (
             <span key={`${index}-${item}`} style={tagStyle(resolved)}>
               {String(item)}
@@ -91,7 +124,7 @@ function TagCell(params) {
     );
   }
 
-  const resolved = resolveColor(colorFor(value) ?? defaultColor);
+  const resolved = resolveColor(pickColor(value));
   return <span style={tagStyle(resolved)}>{String(value)}</span>;
 }
 

--- a/packages/plugins/blocks/blocks-aggrid/src/cellRenderers/TagCell.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/cellRenderers/TagCell.js
@@ -40,22 +40,8 @@ function resolveColor(value) {
   return ANTD_TAG_COLOR_TOKENS[value] ?? value;
 }
 
-function TagCell(params) {
-  const { value, data, cellConfig } = params;
-  if (type.isNone(value) || value === '') {
-    return <NullCell />;
-  }
-
-  const { colorMap, colorFrom, default: defaultColor } = cellConfig ?? {};
-  let color;
-  if (type.isString(colorFrom)) {
-    color = resolvePath(colorFrom, data);
-  } else if (type.isObject(colorMap)) {
-    color = colorMap[value];
-  }
-  const resolved = resolveColor(color ?? defaultColor);
-
-  const style = {
+function tagStyle(resolved) {
+  return {
     display: 'inline-flex',
     alignItems: 'center',
     padding: 'var(--ant-padding-xxs, 4px) var(--ant-padding-xs, 8px)',
@@ -67,8 +53,46 @@ function TagCell(params) {
     background: `color-mix(in srgb, ${resolved} 12%, transparent)`,
     border: `1px solid color-mix(in srgb, ${resolved} 30%, transparent)`,
   };
+}
 
-  return <span style={style}>{String(value)}</span>;
+function TagCell(params) {
+  const { value, data, cellConfig } = params;
+  if (type.isNone(value) || value === '') {
+    return <NullCell />;
+  }
+
+  const { colorMap, colorFrom, default: defaultColor } = cellConfig ?? {};
+  const useColorFrom = type.isString(colorFrom);
+  const fromColor = useColorFrom ? resolvePath(colorFrom, data) : undefined;
+
+  function colorFor(item) {
+    if (useColorFrom) return fromColor;
+    if (type.isObject(colorMap)) return colorMap[item];
+    return undefined;
+  }
+
+  if (type.isArray(value)) {
+    const items = value.filter((item) => !type.isNone(item) && item !== '');
+    if (items.length === 0) {
+      return <NullCell />;
+    }
+    const containerStyle = { display: 'inline-flex', flexWrap: 'wrap', gap: 4 };
+    return (
+      <span style={containerStyle}>
+        {items.map((item, index) => {
+          const resolved = resolveColor(colorFor(item) ?? defaultColor);
+          return (
+            <span key={`${index}-${item}`} style={tagStyle(resolved)}>
+              {String(item)}
+            </span>
+          );
+        })}
+      </span>
+    );
+  }
+
+  const resolved = resolveColor(colorFor(value) ?? defaultColor);
+  return <span style={tagStyle(resolved)}>{String(value)}</span>;
 }
 
 export default TagCell;


### PR DESCRIPTION
## Summary

Two upgrades to the AG Grid `cell.type: tag` renderer. First, array-valued fields (e.g. `roles: ['admin', 'editor']`) now render one styled tag per item instead of being stringified into a single tag. Second, when a tag column is configured with no `colorMap`, no `colorFrom`, and no `default`, tag values are auto-coloured from a stable hash of the value — so the same word always renders in the same colour across rows, columns, and tables.

## Changes

- **@lowdefy/blocks-aggrid**: `TagCell` accepts arrays and renders one tag per item, sharing the existing `colorMap` / `colorFrom` / `default` colour resolution. When no colour config is provided, a 12-entry palette of antd named hues is selected by hashing `String(value)`. Per-theme meta descriptions, the AgGridAlpine docs gallery, and the AgGridBalham e2e suite were updated to cover both behaviours.

## Notes

- A bare `cell: { type: tag }` column previously rendered every value in the same secondary-text grey. With this change those columns get auto-coloured. Set `cell: { type: tag, default: default }` to recover grey.
- Auto-colouring only kicks in when **none** of `colorMap`, `colorFrom`, or `default` is set. Any explicit configuration keeps today's behaviour.
- For arrays, each item is hashed independently — duplicate values within a row render in the same colour.