### PR TITLE
docs(website): Fix broken links in agents article

### DIFF
--- a/packages/website/content/articles/lowdefy-agents.md
+++ b/packages/website/content/articles/lowdefy-agents.md
@@ -116,11 +116,11 @@ agents:
       - search-products
 ```
 
-This endpoint is a regular Lowdefy API. A page can hit it through a [`CallApi`](https://docs.lowdefy.com/CallApi) action; another endpoint can compose it as a routine step. Adding `description` and `payloadSchema` doesn't change any of that. It only makes the endpoint discoverable to the model. When the agent calls it, [`_payload`](https://docs.lowdefy.com/_payload) carries the model's tool input, the same as if a page had sent it.
+This endpoint is a regular Lowdefy API. A page can hit it through a [`CallAPI`](https://docs.lowdefy.com/CallAPI) action; another endpoint can compose it as a routine step. Adding `description` and `payloadSchema` doesn't change any of that. It only makes the endpoint discoverable to the model. When the agent calls it, [`_payload`](https://docs.lowdefy.com/lowdefy-api) carries the model's tool input, the same as if a page had sent it.
 
 An agent has the same surface area as the rest of your app. Every operator, every connection, every secret, every authenticated user reference ([`_user`](https://docs.lowdefy.com/_user)) is available inside a tool's routine. An insert endpoint that writes to MongoDB is already a tool. An endpoint that calls a third-party API with a stored key is already a tool. The agent isn't a new server, it's a different caller of the server you already have.
 
-For tools that shouldn't be exposed to the browser at all, change the type from `Api` to [`InternalApi`](https://docs.lowdefy.com/InternalApi). The endpoint stops serving HTTP requests and stays callable from agents and from other endpoints.
+For tools that shouldn't be exposed to the browser at all, change the type from `Api` to [`InternalApi`](https://docs.lowdefy.com/lowdefy-api). The endpoint stops serving HTTP requests and stays callable from agents and from other endpoints.
 
 ### MCP servers by ID
 

--- a/packages/website/content/articles/lowdefy-agents.md
+++ b/packages/website/content/articles/lowdefy-agents.md
@@ -116,7 +116,7 @@ agents:
       - search-products
 ```
 
-This endpoint is a regular Lowdefy API. A page can hit it through a [`CallAPI`](https://docs.lowdefy.com/CallAPI) action; another endpoint can compose it as a routine step. Adding `description` and `payloadSchema` doesn't change any of that. It only makes the endpoint discoverable to the model. When the agent calls it, [`_payload`](https://docs.lowdefy.com/lowdefy-api) carries the model's tool input, the same as if a page had sent it.
+This endpoint is a regular Lowdefy API. A page can hit it through a [`CallAPI`](https://docs.lowdefy.com/CallAPI) action; another endpoint can compose it as a routine step. Adding `description` and `payloadSchema` doesn't change any of that. It only makes the endpoint discoverable to the model. When the agent calls it, `_payload` carries the model's tool input, the same as if a page had sent it.
 
 An agent has the same surface area as the rest of your app. Every operator, every connection, every secret, every authenticated user reference ([`_user`](https://docs.lowdefy.com/_user)) is available inside a tool's routine. An insert endpoint that writes to MongoDB is already a tool. An endpoint that calls a third-party API with a stored key is already a tool. The agent isn't a new server, it's a different caller of the server you already have.
 


### PR DESCRIPTION
## Summary

Three doc links in the lowdefy-agents article currently 307 on `docs.lowdefy.com`:

| Article link | Fix | Why |
|---|---|---|
| `/CallApi` | `/CallAPI` | pageId is uppercase (`actions/CallAPI.yaml`) |
| `/_payload` | unlinked | No dedicated `_payload` page exists |
| `/InternalApi` | `/lowdefy-api` | No dedicated `InternalApi` page; it's a `type` value within the api concept |

Verified live with `curl -o /dev/null -w "%{http_code}"`:

```
200 /AgentChat
307 /CallApi          → 200 /CallAPI
307 /_payload         → unlinked (kept as inline code)
200 /_user
307 /InternalApi      → 200 /lowdefy-api
```

Article: https://lowdefy.com/articles/lowdefy-agents/

## Test plan

- [ ] After deploy, confirm `CallAPI` and `lowdefy-api` links resolve 200 from the live article.

🤖 Generated with [Claude Code](https://claude.com/claude-code)