### PR TITLE
Match 7-char changeset hashes in release notes generator

### DIFF
--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -315,7 +315,7 @@ function parseChangesetEntries(content) {
     if (line.match(/^\s+- @?[\w/-]+@\d+\.\d+\.\d+$/)) continue;
 
     // New changeset entry: `- {hash}: {description}`
-    const entryMatch = line.match(/^- ([a-f0-9]{8,}): (.+)/);
+    const entryMatch = line.match(/^- ([a-f0-9]{7,}): (.+)/);
     if (entryMatch) {
       if (currentEntry) entries.push(currentEntry);
       currentEntry = {


### PR DESCRIPTION
## Summary

The release-notes script in `scripts/release-notes.mjs` was emitting bloated, per-package-duplicated content for v5.3.0 (62 KB body) instead of the intended deduplicated `## What's New` / `## Fixes & Improvements` sections. The cause: `parseChangesetEntries` matches entries with a regex requiring 8+ hex chars, but current `@changesets/cli` releases emit 7-char short hashes (e.g. `6955341`, `7f40746`), so every entry fell through to the plain-text fallback and the same minor-changes block was inlined into every package section.

## Changes

- **scripts/release-notes.mjs**: Lower the hash regex floor from `[a-f0-9]{8,}` to `[a-f0-9]{7,}` so current 7-char changeset IDs match. Legacy 9-10 char hashes still match. Re-running the script on v5.3.0 reduces output from ~950 lines to ~120 lines, with each changeset appearing once and packages listed under it.

## Notes

This bug only became visible on the v5.3.0 release, because the script was originally written when older releases used 9-10 char hashes. No tests exist for this script; verified by re-running locally against the v5.3.0 CHANGELOGs and inspecting the output.