### PR TITLE
Opt-in label tooltips with icon, color and onTooltipClick event

### DIFF
--- a/.changeset/fix-label-tooltip.md
+++ b/.changeset/fix-label-tooltip.md
@@ -2,4 +2,16 @@
 '@lowdefy/blocks-antd': minor
 ---
 
-Label and input blocks no longer show an unwanted browser tooltip duplicating the label, which previously leaked raw HTML markup on hover when the label title contained HTML. Tooltips are now opt-in: set the new `tooltip` property (supports HTML) to show a help icon beside the label with an accessible Ant Design tooltip. This applies to all label-based inputs (ButtonSelector, Selector, CheckboxSelector, RadioSelector, etc.).
+Label and input blocks no longer show an unwanted browser tooltip duplicating the label, which previously leaked raw HTML markup on hover when the label title contained HTML.
+
+Tooltips are now opt-in via a new `tooltip` label property, which shows an icon beside the label with an accessible Ant Design tooltip. It accepts either a string (the tooltip text, supports HTML) or an object to also customize the icon and color:
+
+```yaml
+label:
+  tooltip:
+    title: More information # supports HTML
+    icon: AiOutlineInfoCircle # defaults to AiOutlineQuestionCircle
+    color: '#1677ff'
+```
+
+A new `onTooltipClick` event fires when the tooltip icon is clicked. This applies to the `Label` block and all label-based inputs (ButtonSelector, Selector, CheckboxSelector, RadioSelector, TextInput, etc.).

--- a/.changeset/fix-label-tooltip.md
+++ b/.changeset/fix-label-tooltip.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/blocks-antd': minor
+---
+
+Label and input blocks no longer show an unwanted browser tooltip duplicating the label, which previously leaked raw HTML markup on hover when the label title contained HTML. Tooltips are now opt-in: set the new `tooltip` property (supports HTML) to show a help icon beside the label with an accessible Ant Design tooltip. This applies to all label-based inputs (ButtonSelector, Selector, CheckboxSelector, RadioSelector, etc.).

--- a/packages/build/src/tests/success/30-multifile-pages-ref/snapshot.json
+++ b/packages/build/src/tests/success/30-multifile-pages-ref/snapshot.json
@@ -3763,6 +3763,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -4341,6 +4371,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -4484,6 +4531,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -4981,6 +5058,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/33-multifile-nested-refs/snapshot.json
+++ b/packages/build/src/tests/success/33-multifile-nested-refs/snapshot.json
@@ -5406,6 +5406,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -5984,6 +6014,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -8307,26 +8354,6 @@
       "lineNumber": 13,
       "path": "pages/settings.yaml"
     },
-    "pages.1.blocks.0": {
-      "parent": "pages.1",
-      "lineNumber": 6,
-      "path": "blocks/page-header.yaml"
-    },
-    "pages.1.blocks.1.blocks.0": {
-      "parent": "pages.1",
-      "lineNumber": 12,
-      "path": "components/form-field.yaml"
-    },
-    "pages.1.blocks.1.blocks.1": {
-      "parent": "pages.1",
-      "lineNumber": 17,
-      "path": "components/form-field.yaml"
-    },
-    "pages.1.blocks.2": {
-      "parent": "pages.1",
-      "lineNumber": 22,
-      "path": "blocks/page-footer.yaml"
-    },
     "pages.0.blocks.0": {
       "parent": "pages.0",
       "lineNumber": 6,
@@ -8345,6 +8372,26 @@
     "pages.0.blocks.2": {
       "parent": "pages.0",
       "lineNumber": 20,
+      "path": "blocks/page-footer.yaml"
+    },
+    "pages.1.blocks.0": {
+      "parent": "pages.1",
+      "lineNumber": 6,
+      "path": "blocks/page-header.yaml"
+    },
+    "pages.1.blocks.1.blocks.0": {
+      "parent": "pages.1",
+      "lineNumber": 12,
+      "path": "components/form-field.yaml"
+    },
+    "pages.1.blocks.1.blocks.1": {
+      "parent": "pages.1",
+      "lineNumber": 17,
+      "path": "components/form-field.yaml"
+    },
+    "pages.1.blocks.2": {
+      "parent": "pages.1",
+      "lineNumber": 22,
       "path": "blocks/page-footer.yaml"
     }
   },

--- a/packages/build/src/tests/success/34-crud-app-complete/snapshot.json
+++ b/packages/build/src/tests/success/34-crud-app-complete/snapshot.json
@@ -6001,6 +6001,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -6579,6 +6609,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
+++ b/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
@@ -3480,6 +3480,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -3902,6 +3932,23 @@
                       "value": "The switch value."
                     }
                   }
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -4027,6 +4074,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -4813,6 +4890,23 @@
                       "value": "The search input value."
                     }
                   }
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/39-global-state-app/snapshot.json
+++ b/packages/build/src/tests/success/39-global-state-app/snapshot.json
@@ -4292,6 +4292,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -5077,6 +5107,23 @@
                       "value": "The search input value."
                     }
                   }
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -5208,6 +5255,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -5631,6 +5708,23 @@
                       "value": "The switch value."
                     }
                   }
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/40-form-validation-app/snapshot.json
+++ b/packages/build/src/tests/success/40-form-validation-app/snapshot.json
@@ -4716,6 +4716,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -5294,6 +5324,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -5412,6 +5459,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -5876,6 +5953,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -6007,6 +6101,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -6503,6 +6627,23 @@
                     }
                   ],
                   "description": "Trigger actions when input is focused and enter is pressed."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -6634,6 +6775,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -7057,6 +7228,23 @@
                       "value": "The switch value."
                     }
                   }
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/41-list-crud-app/snapshot.json
+++ b/packages/build/src/tests/success/41-list-crud-app/snapshot.json
@@ -3903,6 +3903,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -4481,6 +4511,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -4612,6 +4659,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -5035,6 +5112,23 @@
                       "value": "The switch value."
                     }
                   }
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/43-wizard-flow-app/snapshot.json
+++ b/packages/build/src/tests/success/43-wizard-flow-app/snapshot.json
@@ -5275,6 +5275,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -5853,6 +5883,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/44-modal-drawer-app/snapshot.json
+++ b/packages/build/src/tests/success/44-modal-drawer-app/snapshot.json
@@ -4771,6 +4771,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -5349,6 +5379,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -5480,6 +5527,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -5903,6 +5980,23 @@
                       "value": "The switch value."
                     }
                   }
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/45-tabs-layout-app/snapshot.json
+++ b/packages/build/src/tests/success/45-tabs-layout-app/snapshot.json
@@ -5581,6 +5581,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -6159,6 +6189,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -6302,6 +6349,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -6799,6 +6876,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -6930,6 +7024,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -7353,6 +7477,23 @@
                       "value": "The switch value."
                     }
                   }
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -7484,6 +7625,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -7980,6 +8151,23 @@
                     }
                   ],
                   "description": "Trigger actions when input is focused and enter is pressed."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -8105,6 +8293,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -8891,6 +9109,23 @@
                       "value": "The search input value."
                     }
                   }
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/47-operators-comprehensive/snapshot.json
+++ b/packages/build/src/tests/success/47-operators-comprehensive/snapshot.json
@@ -4956,6 +4956,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -5378,6 +5408,23 @@
                       "value": "The switch value."
                     }
                   }
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -6398,6 +6445,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -6976,6 +7053,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -7417,6 +7511,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -7913,6 +8037,23 @@
                     }
                   ],
                   "description": "Trigger actions when input is focused and enter is pressed."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/48-events-actions-comprehensive/snapshot.json
+++ b/packages/build/src/tests/success/48-events-actions-comprehensive/snapshot.json
@@ -6041,6 +6041,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -6619,6 +6649,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/49-request-payload-app/snapshot.json
+++ b/packages/build/src/tests/success/49-request-payload-app/snapshot.json
@@ -5551,6 +5551,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -6129,6 +6159,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -6260,6 +6307,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -6756,6 +6833,23 @@
                     }
                   ],
                   "description": "Trigger actions when input is focused and enter is pressed."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -6881,6 +6975,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -7667,6 +7791,23 @@
                       "value": "The search input value."
                     }
                   }
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -7810,6 +7951,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -8307,6 +8478,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/52-skeleton-loading-app/snapshot.json
+++ b/packages/build/src/tests/success/52-skeleton-loading-app/snapshot.json
@@ -3723,6 +3723,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -4145,6 +4175,23 @@
                       "value": "The switch value."
                     }
                   }
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
+++ b/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
@@ -8191,6 +8191,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -8769,6 +8799,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -8894,6 +8941,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -9680,6 +9757,23 @@
                       "value": "The search input value."
                     }
                   }
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -10133,6 +10227,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -10630,6 +10754,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -10761,6 +10902,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -11257,6 +11428,23 @@
                     }
                   ],
                   "description": "Trigger actions when input is focused and enter is pressed."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -11388,6 +11576,36 @@
                 "title": {
                   "type": "string",
                   "description": "Label title - supports html."
+                },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "span": {
                   "type": "number",
@@ -11811,6 +12029,23 @@
                       "value": "The switch value."
                     }
                   }
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }
@@ -12514,6 +12749,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -12977,6 +13242,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/61-module-multi-instance/snapshot.json
+++ b/packages/build/src/tests/success/61-module-multi-instance/snapshot.json
@@ -4219,6 +4219,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -4797,6 +4827,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/71-cross-module-mutual-refs/snapshot.json
+++ b/packages/build/src/tests/success/71-cross-module-mutual-refs/snapshot.json
@@ -3614,6 +3614,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -4399,6 +4429,23 @@
                       "value": "The search input value."
                     }
                   }
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/78-cross-module-mutual-nested/snapshot.json
+++ b/packages/build/src/tests/success/78-cross-module-mutual-nested/snapshot.json
@@ -3607,6 +3607,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -4392,6 +4422,23 @@
                       "value": "The search input value."
                     }
                   }
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/82-cross-module-mutual-refs-reversed/snapshot.json
+++ b/packages/build/src/tests/success/82-cross-module-mutual-refs-reversed/snapshot.json
@@ -3614,6 +3614,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -4399,6 +4429,23 @@
                       "value": "The search input value."
                     }
                   }
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/build/src/tests/success/90-module-lazy-default-resolution/snapshot.json
+++ b/packages/build/src/tests/success/90-module-lazy-default-resolution/snapshot.json
@@ -3739,6 +3739,36 @@
                   "type": "string",
                   "description": "Label title - supports html."
                 },
+                "tooltip": {
+                  "description": "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Tooltip text shown on hover - supports html."
+                        },
+                        "icon": {
+                          "type": "string",
+                          "default": "AiOutlineQuestionCircle",
+                          "description": "Name of the icon to show beside the label."
+                        },
+                        "color": {
+                          "type": "string",
+                          "description": "Color of the tooltip icon.",
+                          "docs": {
+                            "displayType": "color"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
                 "span": {
                   "type": "number",
                   "description": "Label inline span."
@@ -4317,6 +4347,23 @@
                     }
                   ],
                   "description": "Trigger action when enter is pressed while text input is focused."
+                },
+                "onTooltipClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the tooltip icon is clicked."
                 }
               }
             }

--- a/packages/plugins/blocks/blocks-antd/src/blocks/AutoComplete/AutoComplete.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/AutoComplete/AutoComplete.js
@@ -40,6 +40,7 @@ const AutoCompleteInput = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={components}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/AutoComplete/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/AutoComplete/meta.js
@@ -49,6 +49,7 @@ export default {
       description: 'Called when searching items.',
       event: { value: 'The search input value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/ButtonSelector/ButtonSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/ButtonSelector/ButtonSelector.js
@@ -113,6 +113,7 @@ const ButtonSelector = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={components}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/ButtonSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/ButtonSelector/meta.js
@@ -35,6 +35,7 @@ export default {
       description: 'Trigger actions when selection is changed.',
       event: { value: 'The selected value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/CheckboxSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/CheckboxSelector.js
@@ -102,6 +102,7 @@ const CheckboxSelector = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={components}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/meta.js
@@ -35,6 +35,7 @@ export default {
       description: 'Trigger actions when selection is changed.',
       event: { value: 'The selected value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSwitch/CheckboxSwitch.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSwitch/CheckboxSwitch.js
@@ -55,6 +55,7 @@ const CheckboxSwitch = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={components}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSwitch/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSwitch/meta.js
@@ -15,6 +15,7 @@
 */
 
 import LabelMeta from '../Label/meta.js';
+import tooltip from '../../schemas/labelTooltip.js';
 
 export default {
   category: 'input',
@@ -31,6 +32,7 @@ export default {
       description: 'Trigger actions when selection is changed.',
       event: { value: 'The checkbox value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',
@@ -76,6 +78,7 @@ export default {
             type: 'string',
             description: 'Label title - supports html.',
           },
+          tooltip,
           span: {
             type: 'number',
             description: 'Label inline span.',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/ColorSelector/ColorSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/ColorSelector/ColorSelector.js
@@ -38,6 +38,7 @@ const ColorSelectorInput = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={components}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/ColorSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/ColorSelector/meta.js
@@ -45,6 +45,7 @@ export default {
       description: 'Trigger actions when the color picker popup open state changes.',
       event: { open: 'Whether the popup is open.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/DateRangeSelector/DateRangeSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/DateRangeSelector/DateRangeSelector.js
@@ -52,6 +52,7 @@ const DateRangeSelector = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={{ Icon }}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/DateRangeSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/DateRangeSelector/meta.js
@@ -43,6 +43,7 @@ export default {
       description: 'Trigger actions when selection is changed.',
       event: { value: 'The selected date range value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/DateSelector/DateSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/DateSelector/DateSelector.js
@@ -44,6 +44,7 @@ const DateSelector = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={{ Icon }}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/DateSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/DateSelector/meta.js
@@ -44,6 +44,7 @@ export default {
       description: 'Trigger actions when selection is changed.',
       event: { value: 'The selected date value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/DateTimeSelector/DateTimeSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/DateTimeSelector/DateTimeSelector.js
@@ -63,6 +63,7 @@ const DateTimeSelector = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={{ Icon }}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/DateTimeSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/DateTimeSelector/meta.js
@@ -44,6 +44,7 @@ export default {
       description: 'Trigger actions when selection is changed.',
       event: { value: 'The selected date-time value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Label/Label.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Label/Label.js
@@ -19,6 +19,7 @@
 
 import React from 'react';
 import { renderHtml, withBlockDefaults } from '@lowdefy/block-utils';
+import { type } from '@lowdefy/helpers';
 import { Col, Row, Tooltip } from 'antd';
 import classNames from 'classnames';
 import CSSMotion from '@rc-component/motion';
@@ -38,6 +39,7 @@ const Label = ({
   classNames: blockClassNames = {},
   components: { Icon },
   content,
+  methods,
   properties,
   required,
   styles = {},
@@ -77,19 +79,30 @@ const Label = ({
       </span>
     ) : null;
 
+  // tooltip is either a string (the tooltip text) or an object that also
+  // customizes the icon and color. The onClick is exposed as the block's
+  // onTooltipClick event, not a property.
+  const tooltip = type.isString(properties.tooltip)
+    ? { title: properties.tooltip }
+    : properties.tooltip;
+
   return (
     <Row id={blockId} className={rowClassName} style={rowStyle}>
       {label && (
         <Col {...labelCol} className={labelColClassName} style={labelColStyle}>
           <label htmlFor={`${blockId}_input`} className={labelClassName} style={labelStyle}>
             {renderHtml({ html: label })}
-            {properties.tooltip && (
-              <Tooltip title={renderHtml({ html: properties.tooltip })}>
+            {tooltip && (
+              <Tooltip title={tooltip.title ? renderHtml({ html: tooltip.title }) : undefined}>
                 <span
                   className="ldf-label-tooltip"
-                  style={{ marginInlineStart: 4, cursor: 'help' }}
+                  style={{ marginInlineStart: 4, cursor: 'pointer', color: tooltip.color }}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    methods?.triggerEvent({ name: 'onTooltipClick' });
+                  }}
                 >
-                  <Icon properties="AiOutlineQuestionCircle" />
+                  <Icon properties={tooltip.icon ?? 'AiOutlineQuestionCircle'} />
                 </span>
               </Tooltip>
             )}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Label/Label.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Label/Label.js
@@ -19,7 +19,7 @@
 
 import React from 'react';
 import { renderHtml, withBlockDefaults } from '@lowdefy/block-utils';
-import { Col, Row } from 'antd';
+import { Col, Row, Tooltip } from 'antd';
 import classNames from 'classnames';
 import CSSMotion from '@rc-component/motion';
 
@@ -81,13 +81,18 @@ const Label = ({
     <Row id={blockId} className={rowClassName} style={rowStyle}>
       {label && (
         <Col {...labelCol} className={labelColClassName} style={labelColStyle}>
-          <label
-            htmlFor={`${blockId}_input`}
-            className={labelClassName}
-            style={labelStyle}
-            title={label}
-          >
+          <label htmlFor={`${blockId}_input`} className={labelClassName} style={labelStyle}>
             {renderHtml({ html: label })}
+            {properties.tooltip && (
+              <Tooltip title={renderHtml({ html: properties.tooltip })}>
+                <span
+                  className="ldf-label-tooltip"
+                  style={{ marginInlineStart: 4, cursor: 'help' }}
+                >
+                  <Icon properties="AiOutlineQuestionCircle" />
+                </span>
+              </Tooltip>
+            )}
           </label>
         </Col>
       )}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Label/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Label/meta.js
@@ -16,7 +16,13 @@
 
 export default {
   category: 'container',
-  icons: ['AiFillCloseCircle', 'AiFillCheckCircle', 'AiOutlineLoading', 'AiFillExclamationCircle'],
+  icons: [
+    'AiFillCloseCircle',
+    'AiFillCheckCircle',
+    'AiOutlineLoading',
+    'AiFillExclamationCircle',
+    'AiOutlineQuestionCircle',
+  ],
   valueType: null,
   slots: {
     content: 'The labeled input or content blocks.',
@@ -60,6 +66,10 @@ export default {
       title: {
         type: 'string',
         description: 'Label title - supports html.',
+      },
+      tooltip: {
+        type: 'string',
+        description: 'Help tooltip shown via a question icon beside the label - supports html.',
       },
       span: {
         type: 'number',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Label/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Label/meta.js
@@ -14,8 +14,13 @@
   limitations under the License.
 */
 
+import tooltip from '../../schemas/labelTooltip.js';
+
 export default {
   category: 'container',
+  events: {
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
+  },
   icons: [
     'AiFillCloseCircle',
     'AiFillCheckCircle',
@@ -67,10 +72,7 @@ export default {
         type: 'string',
         description: 'Label title - supports html.',
       },
-      tooltip: {
-        type: 'string',
-        description: 'Help tooltip shown via a question icon beside the label - supports html.',
-      },
+      tooltip,
       span: {
         type: 'number',
         description: 'Label inline span.',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Label/tests/Label.e2e.spec.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Label/tests/Label.e2e.spec.js
@@ -79,12 +79,8 @@ test.describe('Label Block', () => {
     const block = getBlock(page, 'label_disabled');
     await expect(block).toBeVisible();
 
-    // When disabled, Label doesn't render the outer label element
-    // Only the nested content's label (from TextInput) should be present
-    // Check the outer Label's element count is 0 by checking for title attribute
-    const outerLabel = getLabel(page, 'label_disabled').locator(
-      'label[title="This Should Not Appear"]'
-    );
+    // When disabled, Label renders no <label> element of its own.
+    const outerLabel = getLabel(page, 'label_disabled').locator('> div > label');
     await expect(outerLabel).toHaveCount(0);
   });
 

--- a/packages/plugins/blocks/blocks-antd/src/blocks/MonthSelector/MonthSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/MonthSelector/MonthSelector.js
@@ -44,6 +44,7 @@ const MonthSelector = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={{ Icon }}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/MonthSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/MonthSelector/meta.js
@@ -43,6 +43,7 @@ export default {
       description: 'Trigger actions when selection is changed.',
       event: { value: 'The selected month value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/MultipleSelector/MultipleSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/MultipleSelector/MultipleSelector.js
@@ -83,6 +83,7 @@ const MultipleSelector = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={{ Icon }}
       properties={{ title: properties.title, size: properties.size, ...properties.label }}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/MultipleSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/MultipleSelector/meta.js
@@ -52,6 +52,7 @@ export default {
       description: 'Trigger actions when input is changed.',
       event: { value: 'The search input value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/NumberInput/NumberInput.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/NumberInput/NumberInput.js
@@ -38,6 +38,7 @@ const NumberInput = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={components}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/NumberInput/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/NumberInput/meta.js
@@ -42,6 +42,7 @@ export default {
     },
     onFocus: 'Trigger action when number input gets focus.',
     onPressEnter: 'Trigger actions when input is focused and enter is pressed.',
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PasswordInput/PasswordInput.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PasswordInput/PasswordInput.js
@@ -37,6 +37,7 @@ const PasswordInput = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={components}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PasswordInput/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PasswordInput/meta.js
@@ -44,6 +44,7 @@ export default {
     },
     onFocus: 'Trigger action when text input gets focus.',
     onPressEnter: 'Trigger action when enter is pressed while text input is focused.',
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PhoneNumberInput/PhoneNumberInput.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PhoneNumberInput/PhoneNumberInput.js
@@ -171,6 +171,7 @@ const PhoneNumberInput = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={{ Icon, Link }}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PhoneNumberInput/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PhoneNumberInput/meta.js
@@ -54,6 +54,7 @@ export default {
     onBlur: 'Trigger action event occurs when input loses focus.',
     onFocus: 'Trigger action when input gets focus.',
     onPressEnter: 'Trigger action when enter is pressed while text input is focused.',
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/RadioSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/RadioSelector.js
@@ -97,6 +97,7 @@ const RadioSelector = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={components}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/meta.js
@@ -35,6 +35,7 @@ export default {
       description: 'Trigger action when selection is changed.',
       event: { value: 'The selected value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/RatingSlider/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/RatingSlider/meta.js
@@ -36,6 +36,7 @@ export default {
       description: 'Trigger action when rating is changed.',
       event: { value: 'The selected rating value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/SegmentedSelector/SegmentedSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/SegmentedSelector/SegmentedSelector.js
@@ -41,6 +41,7 @@ const SegmentedSelector = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={{ Icon }}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/SegmentedSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/SegmentedSelector/meta.js
@@ -35,6 +35,7 @@ export default {
       description: 'Trigger actions when selection is changed.',
       event: { value: 'The selected value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Selector/Selector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Selector/Selector.js
@@ -62,6 +62,7 @@ const Selector = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={{ Icon, Link }}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Selector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Selector/meta.js
@@ -54,6 +54,7 @@ export default {
       description: 'Trigger actions when input is changed.',
       event: { value: 'The search input value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Slider/Slider.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Slider/Slider.js
@@ -37,6 +37,7 @@ const SliderBlock = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={{ Icon, Link }}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Slider/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Slider/meta.js
@@ -31,6 +31,7 @@ export default {
       description: 'Trigger action when the slider value changes.',
       event: { value: 'The current slider value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Switch/Switch.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Switch/Switch.js
@@ -93,6 +93,7 @@ const SwitchBlock = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={{ Icon, Link }}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Switch/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Switch/meta.js
@@ -36,6 +36,7 @@ export default {
       description: 'Trigger action when switch is changed.',
       event: { value: 'The switch value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TextArea/TextArea.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TextArea/TextArea.js
@@ -41,6 +41,7 @@ const TextAreaBlock = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={components}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TextArea/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TextArea/meta.js
@@ -45,6 +45,7 @@ export default {
     },
     onFocus: 'Trigger action when text input gets focus.',
     onPressEnter: 'Trigger action when enter is pressed while text input is focused.',
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TextInput/TextInput.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TextInput/TextInput.js
@@ -38,6 +38,7 @@ const TextInput = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={{ Icon, Link }}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TextInput/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TextInput/meta.js
@@ -47,6 +47,7 @@ export default {
     },
     onFocus: 'Trigger action when text input gets focus.',
     onPressEnter: 'Trigger action when enter is pressed while text input is focused.',
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TreeMultipleSelector/TreeMultipleSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TreeMultipleSelector/TreeMultipleSelector.js
@@ -61,6 +61,7 @@ const TreeMultipleSelector = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={{ Icon }}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TreeMultipleSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TreeMultipleSelector/meta.js
@@ -55,6 +55,7 @@ export default {
       description: 'Trigger action when the search input changes.',
       event: { value: 'The search input value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TreeSelector/TreeSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TreeSelector/TreeSelector.js
@@ -51,6 +51,7 @@ const TreeSelector = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={{ Icon }}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TreeSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TreeSelector/meta.js
@@ -55,6 +55,7 @@ export default {
       description: 'Trigger action when the search input changes.',
       event: { value: 'The search input value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/WeekSelector/WeekSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/WeekSelector/WeekSelector.js
@@ -48,6 +48,7 @@ const WeekSelector = ({
   return (
     <Label
       blockId={blockId}
+      methods={methods}
       classNames={classNames}
       components={{ Icon, Link }}
       events={events}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/WeekSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/WeekSelector/meta.js
@@ -44,6 +44,7 @@ export default {
       description: 'Trigger action when week is changed.',
       event: { value: 'The selected week value.' },
     },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
   properties: {
     type: 'object',

--- a/packages/plugins/blocks/blocks-antd/src/schemas/label.js
+++ b/packages/plugins/blocks/blocks-antd/src/schemas/label.js
@@ -14,6 +14,8 @@
   limitations under the License.
 */
 
+import tooltip from './labelTooltip.js';
+
 export default {
   type: 'object',
   description: 'Label properties.',
@@ -38,6 +40,7 @@ export default {
       type: 'string',
       description: 'Label title - supports html.',
     },
+    tooltip,
     span: {
       type: 'number',
       description: 'Label inline span.',

--- a/packages/plugins/blocks/blocks-antd/src/schemas/labelTooltip.js
+++ b/packages/plugins/blocks/blocks-antd/src/schemas/labelTooltip.js
@@ -1,0 +1,47 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+export default {
+  description:
+    "Help tooltip shown via an icon beside the label. A string sets the tooltip text (supports html), or an object to also customize the icon and color. Use the block's onTooltipClick event to respond to clicks on the icon.",
+  oneOf: [
+    {
+      type: 'string',
+    },
+    {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        title: {
+          type: 'string',
+          description: 'Tooltip text shown on hover - supports html.',
+        },
+        icon: {
+          type: 'string',
+          default: 'AiOutlineQuestionCircle',
+          description: 'Name of the icon to show beside the label.',
+        },
+        color: {
+          type: 'string',
+          description: 'Color of the tooltip icon.',
+          docs: {
+            displayType: 'color',
+          },
+        },
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

The shared `Label` component hardcoded the native HTML `title` attribute to the label text. Because Lowdefy labels support HTML, passing markup as a label leaked raw `<span ...>` markup into the browser's hover tooltip, and a redundant native tooltip appeared even for plain labels — affecting every label-based input.

This removes the auto-generated native tooltip and replaces it with an opt-in, accessible tooltip following the Ant Design `Form.Item` convention: an icon beside the label wrapped in antd's `<Tooltip>`. The `tooltip` property accepts a string (the text) or an object that also customizes the icon and color, and a new `onTooltipClick` event fires when the icon is clicked.

## Changes

- **@lowdefy/blocks-antd**:
  - `Label` no longer sets the native `title` attribute (an accessibility anti-pattern and the source of the markup leak).
  - New opt-in `tooltip` label property — `string` (text, supports HTML) or `object { title, icon, color }`. Renders an icon (default `AiOutlineQuestionCircle`) in an antd `<Tooltip>`.
  - New `onTooltipClick` block event, fired from the tooltip icon via `methods.triggerEvent`.
  - Applies to the `Label` block and all 24 label-based inputs (ButtonSelector, Selector, CheckboxSelector, RadioSelector, TextInput, etc.).

## Key Files

- `packages/plugins/blocks/blocks-antd/src/blocks/Label/Label.js` — Removes native `title`; normalizes `tooltip` (string|object), renders icon + color in an antd `<Tooltip>`, wires icon click to `onTooltipClick`.
- `packages/plugins/blocks/blocks-antd/src/schemas/labelTooltip.js` — New shared `oneOf` schema fragment (string | object) reused across label schemas.
- `packages/plugins/blocks/blocks-antd/src/schemas/label.js` — Imports the shared `tooltip` fragment (covers 21 inputs).
- 24 input block `*.js` files — Pass `methods={methods}` to their internal `<Label>` so `onTooltipClick` fires on the right block; `meta.js` documents the event.

## Notes

- Behavior change: labels no longer show a native browser tooltip duplicating the label text. Tooltips are now opt-in via the `tooltip` property.
- `ColorSelector` has no `label` property in its schema today (pre-existing gap), so it cannot use `label.tooltip`. Left as-is rather than expanding its API.