### PR TITLE
docs: Restructure tutorials into Tutorials menu group

### DIFF
--- a/packages/docs/menus.yaml
+++ b/packages/docs/menus.yaml
@@ -6,57 +6,62 @@
       properties:
         title: Introduction
         icon: AiOutlineCoffee
-    - id: tutorial
+    - id: tutorials
       type: MenuGroup
       properties:
-        title: Tutorial
+        title: Tutorials
         icon: AiOutlineRocket
       links:
-        - id: tutorial-start
-          type: MenuLink
-          pageId: tutorial-start
+        - id: tutorial-ticketing-app
+          type: MenuGroup
           properties:
-            title: Getting started
-        - id: tutorial-create-page
-          type: MenuLink
-          pageId: tutorial-create-page
-          properties:
-            title: Creating a page
-        - id: tutorial-add-blocks
-          type: MenuLink
-          pageId: tutorial-add-blocks
-          properties:
-            title: Adding blocks
-        - id: tutorial-actions-operators
-          type: MenuLink
-          pageId: tutorial-actions-operators
-          properties:
-            title: Interactive pages
-        - id: tutorial-requests-api
-          type: MenuLink
-          pageId: tutorial-requests-api
-          properties:
-            title: API / HTTP requests
-        - id: tutorial-requests-sql
-          type: MenuLink
-          pageId: tutorial-requests-sql
-          properties:
-            title: Saving data
-        - id: tutorial-display-data-page
-          type: MenuLink
-          pageId: tutorial-display-data-page
-          properties:
-            title: Display data
-        # - id: tutorial-deploy
-        #   type: MenuLink
-        #   pageId: tutorial-deploy
-        #   properties:
-        #     title: Deploy to Netlify
-        - id: tutorial-next-steps
-          type: MenuLink
-          pageId: tutorial-next-steps
-          properties:
-            title: Next steps
+            title: Ticketing App
+          links:
+            - id: tutorial-start
+              type: MenuLink
+              pageId: tutorial-start
+              properties:
+                title: Getting started
+            - id: tutorial-create-page
+              type: MenuLink
+              pageId: tutorial-create-page
+              properties:
+                title: Creating a page
+            - id: tutorial-add-blocks
+              type: MenuLink
+              pageId: tutorial-add-blocks
+              properties:
+                title: Adding blocks
+            - id: tutorial-actions-operators
+              type: MenuLink
+              pageId: tutorial-actions-operators
+              properties:
+                title: Interactive pages
+            - id: tutorial-requests-api
+              type: MenuLink
+              pageId: tutorial-requests-api
+              properties:
+                title: API / HTTP requests
+            - id: tutorial-requests-sql
+              type: MenuLink
+              pageId: tutorial-requests-sql
+              properties:
+                title: Saving data
+            - id: tutorial-display-data-page
+              type: MenuLink
+              pageId: tutorial-display-data-page
+              properties:
+                title: Display data
+            # - id: tutorial-deploy
+            #   type: MenuLink
+            #   pageId: tutorial-deploy
+            #   properties:
+            #     title: Deploy to Netlify
+            - id: tutorial-next-steps
+              type: MenuLink
+              pageId: tutorial-next-steps
+              properties:
+                title: Next steps
     - id: concepts
       type: MenuGroup
       properties:

--- a/packages/docs/pages.yaml
+++ b/packages/docs/pages.yaml
@@ -1,12 +1,12 @@
 - _ref: introduction.yaml
-- _ref: tutorial/tutorial-start.yaml
-- _ref: tutorial/tutorial-create-page.yaml
-- _ref: tutorial/tutorial-add-blocks.yaml
-- _ref: tutorial/tutorial-actions-operators.yaml
-- _ref: tutorial/tutorial-requests-api.yaml
-- _ref: tutorial/tutorial-requests-sql.yaml
-- _ref: tutorial/tutorial-display-data-page.yaml
-- _ref: tutorial/tutorial-next-steps.yaml
+- _ref: tutorials/ticketing-app/tutorial-start.yaml
+- _ref: tutorials/ticketing-app/tutorial-create-page.yaml
+- _ref: tutorials/ticketing-app/tutorial-add-blocks.yaml
+- _ref: tutorials/ticketing-app/tutorial-actions-operators.yaml
+- _ref: tutorials/ticketing-app/tutorial-requests-api.yaml
+- _ref: tutorials/ticketing-app/tutorial-requests-sql.yaml
+- _ref: tutorials/ticketing-app/tutorial-display-data-page.yaml
+- _ref: tutorials/ticketing-app/tutorial-next-steps.yaml
 
 - _ref: concepts/overview.yaml
 - _ref: concepts/lowdefy-schema.yaml

--- a/packages/docs/templates/general.yaml.njk
+++ b/packages/docs/templates/general.yaml.njk
@@ -53,6 +53,11 @@ blocks:
           - _ref: version.yaml
       {% if section %}
           - {{ section }}
+      {% endif %}
+      {% if subSection %}
+          - {{ subSection }}
+      {% endif %}
+      {% if section or subSection %}
           - {{ pageTitle }}
       {% endif %}
 

--- a/packages/docs/templates/navigation_buttons.yaml
+++ b/packages/docs/templates/navigation_buttons.yaml
@@ -27,7 +27,14 @@ blocks:
         - _var: previous_page_id
         - _var: previous_page_title
     layout:
-      span: 12
+      span:
+        _if:
+          test:
+            _and:
+              - _var: next_page_id
+              - _var: next_page_title
+          then: 12
+          else: 24
     properties:
       block: true
       hideActionLoading: true
@@ -53,7 +60,14 @@ blocks:
         - _var: next_page_id
         - _var: next_page_title
     layout:
-      span: 12
+      span:
+        _if:
+          test:
+            _and:
+              - _var: previous_page_id
+              - _var: previous_page_title
+          then: 12
+          else: 24
     properties:
       block: true
       hideActionLoading: true

--- a/packages/docs/templates/navigation_buttons.yaml
+++ b/packages/docs/templates/navigation_buttons.yaml
@@ -22,6 +22,10 @@ layout:
 blocks:
   - id: previous_button
     type: Button
+    visible:
+      _and:
+        - _var: previous_page_id
+        - _var: previous_page_title
     layout:
       span: 12
     properties:
@@ -44,6 +48,10 @@ blocks:
             top: 0
   - id: next_button
     type: Button
+    visible:
+      _and:
+        - _var: next_page_id
+        - _var: next_page_title
     layout:
       span: 12
     properties:

--- a/packages/docs/tutorials/ticketing-app/tutorial-actions-operators.yaml
+++ b/packages/docs/tutorials/ticketing-app/tutorial-actions-operators.yaml
@@ -380,7 +380,6 @@ _ref:
                 properties:
                   title: Reset
                   block: true # Make the button fill all the space available to it
-                  type: default # Make the button a plain button
                   icon: AiOutlineClear
                 events:
                   onClick:
@@ -393,7 +392,8 @@ _ref:
                 properties:
                   title: Submit
                   block: true
-                  type: primary # Make the button a primary button with color
+                  color: primary
+                  variant: solid
                   icon: AiOutlineSave
                 events:
                   onClick:

--- a/packages/docs/tutorials/ticketing-app/tutorial-actions-operators.yaml
+++ b/packages/docs/tutorials/ticketing-app/tutorial-actions-operators.yaml
@@ -17,8 +17,9 @@ _ref:
   vars:
     pageId: tutorial-actions-operators
     pageTitle: 4. Interactive pages with actions and operators
-    section: Tutorial
-    filePath: tutorial/tutorial-actions-operators.yaml
+    section: Tutorials
+    subSection: Ticketing App
+    filePath: tutorials/ticketing-app/tutorial-actions-operators.yaml
     content:
       - id: body_reset
         type: MarkdownWithCode

--- a/packages/docs/tutorials/ticketing-app/tutorial-add-blocks.yaml
+++ b/packages/docs/tutorials/ticketing-app/tutorial-add-blocks.yaml
@@ -74,7 +74,6 @@ _ref:
                     properties:
                       title: Reset
                       block: true # Make the button fill all the space available to it
-                      type: default # Make the button a plain button
                       icon: AiOutlineClear
                   - id: submit_button
                     type: Button
@@ -83,7 +82,8 @@ _ref:
                     properties:
                       title: Submit
                       block: true
-                      type: primary # Make the button a primary button with color
+                      color: primary
+                      variant: solid
                       icon: AiOutlineSave
             ################ -------- Copy to here ---------- ################
             ```

--- a/packages/docs/tutorials/ticketing-app/tutorial-add-blocks.yaml
+++ b/packages/docs/tutorials/ticketing-app/tutorial-add-blocks.yaml
@@ -17,8 +17,9 @@ _ref:
   vars:
     pageId: tutorial-add-blocks
     pageTitle: 3. Adding blocks
-    section: Tutorial
-    filePath: tutorial/tutorial-add-blocks.yaml
+    section: Tutorials
+    subSection: Ticketing App
+    filePath: tutorials/ticketing-app/tutorial-add-blocks.yaml
     content:
       - id: body_add_blocks
         type: MarkdownWithCode

--- a/packages/docs/tutorials/ticketing-app/tutorial-create-page.yaml
+++ b/packages/docs/tutorials/ticketing-app/tutorial-create-page.yaml
@@ -17,8 +17,9 @@ _ref:
   vars:
     pageId: tutorial-create-page
     pageTitle: 2. Creating a page
-    section: Tutorial
-    filePath: tutorial/tutorial-create-page.yaml
+    section: Tutorials
+    subSection: Ticketing App
+    filePath: tutorials/ticketing-app/tutorial-create-page.yaml
     content:
       - id: body_create_page
         type: MarkdownWithCode

--- a/packages/docs/tutorials/ticketing-app/tutorial-deploy.yaml
+++ b/packages/docs/tutorials/ticketing-app/tutorial-deploy.yaml
@@ -17,8 +17,9 @@ _ref:
   vars:
     pageId: tutorial-deploy
     pageTitle: 6. Deploy to Netlify
-    section: Tutorial
-    filePath: tutorial/tutorial-deploy.yaml
+    section: Tutorials
+    subSection: Ticketing App
+    filePath: tutorials/ticketing-app/tutorial-deploy.yaml
     prefetchPages:
       - next-steps
     content:

--- a/packages/docs/tutorials/ticketing-app/tutorial-display-data-page.yaml
+++ b/packages/docs/tutorials/ticketing-app/tutorial-display-data-page.yaml
@@ -17,8 +17,9 @@ _ref:
   vars:
     pageId: tutorial-display-data-page
     pageTitle: 7. Display ticket data
-    section: Tutorial
-    filePath: tutorial/tutorial-display-data-page.yaml
+    section: Tutorials
+    subSection: Ticketing App
+    filePath: tutorials/ticketing-app/tutorial-display-data-page.yaml
     content:
       - id: add_page
         type: MarkdownWithCode

--- a/packages/docs/tutorials/ticketing-app/tutorial-next-steps.yaml
+++ b/packages/docs/tutorials/ticketing-app/tutorial-next-steps.yaml
@@ -17,10 +17,11 @@ _ref:
   vars:
     pageId: tutorial-next-steps
     pageTitle: Next steps
-    section: Tutorial
+    section: Tutorials
+    subSection: Ticketing App
     prefetchPages:
       - overview
-    filePath: tutorial/tutorial-next-steps.yaml
+    filePath: tutorials/ticketing-app/tutorial-next-steps.yaml
     content:
       - id: body_next_steps
         type: MarkdownWithCode

--- a/packages/docs/tutorials/ticketing-app/tutorial-requests-api.yaml
+++ b/packages/docs/tutorials/ticketing-app/tutorial-requests-api.yaml
@@ -17,8 +17,9 @@ _ref:
   vars:
     pageId: tutorial-requests-api
     pageTitle: 5. API / HTTP requests
-    section: Tutorial
-    filePath: tutorial/tutorial-requests-api.yaml
+    section: Tutorials
+    subSection: Ticketing App
+    filePath: tutorials/ticketing-app/tutorial-requests-api.yaml
     content:
       - id: body_axios
         type: MarkdownWithCode

--- a/packages/docs/tutorials/ticketing-app/tutorial-requests-sql.yaml
+++ b/packages/docs/tutorials/ticketing-app/tutorial-requests-sql.yaml
@@ -17,8 +17,9 @@ _ref:
   vars:
     pageId: tutorial-requests-sql
     pageTitle: 6. Saving data to SQL
-    section: Tutorial
-    filePath: tutorial/tutorial-requests-sql.yaml
+    section: Tutorials
+    subSection: Ticketing App
+    filePath: tutorials/ticketing-app/tutorial-requests-sql.yaml
     content:
       - id: body_sqlite
         type: MarkdownWithCode

--- a/packages/docs/tutorials/ticketing-app/tutorial-requests-sql.yaml
+++ b/packages/docs/tutorials/ticketing-app/tutorial-requests-sql.yaml
@@ -97,7 +97,8 @@ _ref:
                     - id: knex
                       type: Knex
                       properties:
-                        client: sqlite
+                        client: better-sqlite3
+                        useNullAsDefault: true
                         connection:
                           filename:
                             _secret: SQLITE_FILENAME
@@ -123,7 +124,16 @@ _ref:
                     type: KnexRaw
                     connectionId: knex
                     payload:
-                      _state: true
+                      ticket_title:
+                        _state: ticket_title
+                      ticket_type:
+                        _state: ticket_type
+                      ticket_description:
+                        _state: ticket_description
+                      product:
+                        _state: product
+                      purchase_in_last_month:
+                        _state: purchase_in_last_month
                     properties:
                       query: |
                         INSERT INTO tickets (
@@ -202,7 +212,7 @@ _ref:
 
                 We set up the table and column names we will be using in our SQLite database. We need to do this to use the `SQLite` connection.
 
-                We defined the `Knex` connection, with the SQLite client.
+                We defined the `Knex` connection, using the `better-sqlite3` client.
 
                 We also defined a `KnexRaw` request, to save the data to our SQLite database, and called that request when clicking the submit button. This was done by making use of the `onCLick` event on the button to execute the [`Request`](/Request) action to make the API call.
 

--- a/packages/docs/tutorials/ticketing-app/tutorial-start.yaml
+++ b/packages/docs/tutorials/ticketing-app/tutorial-start.yaml
@@ -17,8 +17,9 @@ _ref:
   vars:
     pageId: tutorial-start
     pageTitle: 1. Getting started
-    section: Tutorial
-    filePath: tutorial/tutorial-start.yaml
+    section: Tutorials
+    subSection: Ticketing App
+    filePath: tutorials/ticketing-app/tutorial-start.yaml
     content:
       # TODO: Create new tutorial videos
       # - id: tutorial_video


### PR DESCRIPTION
## Summary

Reorganises the existing tutorial under a new `Tutorials` menu group called **Ticketing App**, in preparation for a second tutorial that will land in a follow-up PR. Also brings the Ticketing App docs in sync with the v5 example code (`better-sqlite3` driver, `KnexRaw` named bindings, button `color`/`variant`), adds a `subSection` breadcrumb var so nested tutorial groups render as proper crumbs, and fixes the nav buttons to span the full row when only one direction is present.

## Changes

- **@lowdefy/docs**: `packages/docs/tutorial/` renamed to `packages/docs/tutorials/ticketing-app/`. Top-level `Tutorial` menu group replaced with `Tutorials > Ticketing App`. Each Ticketing App page's `section`/`subSection` updated to match the new nesting.
- **@lowdefy/docs**: `templates/general.yaml.njk` gains an optional `subSection` var so breadcrumbs can render `<section> / <subSection> / <pageTitle>`. Pages that only set `section` continue to work unchanged.
- **@lowdefy/docs**: `templates/navigation_buttons.yaml` — `previous`/`next` buttons now switch between span 12 (paired) and span 24 (alone) using `_if` on the opposite button's vars, plus existing `visible` guards. No more half-empty rows on tutorial intro/end pages.
- **@lowdefy/docs**: Ticketing App tutorial code blocks updated to v5: Knex `client: better-sqlite3` + `useNullAsDefault: true`, `KnexRaw` `payload: { _state: true }` shortcut replaced with explicit named bindings, Button `type: primary` → `color: primary` + `variant: solid` (and `type: default` dropped on Reset). Live preview blocks were already on v5 — only embedded code-as-text snippets needed updating.

## Notes

- The Incident Tracker tutorial pages and their menu/page-list entries are still uncommitted on this branch — they'll go in a separate PR.
- The `tutorial_db.sqlite` download lives at `public/tutorial/`, served from the URL root, so the docs folder rename doesn't break the download link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)