### PR TITLE
Fix false CallAPI non-existent-endpoint warnings in dev server (top-level + module endpoints)

### DIFF
--- a/.changeset/fix-jit-callapi-endpoint-refs.md
+++ b/.changeset/fix-jit-callapi-endpoint-refs.md
@@ -1,0 +1,9 @@
+---
+'@lowdefy/server-dev': patch
+---
+
+fix(server-dev): Stop false "non-existent endpoint" warnings for CallAPI actions in dev.
+
+Under `lowdefy dev`, every `CallAPI` action logged a `ConfigWarning` that its endpoint did not exist, even when the endpoint was correctly defined under `api:` and worked at runtime. A full `lowdefy build` was unaffected.
+
+The JIT page builder validates CallAPI references against `context.components.api`, but the dev server's build context (`getBuildContext`) is rebuilt from disk artifacts and never restored the api endpoints, so the endpoint set was always empty and every reference was flagged. The dev context now hydrates the endpoints from the persisted `build/api/<endpointId>.json` artifacts (written by the skeleton build), so the non-existent-endpoint and InternalApi-not-client-callable checks behave the same in dev as in a full build.

--- a/.changeset/fix-jit-callapi-endpoint-refs.md
+++ b/.changeset/fix-jit-callapi-endpoint-refs.md
@@ -7,3 +7,5 @@ fix(server-dev): Stop false "non-existent endpoint" warnings for CallAPI actions
 Under `lowdefy dev`, every `CallAPI` action logged a `ConfigWarning` that its endpoint did not exist, even when the endpoint was correctly defined under `api:` and worked at runtime. A full `lowdefy build` was unaffected.
 
 The JIT page builder validates CallAPI references against `context.components.api`, but the dev server's build context (`getBuildContext`) is rebuilt from disk artifacts and never restored the api endpoints, so the endpoint set was always empty and every reference was flagged. The dev context now hydrates the endpoints from the persisted `build/api/<endpointId>.json` artifacts (written by the skeleton build), so the non-existent-endpoint and InternalApi-not-client-callable checks behave the same in dev as in a full build.
+
+Module endpoints are written to nested paths (`build/api/<moduleId>/<endpointId>.json`) because their scoped `endpointId` contains a `/`. The artifact reader now walks the api directory recursively so these endpoints are hydrated too; previously every module CallAPI was still flagged as referencing a non-existent endpoint.

--- a/packages/build/src/build/jit/buildPageJit.test.js
+++ b/packages/build/src/build/jit/buildPageJit.test.js
@@ -799,3 +799,87 @@ blocks:
   );
   expect(iconDynamicCall).toBeUndefined();
 });
+
+// CallAPI endpoint reference validation (validateCallApiRefs) in the JIT path.
+// The dev server hydrates context.components.api from build/api/*.json before building
+// a page (see getBuildContext + readBuildApiArtifacts). These tests assert that, given
+// that hydrated context, a valid CallAPI endpointId does NOT produce a false warning,
+// while a genuinely missing endpointId still does.
+function createTestContextWithApi(api) {
+  const context = createTestContext();
+  context.components = { api };
+  context.typesMap = {
+    ...snapshotTypesMap,
+    actions: {
+      ...snapshotTypesMap.actions,
+      CallAPI: { package: '@lowdefy/actions-core' },
+    },
+  };
+  return context;
+}
+
+const callApiPageYaml = `
+id: home
+type: PageHeaderMenu
+blocks:
+  - id: btn
+    type: Button
+    events:
+      onClick:
+        - id: call_endpoint
+          type: CallAPI
+          params:
+            endpointId: my_endpoint
+`;
+
+function callApiPageRegistry() {
+  return new Map([
+    [
+      'home',
+      {
+        pageId: 'home',
+        auth: { public: true },
+        refId: 'ref-home',
+        refPath: 'home.yaml',
+        unresolvedVars: null,
+      },
+    ],
+  ]);
+}
+
+test('buildPageJit does not warn for a CallAPI action when the endpoint exists in components.api', async () => {
+  const context = createTestContextWithApi([{ endpointId: 'my_endpoint', type: 'Api' }]);
+  const warnings = [];
+  context.handleWarning = (warning) => warnings.push(warning);
+
+  mockFiles([{ path: 'home.yaml', content: callApiPageYaml }]);
+
+  const result = await buildPageJit({
+    pageId: 'home',
+    pageRegistry: callApiPageRegistry(),
+    context,
+  });
+
+  expect(result.id).toBe('page:home');
+  expect(warnings.find((w) => w.message.includes('non-existent endpoint'))).toBeUndefined();
+});
+
+test('buildPageJit warns for a CallAPI action when the endpoint is missing from components.api', async () => {
+  const context = createTestContextWithApi([]);
+  const warnings = [];
+  context.handleWarning = (warning) => warnings.push(warning);
+
+  mockFiles([{ path: 'home.yaml', content: callApiPageYaml }]);
+
+  await buildPageJit({
+    pageId: 'home',
+    pageRegistry: callApiPageRegistry(),
+    context,
+  });
+
+  const warning = warnings.find((w) => w.checkSlug === 'callapi-refs');
+  expect(warning).toBeDefined();
+  expect(warning.message).toBe(
+    'CallAPI action on page "home" references non-existent endpoint "my_endpoint".'
+  );
+});

--- a/packages/build/src/build/jit/buildPageJitCallApi.integration.test.js
+++ b/packages/build/src/build/jit/buildPageJitCallApi.integration.test.js
@@ -1,0 +1,301 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Integration test that crosses the *real* dev-server seam for CallAPI endpoint
+// validation:
+//
+//   shallowBuild  ->  build/api/<id>.json on disk  ->  hydrate context (mirror of
+//   server-dev getBuildContext + readBuildApiArtifacts)  ->  buildPageJit  ->
+//   validateCallApiRefs
+//
+// The existing buildPageJit.test.js sets context.components.api directly, so it
+// never exercises the write/read of build/api/*.json nor the walker resolution of
+// _module.endpointId during a JIT build. This test runs the actual pipeline against
+// real files on disk to reproduce the dev-server behaviour Gerrie reported.
+
+import { jest } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { serializer } from '@lowdefy/helpers';
+
+process.env.NEXTAUTH_SECRET = 'test-secret-for-integration-test';
+
+// Mock the steps that touch the real server filesystem / git so shallowBuild can
+// run against a throwaway temp directory. Everything that matters for CallAPI
+// validation (buildRefs/walker, buildModules, buildApi, writeApi, buildShallowPages,
+// writeMaps, buildPageJit, validateCallApiRefs) runs for real.
+jest.unstable_mockModule('../buildApp.js', () => ({
+  default: ({ components }) => {
+    components.app = components.app ?? {};
+    components.app.html = components.app.html ?? {};
+    components.app.html.appendBody = components.app.html.appendBody ?? '';
+    components.app.html.appendHead = components.app.html.appendHead ?? '';
+    components.appMeta = {
+      slug: components.slug ?? null,
+      name: components.name ?? null,
+      version: components.version ?? null,
+      description: components.description ?? null,
+      license: components.license ?? null,
+      lowdefyVersion: components.lowdefy ?? null,
+      gitSha: 'test-git-sha',
+    };
+    return components;
+  },
+}));
+jest.unstable_mockModule('../full/updateServerPackageJson.js', () => ({
+  default: jest.fn(async () => {}),
+}));
+jest.unstable_mockModule('../copyPublicFolder.js', () => ({
+  default: jest.fn(async () => {}),
+}));
+jest.unstable_mockModule('../copyAgentFileSystems.js', () => ({
+  default: jest.fn(async () => {}),
+}));
+
+const { default: shallowBuild } = await import('./shallowBuild.js');
+const { default: buildPageJit } = await import('./buildPageJit.js');
+const { default: createContext } = await import('../../createContext.js');
+const { default: makeId } = await import('../../utils/makeId.js');
+const { snapshotTypesMap } = await import('../../test-utils/runBuildForSnapshots.js');
+
+// typesMap used by the dev server (snapshot map + the CallAPI action plugin).
+const typesMap = {
+  ...snapshotTypesMap,
+  actions: {
+    ...snapshotTypesMap.actions,
+    CallAPI: { package: '@lowdefy/actions-core' },
+  },
+};
+
+// Packages that would be installed in a real dev server using these blocks/actions.
+// Set on the hydrated context so detectMissingPluginPackages doesn't short-circuit
+// buildPageJit into "installing" mode.
+const installedPluginPackages = new Set(['@lowdefy/blocks-basic', '@lowdefy/actions-core']);
+
+function callApiPage(id, endpointId) {
+  return `id: ${id}
+type: Box
+blocks:
+  - id: call_btn
+    type: Button
+    properties:
+      title: Call
+    events:
+      onClick:
+        - id: call_action
+          type: CallAPI
+          params:
+            endpointId: ${endpointId}
+`;
+}
+
+const moduleCallApiPage = `id: invite
+type: Box
+blocks:
+  - id: call_btn
+    type: Button
+    properties:
+      title: Invite
+    events:
+      onClick:
+        - id: call_action
+          type: CallAPI
+          params:
+            endpointId:
+              _module.endpointId: send-invite
+`;
+
+const returnEndpoint = (id) => `id: ${id}
+type: Api
+routine:
+  - ':return': ok
+`;
+
+function writeFixture(configDir) {
+  const write = (rel, content) => {
+    const full = path.join(configDir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  };
+
+  write(
+    'lowdefy.yaml',
+    `lowdefy: local
+name: CallAPI JIT Integration Test
+
+modules:
+  - id: inviter
+    source: 'file:modules/inviter'
+
+api:
+  - _ref: api/top-endpoint.yaml
+
+pages:
+  - _ref: pages/home.yaml
+  - _ref: pages/missing.yaml
+`
+  );
+
+  write('api/top-endpoint.yaml', returnEndpoint('top_endpoint'));
+  write('pages/home.yaml', callApiPage('home', 'top_endpoint'));
+  write('pages/missing.yaml', callApiPage('missing', 'does_not_exist'));
+
+  write(
+    'modules/inviter/module.lowdefy.yaml',
+    `name: Inviter
+
+pages:
+  - _ref: pages/invite.yaml
+
+api:
+  - _ref: api/send-invite.yaml
+`
+  );
+  write('modules/inviter/api/send-invite.yaml', returnEndpoint('send-invite'));
+  write('modules/inviter/pages/invite.yaml', moduleCallApiPage);
+}
+
+function readArtifact(buildDir, fileName) {
+  try {
+    return serializer.deserialize(JSON.parse(fs.readFileSync(path.join(buildDir, fileName), 'utf8')));
+  } catch {
+    return null;
+  }
+}
+
+// Mirror of server-dev readBuildApiArtifacts: recursively read every endpoint
+// artifact. Module endpoints live in nested dirs (build/api/<moduleId>/<id>.json)
+// because their scoped endpointId contains a "/".
+function readApiConfigs(directory) {
+  const configs = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      configs.push(...readApiConfigs(entryPath));
+    } else if (entry.name.endsWith('.json')) {
+      configs.push(serializer.deserialize(JSON.parse(fs.readFileSync(entryPath, 'utf8'))));
+    }
+  }
+  return configs;
+}
+
+function readBuildApiArtifacts(buildDir) {
+  try {
+    return readApiConfigs(path.join(buildDir, 'api'));
+  } catch (error) {
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
+// Mirror of server-dev getBuildContext: build a fresh dev context and restore the
+// skeleton artifacts from disk, including components.api (the fix under test).
+function hydrateContext({ buildDir, configDir }) {
+  const context = createContext({
+    customTypesMap: typesMap,
+    directories: {
+      build: buildDir,
+      config: configDir,
+      server: path.resolve(buildDir, '..'),
+    },
+    logger: { info: () => {}, log: () => {}, warn: () => {}, error: () => {}, succeed: () => {} },
+    stage: 'dev',
+  });
+
+  Object.assign(context.refMap, readArtifact(buildDir, 'refMap.json') ?? {});
+  Object.assign(context.keyMap, readArtifact(buildDir, 'keyMap.json') ?? {});
+  const jsMap = readArtifact(buildDir, 'jsMap.json') ?? { client: {}, server: {} };
+  context.jsMap.client = jsMap.client ?? {};
+  context.jsMap.server = jsMap.server ?? {};
+  for (const id of readArtifact(buildDir, 'connectionIds.json') ?? []) {
+    context.connectionIds.add(id);
+  }
+  const modules = readArtifact(buildDir, 'modules.json');
+  if (modules) Object.assign(context.modules, modules);
+
+  context.installedPluginPackages = installedPluginPackages;
+  context.components = { api: readBuildApiArtifacts(buildDir) };
+  context.iconImports = readArtifact(buildDir, 'iconImports.json') ?? [];
+  context.dynamicIconData = {};
+
+  const idCounter = readArtifact(buildDir, 'idCounter.json');
+  if (idCounter != null) makeId.setCounter(idCounter);
+
+  return context;
+}
+
+let buildDir;
+let configDir;
+let pageRegistry;
+let apiArtifacts;
+
+beforeAll(async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ldf-callapi-jit-'));
+  configDir = path.join(root, 'config');
+  buildDir = path.join(root, '.lowdefy', 'server', 'build');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.mkdirSync(buildDir, { recursive: true });
+
+  writeFixture(configDir);
+
+  await shallowBuild({
+    customTypesMap: typesMap,
+    directories: {
+      config: configDir,
+      build: buildDir,
+      server: path.join(root, '.lowdefy', 'server'),
+    },
+    logger: { info: () => {}, log: () => {}, warn: () => {}, error: () => {}, succeed: () => {} },
+    stage: 'dev',
+  });
+
+  pageRegistry = readArtifact(buildDir, 'pageRegistry.json');
+  apiArtifacts = readBuildApiArtifacts(buildDir);
+});
+
+async function buildAndCollectWarnings(pageId) {
+  const context = hydrateContext({ buildDir, configDir });
+  const result = await buildPageJit({ pageId, pageRegistry, context });
+  const warnings = (result?._warnings ?? []).filter((w) => w.message.includes('non-existent endpoint'));
+  return { result, warnings };
+}
+
+test('shallowBuild writes scoped api endpoint artifacts to build/api', () => {
+  const endpointIds = apiArtifacts.map((c) => c.endpointId).sort();
+  // Top-level keeps its id; module endpoint is scoped with the module entry id.
+  expect(endpointIds).toEqual(['inviter/send-invite', 'top_endpoint']);
+});
+
+test('JIT build of a page calling a top-level endpoint emits no false non-existent warning', async () => {
+  const { result, warnings } = await buildAndCollectWarnings('home');
+  expect(result.id).toBe('page:home');
+  expect(warnings).toEqual([]);
+});
+
+test('JIT build of a module page calling its endpoint via _module.endpointId emits no false warning', async () => {
+  const { result, warnings } = await buildAndCollectWarnings('inviter/invite');
+  expect(result.id).toBe('page:inviter/invite');
+  expect(warnings).toEqual([]);
+});
+
+test('JIT build still warns when a CallAPI targets a genuinely missing endpoint', async () => {
+  const { warnings } = await buildAndCollectWarnings('missing');
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].message).toBe(
+    'CallAPI action on page "missing" references non-existent endpoint "does_not_exist".'
+  );
+});

--- a/packages/servers/server-dev/lib/server/jitPageBuilder.js
+++ b/packages/servers/server-dev/lib/server/jitPageBuilder.js
@@ -22,6 +22,7 @@ import { buildPageJit, createContext, makeId } from '@lowdefy/build/dev';
 import compileCss from './compileCss.js';
 import createLogger from './log/createLogger.js';
 import PageCache from './pageCache.mjs';
+import readBuildApiArtifacts from './readBuildApiArtifacts.mjs';
 
 const jitLogger = createLogger({ name: 'jit-build' });
 
@@ -127,6 +128,11 @@ function getBuildContext(buildDirectory, configDirectory) {
   if (modules) {
     Object.assign(cachedBuildContext.modules, modules);
   }
+
+  // Restore api endpoint configs so JIT CallAPI validation (validateCallApiRefs in
+  // buildPageJit) can resolve endpointIds. Without this the dev context has no
+  // components.api and every CallAPI action is flagged as a non-existent endpoint.
+  cachedBuildContext.components = { api: readBuildApiArtifacts(buildDirectory) };
 
   // Use the frozen icon imports from the initial build for JIT detection.
   // This represents what's actually in the Next.js bundle — not what shallowBuild

--- a/packages/servers/server-dev/lib/server/readBuildApiArtifacts.mjs
+++ b/packages/servers/server-dev/lib/server/readBuildApiArtifacts.mjs
@@ -18,26 +18,36 @@ import fs from 'fs';
 import path from 'path';
 import { serializer } from '@lowdefy/helpers';
 
+// Recursively collect every endpoint artifact under the api directory. Module
+// endpoints are written to build/api/<moduleId>/<endpointId>.json because their
+// scoped endpointId contains a "/" (buildModules prefixes ids with the module entry
+// id), so a flat read would miss them and flag every module CallAPI as non-existent.
+function readApiConfigs(directory) {
+  const configs = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      configs.push(...readApiConfigs(entryPath));
+    } else if (entry.name.endsWith('.json')) {
+      configs.push(serializer.deserialize(JSON.parse(fs.readFileSync(entryPath, 'utf8'))));
+    }
+  }
+  return configs;
+}
+
 // Read the endpoint artifacts persisted by writeApi (build/api/<endpointId>.json).
 // The full build keeps endpoints in memory on components.api, but the dev context is
 // rebuilt from disk, so getBuildContext hydrates them here. validateCallApiRefs needs
 // each config's endpointId and type, both of which are present in the artifact.
 function readBuildApiArtifacts(buildDirectory) {
   const apiDirectory = path.join(buildDirectory, 'api');
-  let fileNames;
   try {
-    fileNames = fs.readdirSync(apiDirectory);
+    return readApiConfigs(apiDirectory);
   } catch (error) {
     // writeApi only creates the directory when endpoints are defined — absent means none.
     if (error.code === 'ENOENT') return [];
     throw error;
   }
-  return fileNames
-    .filter((fileName) => fileName.endsWith('.json'))
-    .map((fileName) => {
-      const content = fs.readFileSync(path.join(apiDirectory, fileName), 'utf8');
-      return serializer.deserialize(JSON.parse(content));
-    });
 }
 
 export default readBuildApiArtifacts;

--- a/packages/servers/server-dev/lib/server/readBuildApiArtifacts.mjs
+++ b/packages/servers/server-dev/lib/server/readBuildApiArtifacts.mjs
@@ -1,0 +1,43 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import fs from 'fs';
+import path from 'path';
+import { serializer } from '@lowdefy/helpers';
+
+// Read the endpoint artifacts persisted by writeApi (build/api/<endpointId>.json).
+// The full build keeps endpoints in memory on components.api, but the dev context is
+// rebuilt from disk, so getBuildContext hydrates them here. validateCallApiRefs needs
+// each config's endpointId and type, both of which are present in the artifact.
+function readBuildApiArtifacts(buildDirectory) {
+  const apiDirectory = path.join(buildDirectory, 'api');
+  let fileNames;
+  try {
+    fileNames = fs.readdirSync(apiDirectory);
+  } catch (error) {
+    // writeApi only creates the directory when endpoints are defined — absent means none.
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  }
+  return fileNames
+    .filter((fileName) => fileName.endsWith('.json'))
+    .map((fileName) => {
+      const content = fs.readFileSync(path.join(apiDirectory, fileName), 'utf8');
+      return serializer.deserialize(JSON.parse(content));
+    });
+}
+
+export default readBuildApiArtifacts;

--- a/packages/servers/server-dev/lib/server/readBuildApiArtifacts.test.mjs
+++ b/packages/servers/server-dev/lib/server/readBuildApiArtifacts.test.mjs
@@ -1,0 +1,90 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { serializer } from '@lowdefy/helpers';
+
+import readBuildApiArtifacts from './readBuildApiArtifacts.mjs';
+
+function makeBuildDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ldf-read-api-'));
+}
+
+// Mirror writeApi: each endpoint is serialized to build/api/<endpointId>.json.
+function writeEndpoint(buildDir, endpoint) {
+  const apiDir = path.join(buildDir, 'api');
+  fs.mkdirSync(apiDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(apiDir, `${endpoint.endpointId}.json`),
+    serializer.serializeToString(endpoint)
+  );
+}
+
+test('readBuildApiArtifacts returns [] when the api directory does not exist', () => {
+  const buildDir = makeBuildDir();
+  try {
+    expect(readBuildApiArtifacts(buildDir)).toEqual([]);
+  } finally {
+    fs.rmSync(buildDir, { recursive: true, force: true });
+  }
+});
+
+test('readBuildApiArtifacts returns [] when the api directory is empty', () => {
+  const buildDir = makeBuildDir();
+  fs.mkdirSync(path.join(buildDir, 'api'));
+  try {
+    expect(readBuildApiArtifacts(buildDir)).toEqual([]);
+  } finally {
+    fs.rmSync(buildDir, { recursive: true, force: true });
+  }
+});
+
+test('readBuildApiArtifacts reads and deserializes endpoint artifacts with endpointId and type', () => {
+  const buildDir = makeBuildDir();
+  writeEndpoint(buildDir, { id: 'endpoint:my_api', endpointId: 'my_api', type: 'Api' });
+  writeEndpoint(buildDir, {
+    id: 'endpoint:internal_api',
+    endpointId: 'internal_api',
+    type: 'InternalApi',
+  });
+  try {
+    const result = readBuildApiArtifacts(buildDir);
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ endpointId: 'my_api', type: 'Api' }),
+        expect.objectContaining({ endpointId: 'internal_api', type: 'InternalApi' }),
+      ])
+    );
+  } finally {
+    fs.rmSync(buildDir, { recursive: true, force: true });
+  }
+});
+
+test('readBuildApiArtifacts ignores non-json files in the api directory', () => {
+  const buildDir = makeBuildDir();
+  writeEndpoint(buildDir, { id: 'endpoint:my_api', endpointId: 'my_api', type: 'Api' });
+  fs.writeFileSync(path.join(buildDir, 'api', 'notes.txt'), 'ignore me');
+  try {
+    const result = readBuildApiArtifacts(buildDir);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(expect.objectContaining({ endpointId: 'my_api', type: 'Api' }));
+  } finally {
+    fs.rmSync(buildDir, { recursive: true, force: true });
+  }
+});

--- a/packages/servers/server-dev/lib/server/readBuildApiArtifacts.test.mjs
+++ b/packages/servers/server-dev/lib/server/readBuildApiArtifacts.test.mjs
@@ -26,13 +26,11 @@ function makeBuildDir() {
 }
 
 // Mirror writeApi: each endpoint is serialized to build/api/<endpointId>.json.
+// Scoped module endpointIds contain a "/", so the file lands in a nested directory.
 function writeEndpoint(buildDir, endpoint) {
-  const apiDir = path.join(buildDir, 'api');
-  fs.mkdirSync(apiDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(apiDir, `${endpoint.endpointId}.json`),
-    serializer.serializeToString(endpoint)
-  );
+  const filePath = path.join(buildDir, 'api', `${endpoint.endpointId}.json`);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, serializer.serializeToString(endpoint));
 }
 
 test('readBuildApiArtifacts returns [] when the api directory does not exist', () => {
@@ -71,6 +69,24 @@ test('readBuildApiArtifacts reads and deserializes endpoint artifacts with endpo
         expect.objectContaining({ endpointId: 'internal_api', type: 'InternalApi' }),
       ])
     );
+  } finally {
+    fs.rmSync(buildDir, { recursive: true, force: true });
+  }
+});
+
+test('readBuildApiArtifacts reads scoped module endpoints from nested subdirectories', () => {
+  const buildDir = makeBuildDir();
+  // Top-level endpoint at build/api/top_api.json
+  writeEndpoint(buildDir, { id: 'endpoint:top_api', endpointId: 'top_api', type: 'Api' });
+  // Module endpoint at build/api/inviter/send-invite.json (scoped id contains "/")
+  writeEndpoint(buildDir, {
+    id: 'endpoint:inviter/send-invite',
+    endpointId: 'inviter/send-invite',
+    type: 'Api',
+  });
+  try {
+    const result = readBuildApiArtifacts(buildDir);
+    expect(result.map((c) => c.endpointId).sort()).toEqual(['inviter/send-invite', 'top_api']);
   } finally {
     fs.rmSync(buildDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Under `lowdefy dev`, every `CallAPI` action logged a false `[ConfigWarning] ... references non-existent endpoint "..."`, even when the endpoint was correctly defined under `api:` and worked at runtime. A full `lowdefy build` was unaffected.

The JIT page builder validates CallAPI references against `context.components.api`, but the dev server's `getBuildContext` rebuilds its context from disk artifacts. This PR restores the api endpoints from the persisted `build/api/*.json` artifacts so the dev-time checks (`validateCallApiRefs`) match a full build.

There were **two layers** to the bug:

1. **Top-level endpoints** — `getBuildContext` never restored `components.api`, so the endpoint set was always empty and every CallAPI was flagged.
2. **Module endpoints** — module endpoint ids are scoped with the module entry id (`<moduleId>/<endpointId>`), so `writeApi` writes them to a _nested_ path (`build/api/<moduleId>/<endpointId>.json`). The first version of the reader did a flat `readdirSync` and skipped subdirectories, so every module CallAPI was still flagged. The reader now walks the api directory recursively.

## Changes

- **@lowdefy/server-dev**
  - New `readBuildApiArtifacts` helper **recursively** reads and deserializes `build/api/**/*.json`; `getBuildContext` sets `context.components = { api: ... }` from it.
  - `validateCallApiRefs`' `non-existent endpoint` and `InternalApi`-not-client-callable checks now behave the same in dev as in a full build, for **both top-level and module endpoints**.
  - Returns `[]` when no endpoints exist (matching `components.api = []`), so a CallAPI to a genuinely missing endpoint still correctly warns.
- **@lowdefy/build** (test-only)
  - New `buildPageJitCallApi.integration.test.js`: a full-pipeline test (`shallowBuild` → real `build/api/*.json` on disk → `buildPageJit`) covering a top-level endpoint, a module endpoint resolved via `_module.endpointId`, and a genuinely-missing endpoint. This crosses the seam the existing unit test bypassed (it set `context.components.api` directly, so it could never catch the nested-path read).

## Notes

- **Fix at the source:** the nested `build/api/<moduleId>/...` layout is correct and is what the runtime executor reads by path; only the dev hydration's flat directory scan was wrong, so the reader was made recursive rather than changing the write path.
- No extra cache-invalidation work was needed: api endpoint files are skeleton sources, so editing one re-runs `shallowBuild`, which rewrites both `build/api/*.json` and `pageRegistry.json`; the new `pageRegistry.json` mtime resets the cached dev context.
- Patch changeset included for `@lowdefy/server-dev`.

## Follow-ups (pre-existing, not addressed here)

These predate this branch (in `develop` already) and are unverified code-reading observations:

- `buildPageJit` doesn't reset `context.callApiActionRefs` between page builds on the shared cached dev context, so refs accumulate across pages in a session (can mis-attribute/duplicate other CallAPI warnings; won't cause "non-existent" warnings).
- On the cached path, `buildPageIfNeeded` returns bare `true`, so `pageConfig._warnings` is never re-attached — warnings only show on a page's first build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
