### PR TITLE
Support list-child blocks in ldf.block() and add ldf.list() helper

### DIFF
--- a/.changeset/feat-e2e-utils-list-block-helpers.md
+++ b/.changeset/feat-e2e-utils-list-block-helpers.md
@@ -1,0 +1,12 @@
+---
+'@lowdefy/e2e-utils': minor
+---
+
+feat(e2e-utils): Support list-child blocks in `ldf.block()` and add `ldf.list()` helper.
+
+Manifest now records list children under their templated id (`listId.$.childId`) by
+reading block category from `plugins/blockMetas.json`. At runtime `ldf.block()` falls
+back from the literal id to the template by replacing integer-only path segments with
+`$`, so `ldf.block('legal_rows.0.toggle').do.toggle()` resolves to the Switch helper
+without app authors writing raw `page.locator(...)`. `ldf.list(listId)` adds
+`.count()`, `.row(i)`, `.rowBy(key, value)` and `.rowWhere(predicate)` sugar.

--- a/packages/utils/e2e-utils/README.md
+++ b/packages/utils/e2e-utils/README.md
@@ -89,6 +89,44 @@ test('validates required fields', async ({ ldf }) => {
 });
 ```
 
+### Testing List Children (`ldf.list()` / `ldf.block()` with indexed ids)
+
+List blocks render their slot children with runtime-prefixed ids
+(`legal_rows.0.toggle`, `legal_rows.1.toggle`, ...). You can pass these indexed ids
+straight into `ldf.block()` — the manifest stores `legal_rows.$.toggle` and the runtime
+resolves the numeric segment automatically:
+
+```javascript
+await ldf.block('legal_rows.0.toggle').do.toggle();
+await ldf.block('legal_rows.0.toggle').expect.checked();
+```
+
+For ergonomic row addressing, use `ldf.list(listId)`:
+
+```javascript
+// Number of rows in state
+const count = await ldf.list('legal_rows').count();
+
+// Positional access (synchronous)
+await ldf.list('legal_rows').row(0).block('toggle').do.toggle();
+
+// By key (async — reads list state to find the index)
+const row = await ldf.list('legal_rows').rowBy('_id', 'bbbee');
+await row.block('toggle').do.toggle();
+await row.block('toggle').expect.checked();
+
+// By predicate (async)
+const archived = await ldf.list('legal_rows').rowWhere((it) => it.archived === true);
+await archived.block('restore_btn').do.click();
+```
+
+Nested lists work the same way — every level of nesting adds another numeric
+segment, all resolved through one templated lookup:
+
+```javascript
+await ldf.block('outer.0.inner.2.button').do.click();
+```
+
 ### State (`ldf.state()`)
 
 ```javascript

--- a/packages/utils/e2e-utils/src/proxy/createPageManager.js
+++ b/packages/utils/e2e-utils/src/proxy/createPageManager.js
@@ -26,6 +26,7 @@ import { setUserCookie, clearUserCookie } from '../core/userCookie.js';
 import { get, type } from '@lowdefy/helpers';
 
 import createBlockMethodProxy from './createBlockMethodProxy.js';
+import resolveTemplateId from './resolveTemplateId.js';
 
 function createPageManager({ page, manifest, helperRegistry, mockManager }) {
   let currentBlockMap = null;
@@ -35,6 +36,87 @@ function createPageManager({ page, manifest, helperRegistry, mockManager }) {
     if (!currentBlockMap) {
       throw new Error('Call goto() before accessing blocks');
     }
+  }
+
+  // Block locator - ldf.block('id').do.*/expect.*/locator()/state()/validation()
+  // List children: pass the concrete runtime blockId (e.g. `legal_rows.0.toggle`) and we
+  // fall back to the templated entry (`legal_rows.$.toggle`) for the type/helper. The
+  // concrete blockId still flows into each helper's locator(page, blockId) so the DOM
+  // selector targets the right row.
+  function block(blockId) {
+    ensurePageLoaded();
+    let blockInfo = currentBlockMap[blockId];
+    if (!blockInfo) {
+      const templateId = resolveTemplateId(blockId);
+      if (templateId !== blockId) {
+        blockInfo = currentBlockMap[templateId];
+      }
+    }
+    if (!blockInfo) {
+      const available = Object.keys(currentBlockMap).join(', ');
+      throw new Error(
+        `Block "${blockId}" not found on page. Available blocks: ${available || '(none)'}`
+      );
+    }
+
+    return {
+      do: createBlockMethodProxy({ page, blockId, blockInfo, helperRegistry, mode: 'do' }),
+      expect: createBlockMethodProxy({
+        page,
+        blockId,
+        blockInfo,
+        helperRegistry,
+        mode: 'expect',
+      }),
+      locator: () => getBlock(page, blockId),
+      state: () => getBlockState(page, { blockId }),
+      validation: () => getValidation(page, blockId),
+    };
+  }
+
+  // List locator - ldf.list('id') for ergonomic addressing of list children.
+  //   .count()                  → number of items currently in state
+  //   .row(i).block('childId')  → synchronous, positional access
+  //   .rowBy('_id', 'bbbee')    → async; resolves to a row whose block(...) is sync
+  //   .rowWhere(item => ...)    → async; same shape as rowBy
+  // All paths delegate to block(`${listId}.${index}.${childId}`), so the templated
+  // manifest lookup above takes over from there.
+  function list(listId) {
+    ensurePageLoaded();
+
+    const readItems = async () => {
+      const state = await getState(page);
+      const items = get(state, listId);
+      if (!Array.isArray(items)) {
+        throw new Error(
+          `ldf.list("${listId}"): state value is not an array (got ${
+            items === undefined ? 'undefined' : typeof items
+          }). Make sure a Request has populated the list state before reading rows.`
+        );
+      }
+      return items;
+    };
+
+    const rowAt = (index) => ({
+      block: (childId) => block(`${listId}.${index}.${childId}`),
+    });
+
+    const findRow = async (predicate, describe) => {
+      const items = await readItems();
+      const index = items.findIndex(predicate);
+      if (index < 0) {
+        throw new Error(`ldf.list("${listId}"): no row matched ${describe}.`);
+      }
+      return rowAt(index);
+    };
+
+    return {
+      count: async () => (await readItems()).length,
+      row: (index) => rowAt(index),
+      rowBy: (key, value) =>
+        findRow((item) => item != null && item[key] === value, `${key}=${JSON.stringify(value)}`),
+      rowWhere: (predicate) => findRow(predicate, 'predicate'),
+    };
   }
 
   return {
@@ -74,31 +156,9 @@ function createPageManager({ page, manifest, helperRegistry, mockManager }) {
       return currentPageId;
     },
 
-    // Block locator - ldf.block('id').do.*/expect.*/locator()/state()/validation()
-    block(blockId) {
-      ensurePageLoaded();
-      const blockInfo = currentBlockMap[blockId];
-      if (!blockInfo) {
-        const available = Object.keys(currentBlockMap).join(', ');
-        throw new Error(
-          `Block "${blockId}" not found on page. Available blocks: ${available || '(none)'}`
-        );
-      }
+    block,
 
-      return {
-        do: createBlockMethodProxy({ page, blockId, blockInfo, helperRegistry, mode: 'do' }),
-        expect: createBlockMethodProxy({
-          page,
-          blockId,
-          blockInfo,
-          helperRegistry,
-          mode: 'expect',
-        }),
-        locator: () => getBlock(page, blockId),
-        state: () => getBlockState(page, { blockId }),
-        validation: () => getValidation(page, blockId),
-      };
-    },
+    list,
 
     // Request locator - ldf.request('id').expect.*/response()/state()
     request(requestId) {

--- a/packages/utils/e2e-utils/src/proxy/resolveTemplateId.js
+++ b/packages/utils/e2e-utils/src/proxy/resolveTemplateId.js
@@ -1,0 +1,27 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Convert a runtime blockId (e.g. `legal_rows.0.toggle`) into the template form
+// stored in the e2e manifest (`legal_rows.$.toggle`) by replacing each integer-only
+// dot-separated segment with `$`. Mixed segments like `step_1d` are left as-is.
+function resolveTemplateId(blockId) {
+  return blockId
+    .split('.')
+    .map((segment) => (/^\d+$/.test(segment) ? '$' : segment))
+    .join('.');
+}
+
+export default resolveTemplateId;

--- a/packages/utils/e2e-utils/src/proxy/resolveTemplateId.test.js
+++ b/packages/utils/e2e-utils/src/proxy/resolveTemplateId.test.js
@@ -1,0 +1,47 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import resolveTemplateId from './resolveTemplateId.js';
+
+test('returns id unchanged when no numeric segments are present', () => {
+  expect(resolveTemplateId('next_button')).toBe('next_button');
+  expect(resolveTemplateId('form.email_input')).toBe('form.email_input');
+});
+
+test('replaces a single numeric segment with `$`', () => {
+  expect(resolveTemplateId('legal_rows.0.toggle')).toBe('legal_rows.$.toggle');
+  expect(resolveTemplateId('legal_rows.12.toggle')).toBe('legal_rows.$.toggle');
+});
+
+test('replaces every numeric segment for nested lists', () => {
+  expect(resolveTemplateId('outer.0.inner.2.button')).toBe('outer.$.inner.$.button');
+});
+
+test('does not replace segments that contain digits but are not all digits', () => {
+  // The whole segment must be digits; `step_1d` includes letters and stays put.
+  expect(resolveTemplateId('step_1d_input')).toBe('step_1d_input');
+  expect(resolveTemplateId('list.row42.btn')).toBe('list.row42.btn');
+  expect(resolveTemplateId('list.42a.btn')).toBe('list.42a.btn');
+});
+
+test('treats `0` and large indices the same', () => {
+  expect(resolveTemplateId('list.0.btn')).toBe('list.$.btn');
+  expect(resolveTemplateId('list.999999.btn')).toBe('list.$.btn');
+});
+
+test('passes single-segment ids through unchanged', () => {
+  expect(resolveTemplateId('home')).toBe('home');
+});

--- a/packages/utils/e2e-utils/src/testPrep/extractBlockMap.js
+++ b/packages/utils/e2e-utils/src/testPrep/extractBlockMap.js
@@ -21,47 +21,53 @@ function getBlocksArray(container) {
   return [];
 }
 
-function extractBlockMap({ pageConfig, typesBlocks }) {
+function extractBlockMap({ pageConfig, typesBlocks, blockMetas = {} }) {
   const blockMap = {};
 
-  function traverse(obj) {
+  function traverse(obj, prefix) {
     if (!obj || typeof obj !== 'object') return;
 
-    // If this object has blockId and type, record it
+    let nextPrefix = prefix;
+
+    // If this object has blockId and type, record it under prefix + blockId.
+    // List-category blocks (category: 'list' on their meta) iterate their slot children
+    // at runtime under {blockId}.{index}.{childId}, so we record children under the
+    // template id `{blockId}.$.{childId}` and downstream resolves numeric runtime
+    // segments back to `$` for lookup.
     if (obj.blockId && obj.type) {
       const packageName = typesBlocks[obj.type]?.package;
       if (packageName) {
-        blockMap[obj.blockId] = {
+        blockMap[`${prefix}${obj.blockId}`] = {
           type: obj.type,
           helper: `${packageName}/e2e`,
         };
+      }
+      if (blockMetas[obj.type]?.category === 'list') {
+        nextPrefix = `${prefix}${obj.blockId}.$.`;
       }
     }
 
     // Traverse slots - slot.blocks is { "~arr": [...blocks...] }
     if (obj.slots) {
       Object.values(obj.slots).forEach((slot) => {
-        const blocks = getBlocksArray(slot.blocks);
-        blocks.forEach((block) => traverse(block));
+        getBlocksArray(slot.blocks).forEach((block) => traverse(block, nextPrefix));
       });
     }
 
     // Traverse areas - area.blocks is { "~arr": [...blocks...] }
     if (obj.areas) {
       Object.values(obj.areas).forEach((area) => {
-        const blocks = getBlocksArray(area.blocks);
-        blocks.forEach((block) => traverse(block));
+        getBlocksArray(area.blocks).forEach((block) => traverse(block, nextPrefix));
       });
     }
 
     // Traverse direct blocks array (may also be { "~arr": [...] })
     if (obj.blocks) {
-      const blocks = getBlocksArray(obj.blocks);
-      blocks.forEach((block) => traverse(block));
+      getBlocksArray(obj.blocks).forEach((block) => traverse(block, nextPrefix));
     }
   }
 
-  traverse(pageConfig);
+  traverse(pageConfig, '');
   return blockMap;
 }
 

--- a/packages/utils/e2e-utils/src/testPrep/extractBlockMap.test.js
+++ b/packages/utils/e2e-utils/src/testPrep/extractBlockMap.test.js
@@ -21,6 +21,16 @@ const typesBlocks = {
   Card: { package: '@lowdefy/blocks-antd' },
   Markdown: { package: '@lowdefy/blocks-markdown' },
   Button: { package: '@lowdefy/blocks-antd' },
+  Switch: { package: '@lowdefy/blocks-antd' },
+  List: { package: '@lowdefy/blocks-basic' },
+  ControlledList: { package: '@lowdefy/blocks-antd' },
+};
+
+const blockMetas = {
+  List: { category: 'list' },
+  ControlledList: { category: 'list' },
+  Box: { category: 'container' },
+  Card: { category: 'container' },
 };
 
 test('extracts blocks nested in slots.<name>.blocks.~arr', () => {
@@ -130,4 +140,148 @@ test('skips blocks whose type is not in typesBlocks', () => {
   expect(blockMap).toEqual({
     home: { type: 'Box', helper: '@lowdefy/blocks-basic/e2e' },
   });
+});
+
+test('prefixes list-category children with the list blockId and `.$.`', () => {
+  const pageConfig = {
+    blockId: 'home',
+    type: 'Box',
+    slots: {
+      content: {
+        blocks: {
+          '~arr': [
+            {
+              blockId: 'legal_rows',
+              type: 'List',
+              slots: {
+                content: {
+                  blocks: {
+                    '~arr': [
+                      { blockId: 'toggle', type: 'Switch' },
+                      { blockId: 'label', type: 'Markdown' },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+  const blockMap = extractBlockMap({ pageConfig, typesBlocks, blockMetas });
+  expect(blockMap).toEqual({
+    home: { type: 'Box', helper: '@lowdefy/blocks-basic/e2e' },
+    legal_rows: { type: 'List', helper: '@lowdefy/blocks-basic/e2e' },
+    'legal_rows.$.toggle': { type: 'Switch', helper: '@lowdefy/blocks-antd/e2e' },
+    'legal_rows.$.label': { type: 'Markdown', helper: '@lowdefy/blocks-markdown/e2e' },
+  });
+});
+
+test('handles nested lists with one `.$.` per nesting level', () => {
+  const pageConfig = {
+    blockId: 'home',
+    type: 'Box',
+    slots: {
+      content: {
+        blocks: {
+          '~arr': [
+            {
+              blockId: 'outer',
+              type: 'List',
+              slots: {
+                content: {
+                  blocks: {
+                    '~arr': [
+                      {
+                        blockId: 'inner',
+                        type: 'ControlledList',
+                        slots: {
+                          content: {
+                            blocks: { '~arr': [{ blockId: 'btn', type: 'Button' }] },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+  const blockMap = extractBlockMap({ pageConfig, typesBlocks, blockMetas });
+  expect(Object.keys(blockMap).sort()).toEqual([
+    'home',
+    'outer',
+    'outer.$.inner',
+    'outer.$.inner.$.btn',
+  ]);
+});
+
+test('non-list containers (Box, Card) inside a list do not add an extra `.$.`', () => {
+  const pageConfig = {
+    blockId: 'home',
+    type: 'Box',
+    slots: {
+      content: {
+        blocks: {
+          '~arr': [
+            {
+              blockId: 'rows',
+              type: 'List',
+              slots: {
+                content: {
+                  blocks: {
+                    '~arr': [
+                      {
+                        blockId: 'wrapper',
+                        type: 'Box',
+                        slots: {
+                          content: {
+                            blocks: { '~arr': [{ blockId: 'btn', type: 'Button' }] },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+  const blockMap = extractBlockMap({ pageConfig, typesBlocks, blockMetas });
+  expect(Object.keys(blockMap).sort()).toEqual(['home', 'rows', 'rows.$.btn', 'rows.$.wrapper']);
+});
+
+test('omitted blockMetas falls back to no prefixing (older builds)', () => {
+  // No blockMetas passed → list children get recorded under their short id, same as
+  // pre-list-aware behaviour. This keeps generateManifest tolerant of older app builds
+  // that do not yet emit plugins/blockMetas.json.
+  const pageConfig = {
+    blockId: 'home',
+    type: 'Box',
+    slots: {
+      content: {
+        blocks: {
+          '~arr': [
+            {
+              blockId: 'rows',
+              type: 'List',
+              slots: {
+                content: { blocks: { '~arr': [{ blockId: 'toggle', type: 'Switch' }] } },
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+  const blockMap = extractBlockMap({ pageConfig, typesBlocks });
+  expect(Object.keys(blockMap).sort()).toEqual(['home', 'rows', 'toggle']);
 });

--- a/packages/utils/e2e-utils/src/testPrep/generateManifest.js
+++ b/packages/utils/e2e-utils/src/testPrep/generateManifest.js
@@ -26,6 +26,15 @@ function generateManifest({ buildDir = '.lowdefy' }) {
   }
 
   const types = JSON.parse(fs.readFileSync(typesPath, 'utf-8'));
+
+  // blockMetas tells us which block types iterate their slot children (category === 'list').
+  // Missing file is non-fatal: older builds keep working, list children just don't get the
+  // .$. prefix applied.
+  const blockMetasPath = path.join(buildDir, 'plugins/blockMetas.json');
+  const blockMetas = fs.existsSync(blockMetasPath)
+    ? JSON.parse(fs.readFileSync(blockMetasPath, 'utf-8'))
+    : {};
+
   const pagesDir = path.join(buildDir, 'pages');
 
   const manifest = { pages: {} };
@@ -51,6 +60,7 @@ function generateManifest({ buildDir = '.lowdefy' }) {
           manifest.pages[pageId] = extractBlockMap({
             pageConfig,
             typesBlocks: types.blocks ?? {},
+            blockMetas,
           });
         }
       }


### PR DESCRIPTION
## Summary

App authors writing Playwright tests against Lowdefy apps couldn't use `ldf.block(...)` on list-iterated children. Every per-row toggle/input/button forced raw `page.locator('[id="..."]')` selectors that coupled tests to per-block DOM internals (e.g. Switch's `_input` suffix) and lost every common helper assertion (`expect.checked`, `.disabled`, `.visible`, `.validationError`). This PR fixes both halves of the gap: the build records list children under their templated id (`legal_rows.$.toggle`), the runtime resolves numeric segments in literal blockIds back to `$` for manifest lookup, and `ldf.list(listId)` adds ergonomic row addressing.

```js
// Before: raw page.locator, brittle, no helper assertions
await ldf.page.locator('[id="legal_rows.0.toggle_input"]').click();

// After: first-class block helper, by index or by key
await ldf.block('legal_rows.0.toggle').do.toggle();
const row = await ldf.list('legal_rows').rowBy('_id', 'bbbee');
await row.block('toggle').do.toggle();
await row.block('toggle').expect.checked();
```

## Changes

- **@lowdefy/e2e-utils**
  - **Build:** `extractBlockMap` now reads `plugins/blockMetas.json` (loaded by `generateManifest`) and prefixes children of `category: 'list'` blocks with `{listId}.$.` Nested lists stack prefixes (`outer.\$.inner.\$.btn`). Missing blockMetas is non-fatal: older builds keep working but list children fall back to short ids.
  - **Runtime:** `createPageManager.block()` falls back to a templated lookup via the new `resolveTemplateId` helper (integer-only path segments → `\$`). The concrete runtime blockId still flows into each helper's `locator(page, blockId)`, so individual block `e2e.js` files needed no changes.
  - **Sugar:** new `ldf.list(listId)` with `.count()`, `.row(i)`, `.rowBy(key, value)`, `.rowWhere(predicate)`. `row(i)` is synchronous; `rowBy`/`rowWhere` are async (state read).

## Key Files

- \`packages/utils/e2e-utils/src/testPrep/extractBlockMap.js\` — carries a path prefix through traversal, injects \`{blockId}.\$.\` when entering a list-category block
- \`packages/utils/e2e-utils/src/testPrep/generateManifest.js\` — loads blockMetas.json alongside types.json
- \`packages/utils/e2e-utils/src/proxy/resolveTemplateId.js\` — pure helper (new)
- \`packages/utils/e2e-utils/src/proxy/createPageManager.js\` — templated fallback in \`block()\` plus new \`list()\` method
- \`packages/utils/e2e-utils/README.md\` — new "Testing List Children" section

## Notes

- Based on \`fix/server-e2e-plugin-loading\`, not develop — the slots-traversal fix on that branch is a prerequisite (without it nothing nested is discoverable in the modern slots-shaped build output). Once that merges, this branch rebases onto develop and re-targets.
- Skipped row-scoped state/request helpers (\`ldf.list().row(i).state(field)\`) deliberately: narrower hit-rate since users frequently maintain a separate state map keyed by some domain id. Users keep writing \`ldf.state(\\\`\${listId}.\${i}.field\\\`)\` for now.
- \`rowBy\` deliberately takes \`(key, value)\` with no \`_id\` default — name never lies even when matching on \`slug\`, \`type\`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)