### PR TITLE
Add CardList display block

### DIFF
--- a/.changeset/feat-blocks-antd-cardlist.md
+++ b/.changeset/feat-blocks-antd-cardlist.md
@@ -1,0 +1,11 @@
+---
+'@lowdefy/blocks-antd': minor
+---
+
+feat(blocks-antd): Add `CardList` display block.
+
+Data-driven vertical list that renders each item into a headerless antd `Card` whose body comes from a Nunjucks template against the row. Backed by `react-virtuoso` so thousands of variable-height cards render smoothly with only the visible window in the DOM, and rows are `React.memo`'d via a stable `methodsRef` so unrelated parent re-renders don't bust the cache.
+
+Properties: `data`, `html` (Nunjucks), `bordered`, `hoverable`, `size`, `gap`, `height`, `overscan`, `theme`, and an optional `search` object (`placeholder`, `fields`, `caseSensitive`, `debounce`, `sticky`, `allowClear`, `minLength`, `noResultsText`). Search defaults to matching every field path via `JSON.stringify`; supply `fields: ['user.name', 'email']` to restrict. Filtering preserves the original `index` in both the template context and the `onClick` payload. Built-in loading skeleton renders when `loading` is truthy. A text-only no-results placeholder (no image) appears when the filter matches zero items. Colors come from antd theme tokens so light/dark mode work out of the box.
+
+Events: `onClick` (`{ index, item }`) and `onSearch` (`{ value, resultCount }`, fires on debounced query change when `search` is set).

--- a/packages/docs/blocks/list/CardList.yaml
+++ b/packages/docs/blocks/list/CardList.yaml
@@ -1,0 +1,55 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_ref:
+  path: templates/blocks/gallery.yaml.njk
+  vars:
+    pageId: CardList
+    pageTitle: CardList
+    section: List Blocks
+    filePath: blocks/list/CardList.yaml
+    block_type: CardList
+    antd_component: Card
+    antd_url: card
+    github_path: packages/plugins/blocks/blocks-antd/src/blocks/CardList
+    schema: ../plugins/blocks/blocks-antd/src/blocks/CardList/meta.js
+    gallery: ../plugins/blocks/blocks-antd/src/blocks/CardList/gallery.yaml
+    description: >
+      Data-driven vertical list of headerless cards. Each card body is rendered
+      from a Nunjucks template against its row item. Virtualized via
+      `react-virtuoso` so thousands of variable-height cards render smoothly,
+      with a memoized row component to skip unnecessary re-renders. Optional
+      client-side search bar filters rows by text across any field paths, a
+      built-in loading skeleton stands in while data loads, and an `onClick`
+      event reports `{ index, item }` for the row that was clicked.
+    onInit:
+      - id: init_cl_data
+        type: SetState
+        params:
+          people:
+            - name: Ada Lovelace
+              email: ada@hopper.io
+              role: Mathematician
+            - name: Linus Torvalds
+              email: linus@kernel.org
+              role: Engineer
+            - name: Grace Hopper
+              email: grace@compiler.dev
+              role: Computer Scientist
+            - name: Margaret Hamilton
+              email: margaret@apollo.nasa
+              role: Software Engineer
+            - name: Donald Knuth
+              email: don@tex.org
+              role: Author

--- a/packages/docs/menus.yaml
+++ b/packages/docs/menus.yaml
@@ -729,6 +729,9 @@
         title: List Blocks
         icon: AiOutlineOrderedList
       links:
+        - id: CardList
+          type: MenuLink
+          pageId: CardList
         - id: ControlledList
           type: MenuLink
           pageId: ControlledList

--- a/packages/docs/pages.yaml
+++ b/packages/docs/pages.yaml
@@ -179,6 +179,7 @@
 - _ref: blocks/container/Tooltip.yaml
 - _ref: blocks/container/Watermark.yaml
 
+- _ref: blocks/list/CardList.yaml
 - _ref: blocks/list/ControlledList.yaml
 - _ref: blocks/list/List.yaml
 - _ref: blocks/list/MasonryList.yaml

--- a/packages/plugins/blocks/blocks-antd/package.json
+++ b/packages/plugins/blocks/blocks-antd/package.json
@@ -55,10 +55,12 @@
     "@ant-design/icons": "6.1.0",
     "@lowdefy/block-utils": "5.3.0",
     "@lowdefy/helpers": "5.3.0",
+    "@lowdefy/nunjucks": "5.3.0",
     "@rc-component/motion": "1.3.1",
     "classnames": "2.3.2",
     "dayjs": "1.11.19",
-    "minisearch": "7.2.0"
+    "minisearch": "7.2.0",
+    "react-virtuoso": "4.18.7"
   },
   "peerDependencies": {
     "antd": ">=6",

--- a/packages/plugins/blocks/blocks-antd/src/blocks.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks.js
@@ -24,6 +24,7 @@ export { default as Button } from './blocks/Button/Button.js';
 export { default as ButtonSelector } from './blocks/ButtonSelector/ButtonSelector.js';
 export { default as Calendar } from './blocks/Calendar/Calendar.js';
 export { default as Card } from './blocks/Card/Card.js';
+export { default as CardList } from './blocks/CardList/CardList.js';
 export { default as Carousel } from './blocks/Carousel/Carousel.js';
 export { default as CheckboxSelector } from './blocks/CheckboxSelector/CheckboxSelector.js';
 export { default as CheckboxSwitch } from './blocks/CheckboxSwitch/CheckboxSwitch.js';

--- a/packages/plugins/blocks/blocks-antd/src/blocks/CardList/CardList.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/CardList/CardList.js
@@ -1,0 +1,310 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Card, Input, Skeleton, theme } from 'antd';
+import { Virtuoso } from 'react-virtuoso';
+import { renderHtml, withBlockDefaults } from '@lowdefy/block-utils';
+import { nunjucksFunction } from '@lowdefy/nunjucks';
+import { get, type } from '@lowdefy/helpers';
+
+import withTheme from '../withTheme.js';
+
+const FIELD_SEPARATOR = '';
+const SKELETON_COUNT = 4;
+
+const CardListRow = React.memo(function CardListRow({
+  blockId,
+  index,
+  item,
+  template,
+  bordered,
+  hoverable,
+  size,
+  gap,
+  cardClassName,
+  bodyClassName,
+  cardStyle,
+  bodyStyle,
+  clickable,
+  onRowClick,
+  methodsRef,
+}) {
+  const html = useMemo(
+    () => (template ? template({ item, index }) : null),
+    [template, item, index]
+  );
+  const handleClick = useCallback(() => onRowClick(index, item), [onRowClick, index, item]);
+  return (
+    <div style={{ paddingBottom: gap }}>
+      <Card
+        id={`${blockId}_${index}`}
+        variant={bordered === false ? 'borderless' : 'outlined'}
+        hoverable={hoverable}
+        size={size}
+        onClick={clickable ? handleClick : undefined}
+        className={cardClassName}
+        classNames={{ body: bodyClassName }}
+        style={{ outline: 'none', cursor: clickable ? 'pointer' : undefined, ...cardStyle }}
+        styles={{ body: bodyStyle }}
+      >
+        {html != null && renderHtml({ html, methods: methodsRef.current })}
+      </Card>
+    </div>
+  );
+});
+
+function useSearchBlobs(data, fields, caseSensitive) {
+  return useMemo(() => {
+    if (!data || data.length === 0) return null;
+    const normalize = caseSensitive ? (s) => s : (s) => s.toLowerCase();
+    if (!type.isArray(fields) || fields.length === 0) {
+      return data.map((item) => normalize(JSON.stringify(item) ?? ''));
+    }
+    return data.map((item) =>
+      normalize(
+        fields
+          .map((f) => {
+            const v = get(item, f);
+            return type.isNone(v) ? '' : String(v);
+          })
+          .join(FIELD_SEPARATOR)
+      )
+    );
+  }, [data, fields, caseSensitive]);
+}
+
+const CardListBlock = ({
+  blockId,
+  classNames = {},
+  events,
+  loading,
+  methods,
+  properties,
+  styles = {},
+}) => {
+  const data = properties.data ?? [];
+  const template = useMemo(
+    () => (type.isString(properties.html) ? nunjucksFunction(properties.html) : null),
+    [properties.html]
+  );
+
+  const methodsRef = useRef(methods);
+  methodsRef.current = methods;
+
+  const clickable = Boolean(events.onClick);
+  const onRowClick = useCallback((index, item) => {
+    methodsRef.current.triggerEvent({ name: 'onClick', event: { index, item } });
+  }, []);
+
+  const { token } = theme.useToken();
+
+  const gap = properties.gap ?? 8;
+  const useWindowScroll = type.isNone(properties.height);
+  const overscan = properties.overscan ?? 400;
+
+  const search = properties.search;
+  const searchEnabled = type.isObject(search);
+  const searchCaseSensitive = searchEnabled ? !!search.caseSensitive : false;
+  const searchFields = searchEnabled ? search.fields : null;
+  const searchMinLength = searchEnabled ? search.minLength ?? 0 : 0;
+  const searchDebounce = searchEnabled ? search.debounce ?? 150 : 150;
+  const searchSticky = searchEnabled ? search.sticky !== false : false;
+  const searchAllowClear = searchEnabled ? search.allowClear !== false : true;
+  const searchPlaceholder = searchEnabled ? search.placeholder ?? 'Search…' : '';
+  const noResultsText = searchEnabled ? search.noResultsText ?? 'No results' : '';
+
+  const [rawQuery, setRawQuery] = useState('');
+  const [appliedQuery, setAppliedQuery] = useState('');
+  const debounceRef = useRef(null);
+
+  useEffect(
+    () => () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    },
+    []
+  );
+
+  const onSearchChange = useCallback(
+    (e) => {
+      const v = e.target.value;
+      setRawQuery(v);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => setAppliedQuery(v), searchDebounce);
+    },
+    [searchDebounce]
+  );
+
+  const blobs = useSearchBlobs(
+    searchEnabled ? data : null,
+    searchEnabled ? searchFields : null,
+    searchCaseSensitive
+  );
+
+  const filterActive = searchEnabled && appliedQuery && appliedQuery.length >= searchMinLength;
+
+  const filteredEntries = useMemo(() => {
+    if (!filterActive || !blobs) return null;
+    const needle = searchCaseSensitive ? appliedQuery : appliedQuery.toLowerCase();
+    const out = [];
+    for (let i = 0; i < blobs.length; i++) {
+      if (blobs[i].includes(needle)) out.push({ originalIndex: i, item: data[i] });
+    }
+    return out;
+  }, [filterActive, blobs, data, appliedQuery, searchCaseSensitive]);
+
+  const lastFiredQueryRef = useRef('');
+  useEffect(() => {
+    if (!searchEnabled) return;
+    if (lastFiredQueryRef.current === appliedQuery) return;
+    lastFiredQueryRef.current = appliedQuery;
+    const resultCount = filterActive ? (filteredEntries ? filteredEntries.length : 0) : data.length;
+    methodsRef.current.triggerEvent({
+      name: 'onSearch',
+      event: { value: appliedQuery, resultCount },
+    });
+  }, [searchEnabled, appliedQuery, filterActive, filteredEntries, data]);
+
+  const itemContent = useCallback(
+    (_virtualIndex, payload) => {
+      const isEntry =
+        filterActive && payload && type.isObject(payload) && 'originalIndex' in payload;
+      const index = isEntry ? payload.originalIndex : _virtualIndex;
+      const item = isEntry ? payload.item : payload;
+      return (
+        <CardListRow
+          blockId={blockId}
+          index={index}
+          item={item}
+          template={template}
+          bordered={properties.bordered}
+          hoverable={properties.hoverable}
+          size={properties.size}
+          gap={gap}
+          cardClassName={classNames.card}
+          bodyClassName={classNames.body}
+          cardStyle={styles.card}
+          bodyStyle={styles.body}
+          clickable={clickable}
+          onRowClick={onRowClick}
+          methodsRef={methodsRef}
+        />
+      );
+    },
+    [
+      filterActive,
+      blockId,
+      template,
+      properties.bordered,
+      properties.hoverable,
+      properties.size,
+      gap,
+      classNames.card,
+      classNames.body,
+      styles.card,
+      styles.body,
+      clickable,
+      onRowClick,
+    ]
+  );
+
+  const computeItemKey = useCallback(
+    (_virtualIndex, payload) => {
+      if (filterActive && payload && type.isObject(payload) && 'originalIndex' in payload) {
+        return `${blockId}_${payload.originalIndex}`;
+      }
+      return `${blockId}_${_virtualIndex}`;
+    },
+    [blockId, filterActive]
+  );
+
+  const containerStyle = useWindowScroll
+    ? styles.element
+    : { display: 'flex', flexDirection: 'column', height: properties.height, ...styles.element };
+
+  const headerStyle = {
+    position: searchSticky ? 'sticky' : undefined,
+    top: 0,
+    zIndex: 1,
+    paddingBottom: gap,
+  };
+
+  const renderSearch = () =>
+    searchEnabled ? (
+      <div style={headerStyle} className={classNames.search}>
+        <Input.Search
+          id={`${blockId}_search`}
+          placeholder={searchPlaceholder}
+          allowClear={searchAllowClear}
+          value={rawQuery}
+          onChange={onSearchChange}
+        />
+      </div>
+    ) : null;
+
+  if (loading) {
+    return (
+      <div id={blockId} className={classNames.element} style={containerStyle}>
+        {renderSearch()}
+        {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+          <div key={`${blockId}_skeleton_${i}`} style={{ paddingBottom: gap }}>
+            <Card
+              variant={properties.bordered === false ? 'borderless' : 'outlined'}
+              size={properties.size}
+              className={classNames.card}
+              styles={{ body: styles.body }}
+            >
+              <Skeleton active title paragraph={{ rows: 2 }} />
+            </Card>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const virtuosoData = filterActive ? filteredEntries : data;
+  const virtuosoStyle = useWindowScroll ? undefined : { flex: '1 1 auto', minHeight: 0 };
+
+  return (
+    <div id={blockId} className={classNames.element} style={containerStyle}>
+      {renderSearch()}
+      {filterActive && filteredEntries.length === 0 ? (
+        <div
+          className={classNames.noResults}
+          style={{
+            padding: token.paddingLG,
+            textAlign: 'center',
+            color: token.colorTextSecondary,
+          }}
+        >
+          {noResultsText}
+        </div>
+      ) : (
+        <Virtuoso
+          data={virtuosoData}
+          style={virtuosoStyle}
+          useWindowScroll={useWindowScroll}
+          overscan={overscan}
+          increaseViewportBy={overscan}
+          itemContent={itemContent}
+          computeItemKey={computeItemKey}
+        />
+      )}
+    </div>
+  );
+};
+
+export default withTheme('Card', withBlockDefaults(CardListBlock));

--- a/packages/plugins/blocks/blocks-antd/src/blocks/CardList/e2e.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/CardList/e2e.js
@@ -1,0 +1,43 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { createBlockHelper, escapeId } from '@lowdefy/e2e-utils';
+import { expect } from '@playwright/test';
+
+const locator = (page, blockId) => page.locator(`#${escapeId(blockId)}`);
+
+export default createBlockHelper({
+  locator,
+  do: {
+    clickItem: async (page, blockId, index) => {
+      const card = page.locator(`#${escapeId(`${blockId}_${index}`)}`);
+      await card.scrollIntoViewIfNeeded();
+      await card.click();
+    },
+    scrollToIndex: (page, blockId, index) =>
+      page.locator(`#${escapeId(`${blockId}_${index}`)}`).scrollIntoViewIfNeeded(),
+    search: (page, blockId, text) =>
+      page.locator(`#${escapeId(`${blockId}_search`)} input`).fill(text),
+    clearSearch: (page, blockId) =>
+      page.locator(`#${escapeId(`${blockId}_search`)} input`).fill(''),
+  },
+  expect: {
+    renderedCount: (page, blockId, count) =>
+      expect(locator(page, blockId).locator('.ant-card')).toHaveCount(count),
+    noResults: (page, blockId, text = 'No results') =>
+      expect(locator(page, blockId)).toContainText(text),
+  },
+});

--- a/packages/plugins/blocks/blocks-antd/src/blocks/CardList/gallery.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/CardList/gallery.yaml
@@ -1,0 +1,141 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- title: Basic
+  blocks:
+    - id: basic_card_list
+      type: CardList
+      properties:
+        data:
+          - Alpha
+          - Beta
+          - Gamma
+        html: |
+          <h3>{{ index + 1 }}. {{ item }}</h3>
+
+- title: Object Data
+  blocks:
+    - id: people_card_list
+      type: CardList
+      properties:
+        hoverable: true
+        bordered: false
+        data:
+          - name: Ada Lovelace
+            email: ada@example.com
+            role: Mathematician
+          - name: Linus Torvalds
+            email: linus@example.com
+            role: Engineer
+          - name: Grace Hopper
+            email: grace@example.com
+            role: Computer Scientist
+        html: |
+          <div style="display:flex; flex-direction:column; gap:4px;">
+            <strong>{{ item.name }}</strong>
+            <span style="color:#666;">{{ item.role }}</span>
+            <a href="mailto:{{ item.email }}">{{ item.email }}</a>
+          </div>
+
+- title: With onClick
+  blocks:
+    - id: click_card_list
+      type: CardList
+      properties:
+        hoverable: true
+        data:
+          - { id: 1, label: First }
+          - { id: 2, label: Second }
+          - { id: 3, label: Third }
+        html: |
+          <h4>{{ item.label }}</h4>
+          <p>Click to see which row was selected.</p>
+      events:
+        onClick:
+          - id: clicked_message
+            type: Message
+            params:
+              content:
+                _nunjucks:
+                  template: 'Clicked row {{ index }} (id={{ item.id }})'
+                  on:
+                    _event: true
+
+- title: Small Cards with Custom Gap
+  blocks:
+    - id: compact_card_list
+      type: CardList
+      properties:
+        size: small
+        gap: 4
+        data:
+          - One
+          - Two
+          - Three
+          - Four
+        html: |
+          <span>{{ item }}</span>
+
+- title: Large Dataset (Virtualized)
+  blocks:
+    - id: large_card_list
+      type: CardList
+      properties:
+        hoverable: true
+        height: 480
+        data:
+          _array.range:
+            - 1
+            - 1001
+        html: |
+          <h4>Row {{ item }}</h4>
+          <p>This list renders one thousand cards. Only rows in (and near) the viewport are mounted in the DOM.</p>
+
+- title: With Search (all fields)
+  blocks:
+    - id: search_all_card_list
+      type: CardList
+      properties:
+        hoverable: true
+        height: 360
+        search: {}
+        data:
+          - { name: Ada Lovelace, email: ada@example.com, role: Mathematician }
+          - { name: Linus Torvalds, email: linus@example.com, role: Engineer }
+          - { name: Grace Hopper, email: grace@example.com, role: Computer Scientist }
+          - { name: Alan Turing, email: alan@example.com, role: Mathematician }
+          - { name: Margaret Hamilton, email: margaret@example.com, role: Software Engineer }
+        html: |
+          <strong>{{ item.name }}</strong>
+          <div style="color:#666;">{{ item.role }} · <a href="mailto:{{ item.email }}">{{ item.email }}</a></div>
+
+- title: With Search (specific fields)
+  blocks:
+    - id: search_fields_card_list
+      type: CardList
+      properties:
+        hoverable: true
+        height: 360
+        search:
+          placeholder: Filter by name…
+          fields:
+            - name
+          minLength: 1
+        data:
+          - { name: Ada Lovelace, email: ada@example.com, role: Mathematician }
+          - { name: Linus Torvalds, email: linus@example.com, role: Engineer }
+          - { name: Grace Hopper, email: grace@example.com, role: Computer Scientist }
+        html: |
+          <strong>{{ item.name }}</strong>
+          <div style="color:#666;">{{ item.role }}</div>

--- a/packages/plugins/blocks/blocks-antd/src/blocks/CardList/gallery.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/CardList/gallery.yaml
@@ -63,14 +63,11 @@
           <p>Click to see which row was selected.</p>
       events:
         onClick:
-          - id: clicked_message
-            type: Message
+          - id: capture_clicked
+            type: SetState
             params:
-              content:
-                _nunjucks:
-                  template: 'Clicked row {{ index }} (id={{ item.id }})'
-                  on:
-                    _event: true
+              clicked_card:
+                _event: true
 
 - title: Small Cards with Custom Gap
   blocks:
@@ -95,11 +92,14 @@
         hoverable: true
         height: 480
         data:
-          _array.range:
-            - 1
-            - 1001
+          _string.split:
+            on:
+              _string.repeat:
+                on: 'x,'
+                count: 999
+            separator: ','
         html: |
-          <h4>Row {{ item }}</h4>
+          <h4>Row {{ index + 1 }}</h4>
           <p>This list renders one thousand cards. Only rows in (and near) the viewport are mounted in the DOM.</p>
 
 - title: With Search (all fields)

--- a/packages/plugins/blocks/blocks-antd/src/blocks/CardList/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/CardList/meta.js
@@ -1,0 +1,186 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+export default {
+  category: 'display',
+  icons: [],
+  valueType: null,
+  cssKeys: {
+    element: 'The list container.',
+    card: 'Each Card element.',
+    body: 'Each Card body.',
+    search: 'The search bar wrapper above the list.',
+    noResults: 'The "no results" placeholder shown when the search filter matches zero items.',
+  },
+  events: {
+    onClick: {
+      description: 'Triggered when a card is clicked.',
+      event: {
+        index: 'Zero-based index of the clicked card.',
+        item: 'The data item bound to the clicked card.',
+      },
+    },
+    onSearch: {
+      description:
+        'Triggered when the debounced search query changes (only fires when the `search` property is set).',
+      event: {
+        value: 'The current debounced search query string.',
+        resultCount:
+          'Number of items currently visible. Equals data.length when the query is empty or below `minLength`.',
+      },
+    },
+  },
+  properties: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      data: {
+        type: 'array',
+        default: [],
+        description:
+          'Array of items. Each item is rendered as one card by passing it to the html Nunjucks template as `item`.',
+      },
+      html: {
+        type: 'string',
+        description:
+          'Nunjucks template used to render the body of each card. The context exposes `item` (the current data row) and `index` (the zero-based row index).',
+      },
+      bordered: {
+        type: 'boolean',
+        default: true,
+        description: 'Toggles the border around each card.',
+      },
+      hoverable: {
+        type: 'boolean',
+        default: false,
+        description: 'Lift each card up when hovered.',
+      },
+      size: {
+        type: 'string',
+        enum: ['default', 'small'],
+        default: 'default',
+        description: 'Card size.',
+      },
+      gap: {
+        type: 'number',
+        default: 8,
+        description: 'Pixel gap between cards.',
+      },
+      height: {
+        type: ['number', 'string'],
+        description:
+          'Optional pixel height (number) or CSS height string of the scroll container. When omitted, the list scrolls with the page.',
+      },
+      overscan: {
+        type: 'number',
+        default: 400,
+        description:
+          'Pixels of off-screen rows to render above and below the viewport. Increase for smoother fast-scroll, decrease to reduce DOM cost.',
+      },
+      search: {
+        type: 'object',
+        additionalProperties: false,
+        description:
+          'Optional client-side search bar above the list. When this property is set, a debounced search input filters rows by text. Omit to hide the bar.',
+        properties: {
+          placeholder: {
+            type: 'string',
+            default: 'Search…',
+            description: 'Placeholder text in the input.',
+          },
+          fields: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              'Dotted field paths to match against (e.g. "user.name"). When omitted, every field path is searched (whole-item stringify).',
+          },
+          caseSensitive: {
+            type: 'boolean',
+            default: false,
+            description: 'Match case exactly.',
+          },
+          debounce: {
+            type: 'number',
+            default: 150,
+            description: 'Milliseconds to wait after the last keystroke before filtering.',
+          },
+          sticky: {
+            type: 'boolean',
+            default: true,
+            description: 'Stick the search bar to the top while scrolling.',
+          },
+          allowClear: {
+            type: 'boolean',
+            default: true,
+            description: 'Show a clear (×) icon in the input.',
+          },
+          minLength: {
+            type: 'number',
+            default: 0,
+            description: 'Skip filtering until the query is at least this many characters.',
+          },
+          noResultsText: {
+            type: 'string',
+            default: 'No results',
+            description: 'Text shown when the filter matches zero items.',
+          },
+        },
+      },
+      theme: {
+        type: 'object',
+        description:
+          'Antd design token overrides for the cards. See <a href="https://ant.design/components/overview#design-token">antd design tokens</a>.',
+        docs: {
+          displayType: 'yaml',
+          link: 'https://ant.design/components/card#design-token',
+        },
+        properties: {
+          bodyPadding: {
+            type: 'number',
+            default: 24,
+            description: 'Padding of each card body.',
+          },
+          bodyPaddingSM: {
+            type: 'number',
+            default: 12,
+            description: 'Padding of each card body for small cards.',
+          },
+          borderRadiusLG: {
+            type: 'number',
+            default: 8,
+            description: 'Border radius of each card.',
+          },
+          colorBorderSecondary: {
+            type: 'string',
+            description: 'Border color of each card.',
+          },
+          colorBgContainer: {
+            type: 'string',
+            description: 'Background color of each card body.',
+          },
+          colorText: {
+            type: 'string',
+            description: 'Text color inside each card.',
+          },
+          boxShadowTertiary: {
+            type: 'string',
+            description: 'Shadow applied to each card on hover when hoverable is true.',
+          },
+        },
+      },
+    },
+  },
+};

--- a/packages/plugins/blocks/blocks-antd/src/e2e.js
+++ b/packages/plugins/blocks/blocks-antd/src/e2e.js
@@ -24,6 +24,7 @@ export { default as Button } from './blocks/Button/e2e.js';
 export { default as ButtonSelector } from './blocks/ButtonSelector/e2e.js';
 export { default as Calendar } from './blocks/Calendar/e2e.js';
 export { default as Card } from './blocks/Card/e2e.js';
+export { default as CardList } from './blocks/CardList/e2e.js';
 export { default as Carousel } from './blocks/Carousel/e2e.js';
 export { default as CheckboxSelector } from './blocks/CheckboxSelector/e2e.js';
 export { default as CheckboxSwitch } from './blocks/CheckboxSwitch/e2e.js';

--- a/packages/plugins/blocks/blocks-antd/src/metas.js
+++ b/packages/plugins/blocks/blocks-antd/src/metas.js
@@ -24,6 +24,7 @@ export { default as Button } from './blocks/Button/meta.js';
 export { default as ButtonSelector } from './blocks/ButtonSelector/meta.js';
 export { default as Calendar } from './blocks/Calendar/meta.js';
 export { default as Card } from './blocks/Card/meta.js';
+export { default as CardList } from './blocks/CardList/meta.js';
 export { default as Carousel } from './blocks/Carousel/meta.js';
 export { default as CheckboxSelector } from './blocks/CheckboxSelector/meta.js';
 export { default as CheckboxSwitch } from './blocks/CheckboxSwitch/meta.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -739,6 +739,9 @@ importers:
       '@lowdefy/helpers':
         specifier: 5.3.0
         version: link:../../../utils/helpers
+      '@lowdefy/nunjucks':
+        specifier: 5.3.0
+        version: link:../../../utils/nunjucks
       '@rc-component/motion':
         specifier: 1.3.1
         version: 1.3.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -760,6 +763,9 @@ importers:
       react-dom:
         specifier: '>=18'
         version: 18.2.0(react@18.2.0)
+      react-virtuoso:
+        specifier: 4.18.7
+        version: 4.18.7(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@lowdefy/block-dev-e2e':
         specifier: 5.3.0
@@ -11458,6 +11464,12 @@ packages:
     engines: {node: '>= 16.20.2'}
     peerDependencies:
       react: '>= 0.14.0'
+
+  react-virtuoso@4.18.7:
+    resolution: {integrity: sha512-xNF5zDGEEIMB7cKwcen/pLig0YDf6OnfFrVgKFa7sHPf9fRem0CaLshyObbBcP88jzn0enavL39EgplgdyT21g==}
+    peerDependencies:
+      react: '>=16 || >=17 || >= 18 || >= 19'
+      react-dom: '>=16 || >=17 || >= 18 || >=19'
 
   react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
@@ -23899,6 +23911,11 @@ snapshots:
       prismjs: 1.30.0
       react: 18.2.0
       refractor: 5.0.0
+
+  react-virtuoso@4.18.7(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
 
   react@18.2.0:
     dependencies:


### PR DESCRIPTION
## Summary

Adds a new `CardList` display block to `@lowdefy/blocks-antd`. It renders an array of data into a vertical stack of headerless antd `Card`s whose bodies come from a Nunjucks template against each row. The block is tuned for thousands of variable-height rows (windowed via `react-virtuoso`, rows wrapped in `React.memo` with a stable `methodsRef`) and ships with an optional client-side search bar, a built-in loading skeleton, and a text-only no-results placeholder.

## Changes

- **@lowdefy/blocks-antd**: New `CardList` block at `src/blocks/CardList/` (`CardList.js`, `meta.js`, `e2e.js`, `gallery.yaml`). Adds `react-virtuoso` as a dependency. Registered in `blocks.js`, `metas.js`, `e2e.js`. Properties: `data`, `html`, `bordered`, `hoverable`, `size`, `gap`, `height`, `overscan`, `search`, `theme`. Events: `onClick({ index, item })` and `onSearch({ value, resultCount })`. Search defaults to matching every field path via `JSON.stringify`; restrict with `search.fields: ['user.name', ...]` using `@lowdefy/helpers.get` for dotted paths. Filtering preserves the original index in the template context and onClick payload. Colors come from antd theme tokens so light/dark mode work out of the box.
- **@lowdefy/docs**: New `blocks/list/CardList.yaml` page using `templates/blocks/gallery.yaml.njk`. Schema pulled from `meta.js`, live examples from the block's own `gallery.yaml`. Registered in `pages.yaml` and the **List Blocks** group in `menus.yaml`.

## Key Files

- `packages/plugins/blocks/blocks-antd/src/blocks/CardList/CardList.js` — Virtuoso wrapper, memoized `CardListRow`, debounced search, loading skeleton.
- `packages/plugins/blocks/blocks-antd/src/blocks/CardList/meta.js` — Properties schema (incl. nested `search` object) and events.
- `packages/plugins/blocks/blocks-antd/src/blocks/CardList/gallery.yaml` — Eight examples (basic, object data, onClick, compact, 1k virtualized, search-all-fields, search-specific-fields).
- `packages/docs/blocks/list/CardList.yaml` — Docs page wiring.
- `.changeset/feat-blocks-antd-cardlist.md` — Minor bump for `@lowdefy/blocks-antd`.

## Notes

- Search uses a substring filter (`String.includes` over per-item `JSON.stringify` blobs, memoised once per `data` reference). This matches the "all field paths by default" requirement cleanly; MiniSearch would force an explicit `fields` array up front. We can swap in MiniSearch later under a `mode: 'fulltext'` flag if fuzz/boost is requested.
- The block doesn't use the antd `List` component — `Virtuoso` directly wraps a sequence of antd `Card`s in a flex column so heights are free-form and the standard antd Card styling/theme tokens apply.