### PR TITLE
Resolve lowdefy version dynamically in docs code examples

### DIFF
--- a/packages/docs/agents/introduction.yaml
+++ b/packages/docs/agents/introduction.yaml
@@ -23,108 +23,113 @@ _ref:
       - id: md1
         type: MarkdownWithCode
         properties:
-          content: |
-            Lowdefy agents add AI chat capabilities to your app. An agent connects to an AI model provider (like Anthropic, OpenAI, or Google), can use tools to interact with your app's APIs, and streams responses to an [`AgentChat`](/AgentChat) block in the browser.
+          content:
+            _nunjucks:
+              on:
+                version:
+                  _ref: version.yaml
+              template: |
+                Lowdefy agents add AI chat capabilities to your app. An agent connects to an AI model provider (like Anthropic, OpenAI, or Google), can use tools to interact with your app's APIs, and streams responses to an [`AgentChat`](/AgentChat) block in the browser.
 
-            Agents are defined at the root of your Lowdefy configuration, alongside `connections` and `pages`. You define the agent in YAML, and Lowdefy handles the streaming, tool execution, and UI.
+                Agents are defined at the root of your Lowdefy configuration, alongside `connections` and `pages`. You define the agent in YAML, and Lowdefy handles the streaming, tool execution, and UI.
 
-            ## Quick Start
+                ## Quick Start
 
-            A connection, an agent, and a chat block — that's all you need:
+                A connection, an agent, and a chat block — that's all you need:
 
-            ```yaml
-            lowdefy: 4.7.3
+                ```yaml
+                lowdefy: {{ version }}
 
-            connections:
-              - id: anthropic
-                type: Anthropic
-                properties:
-                  apiKey:
-                    _secret: ANTHROPIC_API_KEY
-
-            agents:
-              - id: assistant
-                type: ClaudeAgent
-                connectionId: anthropic
-                properties:
-                  model: claude-sonnet-4-20250514
-                  instructions: |
-                    You are a helpful assistant for Acme Corp. Answer questions
-                    about our products and services. Be friendly and concise.
-
-            pages:
-              - id: chat
-                type: PageHeaderMenu
-                properties:
-                  title: Chat
-                blocks:
-                  - id: chat
-                    type: AgentChat
+                connections:
+                  - id: anthropic
+                    type: Anthropic
                     properties:
-                      agentId: assistant
-            ```
+                      apiKey:
+                        _secret: ANTHROPIC_API_KEY
 
-            Set the `ANTHROPIC_API_KEY` [secret](/secrets) and you have a fully working AI chat — streaming responses, markdown rendering, code highlighting, and editable messages all work out of the box.
-
-            ## How Agents Work
-
-            When a user sends a message in an [`AgentChat`](/AgentChat) block:
-
-            1. The message is sent to the Lowdefy server via a streaming API endpoint.
-            2. The server loads the agent configuration, creates a connection to the AI provider, and starts a conversation with the model.
-            3. If the agent has tools, the model can call them. Tool calls execute server-side (API endpoints, MCP servers, or sub-agents) and the results are sent back to the model.
-            4. The model's response streams back to the browser in real time, updating the chat UI as tokens arrive.
-
-            This tool loop continues until the model produces a final text response or reaches the `maxSteps` limit.
-
-            ## Agent Definition
-
-            Agents are defined in the top-level `agents` array in your Lowdefy configuration:
-
-            - `id: string`: __Required__ - A unique identifier for the agent.
-            - `type: string`: __Required__ - The agent type. See [Anthropic](/Anthropic), [OpenAI](/OpenAI-connection), and [Google](/Google) for available types.
-            - `connectionId: string`: __Required__ - The `id` of the connection to use.
-            - `properties: object`: Model, instructions, and behavior settings. See [Agent Properties](/agent-properties). __Operators are evaluated__.
-            - `tools: array`: API endpoint tools. See [Endpoint Tools](/agent-endpoint-tools).
-            - `mcp: array`: MCP server tools. See [MCP Tools](/agent-mcp-tools).
-            - `agents: array`: Sub-agent tools. See [Multi-Agent](/agent-multi-agent).
-            - `hooks: object`: Server-side lifecycle hooks. See [Server Hooks](/agent-server-hooks).
-
-            ###### Agent with tools, sub-agents, and hooks:
-            ```yaml
-            agents:
-              - id: support_agent
-                type: ClaudeAgent
-                connectionId: anthropic
-                properties:
-                  model: claude-sonnet-4-20250514
-                  instructions: |
-                    You are a customer support agent. Help users find products
-                    and answer questions. Be friendly and concise.
-                  maxSteps: 5
-                tools:
-                  - search-products
-                  - endpointId: create-ticket
-                    confirm: true
-                mcp:
-                  - mcp_knowledge_base
                 agents:
-                  - agentId: billing_agent
-                    description: Handles billing and payment questions.
-                hooks:
-                  onFinish:
-                    - save-conversation
-            ```
+                  - id: assistant
+                    type: ClaudeAgent
+                    connectionId: anthropic
+                    properties:
+                      model: claude-sonnet-4-20250514
+                      instructions: |
+                        You are a helpful assistant for Acme Corp. Answer questions
+                        about our products and services. Be friendly and concise.
 
-            ## What's Next
+                pages:
+                  - id: chat
+                    type: PageHeaderMenu
+                    properties:
+                      title: Chat
+                    blocks:
+                      - id: chat
+                        type: AgentChat
+                        properties:
+                          agentId: assistant
+                ```
 
-            - [Agent Properties](/agent-properties) — Configure model, temperature, pruning, and more.
-            - [Endpoint Tools](/agent-endpoint-tools) — Give the agent access to your database and APIs.
-            - [MCP Tools](/agent-mcp-tools) — Connect to external tool providers via the MCP standard.
-            - [Multi-Agent](/agent-multi-agent) — Delegate tasks to specialized sub-agents.
-            - [Server Hooks](/agent-server-hooks) — Save conversations, generate titles, and run server-side logic.
-            - [AgentChat](/AgentChat) — Configure the chat UI block.
-            - [AgentConversations](/AgentConversations) — Add a conversation history sidebar.
+                Set the `ANTHROPIC_API_KEY` [secret](/secrets) and you have a fully working AI chat — streaming responses, markdown rendering, code highlighting, and editable messages all work out of the box.
+
+                ## How Agents Work
+
+                When a user sends a message in an [`AgentChat`](/AgentChat) block:
+
+                1. The message is sent to the Lowdefy server via a streaming API endpoint.
+                2. The server loads the agent configuration, creates a connection to the AI provider, and starts a conversation with the model.
+                3. If the agent has tools, the model can call them. Tool calls execute server-side (API endpoints, MCP servers, or sub-agents) and the results are sent back to the model.
+                4. The model's response streams back to the browser in real time, updating the chat UI as tokens arrive.
+
+                This tool loop continues until the model produces a final text response or reaches the `maxSteps` limit.
+
+                ## Agent Definition
+
+                Agents are defined in the top-level `agents` array in your Lowdefy configuration:
+
+                - `id: string`: __Required__ - A unique identifier for the agent.
+                - `type: string`: __Required__ - The agent type. See [Anthropic](/Anthropic), [OpenAI](/OpenAI-connection), and [Google](/Google) for available types.
+                - `connectionId: string`: __Required__ - The `id` of the connection to use.
+                - `properties: object`: Model, instructions, and behavior settings. See [Agent Properties](/agent-properties). __Operators are evaluated__.
+                - `tools: array`: API endpoint tools. See [Endpoint Tools](/agent-endpoint-tools).
+                - `mcp: array`: MCP server tools. See [MCP Tools](/agent-mcp-tools).
+                - `agents: array`: Sub-agent tools. See [Multi-Agent](/agent-multi-agent).
+                - `hooks: object`: Server-side lifecycle hooks. See [Server Hooks](/agent-server-hooks).
+
+                ###### Agent with tools, sub-agents, and hooks:
+                ```yaml
+                agents:
+                  - id: support_agent
+                    type: ClaudeAgent
+                    connectionId: anthropic
+                    properties:
+                      model: claude-sonnet-4-20250514
+                      instructions: |
+                        You are a customer support agent. Help users find products
+                        and answer questions. Be friendly and concise.
+                      maxSteps: 5
+                    tools:
+                      - search-products
+                      - endpointId: create-ticket
+                        confirm: true
+                    mcp:
+                      - mcp_knowledge_base
+                    agents:
+                      - agentId: billing_agent
+                        description: Handles billing and payment questions.
+                    hooks:
+                      onFinish:
+                        - save-conversation
+                ```
+
+                ## What's Next
+
+                - [Agent Properties](/agent-properties) — Configure model, temperature, pruning, and more.
+                - [Endpoint Tools](/agent-endpoint-tools) — Give the agent access to your database and APIs.
+                - [MCP Tools](/agent-mcp-tools) — Connect to external tool providers via the MCP standard.
+                - [Multi-Agent](/agent-multi-agent) — Delegate tasks to specialized sub-agents.
+                - [Server Hooks](/agent-server-hooks) — Save conversations, generate titles, and run server-side logic.
+                - [AgentChat](/AgentChat) — Configure the chat UI block.
+                - [AgentConversations](/AgentConversations) — Add a conversation history sidebar.
 
       - _ref:
           path: templates/navigation_buttons.yaml

--- a/packages/docs/concepts/logger.yaml
+++ b/packages/docs/concepts/logger.yaml
@@ -23,88 +23,93 @@ _ref:
       - id: md1
         type: Markdown
         properties:
-          content: |
-            Lowdefy provides built-in error logging and monitoring capabilities. When properly configured, errors from both client and server are captured and sent to external logging services.
+          content:
+            _nunjucks:
+              on:
+                version:
+                  _ref: version.yaml
+              template: |
+                Lowdefy provides built-in error logging and monitoring capabilities. When properly configured, errors from both client and server are captured and sent to external logging services.
 
-            ## Sentry Integration
+                ## Sentry Integration
 
-            [Sentry](https://sentry.io) is a popular error tracking and performance monitoring platform. Lowdefy has built-in Sentry integration that captures errors with rich context including page IDs, block IDs, and config file locations.
+                [Sentry](https://sentry.io) is a popular error tracking and performance monitoring platform. Lowdefy has built-in Sentry integration that captures errors with rich context including page IDs, block IDs, and config file locations.
 
-            ### Quick Start
+                ### Quick Start
 
-            To enable Sentry, set the `SENTRY_DSN` environment variable:
+                To enable Sentry, set the `SENTRY_DSN` environment variable:
 
-            ```
-            SENTRY_DSN=https://your-dsn@sentry.io/project
-            ```
+                ```
+                SENTRY_DSN=https://your-dsn@sentry.io/project
+                ```
 
-            With this environment variable set, Sentry will capture errors from both client and server with sensible defaults.
+                With this environment variable set, Sentry will capture errors from both client and server with sensible defaults.
 
-            ### Client-Side Configuration
+                ### Client-Side Configuration
 
-            For client-side error capture, you also need to expose the DSN to the browser:
+                For client-side error capture, you also need to expose the DSN to the browser:
 
-            ```
-            NEXT_PUBLIC_SENTRY_DSN=https://your-dsn@sentry.io/project
-            ```
+                ```
+                NEXT_PUBLIC_SENTRY_DSN=https://your-dsn@sentry.io/project
+                ```
 
-            ### Configuration Options
+                ### Configuration Options
 
-            You can customize Sentry behavior using the `logger` configuration in your `lowdefy.yaml`:
+                You can customize Sentry behavior using the `logger` configuration in your `lowdefy.yaml`:
 
-            ```yaml
-            lowdefy: 4.5.2
+                ```yaml
+                lowdefy: {{ version }}
 
-            logger:
-              sentry:
-                # Enable/disable client-side logging (default: true)
-                client: true
-                # Enable/disable server-side logging (default: true)
-                server: true
-                # Sample rate for performance traces (default: 0.1)
-                tracesSampleRate: 0.1
-                # Sample rate for session replay (default: 0)
-                replaysSessionSampleRate: 0
-                # Sample rate for replay on errors (default: 0.1)
-                replaysOnErrorSampleRate: 0.1
-                # Enable user feedback widget (default: false)
-                feedback: false
-                # Override environment detection (default: auto from NODE_ENV)
-                environment: production
-                # User fields to include in error reports (default: ['id', '_id'])
-                userFields:
-                  - id
-                  - _id
-            ```
+                logger:
+                  sentry:
+                    # Enable/disable client-side logging (default: true)
+                    client: true
+                    # Enable/disable server-side logging (default: true)
+                    server: true
+                    # Sample rate for performance traces (default: 0.1)
+                    tracesSampleRate: 0.1
+                    # Sample rate for session replay (default: 0)
+                    replaysSessionSampleRate: 0
+                    # Sample rate for replay on errors (default: 0.1)
+                    replaysOnErrorSampleRate: 0.1
+                    # Enable user feedback widget (default: false)
+                    feedback: false
+                    # Override environment detection (default: auto from NODE_ENV)
+                    environment: production
+                    # User fields to include in error reports (default: ['id', '_id'])
+                    userFields:
+                      - id
+                      - _id
+                ```
 
-            ### Default Configuration
+                ### Default Configuration
 
-            If you only set `SENTRY_DSN` without any `logger.sentry` configuration, these defaults are used:
+                If you only set `SENTRY_DSN` without any `logger.sentry` configuration, these defaults are used:
 
-            | Option | Default | Description |
-            |--------|---------|-------------|
-            | `client` | `true` | Client-side error capture enabled |
-            | `server` | `true` | Server-side error capture enabled |
-            | `tracesSampleRate` | `0.1` | 10% of transactions traced |
-            | `replaysSessionSampleRate` | `0` | Session replay disabled by default |
-            | `replaysOnErrorSampleRate` | `0.1` | 10% of error sessions replayed |
-            | `feedback` | `false` | User feedback widget disabled |
-            | `userFields` | `['id', '_id']` | Only user ID fields logged |
+                | Option | Default | Description |
+                |--------|---------|-------------|
+                | `client` | `true` | Client-side error capture enabled |
+                | `server` | `true` | Server-side error capture enabled |
+                | `tracesSampleRate` | `0.1` | 10% of transactions traced |
+                | `replaysSessionSampleRate` | `0` | Session replay disabled by default |
+                | `replaysOnErrorSampleRate` | `0.1` | 10% of error sessions replayed |
+                | `feedback` | `false` | User feedback widget disabled |
+                | `userFields` | `['id', '_id']` | Only user ID fields logged |
 
-            ### User Context
+                ### User Context
 
-            For authenticated users, Sentry automatically captures user context based on the `userFields` configuration. By default, only `id` and `_id` fields from the user session are included to avoid logging PII (personally identifiable information).
+                For authenticated users, Sentry automatically captures user context based on the `userFields` configuration. By default, only `id` and `_id` fields from the user session are included to avoid logging PII (personally identifiable information).
 
-            To include additional fields:
+                To include additional fields:
 
-            ```yaml
-            logger:
-              sentry:
-                userFields:
-                  - id
-                  - _id
-                  - organization_id
-            ```
+                ```yaml
+                logger:
+                  sentry:
+                    userFields:
+                      - id
+                      - _id
+                      - organization_id
+                ```
 
       - id: warning_pii
         type: Alert

--- a/packages/docs/concepts/theming.yaml
+++ b/packages/docs/concepts/theming.yaml
@@ -23,420 +23,425 @@ _ref:
       - id: md1
         type: MarkdownWithCode
         properties:
-          content: |
-            Lowdefy uses the [Ant Design](https://ant.design/) design token system for theming. This allows you to customize colors, typography, spacing, and more at the app level, component type level, or individual block level.
+          content:
+            _nunjucks:
+              on:
+                version:
+                  _ref: version.yaml
+              template: |
+                Lowdefy uses the [Ant Design](https://ant.design/) design token system for theming. This allows you to customize colors, typography, spacing, and more at the app level, component type level, or individual block level.
 
-            ## App-level theme
+                ## App-level theme
 
-            Configure your app's theme in `lowdefy.yaml` under `theme.antd`:
+                Configure your app's theme in `lowdefy.yaml` under `theme.antd`:
 
-            ```yaml
-            lowdefy: 5.0.0
-            theme:
-              antd:
-                token:
-                  colorPrimary: '#6366f1'
-                  colorSuccess: '#22c55e'
-                  colorWarning: '#f59e0b'
-                  colorError: '#ef4444'
-                  fontSize: 14
-                  borderRadius: 8
-            ```
-
-            ### Seed tokens
-
-            Seed tokens are the base values from which all other tokens are derived. The most commonly used seed tokens are:
-
-            | Token | Type | Description |
-            |---|---|---|
-            | `colorPrimary` | string | Primary brand color |
-            | `colorSuccess` | string | Success state color |
-            | `colorWarning` | string | Warning state color |
-            | `colorError` | string | Error state color |
-            | `colorInfo` | string | Info state color |
-            | `colorBgBase` | string | Base background color |
-            | `colorTextBase` | string | Base text color |
-            | `fontSize` | number | Base font size (px) |
-            | `borderRadius` | number | Base border radius (px) |
-            | `wireframe` | boolean | Enable wireframe style |
-            | `fontFamily` | string | Font family |
-
-            From these seed tokens, antd derives hundreds of map tokens (e.g. `colorPrimaryHover`, `colorBgContainer`, `fontSizeLG`) automatically.
-
-            ## Algorithms
-
-            Algorithms transform seed tokens into map tokens. Antd provides three built-in algorithms:
-
-            ```yaml
-            # Dark mode
-            theme:
-              antd:
-                algorithm: dark
-
-            # Compact mode
-            theme:
-              antd:
-                algorithm: compact
-
-            # Combine multiple algorithms
-            theme:
-              antd:
-                algorithm:
-                  - dark
-                  - compact
-            ```
-
-            | Algorithm | Description |
-            |---|---|
-            | `default` | Default light theme |
-            | `dark` | Dark color scheme |
-            | `compact` | Reduced spacing and smaller sizes |
-
-            ## Per-component-type overrides
-
-            Override design tokens for all instances of a component type:
-
-            ```yaml
-            theme:
-              antd:
-                token:
-                  colorPrimary: '#6366f1'
-                components:
-                  Button:
-                    fontWeight: 700
-                    paddingInline: 24
-                  Card:
-                    headerBg: '#f5f5f5'
-                    bodyPadding: '24px'
-                  Input:
-                    activeBorderColor: '#6366f1'
-            ```
-
-            Each antd component has its own set of component tokens. See the individual block documentation pages for commonly used tokens, or the [antd component token reference](https://ant.design/components/overview/) for the full list.
-
-            ## Per-block overrides
-
-            Override design tokens for a single block instance using `properties.theme`:
-
-            ```yaml
-            - id: special_button
-              type: Button
-              properties:
-                title: Special Button
+                ```yaml
+                lowdefy: {{ version }}
                 theme:
-                  fontWeight: 700
-                  paddingInline: 24
-                  primaryColor: '#6366f1'
-            ```
+                  antd:
+                    token:
+                      colorPrimary: '#6366f1'
+                      colorSuccess: '#22c55e'
+                      colorWarning: '#f59e0b'
+                      colorError: '#ef4444'
+                      fontSize: 14
+                      borderRadius: 8
+                ```
 
-            Under the hood, `properties.theme` wraps the block in a scoped [ConfigProvider](/ConfigProvider) with the specified component tokens.
+                ### Seed tokens
 
-            ## ConfigProvider block
+                Seed tokens are the base values from which all other tokens are derived. The most commonly used seed tokens are:
 
-            For scoped theming of a group of blocks, use the [ConfigProvider](/ConfigProvider) container block:
+                | Token | Type | Description |
+                |---|---|---|
+                | `colorPrimary` | string | Primary brand color |
+                | `colorSuccess` | string | Success state color |
+                | `colorWarning` | string | Warning state color |
+                | `colorError` | string | Error state color |
+                | `colorInfo` | string | Info state color |
+                | `colorBgBase` | string | Base background color |
+                | `colorTextBase` | string | Base text color |
+                | `fontSize` | number | Base font size (px) |
+                | `borderRadius` | number | Base border radius (px) |
+                | `wireframe` | boolean | Enable wireframe style |
+                | `fontFamily` | string | Font family |
 
-            ```yaml
-            - id: dark_section
-              type: ConfigProvider
-              properties:
-                algorithm: dark
-                token:
-                  colorPrimary: '#a855f7'
-              blocks:
-                - id: themed_card
-                  type: Card
-                  properties:
-                    title: Dark Themed Card
-                - id: themed_button
+                From these seed tokens, antd derives hundreds of map tokens (e.g. `colorPrimaryHover`, `colorBgContainer`, `fontSizeLG`) automatically.
+
+                ## Algorithms
+
+                Algorithms transform seed tokens into map tokens. Antd provides three built-in algorithms:
+
+                ```yaml
+                # Dark mode
+                theme:
+                  antd:
+                    algorithm: dark
+
+                # Compact mode
+                theme:
+                  antd:
+                    algorithm: compact
+
+                # Combine multiple algorithms
+                theme:
+                  antd:
+                    algorithm:
+                      - dark
+                      - compact
+                ```
+
+                | Algorithm | Description |
+                |---|---|
+                | `default` | Default light theme |
+                | `dark` | Dark color scheme |
+                | `compact` | Reduced spacing and smaller sizes |
+
+                ## Per-component-type overrides
+
+                Override design tokens for all instances of a component type:
+
+                ```yaml
+                theme:
+                  antd:
+                    token:
+                      colorPrimary: '#6366f1'
+                    components:
+                      Button:
+                        fontWeight: 700
+                        paddingInline: 24
+                      Card:
+                        headerBg: '#f5f5f5'
+                        bodyPadding: '24px'
+                      Input:
+                        activeBorderColor: '#6366f1'
+                ```
+
+                Each antd component has its own set of component tokens. See the individual block documentation pages for commonly used tokens, or the [antd component token reference](https://ant.design/components/overview/) for the full list.
+
+                ## Per-block overrides
+
+                Override design tokens for a single block instance using `properties.theme`:
+
+                ```yaml
+                - id: special_button
                   type: Button
                   properties:
-                    title: Click Me
-            ```
+                    title: Special Button
+                    theme:
+                      fontWeight: 700
+                      paddingInline: 24
+                      primaryColor: '#6366f1'
+                ```
 
-            ConfigProvider creates a theme scope — all child blocks inherit the specified theme tokens and algorithm.
+                Under the hood, `properties.theme` wraps the block in a scoped [ConfigProvider](/ConfigProvider) with the specified component tokens.
 
-            ## The `_theme` operator
+                ## ConfigProvider block
 
-            Access seed tokens in expressions using the `_theme` operator:
+                For scoped theming of a group of blocks, use the [ConfigProvider](/ConfigProvider) container block:
 
-            ```yaml
-            # String form — get a single token
-            color:
-              _theme: colorPrimary
+                ```yaml
+                - id: dark_section
+                  type: ConfigProvider
+                  properties:
+                    algorithm: dark
+                    token:
+                      colorPrimary: '#a855f7'
+                  blocks:
+                    - id: themed_card
+                      type: Card
+                      properties:
+                        title: Dark Themed Card
+                    - id: themed_button
+                      type: Button
+                      properties:
+                        title: Click Me
+                ```
 
-            # Object form — with default value
-            background:
-              _theme:
-                key: colorBgContainer
-                default: '#ffffff'
+                ConfigProvider creates a theme scope — all child blocks inherit the specified theme tokens and algorithm.
 
-            # Get all tokens
-            allTokens:
-              _theme:
-                all: true
-            ```
+                ## The `_theme` operator
 
-            The `_theme` operator resolves seed tokens from `theme.antd.token`. For derived tokens (like hover/active variants), use CSS variables instead: `var(--ant-color-primary-hover)`.
+                Access seed tokens in expressions using the `_theme` operator:
 
-            See the [`_theme` operator reference](/_theme) for full documentation.
-
-            ## CSS variables
-
-            All antd design tokens are available as CSS variables with the `--ant-` prefix. This is useful in `public/styles.css` or when using CSS-based customizations:
-
-            ```css
-            .my-custom-class {
-              color: var(--ant-color-primary);
-              background: var(--ant-color-bg-container);
-              border: 1px solid var(--ant-color-border);
-              border-radius: var(--ant-border-radius);
-            }
-            ```
-
-            Token names are converted from camelCase to kebab-case for the CSS variable name (e.g. `colorPrimary` → `--ant-color-primary`).
-
-            ## Dark mode
-
-            Lowdefy supports three dark mode behaviors, configured via `theme.darkMode`:
-
-            ```yaml
-            theme:
-              darkMode: system  # 'system' (default), 'light', or 'dark'
-            ```
-
-            | Value | Behavior |
-            |---|---|
-            | `system` | Follows the OS dark mode preference and updates live when it changes. Users can override with `SetDarkMode`. This is the default. |
-            | `light` | Forces light mode. `SetDarkMode` preferences are stored but have no visual effect. |
-            | `dark` | Forces dark mode. `SetDarkMode` preferences are stored but have no visual effect. |
-
-            You can also scope dark mode to a section using [ConfigProvider](/ConfigProvider):
-
-            ```yaml
-            - id: dark_section
-              type: ConfigProvider
-              properties:
-                algorithm: dark
-              blocks:
-                # All blocks here will use dark theme
-            ```
-
-            ### Easy dark mode toggle
-
-            Add a built-in dark mode toggle to your page layout with a single property:
-
-            ```yaml
-            - id: my_page
-              type: PageHeaderMenu  # or PageSiderMenu
-              properties:
-                darkModeToggle: true
-            ```
-
-            This renders a moon/sun icon in the header that cycles through light, dark, and system preferences. The preference is persisted to `localStorage`.
-
-            For custom toggle implementations, see the programmatic approach below.
-
-            ### Programmatic dark mode toggle
-
-            Use the `SetDarkMode` action with `_media: darkMode` to let users control dark mode at runtime:
-
-            ```yaml
-            - id: dark_mode_toggle
-              type: Button
-              properties:
-                hideTitle: true
-                icon:
-                  _if:
-                    test:
-                      _media: darkMode
-                    then: AiOutlineSun
-                    else: AiOutlineMoon
-              events:
-                onClick:
-                  - id: toggle
-                    type: SetDarkMode
-            ```
-
-            Without params, `SetDarkMode` cycles through `light`, `dark`, and `system`. You can also set a specific preference:
-
-            ```yaml
-            - id: set_system
-              type: SetDarkMode
-              params:
-                darkMode: system
-            ```
-
-            The user's preference is persisted to `localStorage` and survives page refreshes. Use `_media: darkModePreference` to read the current preference (`'system'`, `'light'`, or `'dark'`), and `_media: darkMode` for the effective boolean state.
-
-            `SetDarkMode` automatically merges the `dark` algorithm with any existing algorithm configured in `theme.antd.algorithm`. For example, if your app uses `algorithm: compact`, toggling dark mode produces `[compact, dark]`.
-
-            See the [`SetDarkMode` action reference](/SetDarkMode) and [`_media` operator reference](/_media) for full documentation.
-
-            ### Tip: Use CSS variables for dark-mode-safe colors
-
-            When styling blocks with custom colors (e.g. `cellStyle` in AgGrid, or `style` on any block), avoid hardcoded hex values — they won't adapt to dark mode. Use antd CSS variables instead:
-
-            ```yaml
-            # Bad — hardcoded colors look washed out in dark mode
-            cellStyle:
-              backgroundColor: '#e6f7ff'
-
-            # Good — antd palette tokens adapt automatically
-            cellStyle:
-              backgroundColor: var(--ant-blue-1)
-            ```
-
-            Useful palette variables: `var(--ant-blue-1)`, `var(--ant-green-1)`, `var(--ant-orange-1)`, `var(--ant-red-1)`, etc. For semantic colors, use `var(--ant-color-primary-bg)`, `var(--ant-color-success-bg)`, `var(--ant-color-warning-bg)`, `var(--ant-color-error-bg)`.
-
-            ### Customizing base colors per mode
-
-            Antd's default dark algorithm uses pure black (`#000`) for `colorBgLayout`, and the default light algorithm uses a stark off-white. If you want softer, more modern base surfaces, use `lightToken` and `darkToken` on `theme.antd`. These are merged on top of `theme.antd.token` only when the matching mode is active, so you get full per-mode control without juggling two separate theme files:
-
-            ```yaml
-            theme:
-              antd:
-                token:                     # Shared — applied in both modes
-                  colorPrimary: '#6366f1'
-                  borderRadius: 8
-                lightToken:                # Merged when light mode is active
-                  colorBgLayout: '#fafafa'
-                  colorBgContainer: '#ffffff'
-                darkToken:                 # Merged when dark mode is active
-                  colorBgLayout: '#0f1117'
-                  colorBgContainer: '#18181b'
-                  colorBgElevated: '#1f2937'
-              darkMode: system
-            ```
-
-            Tokens to customize for a softer base surface:
-
-            | Token | Where it shows up |
-            |---|---|
-            | `colorBgLayout` | Page background behind the layout — also applied to the `<html>` element to prevent navigation flash |
-            | `colorBgContainer` | Card, Table, Input, Modal body fill |
-            | `colorBgElevated` | Popover, Dropdown, Tooltip-host surfaces |
-            | `colorText` | Primary text color |
-            | `colorTextSecondary` | Secondary / muted text |
-
-            The pre-hydration script reads `darkToken.colorBgLayout` and `lightToken.colorBgLayout` directly, so the `<html>` background matches your configured color on first paint — there is no flash of `#000` or `#fff` before hydration. If you don't set a `lightToken.colorBgLayout`, light mode keeps the browser default white (today's behavior).
-
-            ### Per-mode component overrides
-
-            `colorBg*` seed tokens don't reach every component — Layout's header/sider and Menu have their own component tokens (`Layout.headerBg`, `Layout.siderBg`, `Menu.darkItemBg`, etc.). Use `darkComponents` and `lightComponents` alongside `darkToken`/`lightToken` to soften these surfaces in the active mode only:
-
-            ```yaml
-            theme:
-              antd:
-                darkToken:
-                  colorBgLayout: '#0f172a'
-                  colorBgContainer: '#111a2e'
-                darkComponents:
-                  Layout:
-                    bodyBg: '#0f172a'
-                    headerBg: '#0b1120'
-                    siderBg: '#0b1120'
-                    triggerBg: '#111a2e'
-                    triggerColor: '#e2e8f0'
-                  Menu:
-                    darkItemBg: '#0b1120'
-                    darkSubMenuItemBg: '#0b1120'
-                    darkPopupBg: '#111a2e'
-                    darkItemSelectedBg: '#1e293b'
-                    darkItemHoverBg: '#111a2e'
-            ```
-
-            `darkComponents` / `lightComponents` are merged per-component (deep at the component name level) on top of the shared `components`, so you only need to specify the per-mode deltas.
-
-            See antd's [design token reference](https://ant.design/docs/react/customize-theme#theme) for the full list of tokens you can override.
-
-            ## Tailwind theme bridge (`theme.tailwind`)
-
-            Lowdefy automatically bridges antd design tokens to Tailwind CSS theme variables. This means Tailwind utility classes like `text-primary` or `bg-bg-container` resolve to the current antd theme — including when you switch to dark mode.
-
-            ### Default bridged tokens
-
-            The following Tailwind tokens are mapped to antd CSS variables by default:
-
-            | Tailwind class prefix | Maps to antd token |
-            |---|---|
-            | `text-primary`, `bg-primary`, `border-primary` | `colorPrimary` |
-            | `*-primary-hover` | `colorPrimaryHover` |
-            | `*-primary-active` | `colorPrimaryActive` |
-            | `*-primary-bg` | `colorPrimaryBg` |
-            | `*-success` | `colorSuccess` |
-            | `*-warning` | `colorWarning` |
-            | `*-error` | `colorError` |
-            | `*-info` | `colorInfo` |
-            | `*-text-primary` | `colorText` |
-            | `*-text-secondary` | `colorTextSecondary` |
-            | `*-bg-container` | `colorBgContainer` |
-            | `*-bg-layout` | `colorBgLayout` |
-            | `*-border` | `colorBorder` |
-            | `rounded`, `rounded-sm`, `rounded-lg` | `borderRadius` variants |
-            | `text-sm`, `text-lg` (font-size) | `fontSize` variants |
-            | `font-sans` | `fontFamily` |
-
-            This means you can write:
-
-            ```yaml
-            - id: themed_box
-              type: Box
-              class: "bg-bg-container text-text-primary border border-border rounded-lg p-4"
-            ```
-
-            And the colors will automatically match your antd theme, including dark mode.
-
-            ### Adding custom Tailwind tokens
-
-            Use `theme.tailwind` in `lowdefy.yaml` to add custom tokens or override bridge defaults:
-
-            ```yaml
-            theme:
-              antd:
-                token:
-                  colorPrimary: '#7c3aed'
-              tailwind:
+                ```yaml
+                # String form — get a single token
                 color:
-                  accent: '#7c3aed'
-                  surface: '#f8fafc'
-                  on-surface: '#1e293b'
-                spacing:
-                  section: '3rem'
-            ```
+                  _theme: colorPrimary
 
-            You can then use these in `class`:
+                # Object form — with default value
+                background:
+                  _theme:
+                    key: colorBgContainer
+                    default: '#ffffff'
 
-            ```yaml
-            - id: my_section
-              type: Box
-              class: "bg-surface text-on-surface p-section"
-            ```
+                # Get all tokens
+                allTokens:
+                  _theme:
+                    all: true
+                ```
 
-            Custom tokens are deep-merged with the default bridge, so all antd-bridged tokens remain available.
+                The `_theme` operator resolves seed tokens from `theme.antd.token`. For derived tokens (like hover/active variants), use CSS variables instead: `var(--ant-color-primary-hover)`.
 
-            ### Overriding bridge defaults
+                See the [`_theme` operator reference](/_theme) for full documentation.
 
-            To change how a bridge token resolves, set the same key in `theme.tailwind`:
+                ## CSS variables
 
-            ```yaml
-            theme:
-              tailwind:
-                color:
-                  primary: '#ff4d4f'  # Now a static color, no longer follows antd token
-            ```
+                All antd design tokens are available as CSS variables with the `--ant-` prefix. This is useful in `public/styles.css` or when using CSS-based customizations:
 
-            ## TLDR
-              - Configure app theme via `theme.antd` in `lowdefy.yaml`.
-              - Seed tokens (`colorPrimary`, `fontSize`, etc.) drive all derived tokens automatically.
-              - Use `algorithm: compact` for compact mode. Use `theme.darkMode` for dark mode control.
-              - Dark mode defaults to `system` (follows OS preference). Set to `light` or `dark` to lock.
-              - Override tokens per component type via `theme.antd.components`.
-              - Override tokens per block via `properties.theme`.
-              - Use [ConfigProvider](/ConfigProvider) block for scoped theming of block groups.
-              - Access tokens in expressions with the `_theme` operator.
-              - Access derived tokens in CSS via `var(--ant-color-primary-hover)`.
-              - Tailwind utility classes (`text-primary`, `bg-bg-container`, etc.) automatically reflect the antd theme.
-              - Add custom Tailwind tokens via `theme.tailwind` in `lowdefy.yaml`.
+                ```css
+                .my-custom-class {
+                  color: var(--ant-color-primary);
+                  background: var(--ant-color-bg-container);
+                  border: 1px solid var(--ant-color-border);
+                  border-radius: var(--ant-border-radius);
+                }
+                ```
+
+                Token names are converted from camelCase to kebab-case for the CSS variable name (e.g. `colorPrimary` → `--ant-color-primary`).
+
+                ## Dark mode
+
+                Lowdefy supports three dark mode behaviors, configured via `theme.darkMode`:
+
+                ```yaml
+                theme:
+                  darkMode: system  # 'system' (default), 'light', or 'dark'
+                ```
+
+                | Value | Behavior |
+                |---|---|
+                | `system` | Follows the OS dark mode preference and updates live when it changes. Users can override with `SetDarkMode`. This is the default. |
+                | `light` | Forces light mode. `SetDarkMode` preferences are stored but have no visual effect. |
+                | `dark` | Forces dark mode. `SetDarkMode` preferences are stored but have no visual effect. |
+
+                You can also scope dark mode to a section using [ConfigProvider](/ConfigProvider):
+
+                ```yaml
+                - id: dark_section
+                  type: ConfigProvider
+                  properties:
+                    algorithm: dark
+                  blocks:
+                    # All blocks here will use dark theme
+                ```
+
+                ### Easy dark mode toggle
+
+                Add a built-in dark mode toggle to your page layout with a single property:
+
+                ```yaml
+                - id: my_page
+                  type: PageHeaderMenu  # or PageSiderMenu
+                  properties:
+                    darkModeToggle: true
+                ```
+
+                This renders a moon/sun icon in the header that cycles through light, dark, and system preferences. The preference is persisted to `localStorage`.
+
+                For custom toggle implementations, see the programmatic approach below.
+
+                ### Programmatic dark mode toggle
+
+                Use the `SetDarkMode` action with `_media: darkMode` to let users control dark mode at runtime:
+
+                ```yaml
+                - id: dark_mode_toggle
+                  type: Button
+                  properties:
+                    hideTitle: true
+                    icon:
+                      _if:
+                        test:
+                          _media: darkMode
+                        then: AiOutlineSun
+                        else: AiOutlineMoon
+                  events:
+                    onClick:
+                      - id: toggle
+                        type: SetDarkMode
+                ```
+
+                Without params, `SetDarkMode` cycles through `light`, `dark`, and `system`. You can also set a specific preference:
+
+                ```yaml
+                - id: set_system
+                  type: SetDarkMode
+                  params:
+                    darkMode: system
+                ```
+
+                The user's preference is persisted to `localStorage` and survives page refreshes. Use `_media: darkModePreference` to read the current preference (`'system'`, `'light'`, or `'dark'`), and `_media: darkMode` for the effective boolean state.
+
+                `SetDarkMode` automatically merges the `dark` algorithm with any existing algorithm configured in `theme.antd.algorithm`. For example, if your app uses `algorithm: compact`, toggling dark mode produces `[compact, dark]`.
+
+                See the [`SetDarkMode` action reference](/SetDarkMode) and [`_media` operator reference](/_media) for full documentation.
+
+                ### Tip: Use CSS variables for dark-mode-safe colors
+
+                When styling blocks with custom colors (e.g. `cellStyle` in AgGrid, or `style` on any block), avoid hardcoded hex values — they won't adapt to dark mode. Use antd CSS variables instead:
+
+                ```yaml
+                # Bad — hardcoded colors look washed out in dark mode
+                cellStyle:
+                  backgroundColor: '#e6f7ff'
+
+                # Good — antd palette tokens adapt automatically
+                cellStyle:
+                  backgroundColor: var(--ant-blue-1)
+                ```
+
+                Useful palette variables: `var(--ant-blue-1)`, `var(--ant-green-1)`, `var(--ant-orange-1)`, `var(--ant-red-1)`, etc. For semantic colors, use `var(--ant-color-primary-bg)`, `var(--ant-color-success-bg)`, `var(--ant-color-warning-bg)`, `var(--ant-color-error-bg)`.
+
+                ### Customizing base colors per mode
+
+                Antd's default dark algorithm uses pure black (`#000`) for `colorBgLayout`, and the default light algorithm uses a stark off-white. If you want softer, more modern base surfaces, use `lightToken` and `darkToken` on `theme.antd`. These are merged on top of `theme.antd.token` only when the matching mode is active, so you get full per-mode control without juggling two separate theme files:
+
+                ```yaml
+                theme:
+                  antd:
+                    token:                     # Shared — applied in both modes
+                      colorPrimary: '#6366f1'
+                      borderRadius: 8
+                    lightToken:                # Merged when light mode is active
+                      colorBgLayout: '#fafafa'
+                      colorBgContainer: '#ffffff'
+                    darkToken:                 # Merged when dark mode is active
+                      colorBgLayout: '#0f1117'
+                      colorBgContainer: '#18181b'
+                      colorBgElevated: '#1f2937'
+                  darkMode: system
+                ```
+
+                Tokens to customize for a softer base surface:
+
+                | Token | Where it shows up |
+                |---|---|
+                | `colorBgLayout` | Page background behind the layout — also applied to the `<html>` element to prevent navigation flash |
+                | `colorBgContainer` | Card, Table, Input, Modal body fill |
+                | `colorBgElevated` | Popover, Dropdown, Tooltip-host surfaces |
+                | `colorText` | Primary text color |
+                | `colorTextSecondary` | Secondary / muted text |
+
+                The pre-hydration script reads `darkToken.colorBgLayout` and `lightToken.colorBgLayout` directly, so the `<html>` background matches your configured color on first paint — there is no flash of `#000` or `#fff` before hydration. If you don't set a `lightToken.colorBgLayout`, light mode keeps the browser default white (today's behavior).
+
+                ### Per-mode component overrides
+
+                `colorBg*` seed tokens don't reach every component — Layout's header/sider and Menu have their own component tokens (`Layout.headerBg`, `Layout.siderBg`, `Menu.darkItemBg`, etc.). Use `darkComponents` and `lightComponents` alongside `darkToken`/`lightToken` to soften these surfaces in the active mode only:
+
+                ```yaml
+                theme:
+                  antd:
+                    darkToken:
+                      colorBgLayout: '#0f172a'
+                      colorBgContainer: '#111a2e'
+                    darkComponents:
+                      Layout:
+                        bodyBg: '#0f172a'
+                        headerBg: '#0b1120'
+                        siderBg: '#0b1120'
+                        triggerBg: '#111a2e'
+                        triggerColor: '#e2e8f0'
+                      Menu:
+                        darkItemBg: '#0b1120'
+                        darkSubMenuItemBg: '#0b1120'
+                        darkPopupBg: '#111a2e'
+                        darkItemSelectedBg: '#1e293b'
+                        darkItemHoverBg: '#111a2e'
+                ```
+
+                `darkComponents` / `lightComponents` are merged per-component (deep at the component name level) on top of the shared `components`, so you only need to specify the per-mode deltas.
+
+                See antd's [design token reference](https://ant.design/docs/react/customize-theme#theme) for the full list of tokens you can override.
+
+                ## Tailwind theme bridge (`theme.tailwind`)
+
+                Lowdefy automatically bridges antd design tokens to Tailwind CSS theme variables. This means Tailwind utility classes like `text-primary` or `bg-bg-container` resolve to the current antd theme — including when you switch to dark mode.
+
+                ### Default bridged tokens
+
+                The following Tailwind tokens are mapped to antd CSS variables by default:
+
+                | Tailwind class prefix | Maps to antd token |
+                |---|---|
+                | `text-primary`, `bg-primary`, `border-primary` | `colorPrimary` |
+                | `*-primary-hover` | `colorPrimaryHover` |
+                | `*-primary-active` | `colorPrimaryActive` |
+                | `*-primary-bg` | `colorPrimaryBg` |
+                | `*-success` | `colorSuccess` |
+                | `*-warning` | `colorWarning` |
+                | `*-error` | `colorError` |
+                | `*-info` | `colorInfo` |
+                | `*-text-primary` | `colorText` |
+                | `*-text-secondary` | `colorTextSecondary` |
+                | `*-bg-container` | `colorBgContainer` |
+                | `*-bg-layout` | `colorBgLayout` |
+                | `*-border` | `colorBorder` |
+                | `rounded`, `rounded-sm`, `rounded-lg` | `borderRadius` variants |
+                | `text-sm`, `text-lg` (font-size) | `fontSize` variants |
+                | `font-sans` | `fontFamily` |
+
+                This means you can write:
+
+                ```yaml
+                - id: themed_box
+                  type: Box
+                  class: "bg-bg-container text-text-primary border border-border rounded-lg p-4"
+                ```
+
+                And the colors will automatically match your antd theme, including dark mode.
+
+                ### Adding custom Tailwind tokens
+
+                Use `theme.tailwind` in `lowdefy.yaml` to add custom tokens or override bridge defaults:
+
+                ```yaml
+                theme:
+                  antd:
+                    token:
+                      colorPrimary: '#7c3aed'
+                  tailwind:
+                    color:
+                      accent: '#7c3aed'
+                      surface: '#f8fafc'
+                      on-surface: '#1e293b'
+                    spacing:
+                      section: '3rem'
+                ```
+
+                You can then use these in `class`:
+
+                ```yaml
+                - id: my_section
+                  type: Box
+                  class: "bg-surface text-on-surface p-section"
+                ```
+
+                Custom tokens are deep-merged with the default bridge, so all antd-bridged tokens remain available.
+
+                ### Overriding bridge defaults
+
+                To change how a bridge token resolves, set the same key in `theme.tailwind`:
+
+                ```yaml
+                theme:
+                  tailwind:
+                    color:
+                      primary: '#ff4d4f'  # Now a static color, no longer follows antd token
+                ```
+
+                ## TLDR
+                  - Configure app theme via `theme.antd` in `lowdefy.yaml`.
+                  - Seed tokens (`colorPrimary`, `fontSize`, etc.) drive all derived tokens automatically.
+                  - Use `algorithm: compact` for compact mode. Use `theme.darkMode` for dark mode control.
+                  - Dark mode defaults to `system` (follows OS preference). Set to `light` or `dark` to lock.
+                  - Override tokens per component type via `theme.antd.components`.
+                  - Override tokens per block via `properties.theme`.
+                  - Use [ConfigProvider](/ConfigProvider) block for scoped theming of block groups.
+                  - Access tokens in expressions with the `_theme` operator.
+                  - Access derived tokens in CSS via `var(--ant-color-primary-hover)`.
+                  - Tailwind utility classes (`text-primary`, `bg-bg-container`, etc.) automatically reflect the antd theme.
+                  - Add custom Tailwind tokens via `theme.tailwind` in `lowdefy.yaml`.
 
       - _ref:
           path: templates/navigation_buttons.yaml


### PR DESCRIPTION
## Summary

Three docs pages had hardcoded `lowdefy: X.Y.Z` version strings inside their example code blocks — `agents/introduction.yaml` (4.7.3), `concepts/logger.yaml` (4.5.2), `concepts/theming.yaml` (5.0.0). The current published version is 5.3.0, so all three examples were stale, and they'd drift further out of date with every release.

The tutorial and operator docs already solve this by rendering the code block through `_nunjucks` with `_ref: version.yaml`, so `{{ version }}` resolves to the current `@lowdefy/docs` package version at build time. This PR applies the same pattern to the three stale pages.

## Changes

- **@lowdefy/docs**: Wrap the markdown content of the affected `md1` block in `_nunjucks` with `on.version: { _ref: version.yaml }`, and replace the hardcoded version in the example code block with `lowdefy: {{ version }}`. Applies to `agents/introduction.yaml`, `concepts/logger.yaml`, and `concepts/theming.yaml`.

## Notes

- No content changes — only the indentation under the new `template: |` wrapper and the version literal. Diff is mostly whitespace.
- Branched off and targets `main` per request. The existing v5.3.0 release pages on the live docs site currently show 4.7.3/4.5.2/5.0.0, so merging this to `main` lets the next docs deploy correct them directly.
- Validated each YAML still parses (`js-yaml`). Did not run a full docs build — the templates use the same `_nunjucks` + `_ref: version.yaml` pattern that tutorials and operators already ship with, so behavior should be identical.