### PR TITLE
chore: Node 26 CI support (better-sqlite3 + buffer-equal-constant-time)

### DIFF
--- a/.changeset/chore-node26-better-sqlite3.md
+++ b/.changeset/chore-node26-better-sqlite3.md
@@ -1,0 +1,10 @@
+---
+---
+
+chore: Pin `better-sqlite3` to 12.11.1 so CI installs on Node 26.
+
+`better-sqlite3` versions before 12.11.0 ship no Node 26 (N-API v147) prebuilt binary, so
+`pnpm install --frozen-lockfile` on Node 26 fell back to a source build. That build fails on the
+Windows CI runner because node-gyp cannot detect Visual Studio under Node 26, and with the default
+fail-fast matrix it cancelled the remaining Node 26 jobs. Added a pnpm `overrides` entry (the package
+is transitive via `knex`) so the Node 26 prebuild is used and no compilation is needed.

--- a/.changeset/chore-node26-buffer-equal-constant-time.md
+++ b/.changeset/chore-node26-buffer-equal-constant-time.md
@@ -1,0 +1,12 @@
+---
+---
+
+chore: Patch `buffer-equal-constant-time` so the JWT dependency chain loads on Node 26.
+
+`buffer-equal-constant-time@1.0.1` (transitive via `jwa` → `jws` → `google-auth-library`, used by the
+Google Sheets connection) reads `require('buffer').SlowBuffer` at module load. `SlowBuffer` was removed
+in Node 26, so the reference is `undefined` and every consumer crashes with
+`TypeError: Cannot read properties of undefined (reading 'prototype')`. The package is unmaintained
+(latest is 1.0.1, from 2016), so added a pnpm patch that falls back to `Buffer` when `SlowBuffer` is
+absent. The fallback is only touched by the package's legacy `install`/`restore` helpers, so behaviour
+is unchanged on older Node versions.

--- a/patches/buffer-equal-constant-time@1.0.1.patch
+++ b/patches/buffer-equal-constant-time@1.0.1.patch
@@ -1,0 +1,13 @@
+diff --git a/index.js b/index.js
+index 5462c1f830bdbe79bf2b1fcfd811cd9799b4dd11..d2290974b06c07d5c5beffc28e172c7faf0864aa 100644
+--- a/index.js
++++ b/index.js
+@@ -1,7 +1,7 @@
+ /*jshint node:true */
+ 'use strict';
+ var Buffer = require('buffer').Buffer; // browserify
+-var SlowBuffer = require('buffer').SlowBuffer;
++var SlowBuffer = require('buffer').SlowBuffer || Buffer; // SlowBuffer removed in Node 26; fall back to Buffer (only used by legacy install/restore)
+ 
+ module.exports = bufferEq;
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  better-sqlite3: 12.11.1
+
 packageExtensionsChecksum: sha256-8WIGWQNf+ia1tU2lBx5ORU6YJQC1bgcuatkCdqqyesQ=
 
 importers:
@@ -1388,11 +1391,11 @@ importers:
         specifier: 5.3.0
         version: link:../../../utils/helpers
       better-sqlite3:
-        specifier: 12.9.0
-        version: 12.9.0
+        specifier: 12.11.1
+        version: 12.11.1
       knex:
         specifier: 3.2.9
-        version: 3.2.9(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@20.6.2))(pg@8.20.0)(tedious@19.2.1)
+        version: 3.2.9(better-sqlite3@12.11.1)(mysql2@3.22.3(@types/node@20.6.2))(pg@8.20.0)(tedious@19.2.1)
       mysql2:
         specifier: 3.22.3
         version: 3.22.3(@types/node@20.6.2)
@@ -7029,9 +7032,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  better-sqlite3@12.9.0:
-    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
   big-integer@1.6.51:
     resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
@@ -18210,7 +18213,7 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  better-sqlite3@12.9.0:
+  better-sqlite3@12.11.1:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.2
@@ -21685,7 +21688,7 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  knex@3.2.9(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@20.6.2))(pg@8.20.0)(tedious@19.2.1):
+  knex@3.2.9(better-sqlite3@12.11.1)(mysql2@3.22.3(@types/node@20.6.2))(pg@8.20.0)(tedious@19.2.1):
     dependencies:
       colorette: 2.0.19
       commander: 10.0.1
@@ -21702,7 +21705,7 @@ snapshots:
       tarn: 3.0.2
       tildify: 2.0.0
     optionalDependencies:
-      better-sqlite3: 12.9.0
+      better-sqlite3: 12.11.1
       mysql2: 3.22.3(@types/node@20.6.2)
       pg: 8.20.0
       tedious: 19.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,11 @@ overrides:
 
 packageExtensionsChecksum: sha256-8WIGWQNf+ia1tU2lBx5ORU6YJQC1bgcuatkCdqqyesQ=
 
+patchedDependencies:
+  buffer-equal-constant-time@1.0.1:
+    hash: dd1bd5e7d44b09282824ff95ac138076b146c28db0dbdcd29596779bbed11709
+    path: patches/buffer-equal-constant-time@1.0.1.patch
+
 importers:
 
   .:
@@ -18358,7 +18363,7 @@ snapshots:
 
   buffer-crc32@0.2.13: {}
 
-  buffer-equal-constant-time@1.0.1: {}
+  buffer-equal-constant-time@1.0.1(patch_hash=dd1bd5e7d44b09282824ff95ac138076b146c28db0dbdcd29596779bbed11709): {}
 
   buffer-equal@0.0.1: {}
 
@@ -21645,13 +21650,13 @@ snapshots:
 
   jwa@1.4.1:
     dependencies:
-      buffer-equal-constant-time: 1.0.1
+      buffer-equal-constant-time: 1.0.1(patch_hash=dd1bd5e7d44b09282824ff95ac138076b146c28db0dbdcd29596779bbed11709)
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 
   jwa@2.0.0:
     dependencies:
-      buffer-equal-constant-time: 1.0.1
+      buffer-equal-constant-time: 1.0.1(patch_hash=dd1bd5e7d44b09282824ff95ac138076b146c28db0dbdcd29596779bbed11709)
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,18 +4,20 @@ packages:
   - packages/servers/*
   - packages/utils/*
   - packages/ides/*
+
 onlyBuiltDependencies:
   - '@sentry/cli'
   - '@swc/core'
   - better-sqlite3
   - esbuild
+
 overrides:
-  # better-sqlite3 <12.11.0 ships no Node 26 (N-API v147) prebuilt binary, so
-  # `pnpm install` on Node 26 falls back to a source build — which breaks CI on
-  # Windows (node-gyp cannot detect Visual Studio on Node 26). 12.11.1 ships the
-  # Node 26 prebuild. Pulled in transitively via knex.
-  better-sqlite3: '12.11.1'
+  better-sqlite3: 12.11.1
+
 packageExtensions:
   echarts-for-react:
     dependencies:
       tslib: '*'
+
+patchedDependencies:
+  buffer-equal-constant-time@1.0.1: patches/buffer-equal-constant-time@1.0.1.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,12 @@ onlyBuiltDependencies:
   - '@swc/core'
   - better-sqlite3
   - esbuild
+overrides:
+  # better-sqlite3 <12.11.0 ships no Node 26 (N-API v147) prebuilt binary, so
+  # `pnpm install` on Node 26 falls back to a source build — which breaks CI on
+  # Windows (node-gyp cannot detect Visual Studio on Node 26). 12.11.1 ships the
+  # Node 26 prebuild. Pulled in transitively via knex.
+  better-sqlite3: '12.11.1'
 packageExtensions:
   echarts-for-react:
     dependencies:


### PR DESCRIPTION
Makes the Node 26 CI matrix legs pass. Two independent, pre-existing Node 26 problems, both surfaced once Node 26 was added to the matrix.

## 1. Install fails on Windows + Node 26 — better-sqlite3

`better-sqlite3@12.9.0` (transitive via `knex`) ships no Node 26 (N-API v147) prebuild; its newest Windows prebuild is `node-v141` (Node 25). On Node 26 the install falls back to compiling from source, and node-gyp's Visual Studio detection throws `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` under Node 26 — so the Windows install fails and fail-fast cancels the other Node 26 legs.

**Fix:** pnpm `overrides` pin to `better-sqlite3@12.11.1`, which ships the `node-v147-win32-x64` prebuild.

## 2. Test suites crash at load on Node 26 — buffer-equal-constant-time

`connection-google-sheets` suites fail with `TypeError: Cannot read properties of undefined (reading 'prototype')`. Chain: `google-spreadsheet → google-auth-library → jws → jwa@2.0.1 → buffer-equal-constant-time@1.0.1`, which reads `require('buffer').SlowBuffer` at module load. **`SlowBuffer` was removed in Node 26**, so the reference is `undefined`. Even the newest `google-auth-library@9` still pulls this exact package (latest is 1.0.1, unmaintained since 2016), so a version bump can't fix it.

**Fix:** a pnpm patch falling back to `Buffer` when `SlowBuffer` is absent. Only the package's legacy `install`/`restore` helpers touch it, so no behaviour change on older Node. Fixes the whole JWT ecosystem on Node 26.

## Verification

Local Node v26.4.0: `pnpm install` applies the patch; `pnpm --filter @lowdefy/connection-google-sheets test` → suites load, 13 passed / 1 skipped (previously 2 suites failed to load). CI matrix (22/24/26 × ubuntu/windows) should be green.

Two empty/tooling changesets included (no version bump).