### PR TITLE
fix(server,server-dev): Validate agent path segments are an array

### DIFF
--- a/packages/servers/server-dev/pages/api/agent/[...path].js
+++ b/packages/servers/server-dev/pages/api/agent/[...path].js
@@ -24,7 +24,7 @@ async function handler({ context, req, res }) {
     throw new Error('Only POST requests are supported.');
   }
   const segments = req.query.path;
-  if (!segments || segments.length < 2) {
+  if (!Array.isArray(segments) || segments.length < 2) {
     res.status(400).json({ error: 'Invalid agent path' });
     return;
   }

--- a/packages/servers/server/pages/api/agent/[...path].js
+++ b/packages/servers/server/pages/api/agent/[...path].js
@@ -24,7 +24,7 @@ async function handler({ context, req, res }) {
     throw new Error('Only POST requests are supported.');
   }
   const segments = req.query.path;
-  if (!segments || segments.length < 2) {
+  if (!Array.isArray(segments) || segments.length < 2) {
     res.status(400).json({ error: 'Invalid agent path' });
     return;
   }


### PR DESCRIPTION
## Summary

Resolves the six CodeQL "Type confusion through parameter tampering" alerts surfaced on #2162 against the agent API route. Next.js catch-all routes return `req.query.path` as `string | string[]`, and the existing truthy check did not narrow the type, leaving `.length`, index access, and `.slice` flagged by CodeQL.

## Changes

- **@lowdefy/server**: Guard `segments` with `Array.isArray` in `pages/api/agent/[...path].js` before using array operations.
- **@lowdefy/server-dev**: Same guard in the dev server's agent route.

Mirrors the established pattern in `pages/api/request/[...path].js` (introduced in bba41660e).

## Notes

Source-file changes are already covered by the agent feature changeset that bumps both server packages in this release cycle, so no additional changeset is needed.