### PR TITLE
Restore TipTap editor formatting stripped by antd reset

### DIFF
--- a/.changeset/fix-tiptap-editor-formatting-styles.md
+++ b/.changeset/fix-tiptap-editor-formatting-styles.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/blocks-tiptap': patch
+---
+
+fix(blocks-tiptap): Restore editor formatting that appeared stripped.
+
+Lists, blockquotes, headings, code, horizontal rules and line breaks rendered as flat, unstyled text in the TipTap editor because the global antd reset flattened their styles (the underlying HTML was always intact). The editor now restores correct rendering for all of these, themed to match the active antd theme. Applies to both `TiptapInput` and `TiptapMentionInput`.

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/style.module.css
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/style.module.css
@@ -82,8 +82,140 @@
   outline: none;
 }
 
+/* Editor content styling.
+
+   The antd v6 reset.css is loaded globally by every Lowdefy app and strips or
+   flattens the user-agent styles for the block-level and inline elements that
+   TipTap (StarterKit + configured extensions) produces: lists lose their
+   markers and indent, headings collapse to a single weight/size, blockquotes
+   lose their indent, <hr> renders at zero height, and inline/block code loses
+   its background. The tags are still in getHTML() — they just render unstyled,
+   which reads as "formatting stripped". We restore each one here, scoped to
+   .tiptap so it only affects editor content, using antd theme variables so it
+   tracks the active theme.
+
+   Nodes covered: paragraph, bulletList, orderedList, listItem, blockquote,
+   heading (h1-h6), horizontalRule, code (inline), codeBlock. Marks bold,
+   italic, strike and link survive the reset unchanged. */
+
+/* Paragraphs: a small gap so successive lines (each a new <p> from pressing
+   Enter) read as separate lines instead of merging. */
 :global(.tiptap) :global(p) {
-  margin: 0;
+  margin: 0 0 0.5em;
+}
+
+:global(.tiptap) > :global(p):last-child {
+  margin-bottom: 0;
+}
+
+/* Lists: restore the markers and indent the antd reset removes. */
+:global(.tiptap) :global(ul),
+:global(.tiptap) :global(ol) {
+  margin: 0 0 0.5em;
+  padding-left: 1.5em;
+}
+
+:global(.tiptap) :global(ul) {
+  list-style: disc;
+}
+
+:global(.tiptap) :global(ol) {
+  list-style: decimal;
+}
+
+/* Keep paragraphs inside list items and nested lists tight. */
+:global(.tiptap) :global(li) :global(p),
+:global(.tiptap) :global(li) :global(ul),
+:global(.tiptap) :global(li) :global(ol) {
+  margin-bottom: 0;
+}
+
+/* Blockquote: restore the indent and add a quote bar. */
+:global(.tiptap) :global(blockquote) {
+  margin: 0 0 0.5em;
+  padding-left: 1em;
+  border-left: 3px solid var(--ant-color-border, #d9d9d9);
+  color: var(--ant-color-text-secondary, rgba(0, 0, 0, 0.65));
+}
+
+/* Headings: the reset flattens all six to weight 500 with no size scale.
+   Restore a distinct, descending scale so heading levels are visible. */
+:global(.tiptap) :global(h1),
+:global(.tiptap) :global(h2),
+:global(.tiptap) :global(h3),
+:global(.tiptap) :global(h4),
+:global(.tiptap) :global(h5),
+:global(.tiptap) :global(h6) {
+  margin: 0 0 0.5em;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+:global(.tiptap) :global(h1) {
+  font-size: 2em;
+}
+
+:global(.tiptap) :global(h2) {
+  font-size: 1.5em;
+}
+
+:global(.tiptap) :global(h3) {
+  font-size: 1.25em;
+}
+
+:global(.tiptap) :global(h4) {
+  font-size: 1.1em;
+}
+
+:global(.tiptap) :global(h5) {
+  font-size: 1em;
+}
+
+:global(.tiptap) :global(h6) {
+  font-size: 0.9em;
+}
+
+/* Horizontal rule: the reset sets height 0 with no border, making it invisible.
+   Render it as a themed divider. */
+:global(.tiptap) :global(hr) {
+  height: 0;
+  margin: 0.5em 0;
+  border: none;
+  border-top: 1px solid var(--ant-color-border, #d9d9d9);
+}
+
+/* Inline code: monospace from the reset, but no background — give it the
+   code chip look. */
+:global(.tiptap) :global(code) {
+  padding: 0.1em 0.3em;
+  border-radius: var(--ant-border-radius-sm, 4px);
+  background: var(--ant-color-fill-tertiary, rgba(0, 0, 0, 0.04));
+  font-size: 0.9em;
+}
+
+/* Code block: a padded, scrollable monospace box. The nested <code> resets to
+   plain so it doesn't inherit the inline-code chip styling above. */
+:global(.tiptap) :global(pre) {
+  margin: 0 0 0.5em;
+  padding: 8px 12px;
+  border-radius: var(--ant-border-radius, 6px);
+  background: var(--ant-color-fill-tertiary, rgba(0, 0, 0, 0.04));
+  overflow-x: auto;
+}
+
+:global(.tiptap) :global(pre) :global(code) {
+  padding: 0;
+  border-radius: 0;
+  background: none;
+  font-size: inherit;
+}
+
+/* Highlight marks normally carry an inline background-color from the extension;
+   this is a fallback so a color-less <mark> (e.g. pasted or seeded HTML) stays
+   visible instead of blending into the text. */
+:global(.tiptap) :global(mark) {
+  background-color: var(--ant-color-warning-bg, rgba(255, 229, 143, 0.5));
+  color: inherit;
 }
 
 :global(.tiptap) :global(p.is-editor-empty):first-child::before {


### PR DESCRIPTION
## Summary

The TipTap input editor appeared to "strip" formatting — bullet/ordered lists rendered flat, blockquotes lost their indent, headings all looked the same size, and new lines merged together. The underlying HTML was always intact (`getHTML()` returned the correct tags); the antd v6 `reset.css`, which is loaded globally by every Lowdefy app, flattens the user-agent styles for those elements, so editor content rendered unstyled. This PR restores correct rendering for every node the editor can produce.

## Changes

- **@lowdefy/blocks-tiptap**: Added editor content styling to the shared `utils/style.module.css`, scoped to `.tiptap` and using antd theme variables so it tracks the active theme. Restores bullet/ordered list markers and indent, blockquote indent and quote bar, a descending h1–h6 size scale, a visible `<hr>`, inline-code chip and code-block box, paragraph spacing so successive lines stay separate, and a `<mark>` fallback for color-less highlights. Because it lives in the shared stylesheet, both `TiptapInput` and `TiptapMentionInput` pick it up.

## Notes

- No JS/behavior change — purely CSS in the shared editor stylesheet. The emitted value (`html`/`markdown`/`text`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)