### PR TITLE
feat(connection-google-sheets): upgrade google-spreadsheet 3.3.0 → 5.3.0

### DIFF
--- a/.changeset/feat-google-sheets-v5.md
+++ b/.changeset/feat-google-sheets-v5.md
@@ -1,0 +1,9 @@
+---
+'@lowdefy/connection-google-sheets': minor
+---
+
+Update the Google Sheets connection to the latest `google-spreadsheet` library.
+
+Internal upgrade of the underlying Google Sheets library (and its Google authentication dependency) to
+a current, actively maintained version. This also resolves a crash on Node.js 26. Connection
+configuration is unchanged — existing API-key and service-account setups keep working exactly as before.

--- a/packages/plugins/connections/connection-google-sheets/package.json
+++ b/packages/plugins/connections/connection-google-sheets/package.json
@@ -42,7 +42,8 @@
   },
   "dependencies": {
     "@lowdefy/helpers": "5.3.0",
-    "google-spreadsheet": "3.3.0",
+    "google-auth-library": "9.15.1",
+    "google-spreadsheet": "5.3.0",
     "mingo": "6.4.9",
     "dayjs": "1.11.19"
   },

--- a/packages/plugins/connections/connection-google-sheets/src/connections/GoogleSheet/getSheet.js
+++ b/packages/plugins/connections/connection-google-sheets/src/connections/GoogleSheet/getSheet.js
@@ -15,16 +15,20 @@
 */
 
 import { GoogleSpreadsheet } from 'google-spreadsheet';
+import { JWT } from 'google-auth-library';
 
-async function authenticate({ doc, apiKey, client_email, private_key }) {
+// google-spreadsheet v4+ takes the auth object in the constructor instead of the
+// v3 doc.useApiKey / doc.useServiceAccountAuth methods. An API key gives read-only
+// access; a service account (JWT) is needed for writes.
+function getAuth({ apiKey, client_email, private_key }) {
   if (apiKey) {
-    doc.useApiKey(apiKey);
-  } else {
-    await doc.useServiceAccountAuth({
-      client_email,
-      private_key,
-    });
+    return { apiKey };
   }
+  return new JWT({
+    email: client_email,
+    key: private_key,
+    scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+  });
 }
 
 function getSheetFromDoc({ doc, sheetId, sheetIndex }) {
@@ -45,9 +49,8 @@ function getSheetFromDoc({ doc, sheetId, sheetIndex }) {
 
 async function getSheet({ connection }) {
   const { apiKey, client_email, private_key, sheetId, sheetIndex, spreadsheetId } = connection;
-  const doc = new GoogleSpreadsheet(spreadsheetId);
-
-  await authenticate({ doc, apiKey, client_email, private_key });
+  const auth = getAuth({ apiKey, client_email, private_key });
+  const doc = new GoogleSpreadsheet(spreadsheetId, auth);
 
   await doc.loadInfo();
 

--- a/packages/plugins/connections/connection-google-sheets/src/connections/GoogleSheet/getSheet.test.js
+++ b/packages/plugins/connections/connection-google-sheets/src/connections/GoogleSheet/getSheet.test.js
@@ -14,50 +14,39 @@
   limitations under the License.
 */
 
-/* eslint-disable no-unused-vars */
-
 import { jest } from '@jest/globals';
 import { wait } from '@lowdefy/helpers';
-import getSheet from './getSheet.js';
 
-// TODO: Fix jest mocks
+const SCOPES = ['https://www.googleapis.com/auth/spreadsheets'];
 
-// Not testing if spreadsheetId is given to GoogleSpreadsheet class in
-// const doc = new GoogleSpreadsheet(spreadsheetId);
-
-const mockSheetsById = {};
-const mockSheetsByIndex = {};
-const mockUseApiKey = jest.fn();
-const mockUseServiceAccountAuth = jest.fn();
+// google-spreadsheet v4+ takes auth in the constructor, so we record the
+// constructor args instead of the removed useApiKey / useServiceAccountAuth calls.
+const mockGoogleSpreadsheet = jest.fn();
+const mockJWT = jest.fn();
 const mockLoadInfo = jest.fn();
 
-jest.unstable_mockModule('google-spreadsheet', () => {
-  function GoogleSpreadsheet() {
-    return {
-      sheetsById: mockSheetsById,
-      sheetsByIndex: mockSheetsByIndex,
-      useApiKey: mockUseApiKey,
-      useServiceAccountAuth: mockUseServiceAccountAuth,
-      loadInfo: mockLoadInfo,
-    };
-  }
-  return {
-    GoogleSpreadsheet,
-  };
-});
+let mockSheetsById = {};
+let mockSheetsByIndex = {};
 
-const useApiKeyDefaultImp = (apiKey) => {
-  if (apiKey !== 'valid') {
-    throw new Error('Test Api Key Auth Error.');
-  }
-};
+jest.unstable_mockModule('google-spreadsheet', () => ({
+  GoogleSpreadsheet: function GoogleSpreadsheet(spreadsheetId, auth) {
+    mockGoogleSpreadsheet(spreadsheetId, auth);
+    this.loadInfo = mockLoadInfo;
+    this.sheetsById = mockSheetsById;
+    this.sheetsByIndex = mockSheetsByIndex;
+  },
+}));
 
-const useServiceAccountAuthDefaultImp = async ({ client_email, private_key }) => {
-  await wait(3);
-  if (client_email !== 'client_email' || private_key !== 'private_key') {
-    throw new Error('Test Service Account Auth Error.');
-  }
-};
+jest.unstable_mockModule('google-auth-library', () => ({
+  JWT: function JWT(config) {
+    mockJWT(config);
+    // Tag so we can assert the doc was constructed with the JWT instance.
+    this.__jwt = true;
+    this.config = config;
+  },
+}));
+
+const { default: getSheet } = await import('./getSheet.js');
 
 const loadInfoDefaultImp = async () => {
   await wait(3);
@@ -66,23 +55,13 @@ const loadInfoDefaultImp = async () => {
 };
 
 beforeEach(() => {
-  jest.resetAllMocks();
-  Object.keys(mockSheetsById).forEach((key) => {
-    delete mockSheetsById[key];
-  });
-  Object.keys(mockSheetsByIndex).forEach((key) => {
-    delete mockSheetsByIndex[key];
-  });
+  jest.clearAllMocks();
+  mockSheetsById = {};
+  mockSheetsByIndex = {};
+  mockLoadInfo.mockImplementation(loadInfoDefaultImp);
 });
 
-test.skip('getSheet with apiKey, sheetId', async () => {
-  // const { GoogleSpreadsheet } = await import('google-spreadsheet');
-  // console.log(GoogleSpreadsheet());
-  const getSheet = (await import('./getSheet.js')).default;
-
-  mockUseApiKey.mockImplementation(useApiKeyDefaultImp);
-  mockUseServiceAccountAuth.mockImplementation(useServiceAccountAuthDefaultImp);
-  mockLoadInfo.mockImplementation(loadInfoDefaultImp);
+test('getSheet with apiKey, sheetId', async () => {
   const sheet = await getSheet({
     connection: {
       apiKey: 'valid',
@@ -90,18 +69,13 @@ test.skip('getSheet with apiKey, sheetId', async () => {
       sheetId: 'sheetId1',
     },
   });
-  expect(mockUseApiKey.mock.calls).toEqual([['valid']]);
-  expect(mockUseServiceAccountAuth.mock.calls).toEqual([]);
+  expect(mockJWT.mock.calls).toEqual([]);
+  expect(mockGoogleSpreadsheet.mock.calls).toEqual([['spreadsheetId', { apiKey: 'valid' }]]);
   expect(mockLoadInfo.mock.calls).toEqual([[]]);
   expect(sheet).toEqual({ id: 'sheetId1' });
 });
 
-test.skip('getSheet with service account, sheetId', async () => {
-  const { GoogleSpreadsheet } = await import('google-spreadsheet');
-
-  mockUseApiKey.mockImplementation(useApiKeyDefaultImp);
-  mockUseServiceAccountAuth.mockImplementation(useServiceAccountAuthDefaultImp);
-  mockLoadInfo.mockImplementation(loadInfoDefaultImp);
+test('getSheet with service account, sheetId', async () => {
   const sheet = await getSheet({
     connection: {
       client_email: 'client_email',
@@ -110,25 +84,17 @@ test.skip('getSheet with service account, sheetId', async () => {
       sheetId: 'sheetId1',
     },
   });
-  expect(mockUseApiKey.mock.calls).toEqual([]);
-  expect(mockUseServiceAccountAuth.mock.calls).toEqual([
-    [
-      {
-        client_email: 'client_email',
-        private_key: 'private_key',
-      },
-    ],
+  expect(mockJWT.mock.calls).toEqual([
+    [{ email: 'client_email', key: 'private_key', scopes: SCOPES }],
   ]);
+  // The doc is constructed with the JWT instance created above.
+  expect(mockGoogleSpreadsheet.mock.calls[0][0]).toEqual('spreadsheetId');
+  expect(mockGoogleSpreadsheet.mock.calls[0][1].__jwt).toBe(true);
   expect(mockLoadInfo.mock.calls).toEqual([[]]);
   expect(sheet).toEqual({ id: 'sheetId1' });
 });
 
-test.skip('getSheet with service account, sheetIndex', async () => {
-  const { GoogleSpreadsheet } = await import('google-spreadsheet');
-
-  mockUseApiKey.mockImplementation(useApiKeyDefaultImp);
-  mockUseServiceAccountAuth.mockImplementation(useServiceAccountAuthDefaultImp);
-  mockLoadInfo.mockImplementation(loadInfoDefaultImp);
+test('getSheet with service account, sheetIndex', async () => {
   const sheet = await getSheet({
     connection: {
       client_email: 'client_email',
@@ -137,95 +103,30 @@ test.skip('getSheet with service account, sheetIndex', async () => {
       sheetIndex: 0,
     },
   });
-  expect(mockUseApiKey.mock.calls).toEqual([]);
-  expect(mockUseServiceAccountAuth.mock.calls).toEqual([
-    [
-      {
-        client_email: 'client_email',
-        private_key: 'private_key',
-      },
-    ],
+  expect(mockJWT.mock.calls).toEqual([
+    [{ email: 'client_email', key: 'private_key', scopes: SCOPES }],
   ]);
-  expect(mockLoadInfo.mock.calls).toEqual([[]]);
   expect(sheet).toEqual({ index: 0 });
 });
 
-test.skip('getSheet with invalid apiKey', async () => {
-  const { GoogleSpreadsheet } = await import('google-spreadsheet');
-
-  mockUseApiKey.mockImplementation(useApiKeyDefaultImp);
-  mockUseServiceAccountAuth.mockImplementation(useServiceAccountAuthDefaultImp);
-  mockLoadInfo.mockImplementation(loadInfoDefaultImp);
-  await expect(() =>
+test('getSheet propagates a loadInfo (auth/network) error', async () => {
+  mockLoadInfo.mockImplementation(async () => {
+    await wait(3);
+    throw new Error('Google API error.');
+  });
+  await expect(
     getSheet({
       connection: {
-        apiKey: 'invalid',
-        spreadsheetId: 'spreadsheetId',
-        sheetId: 'sheetId1',
-      },
-    })
-  ).rejects.toThrow('Test Api Key Auth Error.');
-  expect(mockUseApiKey.mock.calls).toEqual([['invalid']]);
-});
-
-test.skip('getSheet with invalid client_id', async () => {
-  const { GoogleSpreadsheet } = await import('google-spreadsheet');
-
-  mockUseApiKey.mockImplementation(useApiKeyDefaultImp);
-  mockUseServiceAccountAuth.mockImplementation(useServiceAccountAuthDefaultImp);
-  mockLoadInfo.mockImplementation(loadInfoDefaultImp);
-  await expect(() =>
-    getSheet({
-      connection: {
-        client_email: 'invalid_client_email',
+        client_email: 'client_email',
         private_key: 'private_key',
         spreadsheetId: 'spreadsheetId',
         sheetId: 'sheetId1',
       },
     })
-  ).rejects.toThrow('Test Service Account Auth Error.');
-  expect(mockUseServiceAccountAuth.mock.calls).toEqual([
-    [
-      {
-        client_email: 'invalid_client_email',
-        private_key: 'private_key',
-      },
-    ],
-  ]);
+  ).rejects.toThrow('Google API error.');
 });
 
-test.skip('getSheet with invalid private_key', async () => {
-  const { GoogleSpreadsheet } = await import('google-spreadsheet');
-
-  mockUseApiKey.mockImplementation(useApiKeyDefaultImp);
-  mockUseServiceAccountAuth.mockImplementation(useServiceAccountAuthDefaultImp);
-  mockLoadInfo.mockImplementation(loadInfoDefaultImp);
-  await expect(() =>
-    getSheet({
-      connection: {
-        client_email: 'client_email',
-        private_key: 'invalid_private_key',
-        spreadsheetId: 'spreadsheetId',
-        sheetId: 'sheetId1',
-      },
-    })
-  ).rejects.toThrow('Test Service Account Auth Error.');
-  expect(mockUseServiceAccountAuth.mock.calls).toEqual([
-    [
-      {
-        client_email: 'client_email',
-        private_key: 'invalid_private_key',
-      },
-    ],
-  ]);
-});
-
-test.skip('getSheet with sheetId, sheet does not exist', async () => {
-  const { GoogleSpreadsheet } = await import('google-spreadsheet');
-
-  mockUseApiKey.mockImplementation(useApiKeyDefaultImp);
-  mockUseServiceAccountAuth.mockImplementation(useServiceAccountAuthDefaultImp);
-  mockLoadInfo.mockImplementation(loadInfoDefaultImp);
+test('getSheet with sheetId, sheet does not exist', async () => {
   await expect(
     getSheet({
       connection: {
@@ -237,12 +138,7 @@ test.skip('getSheet with sheetId, sheet does not exist', async () => {
   ).rejects.toThrow('Could not find sheet with sheetId "sheetId2"');
 });
 
-test.skip('getSheet with sheetIndex, sheet does not exist', async () => {
-  const { GoogleSpreadsheet } = await import('google-spreadsheet');
-
-  mockUseApiKey.mockImplementation(useApiKeyDefaultImp);
-  mockUseServiceAccountAuth.mockImplementation(useServiceAccountAuthDefaultImp);
-  mockLoadInfo.mockImplementation(loadInfoDefaultImp);
+test('getSheet with sheetIndex, sheet does not exist', async () => {
   await expect(
     getSheet({
       connection: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1361,9 +1361,12 @@ importers:
       dayjs:
         specifier: 1.11.19
         version: 1.11.19
+      google-auth-library:
+        specifier: 9.15.1
+        version: 9.15.1(encoding@0.1.13)
       google-spreadsheet:
-        specifier: 3.3.0
-        version: 3.3.0(encoding@0.1.13)
+        specifier: 5.3.0
+        version: 5.3.0(google-auth-library@9.15.1(encoding@0.1.13))
       mingo:
         specifier: 6.4.9
         version: 6.4.9
@@ -6906,10 +6909,6 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
-  arrify@2.0.1:
-    resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
-    engines: {node: '>=8'}
-
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
@@ -6962,9 +6961,6 @@ packages:
   axe-core@4.7.0:
     resolution: {integrity: sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==}
     engines: {node: '>=4'}
-
-  axios@0.21.4:
-    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
 
   axios@0.26.1:
     resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
@@ -8107,6 +8103,9 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
+
   es5-ext@0.10.62:
     resolution: {integrity: sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==}
     engines: {node: '>=0.10'}
@@ -8484,9 +8483,6 @@ packages:
     resolution: {integrity: sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==}
     engines: {node: '>=6'}
 
-  fast-text-encoding@1.0.6:
-    resolution: {integrity: sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==}
-
   fast-xml-parser@4.2.5:
     resolution: {integrity: sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==}
     hasBin: true
@@ -8695,13 +8691,13 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-  gaxios@4.3.3:
-    resolution: {integrity: sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==}
-    engines: {node: '>=10'}
+  gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
 
-  gcp-metadata@4.3.1:
-    resolution: {integrity: sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==}
-    engines: {node: '>=10'}
+  gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
 
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
@@ -8823,19 +8819,21 @@ packages:
     resolution: {integrity: sha512-KVbFv2TQtbzCoxAnfD6JcHZTYCzyliEaaeM/gH8qQdkKr5s0OP9scEgvdcngyk7AVdY6YVW/TJHd+lQ/Df3Daw==}
     engines: {node: '>=0.10.0'}
 
-  google-auth-library@6.1.6:
-    resolution: {integrity: sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==}
-    engines: {node: '>=10'}
+  google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
 
-  google-p12-pem@3.1.4:
-    resolution: {integrity: sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==}
-    engines: {node: '>=10'}
-    deprecated: Package is no longer maintained
-    hasBin: true
+  google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
 
-  google-spreadsheet@3.3.0:
-    resolution: {integrity: sha512-ahmRNh14s1i3phfvbF2mxen1lohWJpUaFWgsU6P6bXu7QrmxMaim1Ys/7BU4W5yucWCzphoIrHMbrbeIR5K9mw==}
-    engines: {node: '>=0.8.0'}
+  google-spreadsheet@5.3.0:
+    resolution: {integrity: sha512-hsMI2hc1aqDgZsfOEvJ+M4vwH6h8OuXKdxwKPPQq/OKs2dYnuaD8qx3GtiPyYcXRSN60j7EHbaHBPihOhzwY/A==}
+    peerDependencies:
+      google-auth-library: '>=8.8.0'
+    peerDependenciesMeta:
+      google-auth-library:
+        optional: true
 
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -8861,9 +8859,9 @@ packages:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
 
-  gtoken@5.3.2:
-    resolution: {integrity: sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==}
-    engines: {node: '>=10'}
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
@@ -9845,6 +9843,10 @@ packages:
       tedious:
         optional: true
 
+  ky@2.0.2:
+    resolution: {integrity: sha512-/GmXpo9F9W+f8n4Ivr2iH+7h7wL7jLbLKWkMlpflcCRb6kGjBfTlASEXaZ9qUgNTn4VgS0P2pwxxzQ4EM6Ulgg==}
+    engines: {node: '>=22'}
+
   langium@4.2.3:
     resolution: {integrity: sha512-sOPIi4hISFnY7twwV97ca1TsxpBtXq0URu/LL1AvxwccPG/RIBBlKS7a/f/EL6w8lTNaS0EFs/F+IdSOaqYpng==}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
@@ -10545,10 +10547,6 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
-
-  node-forge@1.3.1:
-    resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
-    engines: {node: '>= 6.13.0'}
 
   node-gyp@13.0.0:
     resolution: {integrity: sha512-FYYyBDWdc+kzoyPd5PqHUgM9DGs1C/Z4jxBZAOnA2GRUVXPivKRREq5q+VVPXVr9aGVqGMaMqyFHbviy/yb7Hg==}
@@ -18067,8 +18065,6 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
-  arrify@2.0.1: {}
-
   asap@2.0.6: {}
 
   ast-transform@0.0.0:
@@ -18113,12 +18109,6 @@ snapshots:
   axe-core@4.11.1: {}
 
   axe-core@4.7.0: {}
-
-  axios@0.21.4:
-    dependencies:
-      follow-redirects: 1.15.9(debug@4.4.3)
-    transitivePeerDependencies:
-      - debug
 
   axios@0.26.1:
     dependencies:
@@ -19481,6 +19471,8 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  es-toolkit@1.49.0: {}
+
   es5-ext@0.10.62:
     dependencies:
       es6-iterator: 2.0.3
@@ -20007,8 +19999,6 @@ snapshots:
 
   fast-redact@3.3.0: {}
 
-  fast-text-encoding@1.0.6: {}
-
   fast-xml-parser@4.2.5:
     dependencies:
       strnum: 1.0.5
@@ -20212,20 +20202,21 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  gaxios@4.3.3(encoding@0.1.13):
+  gaxios@6.7.1(encoding@0.1.13):
     dependencies:
-      abort-controller: 3.0.0
       extend: 3.0.2
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 7.0.6
       is-stream: 2.0.1
       node-fetch: 2.7.0(encoding@0.1.13)
+      uuid: 9.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  gcp-metadata@4.3.1(encoding@0.1.13):
+  gcp-metadata@6.1.1(encoding@0.1.13):
     dependencies:
-      gaxios: 4.3.3(encoding@0.1.13)
+      gaxios: 6.7.1(encoding@0.1.13)
+      google-logging-utils: 0.0.2
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - encoding
@@ -20380,34 +20371,26 @@ snapshots:
       pify: 2.3.0
       pinkie-promise: 2.0.1
 
-  google-auth-library@6.1.6(encoding@0.1.13):
+  google-auth-library@9.15.1(encoding@0.1.13):
     dependencies:
-      arrify: 2.0.1
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      fast-text-encoding: 1.0.6
-      gaxios: 4.3.3(encoding@0.1.13)
-      gcp-metadata: 4.3.1(encoding@0.1.13)
-      gtoken: 5.3.2(encoding@0.1.13)
+      gaxios: 6.7.1(encoding@0.1.13)
+      gcp-metadata: 6.1.1(encoding@0.1.13)
+      gtoken: 7.1.0(encoding@0.1.13)
       jws: 4.0.0
-      lru-cache: 6.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  google-p12-pem@3.1.4:
-    dependencies:
-      node-forge: 1.3.1
+  google-logging-utils@0.0.2: {}
 
-  google-spreadsheet@3.3.0(encoding@0.1.13):
+  google-spreadsheet@5.3.0(google-auth-library@9.15.1(encoding@0.1.13)):
     dependencies:
-      axios: 0.21.4
-      google-auth-library: 6.1.6(encoding@0.1.13)
-      lodash: 4.17.21
-    transitivePeerDependencies:
-      - debug
-      - encoding
-      - supports-color
+      es-toolkit: 1.49.0
+      ky: 2.0.2
+    optionalDependencies:
+      google-auth-library: 9.15.1(encoding@0.1.13)
 
   gopd@1.0.1:
     dependencies:
@@ -20442,10 +20425,9 @@ snapshots:
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
 
-  gtoken@5.3.2(encoding@0.1.13):
+  gtoken@7.1.0(encoding@0.1.13):
     dependencies:
-      gaxios: 4.3.3(encoding@0.1.13)
-      google-p12-pem: 3.1.4
+      gaxios: 6.7.1(encoding@0.1.13)
       jws: 4.0.0
     transitivePeerDependencies:
       - encoding
@@ -21717,6 +21699,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ky@2.0.2: {}
+
   langium@4.2.3:
     dependencies:
       '@chevrotain/regexp-to-ast': 12.0.0
@@ -22554,8 +22538,6 @@ snapshots:
       whatwg-url: 5.0.0
     optionalDependencies:
       encoding: 0.1.13
-
-  node-forge@1.3.1: {}
 
   node-gyp@13.0.0:
     dependencies:


### PR DESCRIPTION
Modernizes the stale Google Sheets connection dependencies. **Stacked on #2208** (base = `fix/node26-better-sqlite3`) — the connection's transitive JWT chain still pulls `buffer-equal-constant-time`, so it needs that PR's patch to load on Node 26.

## What & why

`connection-google-sheets` shipped `google-spreadsheet@3.3.0` (2021), which dragged in `axios@0.21.4` and `google-auth-library@6.1.6`. This bumps to `google-spreadsheet@5.3.0` (modern `axios@^1`, `google-auth-library` as a peer).

v4+ removed the `doc.useApiKey()` / `doc.useServiceAccountAuth()` methods in favour of **constructor-based auth**, so `getSheet.js` now:
- API key → `new GoogleSpreadsheet(spreadsheetId, { apiKey })`
- Service account → `new GoogleSpreadsheet(spreadsheetId, new JWT({ email, key, scopes }))` (from `google-auth-library`, added as a direct dependency)

## Compatibility

**No change to connection configuration.** Users still supply `spreadsheetId`, `sheetId`/`sheetIndex`, and either `apiKey` or `client_email` + `private_key` exactly as before. The docs example (`packages/docs/connections/GoogleSheet.yaml`) remains valid, so no docs change is required.

## Tests

`getSheet.test.js` was fully `skip`ped ("TODO: Fix jest mocks"). Rewrote the mocks for the `(id, auth)` constructor shape (mocking both `google-spreadsheet` and `google-auth-library`'s `JWT`) and **re-enabled** them; auth is now lazy (surfaces at `loadInfo`), so the old auth-throw cases are replaced with a `loadInfo`-rejection propagation test.

`pnpm --filter @lowdefy/connection-google-sheets test` → 14 suites / 160 tests pass, `getSheet.js` at 100% coverage. Verified in a clean-room install on Node v26.4.0.

Changeset included (minor).

> Review/merge #2208 first; this targets that branch and should be retargeted to `vite-hono` once #2208 lands.