### PR TITLE
Fix tiptap image upload URLs and PageHeaderMenu border alignment

### DIFF
--- a/.changeset/fix-pageheadermenu-menu-border.md
+++ b/.changeset/fix-pageheadermenu-menu-border.md
@@ -2,6 +2,6 @@
 '@lowdefy/blocks-antd': patch
 ---
 
-fix: PageHeaderMenu active menu item underline now sits on the header's bottom border.
+fix: PageHeaderMenu active menu item underline now sits exactly on the header's bottom border.
 
-The horizontal menu was vertically centered in the 64px header, so the active item's underline floated above the header's bottom border (two disconnected lines). The menu now fills the header height (`lineHeight: var(--ant-layout-header-height, 64px)`) so the active underline aligns with the header divider, matching the single-border look of Sider / PageSiderMenu.
+The horizontal menu was vertically centered in the header, so the active item's underline floated half a pixel above the header's bottom divider — two disconnected lines under the selected tab. The menu now reserves the header's 1px bottom border when sizing its line box, so the active underline lands precisely on the divider, forming a single continuous line across the full page width (including the logo) and matching the single-border look of Sider / PageSiderMenu.

--- a/.changeset/fix-tiptap-image-upload-double-slash.md
+++ b/.changeset/fix-tiptap-image-upload-double-slash.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/blocks-tiptap': patch
+---
+
+fix(blocks-tiptap): Fix broken image URLs when pasting or dropping images into the editor.
+
+Images pasted or dropped into `TiptapInput` and `TiptapMentionInput` produced a broken `src` containing a double slash between the S3 bucket host and the object key, so the image failed to load. The uploaded image URL is now constructed correctly.

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PageHeaderMenu/PageHeaderMenu.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PageHeaderMenu/PageHeaderMenu.js
@@ -123,14 +123,16 @@ const PageHeaderMenu = ({
                             properties.menuLg,
                           ])}
                           styles={{
-                            // Fill the header height so the active item's underline lands on the
-                            // header's bottom border (instead of floating above it), matching the
-                            // single-border look of Sider / PageSiderMenu. borderBottom is left to
-                            // the Header so the divider spans the full width, including the logo.
+                            // Size the menu's line box to the header height minus its 1px bottom
+                            // border, so the active item's underline lands exactly on that border
+                            // (antd offsets horizontal items down by 1px expecting the menu's own
+                            // border below them; reserving the border's 1px here makes the underline
+                            // and the header divider coincide as a single line). borderBottom is left
+                            // to the Header so the divider spans the full width, including the logo.
                             element: mergeObjects([
                               {
                                 borderBottom: 'none',
-                                lineHeight: 'var(--ant-layout-header-height, 64px)',
+                                lineHeight: 'calc(var(--ant-layout-header-height, 64px) - 1px)',
                               },
                               styles.menu,
                             ]),

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/s3FileUpload.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/s3FileUpload.js
@@ -40,7 +40,9 @@ async function s3FileUpload({ file, methods }) {
   formData.append('file', file);
 
   await fetch(url, { method: 'POST', body: formData });
-  file.url = `${url}/${key}`;
+  // createPresignedPost returns the bucket endpoint with a trailing slash, so only
+  // add a separator when it is missing to avoid a double slash before the key.
+  file.url = url.endsWith('/') ? `${url}${key}` : `${url}/${key}`;
   return file.url;
 }
 


### PR DESCRIPTION
## Summary

Two small, independent bug fixes in antd-based blocks. Images pasted or dropped into the TipTap editor produced broken (403) image URLs, and the PageHeaderMenu's active-tab underline didn't line up with the header's divider.

## Changes

- **@lowdefy/blocks-tiptap**: Images pasted/dropped into `TiptapInput` and `TiptapMentionInput` built their `src` by joining the presigned S3 url with the object key, producing a double slash when the url already ended in one (`…amazonaws.com//key`) — so S3 returned 403. The join now only inserts a separator when one is missing.
- **@lowdefy/blocks-antd**: `PageHeaderMenu`'s horizontal menu reserved the full header height, but the header's 1px bottom border left the selected item's underline 0.5px above the divider (two disconnected lines). The menu's line box now reserves that 1px, so the active underline lands exactly on the divider — a single continuous line across the page.

## Notes

Two unrelated fixes bundled on one branch (by request). Each ships its own changeset (`@lowdefy/blocks-tiptap` and `@lowdefy/blocks-antd`, both patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)