### PR TITLE
Fix dead @next ESLint config; lint server packages clean

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -24,6 +24,14 @@ rules:
   no-underscore-dangle: 'off'
   no-param-reassign: warn
   no-nested-ternary: warn
+  no-unused-vars:
+    - error
+    - args: after-used
+      argsIgnorePattern: '^_'
+      varsIgnorePattern: '^_'
+      # Destructure-to-omit, e.g. `const { drop, ...rest } = obj` — `drop` is
+      # intentionally pulled out to exclude it from `rest`.
+      ignoreRestSiblings: true
   react/display-name: 'off'
   react/jsx-filename-extension: 'off'
   react/prop-types: 'off'
@@ -49,17 +57,25 @@ parserOptions:
   sourceType: module
   ecmaVersion: latest
 overrides:
+  # Server packages import build-time generated artifacts (../build/*) and
+  # runtime deps that ship exports maps the legacy import resolver can't
+  # follow, so unresolved-import checks only produce false positives there.
+  - files:
+      - 'packages/servers/**/*.js'
+      - 'packages/servers/**/*.jsx'
+    rules:
+      import/no-unresolved: 'off'
   # Playwright e2e tests
   - files:
-      - "**/*.e2e.spec.js"
+      - '**/*.e2e.spec.js'
     extends:
       - plugin:playwright/recommended
     rules:
       # Disable import/named as eslint-plugin-import can't resolve Playwright's TypeScript exports
-      import/named: "off"
+      import/named: 'off'
   # Playwright e2e utilities and block helpers
   - files:
-      - "packages/utils/e2e-utils/src/**/*.js"
-      - "packages/plugins/blocks/*/src/blocks/*/e2e.js"
+      - 'packages/utils/e2e-utils/src/**/*.js'
+      - 'packages/plugins/blocks/*/src/blocks/*/e2e.js'
     rules:
-      import/named: "off"
+      import/named: 'off'

--- a/packages/engine/src/actions/createReset.test.js
+++ b/packages/engine/src/actions/createReset.test.js
@@ -13,8 +13,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-import { jest } from '@jest/globals';
-
 import testContext from '../../test/testContext.js';
 
 const lowdefy = {

--- a/packages/servers/server-dev/.eslintrc.yaml
+++ b/packages/servers/server-dev/.eslintrc.yaml
@@ -1,1 +1,0 @@
-extends: 'plugin:@next/next/core-web-vitals'

--- a/packages/servers/server-dev/client/App.jsx
+++ b/packages/servers/server-dev/client/App.jsx
@@ -40,7 +40,7 @@ function ThemeTokenResolver({ lowdefyRef, children }) {
   return children;
 }
 
-function App({ config, router }) {
+function App({ router }) {
   const lowdefyRef = useRef({});
   const [runtimeErrors, setRuntimeErrors] = useState([]);
   // Subscribe to rootConfig SWR cache — deduplicates with Routing's fetch.
@@ -55,7 +55,11 @@ function App({ config, router }) {
     configDarkMode: lowdefyRef.current.theme?.darkMode,
   });
 
-  const { active: activeLocale, antdLocale, antdXLocale } = useLocale({
+  const {
+    active: activeLocale,
+    antdLocale,
+    antdXLocale,
+  } = useLocale({
     i18n: rootConfig?.i18n,
     antdLocaleLoaders,
     antdXLocaleLoaders,

--- a/packages/servers/server-dev/lib/client/utils/usePageConfig.js
+++ b/packages/servers/server-dev/lib/client/utils/usePageConfig.js
@@ -71,7 +71,6 @@ async function fetchPageConfig(url) {
   data._jsEntries = jsEntries;
   data._dynamicIcons = dynamicIcons;
 
-
   return data;
 }
 

--- a/packages/servers/server-dev/package.json
+++ b/packages/servers/server-dev/package.json
@@ -101,7 +101,6 @@
     "yargs": "17.7.2"
   },
   "devDependencies": {
-    "@next/eslint-plugin-next": "16.1.6",
     "jest": "28.1.3",
     "webpack": "5.94.0"
   },

--- a/packages/servers/server-dev/src/app.js
+++ b/packages/servers/server-dev/src/app.js
@@ -58,7 +58,10 @@ function createApp() {
   app.get('/api/dev-tools', devToolsHandler);
 
   if (authJson.configured === true) {
-    app.use('*', initAuthConfig(() => getAuthConfig({ logger })));
+    app.use(
+      '*',
+      initAuthConfig(() => getAuthConfig({ logger }))
+    );
   }
 
   app.use('/api/*', apiContext());

--- a/packages/servers/server-dev/src/html/renderDevPage.js
+++ b/packages/servers/server-dev/src/html/renderDevPage.js
@@ -47,9 +47,9 @@ function renderDevPage(c, { basePath = '' }) {
   const darkBg = themeConfig?.antd?.darkToken?.colorBgLayout ?? '#000';
   const lightBg = themeConfig?.antd?.lightToken?.colorBgLayout ?? '';
 
-  const darkModeScript = `(function(){var c=${safeScriptJson(configColorMode)};var db=${safeScriptJson(
-    darkBg
-  )};var lb=${safeScriptJson(
+  const darkModeScript = `(function(){var c=${safeScriptJson(
+    configColorMode
+  )};var db=${safeScriptJson(darkBg)};var lb=${safeScriptJson(
     lightBg
   )};var d;if(c==="dark")d=true;else if(c==="light")d=false;else{try{var p=localStorage.getItem("lowdefy_darkMode");if(p==="dark")d=true;else if(p==="light")d=false;else d=window.matchMedia("(prefers-color-scheme:dark)").matches}catch(e){d=window.matchMedia("(prefers-color-scheme:dark)").matches}}var bg=d?db:lb;if(bg)document.documentElement.style.backgroundColor=bg})();`;
 

--- a/packages/servers/server-dev/src/routes/usage.js
+++ b/packages/servers/server-dev/src/routes/usage.js
@@ -17,9 +17,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const packageJson = JSON.parse(
-  fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')
-);
+const packageJson = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
 
 async function usageHandler(c) {
   if (c.req.method !== 'POST') {

--- a/packages/servers/server-e2e/.eslintrc.yaml
+++ b/packages/servers/server-e2e/.eslintrc.yaml
@@ -1,1 +1,0 @@
-extends: 'plugin:@next/next/core-web-vitals'

--- a/packages/servers/server-e2e/client/App.jsx
+++ b/packages/servers/server-e2e/client/App.jsx
@@ -52,7 +52,11 @@ function App({ config }) {
     configDarkMode: lowdefyRef.current.theme?.darkMode,
   });
 
-  const { active: activeLocale, antdLocale, antdXLocale } = useLocale({
+  const {
+    active: activeLocale,
+    antdLocale,
+    antdXLocale,
+  } = useLocale({
     i18n: rootConfig?.i18n,
     antdLocaleLoaders,
     antdXLocaleLoaders,

--- a/packages/servers/server-e2e/lowdefy/createCustomPluginTypesMap.test.mjs
+++ b/packages/servers/server-e2e/lowdefy/createCustomPluginTypesMap.test.mjs
@@ -50,6 +50,8 @@ jest.unstable_mockModule('@lowdefy/node-utils', () => ({
   spawnProcess: jest.fn(),
   readFile: jest.fn(async () => pluginYaml),
   writeFile: jest.fn(),
+  writeFileIfChanged: jest.fn(),
+  installIfPackageJsonChanged: jest.fn(),
 }));
 
 jest.unstable_mockModule('node:module', () => ({

--- a/packages/servers/server-e2e/package.json
+++ b/packages/servers/server-e2e/package.json
@@ -89,7 +89,6 @@
   "devDependencies": {
     "@jest/globals": "28.1.3",
     "@lowdefy/build": "5.3.0",
-    "@next/eslint-plugin-next": "16.1.6",
     "@tailwindcss/postcss": "4.2.1",
     "jest": "28.1.3",
     "tailwindcss": "4.2.1",

--- a/packages/servers/server-e2e/src/routes/usage.js
+++ b/packages/servers/server-e2e/src/routes/usage.js
@@ -17,9 +17,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const packageJson = JSON.parse(
-  fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')
-);
+const packageJson = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
 
 async function usageHandler(c) {
   if (c.req.method !== 'POST') {

--- a/packages/servers/server/.eslintrc.yaml
+++ b/packages/servers/server/.eslintrc.yaml
@@ -1,1 +1,0 @@
-extends: 'plugin:@next/next/core-web-vitals'

--- a/packages/servers/server/client/App.jsx
+++ b/packages/servers/server/client/App.jsx
@@ -67,7 +67,11 @@ function App({ config }) {
     configDarkMode: lowdefyRef.current.theme?.darkMode,
   });
 
-  const { active: activeLocale, antdLocale, antdXLocale } = useLocale({
+  const {
+    active: activeLocale,
+    antdLocale,
+    antdXLocale,
+  } = useLocale({
     i18n: rootConfig?.i18n,
     antdLocaleLoaders,
     antdXLocaleLoaders,

--- a/packages/servers/server/src/app.js
+++ b/packages/servers/server/src/app.js
@@ -76,7 +76,10 @@ function createApp({ serveStaticAssets = true } = {}) {
   });
 
   if (authJson.configured === true) {
-    app.use('*', initAuthConfig(() => getAuthConfig({ logger })));
+    app.use(
+      '*',
+      initAuthConfig(() => getAuthConfig({ logger }))
+    );
   }
 
   app.use('/api/*', apiContext());

--- a/packages/servers/server/src/middleware/sentry.js
+++ b/packages/servers/server/src/middleware/sentry.js
@@ -24,9 +24,8 @@ function sentryMiddleware() {
     if (!process.env.SENTRY_DSN) {
       return next();
     }
-    return Sentry.startSpan(
-      { name: `${c.req.method} ${c.req.path}`, op: 'http.server' },
-      () => next()
+    return Sentry.startSpan({ name: `${c.req.method} ${c.req.path}`, op: 'http.server' }, () =>
+      next()
     );
   };
 }

--- a/packages/servers/server/src/routes/usage.js
+++ b/packages/servers/server/src/routes/usage.js
@@ -17,9 +17,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const packageJson = JSON.parse(
-  fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')
-);
+const packageJson = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
 
 async function usageHandler(c) {
   if (c.req.method !== 'POST') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2337,9 +2337,6 @@ importers:
         specifier: 17.7.2
         version: 17.7.2
     devDependencies:
-      '@next/eslint-plugin-next':
-        specifier: 16.1.6
-        version: 16.1.6
       jest:
         specifier: 28.1.3
         version: 28.1.3(@types/node@20.6.2)
@@ -2467,9 +2464,6 @@ importers:
       '@lowdefy/build':
         specifier: 5.3.0
         version: link:../../build
-      '@next/eslint-plugin-next':
-        specifier: 16.1.6
-        version: 16.1.6
       jest:
         specifier: 28.1.3
         version: 28.1.3(@types/node@20.6.2)


### PR DESCRIPTION
## Summary

The Next→Hono migration left the server packages (`server`, `server-dev`, `server-e2e`) extending the Next.js `core-web-vitals` ESLint config. With ESLint 8 + `@next/eslint-plugin-next` 16 (flat-config only) the legacy loader rejects it (`Unexpected top-level property "name"`), so ESLint could not run on those packages at all. This PR removes the dead configs so the packages inherit the root config, resolves the resulting issues so the server packages lint cleanly, and fixes a pre-existing `server-e2e` test whose `@lowdefy/node-utils` mock was out of date.

> Targets `vite-hono` (this branch was cut from it), not `develop`.

## Changes

- **ESLint config**: Deleted the three dead `.eslintrc.yaml` files (each only extended `plugin:@next/next/core-web-vitals`) so the server packages inherit the root config; dropped the `@next/eslint-plugin-next` devDeps from `server-dev`/`server-e2e`.
- **Root config**: Added `no-unused-vars` `ignoreRestSiblings` + `^_` ignore patterns (restores the destructure-to-omit behaviour Next's config provided — `_lightToken`/`...antdConfig`, `const { error, ...response }` are intentional), and a scoped `import/no-unresolved: off` override for `packages/servers/**` (the 71 failures there were false positives from generated `build/*` artifacts + deps with exports maps the legacy resolver can't follow). Other packages keep the rule.
- **server packages**: `prettier --fix` of pre-existing formatting drift; removed an unused `config` prop in the dev `App.jsx`.
- **@lowdefy/engine**: removed an unused `jest` import in `createReset.test.js`.
- **@lowdefy/server-e2e**: added `writeFileIfChanged`/`installIfPackageJsonChanged` to the `@lowdefy/node-utils` mock so the `createCustomPluginTypesMap` tests pass.

## Key Files

- `.eslintrc.yaml` — `no-unused-vars` ignore patterns + scoped server `import/no-unresolved` override
- `packages/servers/{server,server-dev,server-e2e}/.eslintrc.yaml` — deleted (dead Next config)
- `packages/servers/server-e2e/lowdefy/createCustomPluginTypesMap.test.mjs` — updated node-utils mock

## Notes

- ESLint on the server packages: **97 errors → 0** (17 intentional `no-console` warnings remain, consistent with the root config). `engine`, `server-dev`, and `server-e2e` test suites are green.
- No changeset: changes are dev-tooling / formatting / test only — no runtime behaviour change.
- The `website` package still uses `eslint-config-next` (it is a real Next.js app) and is intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)