### PR TITLE
Fix broken Carousel gallery on docs site

### DIFF
--- a/packages/docs/templates/blocks/galleryTransformer.js
+++ b/packages/docs/templates/blocks/galleryTransformer.js
@@ -131,7 +131,7 @@ function buildCssKeysTable(cssKeys) {
 
 function buildSlotsTable(slots) {
   if (slots === false)
-    return 'Slots are **dynamic** — defined by properties (e.g. `tabs`, `panels`). See the Properties table.';
+    return 'Slot keys are user-defined in your config and resolved at build time — not generated at runtime. The block typically pairs slots with an array property (`tabs`, `panels`, `slides`) listed in the Properties table; see the examples above for the expected shape.';
   if (!slots) return 'No slots defined.';
   const entries = Array.isArray(slots) ? slots.map((key) => [key, '']) : Object.entries(slots);
   if (entries.length === 0) return 'No slots defined.';

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Carousel/gallery.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Carousel/gallery.yaml
@@ -16,158 +16,174 @@
   blocks:
     - id: basic_carousel
       type: Carousel
-      blocks:
-        - id: basic_s1
-          type: Box
-          style:
-            height: 160
-            background: '#364d79'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        basic_s1:
           blocks:
-            - id: basic_s1_text
-              type: Title
-              properties:
-                content: Slide 1
-                level: 3
+            - id: basic_s1
+              type: Box
               style:
-                color: white
-        - id: basic_s2
-          type: Box
-          style:
-            height: 160
-            background: '#263c5a'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#364d79"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: basic_s1_text
+                  type: Title
+                  properties:
+                    content: Slide 1
+                    level: 3
+                  style:
+                    color: white
+        basic_s2:
           blocks:
-            - id: basic_s2_text
-              type: Title
-              properties:
-                content: Slide 2
-                level: 3
+            - id: basic_s2
+              type: Box
               style:
-                color: white
-        - id: basic_s3
-          type: Box
-          style:
-            height: 160
-            background: '#1a2d45'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#263c5a"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: basic_s2_text
+                  type: Title
+                  properties:
+                    content: Slide 2
+                    level: 3
+                  style:
+                    color: white
+        basic_s3:
           blocks:
-            - id: basic_s3_text
-              type: Title
-              properties:
-                content: Slide 3
-                level: 3
+            - id: basic_s3
+              type: Box
               style:
-                color: white
-        - id: basic_s4
-          type: Box
-          style:
-            height: 160
-            background: '#0d1e30'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#1a2d45"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: basic_s3_text
+                  type: Title
+                  properties:
+                    content: Slide 3
+                    level: 3
+                  style:
+                    color: white
+        basic_s4:
           blocks:
-            - id: basic_s4_text
-              type: Title
-              properties:
-                content: Slide 4
-                level: 3
+            - id: basic_s4
+              type: Box
               style:
-                color: white
-
+                height: 160
+                background: "#0d1e30"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: basic_s4_text
+                  type: Title
+                  properties:
+                    content: Slide 4
+                    level: 3
+                  style:
+                    color: white
 - title: Colorful Slides
   blocks:
     - id: color_carousel
       type: Carousel
-      blocks:
-        - id: color_s1
-          type: Box
-          style:
-            height: 180
-            background: '#1677ff'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        color_s1:
           blocks:
-            - id: color_s1_text
-              type: Title
-              properties:
-                content: Blue
-                level: 3
+            - id: color_s1
+              type: Box
               style:
-                color: white
-        - id: color_s2
-          type: Box
-          style:
-            height: 180
-            background: '#52c41a'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 180
+                background: "#1677ff"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: color_s1_text
+                  type: Title
+                  properties:
+                    content: Blue
+                    level: 3
+                  style:
+                    color: white
+        color_s2:
           blocks:
-            - id: color_s2_text
-              type: Title
-              properties:
-                content: Green
-                level: 3
+            - id: color_s2
+              type: Box
               style:
-                color: white
-        - id: color_s3
-          type: Box
-          style:
-            height: 180
-            background: '#722ed1'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 180
+                background: "#52c41a"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: color_s2_text
+                  type: Title
+                  properties:
+                    content: Green
+                    level: 3
+                  style:
+                    color: white
+        color_s3:
           blocks:
-            - id: color_s3_text
-              type: Title
-              properties:
-                content: Purple
-                level: 3
+            - id: color_s3
+              type: Box
               style:
-                color: white
-        - id: color_s4
-          type: Box
-          style:
-            height: 180
-            background: '#fa541c'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 180
+                background: "#722ed1"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: color_s3_text
+                  type: Title
+                  properties:
+                    content: Purple
+                    level: 3
+                  style:
+                    color: white
+        color_s4:
           blocks:
-            - id: color_s4_text
-              type: Title
-              properties:
-                content: Volcano
-                level: 3
+            - id: color_s4
+              type: Box
               style:
-                color: white
-        - id: color_s5
-          type: Box
-          style:
-            height: 180
-            background: '#eb2f96'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 180
+                background: "#fa541c"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: color_s4_text
+                  type: Title
+                  properties:
+                    content: Volcano
+                    level: 3
+                  style:
+                    color: white
+        color_s5:
           blocks:
-            - id: color_s5_text
-              type: Title
-              properties:
-                content: Magenta
-                level: 3
+            - id: color_s5
+              type: Box
               style:
-                color: white
-
+                height: 180
+                background: "#eb2f96"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: color_s5_text
+                  type: Title
+                  properties:
+                    content: Magenta
+                    level: 3
+                  style:
+                    color: white
 - title: Autoplay
   blocks:
     - id: auto_carousel
@@ -175,72 +191,79 @@
       properties:
         autoplay: true
         autoplaySpeed: 2000
-      blocks:
-        - id: auto_s1
-          type: Box
-          style:
-            height: 160
-            background: '#13c2c2'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        auto_s1:
           blocks:
-            - id: auto_s1_text
-              type: Title
-              properties:
-                content: Auto Slide 1
-                level: 3
+            - id: auto_s1
+              type: Box
               style:
-                color: white
-        - id: auto_s2
-          type: Box
-          style:
-            height: 160
-            background: '#1677ff'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#13c2c2"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: auto_s1_text
+                  type: Title
+                  properties:
+                    content: Auto Slide 1
+                    level: 3
+                  style:
+                    color: white
+        auto_s2:
           blocks:
-            - id: auto_s2_text
-              type: Title
-              properties:
-                content: Auto Slide 2
-                level: 3
+            - id: auto_s2
+              type: Box
               style:
-                color: white
-        - id: auto_s3
-          type: Box
-          style:
-            height: 160
-            background: '#722ed1'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#1677ff"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: auto_s2_text
+                  type: Title
+                  properties:
+                    content: Auto Slide 2
+                    level: 3
+                  style:
+                    color: white
+        auto_s3:
           blocks:
-            - id: auto_s3_text
-              type: Title
-              properties:
-                content: Auto Slide 3
-                level: 3
+            - id: auto_s3
+              type: Box
               style:
-                color: white
-        - id: auto_s4
-          type: Box
-          style:
-            height: 160
-            background: '#eb2f96'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#722ed1"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: auto_s3_text
+                  type: Title
+                  properties:
+                    content: Auto Slide 3
+                    level: 3
+                  style:
+                    color: white
+        auto_s4:
           blocks:
-            - id: auto_s4_text
-              type: Title
-              properties:
-                content: Auto Slide 4
-                level: 3
+            - id: auto_s4
+              type: Box
               style:
-                color: white
-
+                height: 160
+                background: "#eb2f96"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: auto_s4_text
+                  type: Title
+                  properties:
+                    content: Auto Slide 4
+                    level: 3
+                  style:
+                    color: white
 - title: Autoplay with Pause on Hover
   blocks:
     - id: pause_carousel
@@ -250,280 +273,305 @@
         autoplaySpeed: 1500
         pauseOnHover: true
         pauseOnFocus: true
-      blocks:
-        - id: pause_s1
-          type: Box
-          style:
-            height: 160
-            background: '#389e0d'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        pause_s1:
           blocks:
-            - id: pause_s1_text
-              type: Title
-              properties:
-                content: Hover to Pause
-                level: 3
+            - id: pause_s1
+              type: Box
               style:
-                color: white
-        - id: pause_s2
-          type: Box
-          style:
-            height: 160
-            background: '#08979c'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#389e0d"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: pause_s1_text
+                  type: Title
+                  properties:
+                    content: Hover to Pause
+                    level: 3
+                  style:
+                    color: white
+        pause_s2:
           blocks:
-            - id: pause_s2_text
-              type: Title
-              properties:
-                content: Autoplay Resumes
-                level: 3
+            - id: pause_s2
+              type: Box
               style:
-                color: white
-        - id: pause_s3
-          type: Box
-          style:
-            height: 160
-            background: '#531dab'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#08979c"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: pause_s2_text
+                  type: Title
+                  properties:
+                    content: Autoplay Resumes
+                    level: 3
+                  style:
+                    color: white
+        pause_s3:
           blocks:
-            - id: pause_s3_text
-              type: Title
-              properties:
-                content: On Mouse Leave
-                level: 3
+            - id: pause_s3
+              type: Box
               style:
-                color: white
-
+                height: 160
+                background: "#531dab"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: pause_s3_text
+                  type: Title
+                  properties:
+                    content: On Mouse Leave
+                    level: 3
+                  style:
+                    color: white
 - title: Dot Position - Top
   blocks:
     - id: dot_top_carousel
       type: Carousel
       properties:
         dotPosition: top
-      blocks:
-        - id: dot_top_s1
-          type: Box
-          style:
-            height: 160
-            background: '#fa8c16'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        dot_top_s1:
           blocks:
-            - id: dot_top_s1_text
-              type: Title
-              properties:
-                content: Dots on Top
-                level: 3
+            - id: dot_top_s1
+              type: Box
               style:
-                color: white
-        - id: dot_top_s2
-          type: Box
-          style:
-            height: 160
-            background: '#d46b08'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#fa8c16"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: dot_top_s1_text
+                  type: Title
+                  properties:
+                    content: Dots on Top
+                    level: 3
+                  style:
+                    color: white
+        dot_top_s2:
           blocks:
-            - id: dot_top_s2_text
-              type: Title
-              properties:
-                content: Navigation Above
-                level: 3
+            - id: dot_top_s2
+              type: Box
               style:
-                color: white
-        - id: dot_top_s3
-          type: Box
-          style:
-            height: 160
-            background: '#ad4e00'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#d46b08"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: dot_top_s2_text
+                  type: Title
+                  properties:
+                    content: Navigation Above
+                    level: 3
+                  style:
+                    color: white
+        dot_top_s3:
           blocks:
-            - id: dot_top_s3_text
-              type: Title
-              properties:
-                content: Slide Content
-                level: 3
+            - id: dot_top_s3
+              type: Box
               style:
-                color: white
-
+                height: 160
+                background: "#ad4e00"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: dot_top_s3_text
+                  type: Title
+                  properties:
+                    content: Slide Content
+                    level: 3
+                  style:
+                    color: white
 - title: Dot Position - Left
   blocks:
     - id: dot_left_carousel
       type: Carousel
       properties:
         dotPosition: left
-      blocks:
-        - id: dot_left_s1
-          type: Box
-          style:
-            height: 200
-            background: '#13c2c2'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        dot_left_s1:
           blocks:
-            - id: dot_left_s1_text
-              type: Title
-              properties:
-                content: Dots on Left
-                level: 3
+            - id: dot_left_s1
+              type: Box
               style:
-                color: white
-        - id: dot_left_s2
-          type: Box
-          style:
-            height: 200
-            background: '#006d75'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 200
+                background: "#13c2c2"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: dot_left_s1_text
+                  type: Title
+                  properties:
+                    content: Dots on Left
+                    level: 3
+                  style:
+                    color: white
+        dot_left_s2:
           blocks:
-            - id: dot_left_s2_text
-              type: Title
-              properties:
-                content: Vertical Dots
-                level: 3
+            - id: dot_left_s2
+              type: Box
               style:
-                color: white
-        - id: dot_left_s3
-          type: Box
-          style:
-            height: 200
-            background: '#00474f'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 200
+                background: "#006d75"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: dot_left_s2_text
+                  type: Title
+                  properties:
+                    content: Vertical Dots
+                    level: 3
+                  style:
+                    color: white
+        dot_left_s3:
           blocks:
-            - id: dot_left_s3_text
-              type: Title
-              properties:
-                content: Side Navigation
-                level: 3
+            - id: dot_left_s3
+              type: Box
               style:
-                color: white
-
+                height: 200
+                background: "#00474f"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: dot_left_s3_text
+                  type: Title
+                  properties:
+                    content: Side Navigation
+                    level: 3
+                  style:
+                    color: white
 - title: Dot Position - Right
   blocks:
     - id: dot_right_carousel
       type: Carousel
       properties:
         dotPosition: right
-      blocks:
-        - id: dot_right_s1
-          type: Box
-          style:
-            height: 200
-            background: '#eb2f96'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        dot_right_s1:
           blocks:
-            - id: dot_right_s1_text
-              type: Title
-              properties:
-                content: Dots on Right
-                level: 3
+            - id: dot_right_s1
+              type: Box
               style:
-                color: white
-        - id: dot_right_s2
-          type: Box
-          style:
-            height: 200
-            background: '#c41d7f'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 200
+                background: "#eb2f96"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: dot_right_s1_text
+                  type: Title
+                  properties:
+                    content: Dots on Right
+                    level: 3
+                  style:
+                    color: white
+        dot_right_s2:
           blocks:
-            - id: dot_right_s2_text
-              type: Title
-              properties:
-                content: Right Aligned
-                level: 3
+            - id: dot_right_s2
+              type: Box
               style:
-                color: white
-        - id: dot_right_s3
-          type: Box
-          style:
-            height: 200
-            background: '#9e1068'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 200
+                background: "#c41d7f"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: dot_right_s2_text
+                  type: Title
+                  properties:
+                    content: Right Aligned
+                    level: 3
+                  style:
+                    color: white
+        dot_right_s3:
           blocks:
-            - id: dot_right_s3_text
-              type: Title
-              properties:
-                content: Navigation
-                level: 3
+            - id: dot_right_s3
+              type: Box
               style:
-                color: white
-
+                height: 200
+                background: "#9e1068"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: dot_right_s3_text
+                  type: Title
+                  properties:
+                    content: Navigation
+                    level: 3
+                  style:
+                    color: white
 - title: Fade Effect
   blocks:
     - id: fade_carousel
       type: Carousel
       properties:
         effect: fade
-      blocks:
-        - id: fade_s1
-          type: Box
-          style:
-            height: 180
-            background: '#531dab'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        fade_s1:
           blocks:
-            - id: fade_s1_text
-              type: Title
-              properties:
-                content: Fade Transition
-                level: 3
+            - id: fade_s1
+              type: Box
               style:
-                color: white
-        - id: fade_s2
-          type: Box
-          style:
-            height: 180
-            background: '#08979c'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 180
+                background: "#531dab"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: fade_s1_text
+                  type: Title
+                  properties:
+                    content: Fade Transition
+                    level: 3
+                  style:
+                    color: white
+        fade_s2:
           blocks:
-            - id: fade_s2_text
-              type: Title
-              properties:
-                content: Smooth Crossfade
-                level: 3
+            - id: fade_s2
+              type: Box
               style:
-                color: white
-        - id: fade_s3
-          type: Box
-          style:
-            height: 180
-            background: '#d4380d'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 180
+                background: "#08979c"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: fade_s2_text
+                  type: Title
+                  properties:
+                    content: Smooth Crossfade
+                    level: 3
+                  style:
+                    color: white
+        fade_s3:
           blocks:
-            - id: fade_s3_text
-              type: Title
-              properties:
-                content: Between Slides
-                level: 3
+            - id: fade_s3
+              type: Box
               style:
-                color: white
-
+                height: 180
+                background: "#d4380d"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: fade_s3_text
+                  type: Title
+                  properties:
+                    content: Between Slides
+                    level: 3
+                  style:
+                    color: white
 - title: Fade with Autoplay
   blocks:
     - id: fade_auto_carousel
@@ -532,144 +580,158 @@
         effect: fade
         autoplay: true
         autoplaySpeed: 2500
-      blocks:
-        - id: fade_auto_s1
-          type: Box
-          style:
-            height: 180
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%)
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        fade_auto_s1:
           blocks:
-            - id: fade_auto_s1_text
-              type: Title
-              properties:
-                content: Gradient Violet
-                level: 3
+            - id: fade_auto_s1
+              type: Box
               style:
-                color: white
-        - id: fade_auto_s2
-          type: Box
-          style:
-            height: 180
-            background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%)
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 180
+                background: linear-gradient(135deg,
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: fade_auto_s1_text
+                  type: Title
+                  properties:
+                    content: Gradient Violet
+                    level: 3
+                  style:
+                    color: white
+        fade_auto_s2:
           blocks:
-            - id: fade_auto_s2_text
-              type: Title
-              properties:
-                content: Gradient Pink
-                level: 3
+            - id: fade_auto_s2
+              type: Box
               style:
-                color: white
-        - id: fade_auto_s3
-          type: Box
-          style:
-            height: 180
-            background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%)
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 180
+                background: linear-gradient(135deg,
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: fade_auto_s2_text
+                  type: Title
+                  properties:
+                    content: Gradient Pink
+                    level: 3
+                  style:
+                    color: white
+        fade_auto_s3:
           blocks:
-            - id: fade_auto_s3_text
-              type: Title
-              properties:
-                content: Gradient Cyan
-                level: 3
+            - id: fade_auto_s3
+              type: Box
               style:
-                color: white
-        - id: fade_auto_s4
-          type: Box
-          style:
-            height: 180
-            background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%)
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 180
+                background: linear-gradient(135deg,
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: fade_auto_s3_text
+                  type: Title
+                  properties:
+                    content: Gradient Cyan
+                    level: 3
+                  style:
+                    color: white
+        fade_auto_s4:
           blocks:
-            - id: fade_auto_s4_text
-              type: Title
-              properties:
-                content: Gradient Mint
-                level: 3
+            - id: fade_auto_s4
+              type: Box
               style:
-                color: white
-
+                height: 180
+                background: linear-gradient(135deg,
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: fade_auto_s4_text
+                  type: Title
+                  properties:
+                    content: Gradient Mint
+                    level: 3
+                  style:
+                    color: white
 - title: With Arrows
   blocks:
     - id: arrows_carousel
       type: Carousel
       properties:
         arrows: true
-      blocks:
-        - id: arrows_s1
-          type: Box
-          style:
-            height: 180
-            background: '#389e0d'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        arrows_s1:
           blocks:
-            - id: arrows_s1_text
-              type: Title
-              properties:
-                content: Navigate with Arrows
-                level: 3
+            - id: arrows_s1
+              type: Box
               style:
-                color: white
-        - id: arrows_s2
-          type: Box
-          style:
-            height: 180
-            background: '#1d39c4'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 180
+                background: "#389e0d"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: arrows_s1_text
+                  type: Title
+                  properties:
+                    content: Navigate with Arrows
+                    level: 3
+                  style:
+                    color: white
+        arrows_s2:
           blocks:
-            - id: arrows_s2_text
-              type: Title
-              properties:
-                content: Click Left or Right
-                level: 3
+            - id: arrows_s2
+              type: Box
               style:
-                color: white
-        - id: arrows_s3
-          type: Box
-          style:
-            height: 180
-            background: '#c41d7f'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 180
+                background: "#1d39c4"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: arrows_s2_text
+                  type: Title
+                  properties:
+                    content: Click Left or Right
+                    level: 3
+                  style:
+                    color: white
+        arrows_s3:
           blocks:
-            - id: arrows_s3_text
-              type: Title
-              properties:
-                content: To Change Slides
-                level: 3
+            - id: arrows_s3
+              type: Box
               style:
-                color: white
-        - id: arrows_s4
-          type: Box
-          style:
-            height: 180
-            background: '#d4380d'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 180
+                background: "#c41d7f"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: arrows_s3_text
+                  type: Title
+                  properties:
+                    content: To Change Slides
+                    level: 3
+                  style:
+                    color: white
+        arrows_s4:
           blocks:
-            - id: arrows_s4_text
-              type: Title
-              properties:
-                content: Arrow Navigation
-                level: 3
+            - id: arrows_s4
+              type: Box
               style:
-                color: white
-
+                height: 180
+                background: "#d4380d"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: arrows_s4_text
+                  type: Title
+                  properties:
+                    content: Arrow Navigation
+                    level: 3
+                  style:
+                    color: white
 - title: Arrows without Dots
   blocks:
     - id: arrows_nodots_carousel
@@ -677,56 +739,61 @@
       properties:
         arrows: true
         dots: false
-      blocks:
-        - id: arrows_nodots_s1
-          type: Box
-          style:
-            height: 160
-            background: '#faad14'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        arrows_nodots_s1:
           blocks:
-            - id: arrows_nodots_s1_text
-              type: Title
-              properties:
-                content: Arrows Only
-                level: 3
+            - id: arrows_nodots_s1
+              type: Box
               style:
-                color: white
-        - id: arrows_nodots_s2
-          type: Box
-          style:
-            height: 160
-            background: '#d48806'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#faad14"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: arrows_nodots_s1_text
+                  type: Title
+                  properties:
+                    content: Arrows Only
+                    level: 3
+                  style:
+                    color: white
+        arrows_nodots_s2:
           blocks:
-            - id: arrows_nodots_s2_text
-              type: Title
-              properties:
-                content: No Dot Indicators
-                level: 3
+            - id: arrows_nodots_s2
+              type: Box
               style:
-                color: white
-        - id: arrows_nodots_s3
-          type: Box
-          style:
-            height: 160
-            background: '#ad6800'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#d48806"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: arrows_nodots_s2_text
+                  type: Title
+                  properties:
+                    content: No Dot Indicators
+                    level: 3
+                  style:
+                    color: white
+        arrows_nodots_s3:
           blocks:
-            - id: arrows_nodots_s3_text
-              type: Title
-              properties:
-                content: Clean Navigation
-                level: 3
+            - id: arrows_nodots_s3
+              type: Box
               style:
-                color: white
-
+                height: 160
+                background: "#ad6800"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: arrows_nodots_s3_text
+                  type: Title
+                  properties:
+                    content: Clean Navigation
+                    level: 3
+                  style:
+                    color: white
 - title: Multiple Slides per View
   blocks:
     - id: multi_carousel
@@ -734,108 +801,119 @@
       properties:
         slidesToShow: 3
         slidesToScroll: 1
-      blocks:
-        - id: multi_s1
-          type: Box
-          style:
-            height: 140
-            background: '#1677ff'
-            display: flex
-            alignItems: center
-            justifyContent: center
-            margin: 0 8px
+      slots:
+        multi_s1:
           blocks:
-            - id: multi_s1_text
-              type: Title
-              properties:
-                content: '1'
-                level: 3
+            - id: multi_s1
+              type: Box
               style:
-                color: white
-        - id: multi_s2
-          type: Box
-          style:
-            height: 140
-            background: '#4096ff'
-            display: flex
-            alignItems: center
-            justifyContent: center
-            margin: 0 8px
+                height: 140
+                background: "#1677ff"
+                display: flex
+                alignItems: center
+                justifyContent: center
+                margin: 0 8px
+              blocks:
+                - id: multi_s1_text
+                  type: Title
+                  properties:
+                    content: "1"
+                    level: 3
+                  style:
+                    color: white
+        multi_s2:
           blocks:
-            - id: multi_s2_text
-              type: Title
-              properties:
-                content: '2'
-                level: 3
+            - id: multi_s2
+              type: Box
               style:
-                color: white
-        - id: multi_s3
-          type: Box
-          style:
-            height: 140
-            background: '#69b1ff'
-            display: flex
-            alignItems: center
-            justifyContent: center
-            margin: 0 8px
+                height: 140
+                background: "#4096ff"
+                display: flex
+                alignItems: center
+                justifyContent: center
+                margin: 0 8px
+              blocks:
+                - id: multi_s2_text
+                  type: Title
+                  properties:
+                    content: "2"
+                    level: 3
+                  style:
+                    color: white
+        multi_s3:
           blocks:
-            - id: multi_s3_text
-              type: Title
-              properties:
-                content: '3'
-                level: 3
+            - id: multi_s3
+              type: Box
               style:
-                color: white
-        - id: multi_s4
-          type: Box
-          style:
-            height: 140
-            background: '#91caff'
-            display: flex
-            alignItems: center
-            justifyContent: center
-            margin: 0 8px
+                height: 140
+                background: "#69b1ff"
+                display: flex
+                alignItems: center
+                justifyContent: center
+                margin: 0 8px
+              blocks:
+                - id: multi_s3_text
+                  type: Title
+                  properties:
+                    content: "3"
+                    level: 3
+                  style:
+                    color: white
+        multi_s4:
           blocks:
-            - id: multi_s4_text
-              type: Title
-              properties:
-                content: '4'
-                level: 3
+            - id: multi_s4
+              type: Box
               style:
-                color: white
-        - id: multi_s5
-          type: Box
-          style:
-            height: 140
-            display: flex
-            alignItems: center
-            justifyContent: center
-            margin: 0 8px
+                height: 140
+                background: "#91caff"
+                display: flex
+                alignItems: center
+                justifyContent: center
+                margin: 0 8px
+              blocks:
+                - id: multi_s4_text
+                  type: Title
+                  properties:
+                    content: "4"
+                    level: 3
+                  style:
+                    color: white
+        multi_s5:
           blocks:
-            - id: multi_s5_text
-              type: Title
-              properties:
-                content: '5'
-                level: 3
+            - id: multi_s5
+              type: Box
               style:
-                color: '#1677ff'
-        - id: multi_s6
-          type: Box
-          style:
-            height: 140
-            display: flex
-            alignItems: center
-            justifyContent: center
-            margin: 0 8px
+                height: 140
+                display: flex
+                alignItems: center
+                justifyContent: center
+                margin: 0 8px
+              blocks:
+                - id: multi_s5_text
+                  type: Title
+                  properties:
+                    content: "5"
+                    level: 3
+                  style:
+                    color: "#1677ff"
+        multi_s6:
           blocks:
-            - id: multi_s6_text
-              type: Title
-              properties:
-                content: '6'
-                level: 3
+            - id: multi_s6
+              type: Box
               style:
-                color: '#1677ff'
-
+                height: 140
+                display: flex
+                alignItems: center
+                justifyContent: center
+                margin: 0 8px
+              blocks:
+                - id: multi_s6_text
+                  type: Title
+                  properties:
+                    content: "6"
+                    level: 3
+                  style:
+                    color: "#1677ff"
 - title: Infinite Loop Disabled
   blocks:
     - id: finite_carousel
@@ -843,56 +921,61 @@
       properties:
         infinite: false
         arrows: true
-      blocks:
-        - id: finite_s1
-          type: Box
-          style:
-            height: 160
-            background: '#cf1322'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        finite_s1:
           blocks:
-            - id: finite_s1_text
-              type: Title
-              properties:
-                content: First Slide
-                level: 3
+            - id: finite_s1
+              type: Box
               style:
-                color: white
-        - id: finite_s2
-          type: Box
-          style:
-            height: 160
-            background: '#a8071a'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#cf1322"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: finite_s1_text
+                  type: Title
+                  properties:
+                    content: First Slide
+                    level: 3
+                  style:
+                    color: white
+        finite_s2:
           blocks:
-            - id: finite_s2_text
-              type: Title
-              properties:
-                content: Middle Slide
-                level: 3
+            - id: finite_s2
+              type: Box
               style:
-                color: white
-        - id: finite_s3
-          type: Box
-          style:
-            height: 160
-            background: '#820014'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#a8071a"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: finite_s2_text
+                  type: Title
+                  properties:
+                    content: Middle Slide
+                    level: 3
+                  style:
+                    color: white
+        finite_s3:
           blocks:
-            - id: finite_s3_text
-              type: Title
-              properties:
-                content: Last Slide (Stops Here)
-                level: 3
+            - id: finite_s3
+              type: Box
               style:
-                color: white
-
+                height: 160
+                background: "#820014"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: finite_s3_text
+                  type: Title
+                  properties:
+                    content: Last Slide (Stops Here)
+                    level: 3
+                  style:
+                    color: white
 - title: Slides with Rich Content
   blocks:
     - id: rich_carousel
@@ -900,110 +983,115 @@
       properties:
         autoplay: true
         autoplaySpeed: 4000
-      blocks:
-        - id: rich_s1
-          type: Box
-          style:
-            height: 220
-            background: linear-gradient(135deg, #1677ff 0%, #0958d9 100%)
-            display: flex
-            flexDirection: column
-            alignItems: center
-            justifyContent: center
-            padding: 24px
+      slots:
+        rich_s1:
           blocks:
-            - id: rich_s1_icon
-              type: Icon
-              properties:
-                name: AiOutlineRocket
-                size: 40
-                color: white
-            - id: rich_s1_title
-              type: Title
-              properties:
-                content: Launch Fast
-                level: 3
+            - id: rich_s1
+              type: Box
               style:
-                color: white
-                marginTop: 12
-                marginBottom: 0
-            - id: rich_s1_desc
-              type: Paragraph
-              properties:
-                content: Build and deploy web apps in record time with config-driven development.
-              style:
-                color: rgba(255, 255, 255, 0.85)
-                textAlign: center
-                maxWidth: 400
-        - id: rich_s2
-          type: Box
-          style:
-            height: 220
-            background: linear-gradient(135deg, #52c41a 0%, #389e0d 100%)
-            display: flex
-            flexDirection: column
-            alignItems: center
-            justifyContent: center
-            padding: 24px
+                height: 220
+                background: linear-gradient(135deg,
+                display: flex
+                flexDirection: column
+                alignItems: center
+                justifyContent: center
+                padding: 24px
+              blocks:
+                - id: rich_s1_icon
+                  type: Icon
+                  properties:
+                    name: AiOutlineRocket
+                    size: 40
+                    color: white
+                - id: rich_s1_title
+                  type: Title
+                  properties:
+                    content: Launch Fast
+                    level: 3
+                  style:
+                    color: white
+                    marginTop: 12
+                    marginBottom: 0
+                - id: rich_s1_desc
+                  type: Paragraph
+                  properties:
+                    content: Build and deploy web apps in record time with config-driven development.
+                  style:
+                    color: rgba(255, 255, 255, 0.85)
+                    textAlign: center
+                    maxWidth: 400
+        rich_s2:
           blocks:
-            - id: rich_s2_icon
-              type: Icon
-              properties:
-                name: AiOutlineCheckCircle
-                size: 40
-                color: white
-            - id: rich_s2_title
-              type: Title
-              properties:
-                content: Production Ready
-                level: 3
+            - id: rich_s2
+              type: Box
               style:
-                color: white
-                marginTop: 12
-                marginBottom: 0
-            - id: rich_s2_desc
-              type: Paragraph
-              properties:
-                content: Enterprise-grade applications with built-in auth, roles, and security.
-              style:
-                color: rgba(255, 255, 255, 0.85)
-                textAlign: center
-                maxWidth: 400
-        - id: rich_s3
-          type: Box
-          style:
-            height: 220
-            background: linear-gradient(135deg, #722ed1 0%, #531dab 100%)
-            display: flex
-            flexDirection: column
-            alignItems: center
-            justifyContent: center
-            padding: 24px
+                height: 220
+                background: linear-gradient(135deg,
+                display: flex
+                flexDirection: column
+                alignItems: center
+                justifyContent: center
+                padding: 24px
+              blocks:
+                - id: rich_s2_icon
+                  type: Icon
+                  properties:
+                    name: AiOutlineCheckCircle
+                    size: 40
+                    color: white
+                - id: rich_s2_title
+                  type: Title
+                  properties:
+                    content: Production Ready
+                    level: 3
+                  style:
+                    color: white
+                    marginTop: 12
+                    marginBottom: 0
+                - id: rich_s2_desc
+                  type: Paragraph
+                  properties:
+                    content: Enterprise-grade applications with built-in auth, roles, and security.
+                  style:
+                    color: rgba(255, 255, 255, 0.85)
+                    textAlign: center
+                    maxWidth: 400
+        rich_s3:
           blocks:
-            - id: rich_s3_icon
-              type: Icon
-              properties:
-                name: AiOutlineApi
-                size: 40
-                color: white
-            - id: rich_s3_title
-              type: Title
-              properties:
-                content: Connect Anything
-                level: 3
+            - id: rich_s3
+              type: Box
               style:
-                color: white
-                marginTop: 12
-                marginBottom: 0
-            - id: rich_s3_desc
-              type: Paragraph
-              properties:
-                content: Integrate with databases, REST APIs, and GraphQL endpoints effortlessly.
-              style:
-                color: rgba(255, 255, 255, 0.85)
-                textAlign: center
-                maxWidth: 400
-
+                height: 220
+                background: linear-gradient(135deg,
+                display: flex
+                flexDirection: column
+                alignItems: center
+                justifyContent: center
+                padding: 24px
+              blocks:
+                - id: rich_s3_icon
+                  type: Icon
+                  properties:
+                    name: AiOutlineApi
+                    size: 40
+                    color: white
+                - id: rich_s3_title
+                  type: Title
+                  properties:
+                    content: Connect Anything
+                    level: 3
+                  style:
+                    color: white
+                    marginTop: 12
+                    marginBottom: 0
+                - id: rich_s3_desc
+                  type: Paragraph
+                  properties:
+                    content: Integrate with databases, REST APIs, and GraphQL endpoints effortlessly.
+                  style:
+                    color: rgba(255, 255, 255, 0.85)
+                    textAlign: center
+                    maxWidth: 400
 - title: Slides with Cards
   blocks:
     - id: card_carousel
@@ -1012,88 +1100,95 @@
         slidesToShow: 2
         slidesToScroll: 1
         arrows: true
-      blocks:
-        - id: card_s1
-          type: Box
-          style:
-            padding: 12px
+      slots:
+        card_s1:
           blocks:
-            - id: card_s1_card
-              type: Card
-              properties:
-                title: Dashboard
-                bordered: true
+            - id: card_s1
+              type: Box
+              style:
+                padding: 12px
               blocks:
-                - id: card_s1_card_desc
-                  type: Paragraph
+                - id: card_s1_card
+                  type: Card
                   properties:
-                    content: Monitor your app metrics and KPIs at a glance with customizable widgets and real-time data.
-                - id: card_s1_card_tag
-                  type: Tag
-                  properties:
-                    title: Analytics
-                    color: blue
-        - id: card_s2
-          type: Box
-          style:
-            padding: 12px
+                    title: Dashboard
+                    bordered: true
+                  blocks:
+                    - id: card_s1_card_desc
+                      type: Paragraph
+                      properties:
+                        content: Monitor your app metrics and KPIs at a glance with customizable widgets and real-time data.
+                    - id: card_s1_card_tag
+                      type: Tag
+                      properties:
+                        title: Analytics
+                        color: blue
+        card_s2:
           blocks:
-            - id: card_s2_card
-              type: Card
-              properties:
-                title: User Management
-                bordered: true
+            - id: card_s2
+              type: Box
+              style:
+                padding: 12px
               blocks:
-                - id: card_s2_card_desc
-                  type: Paragraph
+                - id: card_s2_card
+                  type: Card
                   properties:
-                    content: Handle roles, permissions, and team invitations with a built-in authentication layer.
-                - id: card_s2_card_tag
-                  type: Tag
-                  properties:
-                    title: Security
-                    color: green
-        - id: card_s3
-          type: Box
-          style:
-            padding: 12px
+                    title: User Management
+                    bordered: true
+                  blocks:
+                    - id: card_s2_card_desc
+                      type: Paragraph
+                      properties:
+                        content: Handle roles, permissions, and team invitations with a built-in authentication layer.
+                    - id: card_s2_card_tag
+                      type: Tag
+                      properties:
+                        title: Security
+                        color: green
+        card_s3:
           blocks:
-            - id: card_s3_card
-              type: Card
-              properties:
-                title: Form Builder
-                bordered: true
+            - id: card_s3
+              type: Box
+              style:
+                padding: 12px
               blocks:
-                - id: card_s3_card_desc
-                  type: Paragraph
+                - id: card_s3_card
+                  type: Card
                   properties:
-                    content: Create complex multi-step forms with validation, conditional logic, and file uploads.
-                - id: card_s3_card_tag
-                  type: Tag
-                  properties:
-                    title: Input
-                    color: purple
-        - id: card_s4
-          type: Box
-          style:
-            padding: 12px
+                    title: Form Builder
+                    bordered: true
+                  blocks:
+                    - id: card_s3_card_desc
+                      type: Paragraph
+                      properties:
+                        content: Create complex multi-step forms with validation, conditional logic, and file uploads.
+                    - id: card_s3_card_tag
+                      type: Tag
+                      properties:
+                        title: Input
+                        color: purple
+        card_s4:
           blocks:
-            - id: card_s4_card
-              type: Card
-              properties:
-                title: Workflow Engine
-                bordered: true
+            - id: card_s4
+              type: Box
+              style:
+                padding: 12px
               blocks:
-                - id: card_s4_card_desc
-                  type: Paragraph
+                - id: card_s4_card
+                  type: Card
                   properties:
-                    content: Automate business processes with triggers, conditions, and multi-step action sequences.
-                - id: card_s4_card_tag
-                  type: Tag
-                  properties:
-                    title: Automation
-                    color: orange
-
+                    title: Workflow Engine
+                    bordered: true
+                  blocks:
+                    - id: card_s4_card_desc
+                      type: Paragraph
+                      properties:
+                        content: Automate business processes with triggers, conditions, and multi-step action sequences.
+                    - id: card_s4_card_tag
+                      type: Tag
+                      properties:
+                        title: Automation
+                        color: orange
 - title: Gradient Background Slides
   blocks:
     - id: gradient_carousel
@@ -1102,88 +1197,97 @@
         effect: fade
         autoplay: true
         autoplaySpeed: 3000
-      blocks:
-        - id: grad_s1
-          type: Box
-          style:
-            height: 200
-            background: linear-gradient(120deg, #a1c4fd 0%, #c2e9fb 100%)
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        grad_s1:
           blocks:
-            - id: grad_s1_text
-              type: Title
-              properties:
-                content: Soft Blue
-                level: 2
+            - id: grad_s1
+              type: Box
               style:
-                color: '#1d39c4'
-        - id: grad_s2
-          type: Box
-          style:
-            height: 200
-            background: linear-gradient(120deg, #d4fc79 0%, #96e6a1 100%)
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 200
+                background: linear-gradient(120deg,
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: grad_s1_text
+                  type: Title
+                  properties:
+                    content: Soft Blue
+                    level: 2
+                  style:
+                    color: "#1d39c4"
+        grad_s2:
           blocks:
-            - id: grad_s2_text
-              type: Title
-              properties:
-                content: Fresh Lime
-                level: 2
+            - id: grad_s2
+              type: Box
               style:
-                color: '#135200'
-        - id: grad_s3
-          type: Box
-          style:
-            height: 200
-            background: linear-gradient(120deg, #fccb90 0%, #d57eeb 100%)
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 200
+                background: linear-gradient(120deg,
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: grad_s2_text
+                  type: Title
+                  properties:
+                    content: Fresh Lime
+                    level: 2
+                  style:
+                    color: "#135200"
+        grad_s3:
           blocks:
-            - id: grad_s3_text
-              type: Title
-              properties:
-                content: Warm Sunset
-                level: 2
+            - id: grad_s3
+              type: Box
               style:
-                color: '#610b00'
-        - id: grad_s4
-          type: Box
-          style:
-            height: 200
-            background: linear-gradient(120deg, #e0c3fc 0%, #8ec5fc 100%)
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 200
+                background: linear-gradient(120deg,
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: grad_s3_text
+                  type: Title
+                  properties:
+                    content: Warm Sunset
+                    level: 2
+                  style:
+                    color: "#610b00"
+        grad_s4:
           blocks:
-            - id: grad_s4_text
-              type: Title
-              properties:
-                content: Lavender Mist
-                level: 2
+            - id: grad_s4
+              type: Box
               style:
-                color: '#391085'
-        - id: grad_s5
-          type: Box
-          style:
-            height: 200
-            background: linear-gradient(120deg, #f5576c 0%, #ff6a88 50%, #ffd194 100%)
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 200
+                background: linear-gradient(120deg,
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: grad_s4_text
+                  type: Title
+                  properties:
+                    content: Lavender Mist
+                    level: 2
+                  style:
+                    color: "#391085"
+        grad_s5:
           blocks:
-            - id: grad_s5_text
-              type: Title
-              properties:
-                content: Coral Sunrise
-                level: 2
+            - id: grad_s5
+              type: Box
               style:
-                color: white
-
+                height: 200
+                background: linear-gradient(120deg,
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: grad_s5_text
+                  type: Title
+                  properties:
+                    content: Coral Sunrise
+                    level: 2
+                  style:
+                    color: white
 - title: Draggable
   blocks:
     - id: drag_carousel
@@ -1191,71 +1295,78 @@
       properties:
         draggable: true
         swipeToSlide: true
-      blocks:
-        - id: drag_s1
-          type: Box
-          style:
-            height: 160
-            background: '#2f54eb'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        drag_s1:
           blocks:
-            - id: drag_s1_text
-              type: Title
-              properties:
-                content: Drag to Navigate
-                level: 3
+            - id: drag_s1
+              type: Box
               style:
-                color: white
-        - id: drag_s2
-          type: Box
-          style:
-            height: 160
-            background: '#597ef7'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#2f54eb"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: drag_s1_text
+                  type: Title
+                  properties:
+                    content: Drag to Navigate
+                    level: 3
+                  style:
+                    color: white
+        drag_s2:
           blocks:
-            - id: drag_s2_text
-              type: Title
-              properties:
-                content: Click and Drag
-                level: 3
+            - id: drag_s2
+              type: Box
               style:
-                color: white
-        - id: drag_s3
-          type: Box
-          style:
-            height: 160
-            background: '#85a5ff'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#597ef7"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: drag_s2_text
+                  type: Title
+                  properties:
+                    content: Click and Drag
+                    level: 3
+                  style:
+                    color: white
+        drag_s3:
           blocks:
-            - id: drag_s3_text
-              type: Title
-              properties:
-                content: On Desktop
-                level: 3
+            - id: drag_s3
+              type: Box
               style:
-                color: white
-        - id: drag_s4
-          type: Box
-          style:
-            height: 160
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#85a5ff"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: drag_s3_text
+                  type: Title
+                  properties:
+                    content: On Desktop
+                    level: 3
+                  style:
+                    color: white
+        drag_s4:
           blocks:
-            - id: drag_s4_text
-              type: Title
-              properties:
-                content: Swipe on Mobile
-                level: 3
+            - id: drag_s4
+              type: Box
               style:
-                color: '#2f54eb'
-
+                height: 160
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: drag_s4_text
+                  type: Title
+                  properties:
+                    content: Swipe on Mobile
+                    level: 3
+                  style:
+                    color: "#2f54eb"
 - title: Center Mode
   blocks:
     - id: center_carousel
@@ -1264,300 +1375,325 @@
         centerMode: true
         centerPadding: 60px
         slidesToShow: 1
-      blocks:
-        - id: center_s1
-          type: Box
-          style:
-            height: 160
-            background: '#faad14'
-            display: flex
-            alignItems: center
-            justifyContent: center
-            margin: 0 8px
-            borderRadius: 8
+      slots:
+        center_s1:
           blocks:
-            - id: center_s1_text
-              type: Title
-              properties:
-                content: Center Mode
-                level: 3
+            - id: center_s1
+              type: Box
               style:
-                color: white
-        - id: center_s2
-          type: Box
-          style:
-            height: 160
-            background: '#d48806'
-            display: flex
-            alignItems: center
-            justifyContent: center
-            margin: 0 8px
-            borderRadius: 8
+                height: 160
+                background: "#faad14"
+                display: flex
+                alignItems: center
+                justifyContent: center
+                margin: 0 8px
+                borderRadius: 8
+              blocks:
+                - id: center_s1_text
+                  type: Title
+                  properties:
+                    content: Center Mode
+                    level: 3
+                  style:
+                    color: white
+        center_s2:
           blocks:
-            - id: center_s2_text
-              type: Title
-              properties:
-                content: Peek at Adjacent
-                level: 3
+            - id: center_s2
+              type: Box
               style:
-                color: white
-        - id: center_s3
-          type: Box
-          style:
-            height: 160
-            background: '#ad6800'
-            display: flex
-            alignItems: center
-            justifyContent: center
-            margin: 0 8px
-            borderRadius: 8
+                height: 160
+                background: "#d48806"
+                display: flex
+                alignItems: center
+                justifyContent: center
+                margin: 0 8px
+                borderRadius: 8
+              blocks:
+                - id: center_s2_text
+                  type: Title
+                  properties:
+                    content: Peek at Adjacent
+                    level: 3
+                  style:
+                    color: white
+        center_s3:
           blocks:
-            - id: center_s3_text
-              type: Title
-              properties:
-                content: Slide Previews
-                level: 3
+            - id: center_s3
+              type: Box
               style:
-                color: white
-        - id: center_s4
-          type: Box
-          style:
-            height: 160
-            background: '#874d00'
-            display: flex
-            alignItems: center
-            justifyContent: center
-            margin: 0 8px
-            borderRadius: 8
+                height: 160
+                background: "#ad6800"
+                display: flex
+                alignItems: center
+                justifyContent: center
+                margin: 0 8px
+                borderRadius: 8
+              blocks:
+                - id: center_s3_text
+                  type: Title
+                  properties:
+                    content: Slide Previews
+                    level: 3
+                  style:
+                    color: white
+        center_s4:
           blocks:
-            - id: center_s4_text
-              type: Title
-              properties:
-                content: With Padding
-                level: 3
+            - id: center_s4
+              type: Box
               style:
-                color: white
-
+                height: 160
+                background: "#874d00"
+                display: flex
+                alignItems: center
+                justifyContent: center
+                margin: 0 8px
+                borderRadius: 8
+              blocks:
+                - id: center_s4_text
+                  type: Title
+                  properties:
+                    content: With Padding
+                    level: 3
+                  style:
+                    color: white
 - title: Styled Slides with CSS
   blocks:
     - id: css_carousel
       type: Carousel
-      blocks:
-        - id: css_s1
-          type: Box
-          class: bg-gradient-to-br from-primary/100 to-indigo-600
-          style:
-            height: 200
-            display: flex
-            flexDirection: column
-            alignItems: center
-            justifyContent: center
+      slots:
+        css_s1:
           blocks:
-            - id: css_s1_title
-              type: Title
-              properties:
-                content: Tailwind Gradients
-                level: 2
+            - id: css_s1
+              type: Box
+              class: bg-gradient-to-br from-primary/100 to-indigo-600
               style:
-                color: white
-                marginBottom: 0
-            - id: css_s1_sub
-              type: Paragraph
-              properties:
-                content: Use Tailwind utility classes on slides
-              style:
-                color: rgba(255, 255, 255, 0.8)
-        - id: css_s2
-          type: Box
-          class: bg-gradient-to-br from-emerald-400 to-cyan-500
-          style:
-            height: 200
-            display: flex
-            flexDirection: column
-            alignItems: center
-            justifyContent: center
+                height: 200
+                display: flex
+                flexDirection: column
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: css_s1_title
+                  type: Title
+                  properties:
+                    content: Tailwind Gradients
+                    level: 2
+                  style:
+                    color: white
+                    marginBottom: 0
+                - id: css_s1_sub
+                  type: Paragraph
+                  properties:
+                    content: Use Tailwind utility classes on slides
+                  style:
+                    color: rgba(255, 255, 255, 0.8)
+        css_s2:
           blocks:
-            - id: css_s2_title
-              type: Title
-              properties:
-                content: Green to Cyan
-                level: 2
+            - id: css_s2
+              type: Box
+              class: bg-gradient-to-br from-emerald-400 to-cyan-500
               style:
-                color: white
-                marginBottom: 0
-            - id: css_s2_sub
-              type: Paragraph
-              properties:
-                content: Combine class and style for full control
-              style:
-                color: rgba(255, 255, 255, 0.8)
-        - id: css_s3
-          type: Box
-          class: bg-gradient-to-br from-rose-400 to-orange-400
-          style:
-            height: 200
-            display: flex
-            flexDirection: column
-            alignItems: center
-            justifyContent: center
+                height: 200
+                display: flex
+                flexDirection: column
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: css_s2_title
+                  type: Title
+                  properties:
+                    content: Green to Cyan
+                    level: 2
+                  style:
+                    color: white
+                    marginBottom: 0
+                - id: css_s2_sub
+                  type: Paragraph
+                  properties:
+                    content: Combine class and style for full control
+                  style:
+                    color: rgba(255, 255, 255, 0.8)
+        css_s3:
           blocks:
-            - id: css_s3_title
-              type: Title
-              properties:
-                content: Rose to Orange
-                level: 2
+            - id: css_s3
+              type: Box
+              class: bg-gradient-to-br from-rose-400 to-orange-400
               style:
-                color: white
-                marginBottom: 0
-            - id: css_s3_sub
-              type: Paragraph
-              properties:
-                content: Beautiful color transitions
-              style:
-                color: rgba(255, 255, 255, 0.8)
-        - id: css_s4
-          type: Box
-          class: bg-gradient-to-br from-violet-500 to-fuchsia-500
-          style:
-            height: 200
-            display: flex
-            flexDirection: column
-            alignItems: center
-            justifyContent: center
+                height: 200
+                display: flex
+                flexDirection: column
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: css_s3_title
+                  type: Title
+                  properties:
+                    content: Rose to Orange
+                    level: 2
+                  style:
+                    color: white
+                    marginBottom: 0
+                - id: css_s3_sub
+                  type: Paragraph
+                  properties:
+                    content: Beautiful color transitions
+                  style:
+                    color: rgba(255, 255, 255, 0.8)
+        css_s4:
           blocks:
-            - id: css_s4_title
-              type: Title
-              properties:
-                content: Violet to Fuchsia
-                level: 2
+            - id: css_s4
+              type: Box
+              class: bg-gradient-to-br from-violet-500 to-fuchsia-500
               style:
-                color: white
-                marginBottom: 0
-            - id: css_s4_sub
-              type: Paragraph
-              properties:
-                content: Rich purple gradients
-              style:
-                color: rgba(255, 255, 255, 0.8)
-
+                height: 200
+                display: flex
+                flexDirection: column
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: css_s4_title
+                  type: Title
+                  properties:
+                    content: Violet to Fuchsia
+                    level: 2
+                  style:
+                    color: white
+                    marginBottom: 0
+                - id: css_s4_sub
+                  type: Paragraph
+                  properties:
+                    content: Rich purple gradients
+                  style:
+                    color: rgba(255, 255, 255, 0.8)
 - title: Custom Transition Speed
   blocks:
     - id: speed_label
       type: Markdown
       properties:
-        content: '**Slow transition (1500ms):**'
+        content: "**Slow transition (1500ms):**"
     - id: slow_carousel
       type: Carousel
       properties:
         speed: 1500
         easing: ease-in-out
-      blocks:
-        - id: slow_s1
-          type: Box
-          style:
-            height: 140
-            background: '#595959'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        slow_s1:
           blocks:
-            - id: slow_s1_text
-              type: Title
-              properties:
-                content: Slow and Smooth
-                level: 3
+            - id: slow_s1
+              type: Box
               style:
-                color: white
-        - id: slow_s2
-          type: Box
-          style:
-            height: 140
-            background: '#434343'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 140
+                background: "#595959"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: slow_s1_text
+                  type: Title
+                  properties:
+                    content: Slow and Smooth
+                    level: 3
+                  style:
+                    color: white
+        slow_s2:
           blocks:
-            - id: slow_s2_text
-              type: Title
-              properties:
-                content: Ease In Out
-                level: 3
+            - id: slow_s2
+              type: Box
               style:
-                color: white
-        - id: slow_s3
-          type: Box
-          style:
-            height: 140
-            background: '#262626'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 140
+                background: "#434343"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: slow_s2_text
+                  type: Title
+                  properties:
+                    content: Ease In Out
+                    level: 3
+                  style:
+                    color: white
+        slow_s3:
           blocks:
-            - id: slow_s3_text
-              type: Title
-              properties:
-                content: 1.5 Second Slide
-                level: 3
+            - id: slow_s3
+              type: Box
               style:
-                color: white
+                height: 140
+                background: "#262626"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: slow_s3_text
+                  type: Title
+                  properties:
+                    content: 1.5 Second Slide
+                    level: 3
+                  style:
+                    color: white
     - id: fast_label
       type: Markdown
       properties:
-        content: '**Fast transition (200ms):**'
+        content: "**Fast transition (200ms):**"
     - id: fast_carousel
       type: Carousel
       properties:
         speed: 200
-      blocks:
-        - id: fast_s1
-          type: Box
-          style:
-            height: 140
-            background: '#ff4d4f'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        fast_s1:
           blocks:
-            - id: fast_s1_text
-              type: Title
-              properties:
-                content: Quick Snap
-                level: 3
+            - id: fast_s1
+              type: Box
               style:
-                color: white
-        - id: fast_s2
-          type: Box
-          style:
-            height: 140
-            background: '#ff7875'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 140
+                background: "#ff4d4f"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: fast_s1_text
+                  type: Title
+                  properties:
+                    content: Quick Snap
+                    level: 3
+                  style:
+                    color: white
+        fast_s2:
           blocks:
-            - id: fast_s2_text
-              type: Title
-              properties:
-                content: 200ms Transition
-                level: 3
+            - id: fast_s2
+              type: Box
               style:
-                color: white
-        - id: fast_s3
-          type: Box
-          style:
-            height: 140
-            background: '#ffa39e'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 140
+                background: "#ff7875"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: fast_s2_text
+                  type: Title
+                  properties:
+                    content: 200ms Transition
+                    level: 3
+                  style:
+                    color: white
+        fast_s3:
           blocks:
-            - id: fast_s3_text
-              type: Title
-              properties:
-                content: Instant Feel
-                level: 3
+            - id: fast_s3
+              type: Box
               style:
-                color: '#cf1322'
-
+                height: 140
+                background: "#ffa39e"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: fast_s3_text
+                  type: Title
+                  properties:
+                    content: Instant Feel
+                    level: 3
+                  style:
+                    color: "#cf1322"
 - title: Theme Token Overrides - Large Dots
   blocks:
     - id: theme_large_dots_carousel
@@ -1567,56 +1703,61 @@
           dotWidth: 24
           dotHeight: 6
           dotActiveWidth: 40
-      blocks:
-        - id: theme_ld_s1
-          type: Box
-          style:
-            height: 160
-            background: '#1677ff'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        theme_ld_s1:
           blocks:
-            - id: theme_ld_s1_text
-              type: Title
-              properties:
-                content: Large Dots
-                level: 3
+            - id: theme_ld_s1
+              type: Box
               style:
-                color: white
-        - id: theme_ld_s2
-          type: Box
-          style:
-            height: 160
-            background: '#4096ff'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#1677ff"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: theme_ld_s1_text
+                  type: Title
+                  properties:
+                    content: Large Dots
+                    level: 3
+                  style:
+                    color: white
+        theme_ld_s2:
           blocks:
-            - id: theme_ld_s2_text
-              type: Title
-              properties:
-                content: Custom Indicators
-                level: 3
+            - id: theme_ld_s2
+              type: Box
               style:
-                color: white
-        - id: theme_ld_s3
-          type: Box
-          style:
-            height: 160
-            background: '#69b1ff'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#4096ff"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: theme_ld_s2_text
+                  type: Title
+                  properties:
+                    content: Custom Indicators
+                    level: 3
+                  style:
+                    color: white
+        theme_ld_s3:
           blocks:
-            - id: theme_ld_s3_text
-              type: Title
-              properties:
-                content: More Visible
-                level: 3
+            - id: theme_ld_s3
+              type: Box
               style:
-                color: white
-
+                height: 160
+                background: "#69b1ff"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: theme_ld_s3_text
+                  type: Title
+                  properties:
+                    content: More Visible
+                    level: 3
+                  style:
+                    color: white
 - title: Theme Token Overrides - Round Dots
   blocks:
     - id: theme_round_dots_carousel
@@ -1626,56 +1767,61 @@
           dotWidth: 12
           dotHeight: 12
           dotActiveWidth: 12
-      blocks:
-        - id: theme_rd_s1
-          type: Box
-          style:
-            height: 160
-            background: '#52c41a'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        theme_rd_s1:
           blocks:
-            - id: theme_rd_s1_text
-              type: Title
-              properties:
-                content: Round Dots
-                level: 3
+            - id: theme_rd_s1
+              type: Box
               style:
-                color: white
-        - id: theme_rd_s2
-          type: Box
-          style:
-            height: 160
-            background: '#73d13d'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#52c41a"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: theme_rd_s1_text
+                  type: Title
+                  properties:
+                    content: Round Dots
+                    level: 3
+                  style:
+                    color: white
+        theme_rd_s2:
           blocks:
-            - id: theme_rd_s2_text
-              type: Title
-              properties:
-                content: Circular Indicators
-                level: 3
+            - id: theme_rd_s2
+              type: Box
               style:
-                color: white
-        - id: theme_rd_s3
-          type: Box
-          style:
-            height: 160
-            background: '#95de64'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#73d13d"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: theme_rd_s2_text
+                  type: Title
+                  properties:
+                    content: Circular Indicators
+                    level: 3
+                  style:
+                    color: white
+        theme_rd_s3:
           blocks:
-            - id: theme_rd_s3_text
-              type: Title
-              properties:
-                content: Same Width Active
-                level: 3
+            - id: theme_rd_s3
+              type: Box
               style:
-                color: '#135200'
-
+                height: 160
+                background: "#95de64"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: theme_rd_s3_text
+                  type: Title
+                  properties:
+                    content: Same Width Active
+                    level: 3
+                  style:
+                    color: "#135200"
 - title: Theme Token Overrides - Large Arrows
   blocks:
     - id: theme_large_arrows_carousel
@@ -1685,56 +1831,61 @@
         theme:
           arrowSize: 24
           arrowOffset: 16
-      blocks:
-        - id: theme_la_s1
-          type: Box
-          style:
-            height: 180
-            background: '#722ed1'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        theme_la_s1:
           blocks:
-            - id: theme_la_s1_text
-              type: Title
-              properties:
-                content: Larger Arrows
-                level: 3
+            - id: theme_la_s1
+              type: Box
               style:
-                color: white
-        - id: theme_la_s2
-          type: Box
-          style:
-            height: 180
-            background: '#9254de'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 180
+                background: "#722ed1"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: theme_la_s1_text
+                  type: Title
+                  properties:
+                    content: Larger Arrows
+                    level: 3
+                  style:
+                    color: white
+        theme_la_s2:
           blocks:
-            - id: theme_la_s2_text
-              type: Title
-              properties:
-                content: More Prominent
-                level: 3
+            - id: theme_la_s2
+              type: Box
               style:
-                color: white
-        - id: theme_la_s3
-          type: Box
-          style:
-            height: 180
-            background: '#b37feb'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 180
+                background: "#9254de"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: theme_la_s2_text
+                  type: Title
+                  properties:
+                    content: More Prominent
+                    level: 3
+                  style:
+                    color: white
+        theme_la_s3:
           blocks:
-            - id: theme_la_s3_text
-              type: Title
-              properties:
-                content: Navigation Controls
-                level: 3
+            - id: theme_la_s3
+              type: Box
               style:
-                color: white
-
+                height: 180
+                background: "#b37feb"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: theme_la_s3_text
+                  type: Title
+                  properties:
+                    content: Navigation Controls
+                    level: 3
+                  style:
+                    color: white
 - title: Theme Token Overrides - Spaced Dots
   blocks:
     - id: theme_spaced_dots_carousel
@@ -1746,67 +1897,75 @@
           dotWidth: 20
           dotHeight: 4
           dotActiveWidth: 36
-      blocks:
-        - id: theme_sd_s1
-          type: Box
-          style:
-            height: 160
-            background: '#eb2f96'
-            display: flex
-            alignItems: center
-            justifyContent: center
+      slots:
+        theme_sd_s1:
           blocks:
-            - id: theme_sd_s1_text
-              type: Title
-              properties:
-                content: Spaced Dots
-                level: 3
+            - id: theme_sd_s1
+              type: Box
               style:
-                color: white
-        - id: theme_sd_s2
-          type: Box
-          style:
-            height: 160
-            background: '#f759ab'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#eb2f96"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: theme_sd_s1_text
+                  type: Title
+                  properties:
+                    content: Spaced Dots
+                    level: 3
+                  style:
+                    color: white
+        theme_sd_s2:
           blocks:
-            - id: theme_sd_s2_text
-              type: Title
-              properties:
-                content: Wide Gap
-                level: 3
+            - id: theme_sd_s2
+              type: Box
               style:
-                color: white
-        - id: theme_sd_s3
-          type: Box
-          style:
-            height: 160
-            background: '#ff85c0'
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#f759ab"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: theme_sd_s2_text
+                  type: Title
+                  properties:
+                    content: Wide Gap
+                    level: 3
+                  style:
+                    color: white
+        theme_sd_s3:
           blocks:
-            - id: theme_sd_s3_text
-              type: Title
-              properties:
-                content: More Offset
-                level: 3
+            - id: theme_sd_s3
+              type: Box
               style:
-                color: white
-        - id: theme_sd_s4
-          type: Box
-          style:
-            height: 160
-            display: flex
-            alignItems: center
-            justifyContent: center
+                height: 160
+                background: "#ff85c0"
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: theme_sd_s3_text
+                  type: Title
+                  properties:
+                    content: More Offset
+                    level: 3
+                  style:
+                    color: white
+        theme_sd_s4:
           blocks:
-            - id: theme_sd_s4_text
-              type: Title
-              properties:
-                content: Custom Spacing
-                level: 3
+            - id: theme_sd_s4
+              type: Box
               style:
-                color: '#c41d7f'
+                height: 160
+                display: flex
+                alignItems: center
+                justifyContent: center
+              blocks:
+                - id: theme_sd_s4_text
+                  type: Title
+                  properties:
+                    content: Custom Spacing
+                    level: 3
+                  style:
+                    color: "#c41d7f"

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Carousel/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Carousel/meta.js
@@ -149,6 +149,21 @@ export default {
         default: false,
         description: 'Reverses the slide order.',
       },
+      slides: {
+        type: 'array',
+        description:
+          'Optional list of slides for explicit ordering and metadata. Each entry must have a `key` matching a slot name. When omitted, every defined slot becomes a slide, ordered alphabetically by key. Each entry is passed to `afterChange` and `beforeChange` events as `event.current` and `event.next` — any extra fields on the entry (e.g. a title or analytics id) are available there.',
+        items: {
+          type: 'object',
+          required: ['key'],
+          properties: {
+            key: {
+              type: 'string',
+              description: 'Slot key for this slide.',
+            },
+          },
+        },
+      },
       slidesPerRow: {
         type: 'integer',
         default: 1,


### PR DESCRIPTION
## Summary

The Carousel gallery on docs.lowdefy.com rendered every example with all slides stacked inside a single `slick-slide`. The block reads slides from named `slots:`, but every gallery example used a flat `blocks:` list — so all slides collapsed into the default `content` slot. While fixing the gallery, this PR also documents the previously-undocumented `slides` property and clarifies the misleading "dynamic slots" wording in the docs template.

## Changes

- **@lowdefy/blocks-antd**: Convert 25 Carousel examples in `gallery.yaml` from flat `blocks:` to `slots:` (one slot per slide); structural equivalence verified across all carousels. Add a `slides` property entry to `meta.js` so it appears in the Properties table — covers explicit slide ordering and metadata that flows into `afterChange` / `beforeChange` events as `event.current` / `event.next`.
- **@lowdefy/docs**: Rewrite the `slots: false` docs message in `galleryTransformer.js` — drop the misleading "dynamic" wording (read as runtime-generated) and explicitly say slot keys are user-defined and resolved at build time. Generic across Carousel, Tabs, Collapse, Splitter.

## Notes

No changeset needed — all changes are documentation-only (gallery examples + Properties table copy). The Carousel block's runtime behavior is unchanged.