### PR TITLE
Selector colors & variants, Tabs per-tab events, menu border fix

### DIFF
--- a/.changeset/feat-selector-option-color.md
+++ b/.changeset/feat-selector-option-color.md
@@ -1,0 +1,25 @@
+---
+'@lowdefy/blocks-antd': minor
+---
+
+feat: per-option `color` on selector options.
+
+Object options now accept a `color`, applied when that option is selected. It falls back to the block-level color when not set, and overrides it for that option when set.
+
+- **ButtonSelector** — the selected option uses its own color: `solid` fills the button (with auto-contrast text), `outline` colors the border/text plus a low-opacity tint.
+- **CheckboxSelector** / **RadioSelector** — each selected box tick / radio dot and its label render in the option's color (multiple checked boxes can each show a different color).
+- **Selector** — the whole input is colored with the selected option's color. A `variant` of `solid` fills the input (with auto-contrast text); `outlined` colors the border/text. Dropdown options are tinted.
+- **MultipleSelector** — each selected value's tag/pill renders in the option's color, controlled by `variant`: `solid` → filled tags, `outlined` → outlined tags (hex colors use auto-contrast text, dark-mode safe). An explicit `tag.color` still takes precedence, and per-option tag colors no longer require `renderTags`.
+
+`Selector` and `MultipleSelector` gain `solid` as a `variant` option (alongside the antd input variants). `CheckboxSelector`/`RadioSelector` have no variant — they only apply the per-option color.
+
+```yaml
+- id: priority
+  type: ButtonSelector
+  properties:
+    variant: outlined
+    options:
+      - { label: Low, value: low, color: '#16a34a' }
+      - { label: Medium, value: medium, color: '#d97706' }
+      - { label: High, value: high, color: '#dc2626' }
+```

--- a/.changeset/feat-tabs-per-tab-events.md
+++ b/.changeset/feat-tabs-per-tab-events.md
@@ -1,0 +1,37 @@
+---
+'@lowdefy/blocks-antd': minor
+---
+
+feat: Tabs block now supports per-tab dynamic events.
+
+Each entry in the Tabs `tabs[]` array can declare an `eventName`. When that tab becomes active, the named event is triggered (with `{ key }` of the now-active tab) in addition to the generic `onChange`. This mirrors the per-button `eventName` pattern used by the AgGrid blocks and lets each tab run its own actions without branching inside `onChange`.
+
+The Tabs event surface is `onChange` (fires on any tab change → `{ activeKey }`) plus these per-tab events.
+
+```yaml
+- id: settings_tabs
+  type: Tabs
+  properties:
+    tabs:
+      - key: profile
+        title: Profile
+        eventName: onProfileTab
+      - key: billing
+        title: Billing
+        eventName: onBillingTab
+  events:
+    onChange: # fires on any tab change → { activeKey }
+      - id: log_change
+        type: SetState
+        params:
+          activeTab:
+            _event: true
+    onProfileTab: # fires only when the Profile tab is selected → { key }
+      - id: load_profile
+        type: Request
+        params: get_profile
+    onBillingTab:
+      - id: load_billing
+        type: Request
+        params: get_billing
+```

--- a/.changeset/fix-buttonselector-color.md
+++ b/.changeset/fix-buttonselector-color.md
@@ -1,0 +1,13 @@
+---
+'@lowdefy/blocks-antd': minor
+---
+
+feat: ButtonSelector gains a `variant` (`solid` | `outlined`) property matching the Button block, and `color` now applies consistently across both styles.
+
+The `buttonStyle` (`solid` | `outline`) property is deprecated in favor of `variant`; it still works as an alias. `color` fixes:
+
+Previously `color` was applied as a Radio component-level token, so antd did not re-derive the dependent tokens — the selected solid background, hover/active states, and outline border/text kept using the default primary color, and the selected solid button could render low-contrast text on the colored background.
+
+- `color` is now applied as a global `colorPrimary` token, so the full palette (solid background, hover/active, outline border/text) is re-derived from it. This also means it works correctly under `darkModeToggle` / `darkAlgorithm` — the nested `ConfigProvider` inherits the parent algorithm.
+- The selected button's text now auto-contrasts (black or white, chosen by the background color's luminance) so it stays readable on any `color`, including light/pastel values.
+- In `outline` mode the selected item now gets a low-opacity tint of the active color as its background, giving it visual emphasis. The tint also applies with the default primary color when no `color` is set.

--- a/.changeset/fix-pageheadermenu-menu-border.md
+++ b/.changeset/fix-pageheadermenu-menu-border.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/blocks-antd': patch
+---
+
+fix: PageHeaderMenu active menu item underline now sits on the header's bottom border.
+
+The horizontal menu was vertically centered in the 64px header, so the active item's underline floated above the header's bottom border (two disconnected lines). The menu now fills the header height (`lineHeight: var(--ant-layout-header-height, 64px)`) so the active underline aligns with the header divider, matching the single-border look of Sider / PageSiderMenu.

--- a/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
+++ b/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
@@ -4129,6 +4129,13 @@
                         "docs": {
                           "displayType": "yaml"
                         }
+                      },
+                      "color": {
+                        "type": "string",
+                        "description": "Color applied to the selected value shown in the input, and used to tint this option in the dropdown.",
+                        "docs": {
+                          "displayType": "color"
+                        }
                       }
                     }
                   }
@@ -4188,11 +4195,12 @@
             "variant": {
               "type": "string",
               "enum": [
+                "solid",
                 "outlined",
                 "filled",
                 "borderless"
               ],
-              "description": "Input visual variant. When set, takes precedence over bordered."
+              "description": "Input variant. `solid` fills the whole input with the selected option color; `outlined` colors its border/text. `filled`/`borderless` are the antd input styles."
             },
             "theme": {
               "type": "object",

--- a/packages/build/src/tests/success/39-global-state-app/snapshot.json
+++ b/packages/build/src/tests/success/39-global-state-app/snapshot.json
@@ -4393,6 +4393,13 @@
                         "docs": {
                           "displayType": "yaml"
                         }
+                      },
+                      "color": {
+                        "type": "string",
+                        "description": "Color applied to the selected value shown in the input, and used to tint this option in the dropdown.",
+                        "docs": {
+                          "displayType": "color"
+                        }
                       }
                     }
                   }
@@ -4452,11 +4459,12 @@
             "variant": {
               "type": "string",
               "enum": [
+                "solid",
                 "outlined",
                 "filled",
                 "borderless"
               ],
-              "description": "Input visual variant. When set, takes precedence over bordered."
+              "description": "Input variant. `solid` fills the whole input with the selected option color; `outlined` colors its border/text. `filled`/`borderless` are the antd input styles."
             },
             "theme": {
               "type": "object",

--- a/packages/build/src/tests/success/45-tabs-layout-app/snapshot.json
+++ b/packages/build/src/tests/success/45-tabs-layout-app/snapshot.json
@@ -4121,6 +4121,10 @@
                     "type": "string",
                     "description": "Area key of the tab."
                   },
+                  "eventName": {
+                    "type": "string",
+                    "description": "Block-level event name to trigger when this tab becomes active, in addition to onChange. Declare an event with this name under `events:`. The event receives `{ key }` of the now-active tab."
+                  },
                   "disabled": {
                     "type": "boolean",
                     "default": false,
@@ -4521,13 +4525,13 @@
                     }
                   ],
                   "description": {
-                    "description": "Trigger action on tab change.",
+                    "description": "Trigger action on any tab change.",
                     "event": {
                       "activeKey": "The key of the active tab."
                     }
                   }
                 },
-                "onTabScroll": {
+                "onTabSelect": {
                   "oneOf": [
                     {
                       "type": "array"
@@ -4543,31 +4547,9 @@
                     }
                   ],
                   "description": {
-                    "description": "Trigger action on tab scroll.",
+                    "description": "Documentation reference — not a fixed event name. When a tab becomes active, the `eventName` string declared on that `tabs[]` entry is triggered (in addition to onChange). Declare your named events under `events:` (e.g. `onProfileTab`, `onBillingTab`).",
                     "event": {
-                      "direction": "The scroll direction."
-                    }
-                  }
-                },
-                "onTabClick": {
-                  "oneOf": [
-                    {
-                      "type": "array"
-                    },
-                    {
-                      "type": "object",
-                      "patternProperties": {
-                        "^_": {}
-                      },
-                      "additionalProperties": false,
-                      "minProperties": 1,
-                      "maxProperties": 1
-                    }
-                  ],
-                  "description": {
-                    "description": "Trigger action on tab click.",
-                    "event": {
-                      "key": "The key of the clicked tab."
+                      "key": "The key of the now-active tab."
                     }
                   }
                 }
@@ -8225,6 +8207,13 @@
                         "docs": {
                           "displayType": "yaml"
                         }
+                      },
+                      "color": {
+                        "type": "string",
+                        "description": "Color applied to the selected value shown in the input, and used to tint this option in the dropdown.",
+                        "docs": {
+                          "displayType": "color"
+                        }
                       }
                     }
                   }
@@ -8284,11 +8273,12 @@
             "variant": {
               "type": "string",
               "enum": [
+                "solid",
                 "outlined",
                 "filled",
                 "borderless"
               ],
-              "description": "Input visual variant. When set, takes precedence over bordered."
+              "description": "Input variant. `solid` fills the whole input with the selected option color; `outlined` colors its border/text. `filled`/`borderless` are the antd input styles."
             },
             "theme": {
               "type": "object",

--- a/packages/build/src/tests/success/49-request-payload-app/snapshot.json
+++ b/packages/build/src/tests/success/49-request-payload-app/snapshot.json
@@ -6983,6 +6983,13 @@
                         "docs": {
                           "displayType": "yaml"
                         }
+                      },
+                      "color": {
+                        "type": "string",
+                        "description": "Color applied to the selected value shown in the input, and used to tint this option in the dropdown.",
+                        "docs": {
+                          "displayType": "color"
+                        }
                       }
                     }
                   }
@@ -7042,11 +7049,12 @@
             "variant": {
               "type": "string",
               "enum": [
+                "solid",
                 "outlined",
                 "filled",
                 "borderless"
               ],
-              "description": "Input visual variant. When set, takes precedence over bordered."
+              "description": "Input variant. `solid` fills the whole input with the selected option color; `outlined` colors its border/text. `filled`/`borderless` are the antd input styles."
             },
             "theme": {
               "type": "object",

--- a/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
+++ b/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
@@ -8996,6 +8996,13 @@
                         "docs": {
                           "displayType": "yaml"
                         }
+                      },
+                      "color": {
+                        "type": "string",
+                        "description": "Color applied to the selected value shown in the input, and used to tint this option in the dropdown.",
+                        "docs": {
+                          "displayType": "color"
+                        }
                       }
                     }
                   }
@@ -9055,11 +9062,12 @@
             "variant": {
               "type": "string",
               "enum": [
+                "solid",
                 "outlined",
                 "filled",
                 "borderless"
               ],
-              "description": "Input visual variant. When set, takes precedence over bordered."
+              "description": "Input variant. `solid` fills the whole input with the selected option color; `outlined` colors its border/text. `filled`/`borderless` are the antd input styles."
             },
             "theme": {
               "type": "object",

--- a/packages/build/src/tests/success/71-cross-module-mutual-refs/snapshot.json
+++ b/packages/build/src/tests/success/71-cross-module-mutual-refs/snapshot.json
@@ -3715,6 +3715,13 @@
                         "docs": {
                           "displayType": "yaml"
                         }
+                      },
+                      "color": {
+                        "type": "string",
+                        "description": "Color applied to the selected value shown in the input, and used to tint this option in the dropdown.",
+                        "docs": {
+                          "displayType": "color"
+                        }
                       }
                     }
                   }
@@ -3774,11 +3781,12 @@
             "variant": {
               "type": "string",
               "enum": [
+                "solid",
                 "outlined",
                 "filled",
                 "borderless"
               ],
-              "description": "Input visual variant. When set, takes precedence over bordered."
+              "description": "Input variant. `solid` fills the whole input with the selected option color; `outlined` colors its border/text. `filled`/`borderless` are the antd input styles."
             },
             "theme": {
               "type": "object",

--- a/packages/build/src/tests/success/78-cross-module-mutual-nested/snapshot.json
+++ b/packages/build/src/tests/success/78-cross-module-mutual-nested/snapshot.json
@@ -3708,6 +3708,13 @@
                         "docs": {
                           "displayType": "yaml"
                         }
+                      },
+                      "color": {
+                        "type": "string",
+                        "description": "Color applied to the selected value shown in the input, and used to tint this option in the dropdown.",
+                        "docs": {
+                          "displayType": "color"
+                        }
                       }
                     }
                   }
@@ -3767,11 +3774,12 @@
             "variant": {
               "type": "string",
               "enum": [
+                "solid",
                 "outlined",
                 "filled",
                 "borderless"
               ],
-              "description": "Input visual variant. When set, takes precedence over bordered."
+              "description": "Input variant. `solid` fills the whole input with the selected option color; `outlined` colors its border/text. `filled`/`borderless` are the antd input styles."
             },
             "theme": {
               "type": "object",

--- a/packages/build/src/tests/success/82-cross-module-mutual-refs-reversed/snapshot.json
+++ b/packages/build/src/tests/success/82-cross-module-mutual-refs-reversed/snapshot.json
@@ -3715,6 +3715,13 @@
                         "docs": {
                           "displayType": "yaml"
                         }
+                      },
+                      "color": {
+                        "type": "string",
+                        "description": "Color applied to the selected value shown in the input, and used to tint this option in the dropdown.",
+                        "docs": {
+                          "displayType": "color"
+                        }
                       }
                     }
                   }
@@ -3774,11 +3781,12 @@
             "variant": {
               "type": "string",
               "enum": [
+                "solid",
                 "outlined",
                 "filled",
                 "borderless"
               ],
-              "description": "Input visual variant. When set, takes precedence over bordered."
+              "description": "Input variant. `solid` fills the whole input with the selected option color; `outlined` colors its border/text. `filled`/`borderless` are the antd input styles."
             },
             "theme": {
               "type": "object",

--- a/packages/plugins/blocks/blocks-antd/src/blocks/ButtonSelector/ButtonSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/ButtonSelector/ButtonSelector.js
@@ -22,6 +22,8 @@ import { type } from '@lowdefy/helpers';
 import Label from '../Label/Label.js';
 import getValueIndex from '../../getValueIndex.js';
 import getUniqueValues from '../../getUniqueValues.js';
+import getContrastTextColor from '../../getContrastTextColor.js';
+import getOptionColorStyle from '../../getOptionColorStyle.js';
 import withTheme from '../withTheme.js';
 
 const ButtonSelector = ({
@@ -38,13 +40,26 @@ const ButtonSelector = ({
   methods,
 }) => {
   const uniqueValueOptions = getUniqueValues(properties.options || []);
+  // `variant` (solid | outlined) matches the Button block. `buttonStyle` is a
+  // deprecated alias kept for backward compatibility.
+  const variant =
+    properties.variant ?? (properties.buttonStyle === 'outline' ? 'outlined' : 'solid');
+  const isOutline = variant === 'outlined';
+  const selectedIndex = type.isNone(value)
+    ? undefined
+    : getValueIndex(value, properties.options || []);
+  const contrastColor = getContrastTextColor(properties.color);
+  const themeConfig = { token: { colorPrimary: properties.color } };
+  if (contrastColor) {
+    themeConfig.components = { Radio: { buttonSolidCheckedColor: contrastColor } };
+  }
   const radioGroup = (
     <Radio.Group
       id={`${blockId}_input`}
       className={classNames.element}
       disabled={properties.disabled || loading}
       size={properties.size}
-      buttonStyle={properties.buttonStyle ? properties.buttonStyle : 'solid'}
+      buttonStyle={isOutline ? 'outline' : 'solid'}
       style={styles.element}
       onChange={(event) => {
         const value = type.isPrimitive(uniqueValueOptions[event.target.value])
@@ -55,13 +70,24 @@ const ButtonSelector = ({
       }}
       value={type.isNone(value) ? undefined : getValueIndex(value, properties.options || [])}
     >
-      {uniqueValueOptions.map((opt, i) =>
-        type.isPrimitive(opt) ? (
+      {uniqueValueOptions.map((opt, i) => {
+        const isSelected = `${i}` === selectedIndex;
+        const optColor = type.isPrimitive(opt) ? undefined : opt.color;
+        let selectedStyle;
+        if (isSelected && optColor) {
+          // A selected option with its own color overrides the block-level color.
+          selectedStyle = getOptionColorStyle({ color: optColor, isOutline });
+        } else if (isSelected && isOutline) {
+          // Block-level outline tint follows currentColor (the active colorPrimary).
+          selectedStyle = { backgroundColor: 'color-mix(in srgb, currentColor 12%, transparent)' };
+        }
+        return type.isPrimitive(opt) ? (
           <Radio.Button
             id={`${blockId}_${i}`}
             key={i}
             value={`${i}`}
             disabled={properties.disabled || loading}
+            style={selectedStyle}
           >
             {renderHtml({ html: `${opt}`, methods })}
           </Radio.Button>
@@ -71,14 +97,14 @@ const ButtonSelector = ({
             key={i}
             value={`${i}`}
             disabled={opt.disabled || properties.disabled || loading}
-            style={opt.style}
+            style={{ ...opt.style, ...selectedStyle }}
           >
             {type.isNone(opt.label)
               ? renderHtml({ html: `${opt.value}`, methods })
               : renderHtml({ html: opt.label, methods })}
           </Radio.Button>
-        )
-      )}
+        );
+      })}
     </Radio.Group>
   );
   return (
@@ -94,9 +120,7 @@ const ButtonSelector = ({
       content={{
         content: () =>
           properties.color ? (
-            <ConfigProvider theme={{ components: { Radio: { colorPrimary: properties.color } } }}>
-              {radioGroup}
-            </ConfigProvider>
+            <ConfigProvider theme={themeConfig}>{radioGroup}</ConfigProvider>
           ) : (
             radioGroup
           ),

--- a/packages/plugins/blocks/blocks-antd/src/blocks/ButtonSelector/gallery.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/ButtonSelector/gallery.yaml
@@ -18,7 +18,7 @@
       type: ButtonSelector
       properties:
         title: Solid Style (default)
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Daily
             value: daily
@@ -30,7 +30,7 @@
       type: ButtonSelector
       properties:
         title: Outline Style
-        buttonStyle: outline
+        variant: outlined
         options:
           - label: Daily
             value: daily
@@ -42,7 +42,7 @@
       type: ButtonSelector
       properties:
         title: Solid - filled background on selected
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Left
             value: left
@@ -59,7 +59,7 @@
       type: ButtonSelector
       properties:
         title: Simple String Array
-        buttonStyle: solid
+        variant: solid
         options:
           - Red
           - Green
@@ -68,7 +68,7 @@
       type: ButtonSelector
       properties:
         title: Object Options with Labels
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Active
             value: active
@@ -80,7 +80,7 @@
       type: ButtonSelector
       properties:
         title: HTML in Option Labels
-        buttonStyle: solid
+        variant: solid
         options:
           - label: '<b>Bold</b>'
             value: bold
@@ -92,7 +92,7 @@
       type: ButtonSelector
       properties:
         title: Emoji Labels
-        buttonStyle: solid
+        variant: solid
         options:
           - label: '&#x2705; Approved'
             value: approved
@@ -108,7 +108,7 @@
       properties:
         title: Small
         size: small
-        buttonStyle: solid
+        variant: solid
         options:
           - Small
           - Medium
@@ -117,7 +117,7 @@
       type: ButtonSelector
       properties:
         title: Default
-        buttonStyle: solid
+        variant: solid
         options:
           - Small
           - Medium
@@ -127,7 +127,7 @@
       properties:
         title: Large
         size: large
-        buttonStyle: solid
+        variant: solid
         options:
           - Small
           - Medium
@@ -140,7 +140,7 @@
       properties:
         title: Small Outline
         size: small
-        buttonStyle: outline
+        variant: outlined
         options:
           - Option A
           - Option B
@@ -149,7 +149,7 @@
       type: ButtonSelector
       properties:
         title: Default Outline
-        buttonStyle: outline
+        variant: outlined
         options:
           - Option A
           - Option B
@@ -159,7 +159,7 @@
       properties:
         title: Large Outline
         size: large
-        buttonStyle: outline
+        variant: outlined
         options:
           - Option A
           - Option B
@@ -171,7 +171,7 @@
       type: ButtonSelector
       properties:
         title: Day of the Week
-        buttonStyle: solid
+        variant: solid
         size: small
         options:
           - label: Mon
@@ -192,7 +192,7 @@
       type: ButtonSelector
       properties:
         title: Toggle
-        buttonStyle: solid
+        variant: solid
         options:
           - label: 'Yes'
             value: true
@@ -206,7 +206,7 @@
       properties:
         title: Disabled (Solid)
         disabled: true
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Option A
             value: a
@@ -219,7 +219,7 @@
       properties:
         title: Disabled (Outline)
         disabled: true
-        buttonStyle: outline
+        variant: outlined
         options:
           - label: Option A
             value: a
@@ -231,7 +231,7 @@
       type: ButtonSelector
       properties:
         title: Disabled Individual Option (Solid)
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Available
             value: available
@@ -244,7 +244,7 @@
       type: ButtonSelector
       properties:
         title: Multiple Disabled Options
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Active
             value: active
@@ -263,7 +263,7 @@
       type: ButtonSelector
       properties:
         title: Custom Option Styles
-        buttonStyle: outline
+        variant: outlined
         options:
           - label: Normal
             value: normal
@@ -279,7 +279,7 @@
       type: ButtonSelector
       properties:
         title: Styled Solid Options
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Default
             value: default
@@ -297,7 +297,7 @@
       type: ButtonSelector
       properties:
         title: Mixed Option Styling
-        buttonStyle: outline
+        variant: outlined
         options:
           - label: Regular
             value: regular
@@ -317,7 +317,7 @@
       type: ButtonSelector
       properties:
         title: Default Color (primary)
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Option A
             value: a
@@ -329,7 +329,7 @@
       type: ButtonSelector
       properties:
         title: 'Color: red'
-        buttonStyle: solid
+        variant: solid
         color: red
         options:
           - label: Option A
@@ -342,7 +342,7 @@
       type: ButtonSelector
       properties:
         title: 'Color: green'
-        buttonStyle: solid
+        variant: solid
         color: green
         options:
           - label: Option A
@@ -355,7 +355,7 @@
       type: ButtonSelector
       properties:
         title: 'Color: purple'
-        buttonStyle: solid
+        variant: solid
         color: purple
         options:
           - label: Option A
@@ -371,7 +371,7 @@
       type: ButtonSelector
       properties:
         title: 'Coral (#ff6b6b)'
-        buttonStyle: solid
+        variant: solid
         color: '#ff6b6b'
         options:
           - Low
@@ -381,7 +381,7 @@
       type: ButtonSelector
       properties:
         title: 'Teal (#20c997)'
-        buttonStyle: solid
+        variant: solid
         color: '#20c997'
         options:
           - Low
@@ -391,8 +391,18 @@
       type: ButtonSelector
       properties:
         title: 'Indigo (#4c6ef5)'
-        buttonStyle: solid
+        variant: solid
         color: '#4c6ef5'
+        options:
+          - Low
+          - Medium
+          - High
+    - id: color_hex_light
+      type: ButtonSelector
+      properties:
+        title: 'Light color (#ffe58f) — text auto-contrasts to black'
+        variant: solid
+        color: '#ffe58f'
         options:
           - Low
           - Medium
@@ -404,7 +414,7 @@
       type: ButtonSelector
       properties:
         title: Red Outline
-        buttonStyle: outline
+        variant: outlined
         color: red
         options:
           - Option A
@@ -414,7 +424,7 @@
       type: ButtonSelector
       properties:
         title: Green Outline
-        buttonStyle: outline
+        variant: outlined
         color: green
         options:
           - Option A
@@ -424,12 +434,47 @@
       type: ButtonSelector
       properties:
         title: 'Custom Hex Outline (#e64980)'
-        buttonStyle: outline
+        variant: outlined
         color: '#e64980'
         options:
           - Option A
           - Option B
           - Option C
+
+- title: Color in Dark Mode
+  blocks:
+    - id: dark_mode_box
+      type: Box
+      style:
+        background: '#141414'
+        padding: 24
+        borderRadius: 8
+      blocks:
+        - id: dark_mode_provider
+          type: ConfigProvider
+          properties:
+            algorithm: dark
+          blocks:
+            - id: dark_color_solid
+              type: ButtonSelector
+              properties:
+                title: Solid color (dark)
+                variant: solid
+                color: '#1677ff'
+                options:
+                  - Option A
+                  - Option B
+                  - Option C
+            - id: dark_color_outline
+              type: ButtonSelector
+              properties:
+                title: Outline color with selected tint (dark)
+                variant: outlined
+                color: '#1677ff'
+                options:
+                  - Option A
+                  - Option B
+                  - Option C
 
 - title: Label Properties
   blocks:
@@ -437,7 +482,7 @@
       type: ButtonSelector
       properties:
         title: Default Label
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Option A
             value: a
@@ -449,7 +494,7 @@
         title: With Extra Text
         label:
           extra: Choose your preferred view mode.
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Grid
             value: grid
@@ -463,7 +508,7 @@
         title: No Colon
         label:
           colon: false
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Option A
             value: a
@@ -476,7 +521,7 @@
         label:
           inline: true
           span: 6
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Left
             value: left
@@ -489,7 +534,7 @@
       properties:
         label:
           disabled: true
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Left
             value: left
@@ -504,7 +549,7 @@
       type: ButtonSelector
       properties:
         title: '<b>Bold Title</b>'
-        buttonStyle: solid
+        variant: solid
         options:
           - Option A
           - Option B
@@ -513,7 +558,7 @@
       type: ButtonSelector
       properties:
         title: '<span style="color: #1677ff;">Colored Title</span>'
-        buttonStyle: solid
+        variant: solid
         options:
           - Option A
           - Option B
@@ -525,7 +570,7 @@
       type: ButtonSelector
       properties:
         title: Custom Width
-        buttonStyle: solid
+        variant: solid
         options:
           - Option A
           - Option B
@@ -539,7 +584,7 @@
       type: ButtonSelector
       properties:
         title: Tailwind Padding
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Option A
             value: a
@@ -552,7 +597,7 @@
       type: ButtonSelector
       properties:
         title: Shadow and Rounded
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Option A
             value: a
@@ -565,7 +610,7 @@
       type: ButtonSelector
       properties:
         title: Background Color
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Option A
             value: a
@@ -581,7 +626,7 @@
       type: ButtonSelector
       properties:
         title: Large Border Radius
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Option A
             value: a
@@ -595,7 +640,7 @@
       type: ButtonSelector
       properties:
         title: Custom Button Background
-        buttonStyle: solid
+        variant: solid
         options:
           - label: Option A
             value: a
@@ -611,7 +656,7 @@
       type: ButtonSelector
       properties:
         title: Custom Button Text Color
-        buttonStyle: outline
+        variant: outlined
         options:
           - label: Option A
             value: a
@@ -625,7 +670,7 @@
       type: ButtonSelector
       properties:
         title: Pill Style Selector
-        buttonStyle: solid
+        variant: solid
         color: '#7c3aed'
         options:
           - label: Free
@@ -642,7 +687,7 @@
       type: ButtonSelector
       properties:
         title: Compact Selector
-        buttonStyle: solid
+        variant: solid
         size: small
         options:
           - label: XS
@@ -675,7 +720,7 @@
           type: ButtonSelector
           properties:
             title: How satisfied are you with our service?
-            buttonStyle: solid
+            variant: solid
             color: '#1677ff'
             options:
               - label: Very Unsatisfied
@@ -692,7 +737,7 @@
           type: ButtonSelector
           properties:
             title: Would you recommend us to a friend?
-            buttonStyle: solid
+            variant: solid
             options:
               - label: Definitely
                 value: definitely
@@ -735,7 +780,7 @@
           type: ButtonSelector
           properties:
             title: Theme
-            buttonStyle: solid
+            variant: solid
             options:
               - label: Light
                 value: light
@@ -754,7 +799,7 @@
           type: ButtonSelector
           properties:
             title: Language
-            buttonStyle: outline
+            variant: outlined
             options:
               - label: English
                 value: en
@@ -768,7 +813,7 @@
           type: ButtonSelector
           properties:
             title: Font Size
-            buttonStyle: solid
+            variant: solid
             size: small
             options:
               - label: Small
@@ -799,3 +844,36 @@
                     _state: applied_settings_language
                   fontSize:
                     _state: applied_settings_font_size
+
+- title: Per-option Color
+  blocks:
+    - id: per_option_color_outline
+      type: ButtonSelector
+      properties:
+        title: 'Outline — color per option'
+        variant: outlined
+        options:
+          - label: Low
+            value: low
+            color: '#16a34a'
+          - label: Medium
+            value: medium
+            color: '#d97706'
+          - label: High
+            value: high
+            color: '#dc2626'
+    - id: per_option_color_solid
+      type: ButtonSelector
+      properties:
+        title: 'Solid — color per option (selected fills in its own color)'
+        variant: solid
+        options:
+          - label: To do
+            value: todo
+            color: '#64748b'
+          - label: Doing
+            value: doing
+            color: '#2563eb'
+          - label: Done
+            value: done
+            color: '#16a34a'

--- a/packages/plugins/blocks/blocks-antd/src/blocks/ButtonSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/ButtonSelector/meta.js
@@ -39,15 +39,21 @@ export default {
     type: 'object',
     additionalProperties: false,
     properties: {
+      variant: {
+        type: 'string',
+        enum: ['solid', 'outlined'],
+        default: 'solid',
+        description: 'Visual variant of the selected option button, matching the Button block.',
+      },
       buttonStyle: {
         type: 'string',
         enum: ['solid', 'outline'],
-        default: 'solid',
-        description: 'Style of the selected option button.',
+        description: 'Deprecated — use `variant` (solid | outlined) instead.',
       },
       color: {
         type: 'string',
-        description: 'Selected button color.',
+        description:
+          'Color applied to the selected button. Fills the background in solid mode (with auto-contrasting text) and the border/text in outline mode.',
         docs: {
           displayType: 'color',
         },

--- a/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/CheckboxSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/CheckboxSelector.js
@@ -38,6 +38,9 @@ const CheckboxSelector = ({
   methods,
 }) => {
   const uniqueValueOptions = getUniqueValues(properties.options || []);
+  const selectedIndexes = new Set(
+    type.isNone(value) ? [] : getValueIndex(value, uniqueValueOptions, true)
+  );
   const checkboxGroup = (
     <Checkbox.Group
       id={`${blockId}_input`}
@@ -63,25 +66,36 @@ const CheckboxSelector = ({
         wrap={type.isNone(properties.wrap) ? true : properties.wrap}
         align={type.isNone(properties.align) ? 'start' : properties.align}
       >
-        {uniqueValueOptions.map((opt, i) =>
-          type.isPrimitive(opt) ? (
-            <Checkbox id={`${blockId}_${i}`} key={i} value={`${i}`}>
-              {renderHtml({ html: `${opt}`, methods })}
-            </Checkbox>
-          ) : (
+        {uniqueValueOptions.map((opt, i) => {
+          if (type.isPrimitive(opt)) {
+            return (
+              <Checkbox id={`${blockId}_${i}`} key={i} value={`${i}`}>
+                {renderHtml({ html: `${opt}`, methods })}
+              </Checkbox>
+            );
+          }
+          const isSelected = selectedIndexes.has(`${i}`);
+          const checkbox = (
             <Checkbox
               id={`${blockId}_${i}`}
               key={i}
               value={`${i}`}
               disabled={opt.disabled}
-              style={opt.style}
+              style={{ ...opt.style, ...(isSelected && opt.color ? { color: opt.color } : {}) }}
             >
               {type.isNone(opt.label)
                 ? renderHtml({ html: `${opt.value}`, methods })
                 : renderHtml({ html: opt.label, methods })}
             </Checkbox>
-          )
-        )}
+          );
+          if (type.isNone(opt.color)) return checkbox;
+          // Per-option color: token override colors this checkbox's checked tick.
+          return (
+            <ConfigProvider key={i} theme={{ token: { colorPrimary: opt.color } }}>
+              {checkbox}
+            </ConfigProvider>
+          );
+        })}
       </Space>
     </Checkbox.Group>
   );

--- a/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/gallery.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/gallery.yaml
@@ -679,3 +679,20 @@
           - Blog Post
           - Conference or Event
           - Other
+
+- title: Per-option Color
+  blocks:
+    - id: checkbox_per_option_color
+      type: CheckboxSelector
+      properties:
+        title: 'Each checked box in its option color'
+        options:
+          - label: Low
+            value: low
+            color: '#16a34a'
+          - label: Medium
+            value: medium
+            color: '#d97706'
+          - label: High
+            value: high
+            color: '#dc2626'

--- a/packages/plugins/blocks/blocks-antd/src/blocks/MultipleSelector/MultipleSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/MultipleSelector/MultipleSelector.js
@@ -21,23 +21,32 @@ import { Select } from 'antd';
 
 import getUniqueValues from '../../getUniqueValues.js';
 import getValueIndex from '../../getValueIndex.js';
+import getContrastTextColor from '../../getContrastTextColor.js';
+import getOptionColorStyle from '../../getOptionColorStyle.js';
 import Label from '../Label/Label.js';
 import withTheme from '../withTheme.js';
 import Tag from '../Tag/Tag.js';
 
 const Option = Select.Option;
 
-const tagRender = (props, option, methods, components) => {
+const tagRender = (props, option, methods, components, isOutline) => {
   const { label, closable, onClose } = props;
+  // An explicit tag.color wins; otherwise the per-option color drives the pill.
+  const color = option?.tag?.color ?? option?.color;
+  const contrast = getContrastTextColor(color);
+  // Hex color → explicit solid/outlined pill (dark-mode safe), following the
+  // input variant. Preset name (or none) → antd's Tag color handling.
+  const colorStyle = contrast ? getOptionColorStyle({ color, isOutline }) : {};
   return (
     <Tag
       components={components}
       methods={methods}
       onClose={onClose}
-      styles={{ element: { marginRight: 3, ...(option?.tag?.style ?? {}) } }}
+      styles={{ element: { marginRight: 3, ...colorStyle, ...(option?.tag?.style ?? {}) } }}
       properties={{
         title: label ?? '',
         ...(option?.tag ?? {}),
+        color: contrast ? undefined : color,
         closable,
       }}
     />
@@ -60,6 +69,17 @@ const MultipleSelector = ({
   const [fetchState, setFetch] = useState(false);
   const [elementId] = useState((0 | (Math.random() * 9e2)) + 1e2);
   const uniqueValueOptions = getUniqueValues(properties.options ?? []);
+  // Auto-enable custom tag rendering when any option carries a color/tag, so
+  // per-option pill colors work without requiring renderTags.
+  const hasTagStyling = uniqueValueOptions.some(
+    (opt) => !type.isPrimitive(opt) && (opt.color || opt.tag)
+  );
+  // `outlined` → outlined colored tags; `solid` (or default) → filled colored tags.
+  const isOutline = properties.variant === 'outlined';
+  // `solid` is not a valid antd Select input variant — use outlined for the frame.
+  let antdVariant = properties.variant;
+  if (properties.variant === 'solid') antdVariant = 'outlined';
+  if (properties.bordered === false) antdVariant = 'borderless';
   return (
     <Label
       blockId={blockId}
@@ -78,7 +98,7 @@ const MultipleSelector = ({
               allowClear={properties.allowClear !== false}
               autoClearSearchValue={properties.autoClearSearchValue}
               autoFocus={properties.autoFocus}
-              variant={properties.bordered === false ? 'borderless' : properties.variant}
+              variant={antdVariant}
               className={classNames.element}
               classNames={{ content: classNames.selector }}
               style={{ width: '100%', ...styles.element }}
@@ -87,12 +107,15 @@ const MultipleSelector = ({
               getPopupContainer={() => document.getElementById(`${blockId}_${elementId}_popup`)}
               mode="multiple"
               tagRender={
-                properties.renderTags &&
+                (properties.renderTags || hasTagStyling) &&
                 ((props) =>
-                  tagRender(props, uniqueValueOptions[props.value], methods, {
-                    Icon,
-                    ShortcutBadge,
-                  }))
+                  tagRender(
+                    props,
+                    uniqueValueOptions[props.value],
+                    methods,
+                    { Icon, ShortcutBadge },
+                    isOutline
+                  ))
               }
               maxTagCount={properties.maxTagCount}
               notFoundContent={
@@ -187,7 +210,11 @@ const MultipleSelector = ({
                   </Option>
                 ) : (
                   <Option
-                    style={{ ...styles.options, ...opt.style }}
+                    style={{
+                      ...styles.options,
+                      ...opt.style,
+                      ...(opt.color ? { color: opt.color } : {}),
+                    }}
                     className={classNames.options}
                     disabled={opt.disabled}
                     filterstring={opt.filterString}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/MultipleSelector/gallery.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/MultipleSelector/gallery.yaml
@@ -1196,3 +1196,36 @@
                 params:
                   content: Filters applied successfully.
                   duration: 3
+
+- title: Per-option Color
+  blocks:
+    - id: multiple_color_solid
+      type: MultipleSelector
+      properties:
+        title: 'Solid — filled colored tags'
+        variant: solid
+        options:
+          - label: Low
+            value: low
+            color: '#16a34a'
+          - label: Medium
+            value: medium
+            color: '#d97706'
+          - label: High
+            value: high
+            color: '#dc2626'
+    - id: multiple_color_outlined
+      type: MultipleSelector
+      properties:
+        title: 'Outlined — outlined colored tags'
+        variant: outlined
+        options:
+          - label: Low
+            value: low
+            color: '#16a34a'
+          - label: Medium
+            value: medium
+            color: '#d97706'
+          - label: High
+            value: high
+            color: '#dc2626'

--- a/packages/plugins/blocks/blocks-antd/src/blocks/MultipleSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/MultipleSelector/meta.js
@@ -159,6 +159,14 @@ export default {
                     displayType: 'yaml',
                   },
                 },
+                color: {
+                  type: 'string',
+                  description:
+                    'Color applied when this option is selected: drives the tag/pill color in the input and tints the option in the dropdown. An explicit `tag.color` takes precedence.',
+                  docs: {
+                    displayType: 'color',
+                  },
+                },
                 tag: {
                   type: 'object',
                   properties: {
@@ -230,7 +238,12 @@ export default {
         type: 'string',
         description: 'Multiple selector label title - supports html.',
       },
-      variant,
+      variant: {
+        type: 'string',
+        enum: ['solid', 'outlined', 'filled', 'borderless'],
+        description:
+          'Tag/input variant. `solid` renders filled colored tags; `outlined` renders outlined colored tags. `filled`/`borderless` are the antd input styles.',
+      },
       renderTags: {
         type: 'boolean',
         description:

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PageHeaderMenu/PageHeaderMenu.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PageHeaderMenu/PageHeaderMenu.js
@@ -123,7 +123,17 @@ const PageHeaderMenu = ({
                             properties.menuLg,
                           ])}
                           styles={{
-                            element: mergeObjects([{ borderBottom: 'none' }, styles.menu]),
+                            // Fill the header height so the active item's underline lands on the
+                            // header's bottom border (instead of floating above it), matching the
+                            // single-border look of Sider / PageSiderMenu. borderBottom is left to
+                            // the Header so the divider spans the full width, including the logo.
+                            element: mergeObjects([
+                              {
+                                borderBottom: 'none',
+                                lineHeight: 'var(--ant-layout-header-height, 64px)',
+                              },
+                              styles.menu,
+                            ]),
                           }}
                           rename={{
                             events: {

--- a/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/RadioSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/RadioSelector.js
@@ -40,6 +40,7 @@ const RadioSelector = ({
   methods,
 }) => {
   const uniqueValueOptions = getUniqueValues(properties.options || []);
+  const selectedIndex = getValueIndex(value, uniqueValueOptions);
   const radioGroup = (
     <RadioGroup
       id={`${blockId}_input`}
@@ -60,25 +61,36 @@ const RadioSelector = ({
         wrap={type.isNone(properties.wrap) ? true : properties.wrap}
         align={type.isNone(properties.align) ? 'start' : properties.align}
       >
-        {uniqueValueOptions.map((opt, i) =>
-          type.isPrimitive(opt) ? (
-            <Radio id={`${blockId}_${opt}`} key={i} value={`${i}`}>
-              {renderHtml({ html: `${opt}`, methods })}
-            </Radio>
-          ) : (
+        {uniqueValueOptions.map((opt, i) => {
+          if (type.isPrimitive(opt)) {
+            return (
+              <Radio id={`${blockId}_${opt}`} key={i} value={`${i}`}>
+                {renderHtml({ html: `${opt}`, methods })}
+              </Radio>
+            );
+          }
+          const isSelected = `${i}` === selectedIndex;
+          const radio = (
             <Radio
               id={`${blockId}_${i}`}
               key={i}
               value={`${i}`}
               disabled={opt.disabled}
-              style={opt.style}
+              style={{ ...opt.style, ...(isSelected && opt.color ? { color: opt.color } : {}) }}
             >
               {type.isNone(opt.label)
                 ? renderHtml({ html: `${opt.value}`, methods })
                 : renderHtml({ html: opt.label, methods })}
             </Radio>
-          )
-        )}
+          );
+          if (type.isNone(opt.color)) return radio;
+          // Per-option color: token override colors this radio's selected dot.
+          return (
+            <ConfigProvider key={i} theme={{ token: { colorPrimary: opt.color } }}>
+              {radio}
+            </ConfigProvider>
+          );
+        })}
       </Space>
     </RadioGroup>
   );

--- a/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/gallery.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/gallery.yaml
@@ -728,3 +728,20 @@
             value: medium
           - label: '<span style="color: #52c41a;">&#x1F7E2; Low</span>'
             value: low
+
+- title: Per-option Color
+  blocks:
+    - id: radio_per_option_color
+      type: RadioSelector
+      properties:
+        title: 'Selected dot + label in its option color'
+        options:
+          - label: Low
+            value: low
+            color: '#16a34a'
+          - label: Medium
+            value: medium
+            color: '#d97706'
+          - label: High
+            value: high
+            color: '#dc2626'

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Selector/Selector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Selector/Selector.js
@@ -17,12 +17,13 @@
 import React, { useState } from 'react';
 import { renderHtml, withBlockDefaults } from '@lowdefy/block-utils';
 import { get, type } from '@lowdefy/helpers';
-import { Select } from 'antd';
+import { ConfigProvider, Select } from 'antd';
 
 import Label from '../Label/Label.js';
 import withTheme from '../withTheme.js';
 import getValueIndex from '../../getValueIndex.js';
 import getUniqueValues from '../../getUniqueValues.js';
+import getContrastTextColor from '../../getContrastTextColor.js';
 
 const Option = Select.Option;
 
@@ -42,6 +43,22 @@ const Selector = ({
   const [fetchState, setFetch] = useState(false);
   const [elementId] = useState((0 | (Math.random() * 9e2)) + 1e2);
   const uniqueValueOptions = getUniqueValues(properties.options || []);
+  // Color the whole selector with the selected option's color: `solid` fills the
+  // input, otherwise the border/text is colored.
+  const selectedIndex = getValueIndex(value, uniqueValueOptions);
+  const selectedOption = type.isNone(selectedIndex) ? undefined : uniqueValueOptions[selectedIndex];
+  const selectedColor = type.isObject(selectedOption) ? selectedOption.color : undefined;
+  const isSolid = properties.variant === 'solid';
+  // `solid` is not a valid antd Select input variant — use outlined for the frame.
+  let antdVariant = properties.variant;
+  if (isSolid) antdVariant = 'outlined';
+  if (properties.bordered === false) antdVariant = 'borderless';
+  let selectTheme;
+  if (selectedColor) {
+    const token = { colorPrimary: selectedColor, colorBorder: selectedColor };
+    if (isSolid) token.colorBgContainer = selectedColor;
+    selectTheme = { token };
+  }
   return (
     <Label
       blockId={blockId}
@@ -56,108 +73,121 @@ const Selector = ({
         content: () => (
           <div style={{ width: '100%' }}>
             <div id={`${blockId}_${elementId}_popup`} />
-            <Select
-              id={`${blockId}_input`}
-              variant={properties.bordered === false ? 'borderless' : properties.variant}
-              className={classNames.element}
-              classNames={{ content: classNames.selector }}
-              style={{ width: '100%', ...styles.element }}
-              styles={{ content: styles.selector }}
-              mode="single"
-              autoFocus={properties.autoFocus}
-              getPopupContainer={() => document.getElementById(`${blockId}_${elementId}_popup`)}
-              disabled={properties.disabled || loading}
-              placeholder={get(properties, 'placeholder', { default: 'Select item' })}
-              status={validation.status}
-              suffixIcon={
-                properties.suffixIcon && (
-                  <Icon
-                    blockId={`${blockId}_suffixIcon`}
-                    classNames={{ element: classNames.suffixIcon }}
-                    events={events}
-                    properties={properties.suffixIcon}
-                    styles={{ element: styles.suffixIcon }}
-                  />
-                )
-              }
-              clearIcon={
-                properties.clearIcon && (
-                  <Icon
-                    blockId={`${blockId}_clearIcon`}
-                    classNames={{ element: classNames.clearIcon }}
-                    events={events}
-                    properties={properties.clearIcon}
-                    styles={{ element: styles.clearIcon }}
-                  />
-                )
-              }
-              showArrow={properties.showArrow}
-              allowClear={properties.allowClear !== false}
-              showSearch={get(properties, 'showSearch', { default: true })}
-              size={properties.size}
-              filterOption={(input, option) =>
-                (option.filterstring || option.children.props.html || '')
-                  .toLowerCase()
-                  .indexOf(input.toLowerCase()) >= 0
-              }
-              notFoundContent={
-                fetchState
-                  ? properties.loadingPlaceholder || 'Loading'
-                  : properties.notFoundContent || 'Not found'
-              }
-              onChange={(newVal) => {
-                const val = type.isPrimitive(uniqueValueOptions[newVal])
-                  ? uniqueValueOptions[newVal]
-                  : uniqueValueOptions[newVal].value;
-                methods.setValue(val);
-                methods.triggerEvent({ name: 'onChange', event: { value: val } });
-              }}
-              onBlur={() => {
-                methods.triggerEvent({ name: 'onBlur' });
-              }}
-              onFocus={() => {
-                methods.triggerEvent({ name: 'onFocus' });
-              }}
-              onClear={() => {
-                methods.triggerEvent({ name: 'onClear' });
-              }}
-              onSearch={async (value) => {
-                setFetch(true);
-                const result = await methods.triggerEvent({ name: 'onSearch', event: { value } });
-                if (!result.bounced) {
-                  setFetch(false);
+            <ConfigProvider theme={selectTheme}>
+              <Select
+                id={`${blockId}_input`}
+                variant={antdVariant}
+                className={classNames.element}
+                classNames={{ content: classNames.selector }}
+                style={{ width: '100%', ...styles.element }}
+                styles={{ content: styles.selector }}
+                mode="single"
+                labelRender={(labelProps) => {
+                  const opt = uniqueValueOptions[labelProps.value];
+                  const color = type.isPrimitive(opt) ? undefined : opt?.color;
+                  if (type.isNone(color)) return labelProps.label;
+                  const textColor = isSolid ? getContrastTextColor(color) ?? '#fff' : color;
+                  return <span style={{ color: textColor }}>{labelProps.label}</span>;
+                }}
+                autoFocus={properties.autoFocus}
+                getPopupContainer={() => document.getElementById(`${blockId}_${elementId}_popup`)}
+                disabled={properties.disabled || loading}
+                placeholder={get(properties, 'placeholder', { default: 'Select item' })}
+                status={validation.status}
+                suffixIcon={
+                  properties.suffixIcon && (
+                    <Icon
+                      blockId={`${blockId}_suffixIcon`}
+                      classNames={{ element: classNames.suffixIcon }}
+                      events={events}
+                      properties={properties.suffixIcon}
+                      styles={{ element: styles.suffixIcon }}
+                    />
+                  )
                 }
-              }}
-              value={getValueIndex(value, uniqueValueOptions)}
-            >
-              {uniqueValueOptions.map((opt, i) =>
-                type.isPrimitive(opt) ? (
-                  <Option
-                    style={styles.options}
-                    className={classNames.options}
-                    id={`${blockId}_${i}`}
-                    key={i}
-                    value={`${i}`}
-                  >
-                    {renderHtml({ html: `${opt}`, methods })}
-                  </Option>
-                ) : (
-                  <Option
-                    style={{ ...styles.options, ...opt.style }}
-                    className={classNames.options}
-                    disabled={opt.disabled}
-                    filterstring={opt.filterString}
-                    id={`${blockId}_${i}`}
-                    key={i}
-                    value={`${i}`}
-                  >
-                    {type.isNone(opt.label)
-                      ? renderHtml({ html: `${opt.value}`, methods })
-                      : renderHtml({ html: opt.label, methods })}
-                  </Option>
-                )
-              )}
-            </Select>
+                clearIcon={
+                  properties.clearIcon && (
+                    <Icon
+                      blockId={`${blockId}_clearIcon`}
+                      classNames={{ element: classNames.clearIcon }}
+                      events={events}
+                      properties={properties.clearIcon}
+                      styles={{ element: styles.clearIcon }}
+                    />
+                  )
+                }
+                showArrow={properties.showArrow}
+                allowClear={properties.allowClear !== false}
+                showSearch={get(properties, 'showSearch', { default: true })}
+                size={properties.size}
+                filterOption={(input, option) =>
+                  (option.filterstring || option.children.props.html || '')
+                    .toLowerCase()
+                    .indexOf(input.toLowerCase()) >= 0
+                }
+                notFoundContent={
+                  fetchState
+                    ? properties.loadingPlaceholder || 'Loading'
+                    : properties.notFoundContent || 'Not found'
+                }
+                onChange={(newVal) => {
+                  const val = type.isPrimitive(uniqueValueOptions[newVal])
+                    ? uniqueValueOptions[newVal]
+                    : uniqueValueOptions[newVal].value;
+                  methods.setValue(val);
+                  methods.triggerEvent({ name: 'onChange', event: { value: val } });
+                }}
+                onBlur={() => {
+                  methods.triggerEvent({ name: 'onBlur' });
+                }}
+                onFocus={() => {
+                  methods.triggerEvent({ name: 'onFocus' });
+                }}
+                onClear={() => {
+                  methods.triggerEvent({ name: 'onClear' });
+                }}
+                onSearch={async (value) => {
+                  setFetch(true);
+                  const result = await methods.triggerEvent({ name: 'onSearch', event: { value } });
+                  if (!result.bounced) {
+                    setFetch(false);
+                  }
+                }}
+                value={getValueIndex(value, uniqueValueOptions)}
+              >
+                {uniqueValueOptions.map((opt, i) =>
+                  type.isPrimitive(opt) ? (
+                    <Option
+                      style={styles.options}
+                      className={classNames.options}
+                      id={`${blockId}_${i}`}
+                      key={i}
+                      value={`${i}`}
+                    >
+                      {renderHtml({ html: `${opt}`, methods })}
+                    </Option>
+                  ) : (
+                    <Option
+                      style={{
+                        ...styles.options,
+                        ...opt.style,
+                        ...(opt.color ? { color: opt.color } : {}),
+                      }}
+                      className={classNames.options}
+                      disabled={opt.disabled}
+                      filterstring={opt.filterString}
+                      id={`${blockId}_${i}`}
+                      key={i}
+                      value={`${i}`}
+                    >
+                      {type.isNone(opt.label)
+                        ? renderHtml({ html: `${opt.value}`, methods })
+                        : renderHtml({ html: opt.label, methods })}
+                    </Option>
+                  )
+                )}
+              </Select>
+            </ConfigProvider>
           </div>
         ),
       }}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Selector/gallery.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Selector/gallery.yaml
@@ -1007,3 +1007,36 @@
                 params:
                   content: Order placed successfully!
                   duration: 3
+
+- title: Per-option Color
+  blocks:
+    - id: selector_color_solid
+      type: Selector
+      properties:
+        title: 'Solid — the whole input filled with the selected option color'
+        variant: solid
+        options:
+          - label: Low
+            value: low
+            color: '#16a34a'
+          - label: Medium
+            value: medium
+            color: '#d97706'
+          - label: High
+            value: high
+            color: '#dc2626'
+    - id: selector_color_outlined
+      type: Selector
+      properties:
+        title: 'Outlined — input border + value colored'
+        variant: outlined
+        options:
+          - label: Low
+            value: low
+            color: '#16a34a'
+          - label: Medium
+            value: medium
+            color: '#d97706'
+          - label: High
+            value: high
+            color: '#dc2626'

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Selector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Selector/meta.js
@@ -156,6 +156,14 @@ export default {
                     displayType: 'yaml',
                   },
                 },
+                color: {
+                  type: 'string',
+                  description:
+                    'Color applied to the selected value shown in the input, and used to tint this option in the dropdown.',
+                  docs: {
+                    displayType: 'color',
+                  },
+                },
               },
             },
           },
@@ -194,7 +202,12 @@ export default {
           "Name of an React-Icon (See <a href='https://react-icons.github.io/react-icons/'>all icons</a>) or properties of an Icon block to customize icon at the drop-down position of the selector.",
       },
       title: inputTitle,
-      variant,
+      variant: {
+        type: 'string',
+        enum: ['solid', 'outlined', 'filled', 'borderless'],
+        description:
+          'Input variant. `solid` fills the whole input with the selected option color; `outlined` colors its border/text. `filled`/`borderless` are the antd input styles.',
+      },
       theme: {
         type: 'object',
         description:

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Tabs/Tabs.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Tabs/Tabs.js
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { renderHtml, withBlockDefaults } from '@lowdefy/block-utils';
 import { Tabs } from 'antd';
 
@@ -50,11 +50,30 @@ function TabsBlock({
   }
 
   const [key, setKey] = useState(properties.defaultActiveKey ?? tabs[0].key);
+
+  // Read latest tabs inside the stable handler without re-binding listeners.
+  const tabsRef = useRef(tabs);
+  tabsRef.current = tabs;
+
+  // Fires the generic onChange plus, if the now-active tab declares one, its
+  // own dynamically-named event. Stable identity so shortcut listeners and the
+  // registered method don't re-bind on every render.
+  const fireTabChange = useCallback(
+    (activeKey) => {
+      setKey(activeKey);
+      methods.triggerEvent({ name: 'onChange', event: { activeKey } });
+      const activeTab = tabsRef.current.find((tab) => tab.key === activeKey);
+      if (activeTab?.eventName) {
+        methods.triggerEvent({ name: activeTab.eventName, event: { key: activeKey } });
+      }
+    },
+    [methods]
+  );
+
   useEffect(() => {
     methods.registerMethod('setActiveKey', ({ activeKey }) => {
       if (activeKey !== key) {
-        setKey(activeKey);
-        methods.triggerEvent({ name: 'onChange', event: { activeKey } });
+        fireTabChange(activeKey);
       }
     });
   });
@@ -62,33 +81,17 @@ function TabsBlock({
   const shortcutItems = tabs
     .filter((tab) => tab.shortcut)
     .map((tab) => ({ key: tab.key, shortcut: tab.shortcut, disabled: tab.disabled }));
-  const onShortcutMatch = useCallback(
-    (activeKey) => {
-      setKey(activeKey);
-      methods.triggerEvent({ name: 'onChange', event: { activeKey } });
-    },
-    [methods]
-  );
-  useItemShortcuts({ items: shortcutItems, onMatch: onShortcutMatch });
+  useItemShortcuts({ items: shortcutItems, onMatch: fireTabChange });
 
   return (
     <Tabs
       activeKey={key}
       animated={properties.animated !== undefined ? properties.animated : true}
       id={blockId}
-      onChange={(activeKey) => {
-        setKey(activeKey);
-        methods.triggerEvent({ name: 'onChange', event: { activeKey } });
-      }}
+      onChange={(activeKey) => fireTabChange(activeKey)}
       size={properties.size ?? 'default'}
       tabPlacement={properties.tabPlacement ?? 'top'}
       type={properties.tabType ?? 'line'}
-      onTabScroll={({ direction }) =>
-        methods.triggerEvent({ name: 'onTabScroll', event: { direction } })
-      }
-      onTabClick={(key) => {
-        methods.triggerEvent({ name: 'onTabClick', event: { key } });
-      }}
       className={classNames.element}
       classNames={{
         tabBar: classNames.tabBar,

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Tabs/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Tabs/meta.js
@@ -28,16 +28,13 @@ export default {
   },
   events: {
     onChange: {
-      description: 'Trigger action on tab change.',
+      description: 'Trigger action on any tab change.',
       event: { activeKey: 'The key of the active tab.' },
     },
-    onTabScroll: {
-      description: 'Trigger action on tab scroll.',
-      event: { direction: 'The scroll direction.' },
-    },
-    onTabClick: {
-      description: 'Trigger action on tab click.',
-      event: { key: 'The key of the clicked tab.' },
+    onTabSelect: {
+      description:
+        'Documentation reference — not a fixed event name. When a tab becomes active, the `eventName` string declared on that `tabs[]` entry is triggered (in addition to onChange). Declare your named events under `events:` (e.g. `onProfileTab`, `onBillingTab`).',
+      event: { key: 'The key of the now-active tab.' },
     },
   },
   properties: {
@@ -85,6 +82,11 @@ export default {
             key: {
               type: 'string',
               description: 'Area key of the tab.',
+            },
+            eventName: {
+              type: 'string',
+              description:
+                'Block-level event name to trigger when this tab becomes active, in addition to onChange. Declare an event with this name under `events:`. The event receives `{ key }` of the now-active tab.',
             },
             disabled: {
               type: 'boolean',

--- a/packages/plugins/blocks/blocks-antd/src/getContrastTextColor.js
+++ b/packages/plugins/blocks/blocks-antd/src/getContrastTextColor.js
@@ -1,0 +1,45 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { type } from '@lowdefy/helpers';
+
+// Returns '#000' or '#fff' for best contrast against a hex background color.
+// Returns undefined for non-hex values (named colors, rgb(), etc.) so the
+// caller can fall back to antd's default solid text color.
+function getContrastTextColor(color) {
+  if (!type.isString(color)) return undefined;
+  const hex = color.trim().replace(/^#/, '');
+  let r;
+  let g;
+  let b;
+  if (hex.length === 3) {
+    r = parseInt(hex[0] + hex[0], 16);
+    g = parseInt(hex[1] + hex[1], 16);
+    b = parseInt(hex[2] + hex[2], 16);
+  } else if (hex.length === 6 || hex.length === 8) {
+    r = parseInt(hex.slice(0, 2), 16);
+    g = parseInt(hex.slice(2, 4), 16);
+    b = parseInt(hex.slice(4, 6), 16);
+  } else {
+    return undefined;
+  }
+  if ([r, g, b].some((n) => Number.isNaN(n))) return undefined;
+  // YIQ perceptual brightness: dark text on light backgrounds, light text on dark.
+  const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+  return yiq >= 128 ? '#000' : '#fff';
+}
+
+export default getContrastTextColor;

--- a/packages/plugins/blocks/blocks-antd/src/getOptionColorStyle.js
+++ b/packages/plugins/blocks/blocks-antd/src/getOptionColorStyle.js
@@ -1,0 +1,36 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import getContrastTextColor from './getContrastTextColor.js';
+
+// Color styles for a selected selector option, by variant.
+// outline: color the border/text + a low-opacity tint of the color.
+// solid: fill with the color + auto-contrast text.
+// `color` may be a CSS value such as 'var(--ant-color-primary)' for the active
+// primary when no explicit color is set.
+function getOptionColorStyle({ color, isOutline }) {
+  if (isOutline) {
+    return {
+      color,
+      borderColor: color,
+      backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+    };
+  }
+  const contrast = getContrastTextColor(color);
+  return { backgroundColor: color, borderColor: color, color: contrast ?? '#fff' };
+}
+
+export default getOptionColorStyle;

--- a/packages/plugins/blocks/blocks-antd/src/schemas/options.js
+++ b/packages/plugins/blocks/blocks-antd/src/schemas/options.js
@@ -81,6 +81,14 @@ export default {
               displayType: 'yaml',
             },
           },
+          color: {
+            type: 'string',
+            description:
+              'Color applied to this option when it is selected. Falls back to the block-level color when not set.',
+            docs: {
+              displayType: 'color',
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
## Summary

Rounds out the antd selector blocks with color theming, and bundles two smaller block improvements. Selector blocks gain a per-option `color` and `solid`/`outlined` variants so selected values render in their own color in light and dark mode; the Tabs block gains per-tab events; and a PageHeaderMenu border-alignment bug is fixed.

## Changes

- **@lowdefy/blocks-antd**:
  - **Selector color** — object options accept a per-option `color`, and the block-level color is applied as a global `colorPrimary` token so antd re-derives the full palette (solid bg, hover/active, outline) and inherits the dark algorithm. ButtonSelector's `buttonStyle` is replaced by `variant` (`solid`/`outlined`), with auto-contrast solid text and an outline tint; the selected option uses its own color when set. CheckboxSelector/RadioSelector color the checked control + label (no variant). Selector colors the whole input (`solid` fills, `outlined` borders); MultipleSelector colors tags by variant. New shared `getContrastTextColor`/`getOptionColorStyle` helpers and gallery examples for all five blocks.
  - **Tabs** — `onChange` fires on any tab change (`{ activeKey }`), plus each tab can declare an `eventName` that fires with `{ key }` when it becomes active (modeled on the AgGrid per-button event pattern).
  - **PageHeaderMenu** — the horizontal menu's active-item underline now sits on the header's bottom border (menu line-height matches the header height), matching the Sider/PageSiderMenu border pattern.

## Key Files

- `packages/plugins/blocks/blocks-antd/src/getContrastTextColor.js`, `getOptionColorStyle.js` — shared color/contrast helpers
- `.../blocks/ButtonSelector/ButtonSelector.js` — `variant` + per-option color
- `.../blocks/Selector/Selector.js` — whole-input coloring + `solid`/`outlined` variant
- `.../blocks/MultipleSelector/MultipleSelector.js` — colored tags via variant
- `.../blocks/Tabs/Tabs.js` — `onChange` + per-tab `eventName`

## Notes

- ButtonSelector `buttonStyle` is **deprecated** in favor of `variant` but still works as an alias — no migration required.
- The Tabs `onTabClick`/`onTabScroll` events removed here were added earlier in this dev cycle and never released, so their removal is not a breaking change.
- Per-option color relies on `color-mix(...)` and the `--ant-color-primary` CSS variable (modern-browser features within the antd v6 baseline).