### PR TITLE
fix(ai-utils): Add repository field to package.json

### DIFF
--- a/packages/utils/ai-utils/package.json
+++ b/packages/utils/ai-utils/package.json
@@ -2,6 +2,10 @@
   "name": "@lowdefy/ai-utils",
   "version": "5.3.0",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lowdefy/lowdefy.git"
+  },
   "type": "module",
   "exports": {
     ".": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Adds the missing `repository` field to `packages/utils/ai-utils/package.json`.
- The npm publish for `@lowdefy/ai-utils` failed sigstore provenance verification with:
  ```
  Error verifying sigstore provenance bundle: Failed to validate repository information:
  package.json: "repository.url" is "", expected to match "https://github.com/lowdefy/lowdefy"
  ```
  See failed run: https://github.com/lowdefy/lowdefy/actions/runs/25662322405

This is the only `@lowdefy/*` package.json that was missing the field; all others already use the same `{ "type": "git", "url": "https://github.com/lowdefy/lowdefy.git" }` form.

## Test plan

- [ ] Confirm next release publishes `@lowdefy/ai-utils` successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)