### PR TITLE
Quality: Missing null guard on `config.auth` causes TypeError crash instead of descriptive error

### DIFF
--- a/packages/api/src/context/createAuthorize.js
+++ b/packages/api/src/context/createAuthorize.js
@@ -30,6 +30,11 @@ function createAuthorize({ session }) {
 
   function authorize(config) {
     const { auth } = config;
+    if (!auth) {
+      throw new ConfigError('config.auth is required.', {
+        configKey: config['~k'],
+      });
+    }
     if (auth.public === true) return true;
     if (auth.public === false) {
       if (auth.roles) {


### PR DESCRIPTION
## ✨ Code Quality

### Problem
The `authorize` function destructures `auth` from `config` and then immediately accesses `auth.public` without checking if `auth` exists. If a request or endpoint config is missing the `auth` property (e.g., a misconfigured block), `auth` will be `undefined` and `auth.public` will throw an unhandled `TypeError: Cannot read properties of undefined (reading 'public')`. This crashes the API handler with an unhelpful stack trace instead of the descriptive `ConfigError` the code clearly intends to produce (as evidenced by the `ConfigError` thrown at the end of the function for invalid `auth.public` values). Both `authorizeRequest.js` and `authorizeApiEndpoint.js` call through this function, so any misconfigured config without an `auth` field will crash the entire request pipeline.


**Severity**: `high`
**File**: `packages/api/src/context/createAuthorize.js`

### Solution
Add a null guard for `auth` before accessing its properties:


### Changes
- `packages/api/src/context/createAuthorize.js` (modified)



Closes #ISSUE_NUMBER

### What are the changes and their implications?

## Checklist

- [ ] Pull request is made to the "develop" branch
- [ ] Tests added
- [ ] Documentation added/updated
- [ ] Code has been formatted with Prettier
- [ ] Edits from maintainers are allowed

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #2203