### PR TITLE
feat: Support running multiple dev apps

### DIFF
--- a/.changeset/feat-multi-app-dev.md
+++ b/.changeset/feat-multi-app-dev.md
@@ -1,0 +1,33 @@
+---
+'@lowdefy/api': minor
+'@lowdefy/build': minor
+'@lowdefy/server-dev': minor
+'lowdefy': minor
+---
+
+feat: Support running multiple dev apps side by side.
+
+Running several Lowdefy dev servers on `localhost` previously clashed on
+ports and shared a single auth cookie jar (browsers scope cookies by host,
+not port), so logging into one app logged you out of another. Three changes
+make concurrent dev apps work:
+
+- **Per-app auth cookies.** Cookie names are now resolved through a
+  precedence chain: an explicit `auth.advanced.cookies` is used verbatim;
+  otherwise an explicit `auth.advanced.cookiePrefix` namespaces the cookie
+  names (dev and prod); otherwise the dev server derives a prefix from the
+  app `slug`/`name` so each app gets its own cookie jar. Production with no
+  config is unchanged (NextAuth defaults). The schema gains an optional
+  `auth.advanced.cookiePrefix` string.
+
+- **Automatic port selection.** The CLI now finds the next available port
+  instead of erroring when the requested port is in use, warning which port
+  it landed on.
+
+- **NEXTAUTH_URL reconciliation.** The dev server defaults an unset
+  `NEXTAUTH_URL` to match the port it actually bound to, so OAuth callbacks
+  and sign-in redirects target the right origin. A pinned `NEXTAUTH_URL` on
+  a mismatched port is left untouched but warned about.
+
+Set the same `cookiePrefix` on two apps to intentionally share an auth
+session in dev.

--- a/packages/api/src/routes/auth/createPrefixedCookies.js
+++ b/packages/api/src/routes/auth/createPrefixedCookies.js
@@ -1,0 +1,66 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+function slugifyPrefix(value) {
+  return String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+// Mirrors next-auth's defaultCookies (next-auth/core/lib/cookie.js) but injects an
+// app-specific prefix into each cookie name so multiple apps on the same host do not
+// share a cookie jar (browsers do not scope cookies by port).
+function createPrefixedCookies({ prefix, useSecureCookies }) {
+  const securePrefix = useSecureCookies ? '__Secure-' : '';
+  const hostPrefix = useSecureCookies ? '__Host-' : '';
+  const baseOptions = () => ({
+    httpOnly: true,
+    sameSite: 'lax',
+    path: '/',
+    secure: useSecureCookies,
+  });
+  return {
+    sessionToken: {
+      name: `${securePrefix}${prefix}.next-auth.session-token`,
+      options: baseOptions(),
+    },
+    callbackUrl: {
+      name: `${securePrefix}${prefix}.next-auth.callback-url`,
+      options: baseOptions(),
+    },
+    csrfToken: {
+      name: `${hostPrefix}${prefix}.next-auth.csrf-token`,
+      options: baseOptions(),
+    },
+    pkceCodeVerifier: {
+      name: `${securePrefix}${prefix}.next-auth.pkce.code_verifier`,
+      options: { ...baseOptions(), maxAge: 60 * 15 },
+    },
+    state: {
+      name: `${securePrefix}${prefix}.next-auth.state`,
+      options: { ...baseOptions(), maxAge: 60 * 15 },
+    },
+    nonce: {
+      name: `${securePrefix}${prefix}.next-auth.nonce`,
+      options: baseOptions(),
+    },
+  };
+}
+
+export { slugifyPrefix };
+export default createPrefixedCookies;

--- a/packages/api/src/routes/auth/createPrefixedCookies.test.js
+++ b/packages/api/src/routes/auth/createPrefixedCookies.test.js
@@ -1,0 +1,63 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import createPrefixedCookies, { slugifyPrefix } from './createPrefixedCookies.js';
+
+test('slugifyPrefix lowercases, replaces non-alphanumeric runs, and trims dashes', () => {
+  expect(slugifyPrefix('My App')).toBe('my-app');
+  expect(slugifyPrefix('  Foo__Bar!! ')).toBe('foo-bar');
+  expect(slugifyPrefix('already-slug')).toBe('already-slug');
+});
+
+test('createPrefixedCookies injects the prefix into all six cookie names without secure prefixes', () => {
+  const cookies = createPrefixedCookies({ prefix: 'ld-myapp', useSecureCookies: false });
+  expect(cookies.sessionToken.name).toBe('ld-myapp.next-auth.session-token');
+  expect(cookies.callbackUrl.name).toBe('ld-myapp.next-auth.callback-url');
+  expect(cookies.csrfToken.name).toBe('ld-myapp.next-auth.csrf-token');
+  expect(cookies.pkceCodeVerifier.name).toBe('ld-myapp.next-auth.pkce.code_verifier');
+  expect(cookies.state.name).toBe('ld-myapp.next-auth.state');
+  expect(cookies.nonce.name).toBe('ld-myapp.next-auth.nonce');
+});
+
+test('createPrefixedCookies applies __Secure- and __Host- prefixes when secure', () => {
+  const cookies = createPrefixedCookies({ prefix: 'ld-myapp', useSecureCookies: true });
+  expect(cookies.sessionToken.name).toBe('__Secure-ld-myapp.next-auth.session-token');
+  expect(cookies.csrfToken.name).toBe('__Host-ld-myapp.next-auth.csrf-token');
+  expect(cookies.nonce.name).toBe('__Secure-ld-myapp.next-auth.nonce');
+});
+
+test('createPrefixedCookies sets options matching next-auth defaults', () => {
+  const cookies = createPrefixedCookies({ prefix: 'p', useSecureCookies: true });
+  expect(cookies.sessionToken.options).toEqual({
+    httpOnly: true,
+    sameSite: 'lax',
+    path: '/',
+    secure: true,
+  });
+  expect(cookies.pkceCodeVerifier.options).toEqual({
+    httpOnly: true,
+    sameSite: 'lax',
+    path: '/',
+    secure: true,
+    maxAge: 60 * 15,
+  });
+  expect(cookies.state.options.maxAge).toBe(60 * 15);
+});
+
+test('createPrefixedCookies returns a fresh options object per cookie', () => {
+  const cookies = createPrefixedCookies({ prefix: 'p', useSecureCookies: false });
+  expect(cookies.sessionToken.options).not.toBe(cookies.callbackUrl.options);
+});

--- a/packages/api/src/routes/auth/getNextAuthConfig.js
+++ b/packages/api/src/routes/auth/getNextAuthConfig.js
@@ -22,11 +22,12 @@ import createCallbacks from './callbacks/createCallbacks.js';
 import createEvents from './events/createEvents.js';
 import createLogger from './createLogger.js';
 import createProviders from './createProviders.js';
+import resolveCookies from './resolveCookies.js';
 
 const nextAuthConfig = {};
 let initialized = false;
 
-function getNextAuthConfig({ appMeta, authJson, logger, plugins, secrets }) {
+function getNextAuthConfig({ appMeta, authJson, dev, logger, plugins, secrets }) {
   if (initialized) return nextAuthConfig;
 
   const operatorsParser = new ServerParser({
@@ -55,7 +56,7 @@ function getNextAuthConfig({ appMeta, authJson, logger, plugins, secrets }) {
   nextAuthConfig.pages = authConfig.authPages;
   nextAuthConfig.session = authConfig.session;
   nextAuthConfig.theme = authConfig.theme;
-  nextAuthConfig.cookies = authConfig?.advanced?.cookies;
+  nextAuthConfig.cookies = resolveCookies({ appMeta, authConfig, dev });
   nextAuthConfig.originalRedirectCallback = nextAuthConfig.callbacks.redirect;
   initialized = true;
   return nextAuthConfig;

--- a/packages/api/src/routes/auth/resolveCookies.js
+++ b/packages/api/src/routes/auth/resolveCookies.js
@@ -1,0 +1,39 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { type } from '@lowdefy/helpers';
+
+import createPrefixedCookies, { slugifyPrefix } from './createPrefixedCookies.js';
+
+// Cookie name resolution, in order of precedence:
+//   1. An explicit `auth.advanced.cookies` object is used verbatim.
+//   2. An explicit `auth.advanced.cookiePrefix` namespaces cookie names (dev and prod).
+//   3. When running the dev server, derive a prefix from the app slug/name so multiple
+//      apps on localhost do not share a cookie jar (browsers do not scope cookies by
+//      port). Production is left untouched, returning undefined for NextAuth defaults.
+function resolveCookies({ appMeta, authConfig, dev }) {
+  const explicitCookies = authConfig?.advanced?.cookies;
+  if (!type.isNone(explicitCookies)) return explicitCookies;
+
+  const devPrefix = dev ? slugifyPrefix(appMeta?.slug ?? appMeta?.name ?? '') : '';
+  const prefix = authConfig?.advanced?.cookiePrefix ?? (devPrefix === '' ? undefined : devPrefix);
+  if (type.isNone(prefix) || prefix === '') return undefined;
+
+  const useSecureCookies = process.env.NEXTAUTH_URL?.startsWith('https://') ?? false;
+  return createPrefixedCookies({ prefix, useSecureCookies });
+}
+
+export default resolveCookies;

--- a/packages/api/src/routes/auth/resolveCookies.test.js
+++ b/packages/api/src/routes/auth/resolveCookies.test.js
@@ -1,0 +1,96 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import resolveCookies from './resolveCookies.js';
+
+const originalNextAuthUrl = process.env.NEXTAUTH_URL;
+
+afterEach(() => {
+  if (originalNextAuthUrl === undefined) {
+    delete process.env.NEXTAUTH_URL;
+  } else {
+    process.env.NEXTAUTH_URL = originalNextAuthUrl;
+  }
+});
+
+test('resolveCookies returns undefined in production with no config (NextAuth defaults)', () => {
+  const result = resolveCookies({
+    appMeta: { slug: 'my-app', name: 'My App' },
+    authConfig: {},
+    dev: false,
+  });
+  expect(result).toBeUndefined();
+});
+
+test('resolveCookies uses an explicit cookies object verbatim, even in dev', () => {
+  const cookies = { sessionToken: { name: 'custom', options: {} } };
+  const result = resolveCookies({
+    appMeta: { slug: 'my-app' },
+    authConfig: { advanced: { cookies } },
+    dev: true,
+  });
+  expect(result).toBe(cookies);
+});
+
+test('resolveCookies prefixes from app slug when running the dev server', () => {
+  delete process.env.NEXTAUTH_URL;
+  const result = resolveCookies({
+    appMeta: { slug: 'my-app', name: 'My App' },
+    authConfig: {},
+    dev: true,
+  });
+  expect(result.sessionToken.name).toBe('my-app.next-auth.session-token');
+});
+
+test('resolveCookies falls back to app name when slug is missing in dev', () => {
+  delete process.env.NEXTAUTH_URL;
+  const result = resolveCookies({
+    appMeta: { name: 'My App' },
+    authConfig: {},
+    dev: true,
+  });
+  expect(result.sessionToken.name).toBe('my-app.next-auth.session-token');
+});
+
+test('resolveCookies returns undefined in dev when app has no slug or name', () => {
+  const result = resolveCookies({
+    appMeta: {},
+    authConfig: {},
+    dev: true,
+  });
+  expect(result).toBeUndefined();
+});
+
+test('resolveCookies honors an explicit cookiePrefix even outside dev', () => {
+  delete process.env.NEXTAUTH_URL;
+  const result = resolveCookies({
+    appMeta: { slug: 'my-app' },
+    authConfig: { advanced: { cookiePrefix: 'custom' } },
+    dev: false,
+  });
+  expect(result.sessionToken.name).toBe('custom.next-auth.session-token');
+});
+
+test('resolveCookies applies secure prefixes when NEXTAUTH_URL is https', () => {
+  process.env.NEXTAUTH_URL = 'https://example.com';
+  const result = resolveCookies({
+    appMeta: { slug: 'my-app' },
+    authConfig: { advanced: { cookiePrefix: 'custom' } },
+    dev: false,
+  });
+  expect(result.sessionToken.name).toBe('__Secure-custom.next-auth.session-token');
+  expect(result.csrfToken.name).toBe('__Host-custom.next-auth.csrf-token');
+});

--- a/packages/build/src/lowdefySchema.js
+++ b/packages/build/src/lowdefySchema.js
@@ -292,6 +292,9 @@ export default {
         advanced: {
           type: 'object',
           properties: {
+            cookiePrefix: {
+              type: 'string',
+            },
             cookies: {
               type: 'object',
             },

--- a/packages/cli/src/commands/dev/dev.js
+++ b/packages/cli/src/commands/dev/dev.js
@@ -15,7 +15,7 @@
 */
 
 import addCustomPluginsAsDeps from '../../utils/addCustomPluginsAsDeps.js';
-import checkPortAvailable from '../../utils/checkPortAvailable.js';
+import findAvailablePort from '../../utils/findAvailablePort.js';
 import installServer from '../../utils/installServer.js';
 import resetServerPackageJson from '../../utils/resetServerPackageJson.js';
 import runDevServer from './runDevServer.js';
@@ -24,7 +24,11 @@ import getServer from '../../utils/getServer.js';
 async function dev({ context }) {
   const directory = context.directories.dev;
   context.logger.info('Starting development server.');
-  await checkPortAvailable({ port: context.options.port });
+  const port = await findAvailablePort({ port: context.options.port });
+  if (port !== context.options.port) {
+    context.logger.warn(`Port ${context.options.port} is in use, using port ${port} instead.`);
+    context.options.port = port;
+  }
   await getServer({ context, packageName: '@lowdefy/server-dev', directory });
   await resetServerPackageJson({ context, directory });
   await addCustomPluginsAsDeps({ context, directory });

--- a/packages/cli/src/utils/findAvailablePort.js
+++ b/packages/cli/src/utils/findAvailablePort.js
@@ -1,0 +1,47 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import net from 'net';
+
+function isPortAvailable(port) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', (error) => {
+      if (error.code === 'EADDRINUSE') {
+        resolve(false);
+      } else {
+        reject(error);
+      }
+    });
+    server.listen(port, () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+async function findAvailablePort({ port, maxAttempts = 100 }) {
+  const startPort = Number(port);
+  for (let candidate = startPort; candidate < startPort + maxAttempts; candidate += 1) {
+    if (await isPortAvailable(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    `[Server Error] No available port found in range ${startPort}-${startPort + maxAttempts - 1}.`
+  );
+}
+
+export default findAvailablePort;

--- a/packages/cli/src/utils/findAvailablePort.test.js
+++ b/packages/cli/src/utils/findAvailablePort.test.js
@@ -1,0 +1,70 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import net from 'net';
+import findAvailablePort from './findAvailablePort.js';
+
+function listen(port) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(port, () => resolve(server));
+  });
+}
+
+function close(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+test('findAvailablePort returns the requested port when it is free', async () => {
+  const free = await getFreePort();
+  const port = await findAvailablePort({ port: free });
+  expect(port).toBe(free);
+});
+
+test('findAvailablePort increments past a busy port to the next free one', async () => {
+  const free = await getFreePort();
+  const server = await listen(free);
+  try {
+    const port = await findAvailablePort({ port: free });
+    expect(port).toBeGreaterThan(free);
+  } finally {
+    await close(server);
+  }
+});
+
+test('findAvailablePort throws when no port is free within maxAttempts', async () => {
+  const free = await getFreePort();
+  const server = await listen(free);
+  try {
+    await expect(findAvailablePort({ port: free, maxAttempts: 1 })).rejects.toThrow(
+      'No available port found'
+    );
+  } finally {
+    await close(server);
+  }
+});

--- a/packages/servers/server-dev/lib/server/auth/getAuthOptions.js
+++ b/packages/servers/server-dev/lib/server/auth/getAuthOptions.js
@@ -23,8 +23,10 @@ import callbacks from '../../../build/plugins/auth/callbacks.js';
 import events from '../../../build/plugins/auth/events.js';
 import providers from '../../../build/plugins/auth/providers.js';
 
-function getAuthOptions({ logger }) {
+function getAuthOptions({ appMeta, logger }) {
   return getNextAuthConfig({
+    appMeta,
+    dev: true,
     authJson,
     logger,
     plugins: { adapters, callbacks, events, providers },

--- a/packages/servers/server-dev/manager/processes/reconcileNextAuthUrl.mjs
+++ b/packages/servers/server-dev/manager/processes/reconcileNextAuthUrl.mjs
@@ -1,0 +1,50 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// NextAuth derives its origin (OAuth callbacks, sign-in redirects, base URL) from
+// NEXTAUTH_URL verbatim in self-hosted setups - it ignores the request host. When the
+// dev server picks a port, an unset NEXTAUTH_URL is defaulted to match so auth works on
+// whatever port the app lands on. A pinned NEXTAUTH_URL with a different port is left
+// untouched but warned about, since its redirects would target the wrong port.
+function reconcileNextAuthUrl({ context }) {
+  const { port } = context.options;
+  const current = process.env.NEXTAUTH_URL;
+
+  if (!current) {
+    return `http://localhost:${port}`;
+  }
+
+  let currentPort;
+  try {
+    const url = new URL(current);
+    currentPort = url.port || (url.protocol === 'https:' ? '443' : '80');
+  } catch (_) {
+    context.logger.warn(`NEXTAUTH_URL (${current}) is not a valid URL.`);
+    return current;
+  }
+
+  if (currentPort !== String(port)) {
+    context.logger.warn(
+      `NEXTAUTH_URL (${current}) does not match the dev server port ${port}. ` +
+        `NextAuth sign-in callbacks and redirects will target ${current}. ` +
+        `Update NEXTAUTH_URL or unset it to let the dev server manage it.`
+    );
+  }
+
+  return current;
+}
+
+export default reconcileNextAuthUrl;

--- a/packages/servers/server-dev/manager/processes/reconcileNextAuthUrl.test.mjs
+++ b/packages/servers/server-dev/manager/processes/reconcileNextAuthUrl.test.mjs
@@ -1,0 +1,65 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+import reconcileNextAuthUrl from './reconcileNextAuthUrl.mjs';
+
+const originalNextAuthUrl = process.env.NEXTAUTH_URL;
+
+function createContext(port) {
+  return {
+    options: { port },
+    logger: { warn: jest.fn() },
+  };
+}
+
+afterEach(() => {
+  if (originalNextAuthUrl === undefined) {
+    delete process.env.NEXTAUTH_URL;
+  } else {
+    process.env.NEXTAUTH_URL = originalNextAuthUrl;
+  }
+});
+
+test('reconcileNextAuthUrl defaults to the dev port when NEXTAUTH_URL is unset', () => {
+  delete process.env.NEXTAUTH_URL;
+  const context = createContext(3001);
+  expect(reconcileNextAuthUrl({ context })).toBe('http://localhost:3001');
+  expect(context.logger.warn).not.toHaveBeenCalled();
+});
+
+test('reconcileNextAuthUrl keeps a matching NEXTAUTH_URL without warning', () => {
+  process.env.NEXTAUTH_URL = 'http://localhost:3000';
+  const context = createContext(3000);
+  expect(reconcileNextAuthUrl({ context })).toBe('http://localhost:3000');
+  expect(context.logger.warn).not.toHaveBeenCalled();
+});
+
+test('reconcileNextAuthUrl warns on port mismatch but does not override', () => {
+  process.env.NEXTAUTH_URL = 'http://localhost:3000';
+  const context = createContext(3001);
+  expect(reconcileNextAuthUrl({ context })).toBe('http://localhost:3000');
+  expect(context.logger.warn).toHaveBeenCalledTimes(1);
+  expect(context.logger.warn.mock.calls[0][0]).toContain('does not match the dev server port 3001');
+});
+
+test('reconcileNextAuthUrl warns when NEXTAUTH_URL is not a valid URL', () => {
+  process.env.NEXTAUTH_URL = 'not-a-url';
+  const context = createContext(3000);
+  expect(reconcileNextAuthUrl({ context })).toBe('not-a-url');
+  expect(context.logger.warn).toHaveBeenCalledTimes(1);
+  expect(context.logger.warn.mock.calls[0][0]).toContain('is not a valid URL');
+});

--- a/packages/servers/server-dev/manager/processes/startServer.mjs
+++ b/packages/servers/server-dev/manager/processes/startServer.mjs
@@ -16,6 +16,8 @@
 
 import { spawn } from 'child_process';
 
+import reconcileNextAuthUrl from './reconcileNextAuthUrl.mjs';
+
 function createStdErrLineHandler({ context }) {
   const port = context.options.port;
   return function stdErrLineHandler(line) {
@@ -37,6 +39,7 @@ function startServer(context) {
     env: {
       ...process.env,
       LOWDEFY_DIRECTORY_CONFIG: context.directories.config,
+      NEXTAUTH_URL: reconcileNextAuthUrl({ context }),
       PORT: context.options.port,
     },
   });


### PR DESCRIPTION
## Summary

Running several Lowdefy dev servers on `localhost` previously clashed on ports and shared a single auth cookie jar (browsers scope cookies by host, not port), so logging into one app logged you out of another. This PR makes concurrent dev apps work via three coordinated changes:

- **Per-app auth cookies.** Cookie names resolve through a precedence chain: an explicit `auth.advanced.cookies` is used verbatim; otherwise an explicit `auth.advanced.cookiePrefix` namespaces cookie names (dev and prod); otherwise the dev server derives a prefix from the app `slug`/`name` so each app gets its own cookie jar. Production with no config is unchanged (NextAuth defaults). Adds an optional `auth.advanced.cookiePrefix` schema field.
- **Automatic port selection.** The CLI now finds the next available port instead of erroring when the requested port is in use, warning which port it landed on.
- **NEXTAUTH_URL reconciliation.** The dev server defaults an unset `NEXTAUTH_URL` to match the port it actually bound to, so OAuth callbacks and sign-in redirects target the right origin. A pinned `NEXTAUTH_URL` on a mismatched port is left untouched but warned about.

To intentionally **share** an auth session between two dev apps (e.g. prp team + support), set the same `cookiePrefix` on both (and the same auth secret).

## Test plan

- Start two dev apps with distinct `slug`s on the same host; confirm each keeps an independent session (logging into one does not log out the other).
- Set a matching `cookiePrefix` on both apps; confirm they share a session.
- Start a second app while the first occupies the default port; confirm it auto-selects the next port and warns.
- Leave `NEXTAUTH_URL` unset; confirm sign-in redirects target the bound port. Pin `NEXTAUTH_URL` to a mismatched port; confirm the warning and that it is not overridden.
- Production build with no cookie config; confirm default NextAuth cookie names are unchanged.

## PR Checklist
- [ ] `/r:docs-update` - Documentation updated for behavioral changes
- [ ] `/r:pr-review` - Self-review completed before requesting team review