### PR TITLE
feat(auth): Phase 2 - Hooks (user tier)

### DIFF
--- a/apps/auth-reference/README.md
+++ b/apps/auth-reference/README.md
@@ -3,7 +3,9 @@
 The living definition of done for the auth upgrade. Phase 1 exercises the
 BetterAuth engine: email/password signup with email verification, magic
 link, OAuth, protected/public/role-gated pages, sign out, and session
-revocation. Each later phase grows this app with a scenario.
+revocation. Phase 2 adds auth hooks: `InternalApi` endpoints bound to
+`user.create.before`, `session.create.after`, and `email.verified`. Each
+later phase grows this app with a scenario.
 
 ## Prerequisites
 
@@ -29,6 +31,8 @@ revocation. Each later phase grows this app with a scenario.
   LOWDEFY_SECRET_AUTH_DATABASE_URI=mongodb://localhost:27017/auth-reference
   LOWDEFY_SECRET_BETTER_AUTH_SECRET=<openssl rand -base64 32>
   LOWDEFY_SECRET_SMTP_HOST=localhost
+  # The hook scenarios assert this exact value lands in the audit row:
+  LOWDEFY_SECRET_HOOK_AUDIT_KEY=audit-secret-value
   # Only needed to exercise the OAuth scenario:
   LOWDEFY_SECRET_GOOGLE_CLIENT_ID=<from Google Cloud console>
   LOWDEFY_SECRET_GOOGLE_CLIENT_SECRET=<from Google Cloud console>
@@ -78,5 +82,50 @@ node scripts/dev.mjs --config-directory apps/auth-reference
     shows the fixed names: `users`, `user-sessions`, `user-accounts`,
     `user-verifications`.
 
-Every scenario above is manual in phase 1; automate with the repo's e2e
+## Walkthrough (phase-2 gate - hooks)
+
+The bindings live under `auth.hooks` in `lowdefy.yaml`; the hook bodies are
+the `InternalApi` endpoints in `api/`. Hooks run in a system context: the
+endpoints are unreachable over HTTP (`curl -X POST
+http://localhost:3000/api/endpoint/audit-login` answers "does not exist"),
+`_user` is empty inside the routine, the subject is in `_payload`, and
+`_secret` resolves.
+
+11. **`:return` replaces the record (`user.create.before`)**: sign up on
+    `/signup` with name `lower case name` and a fresh email. Verify via
+    Mailpit and log in - `/dashboard` shows **name: LOWER CASE NAME**: the
+    normalize-signup hook's `:return` replaced the record BetterAuth wrote.
+    Confirm in the database:
+    `mongosh auth-reference --eval 'db.users.find({}, {name: 1}).toArray()'`.
+12. **`:reject` vetoes end to end (`user.create.before`)**: sign up as
+    `anyone@blocked.example` - the signup fails with an error and **no row
+    is written**:
+    `mongosh auth-reference --eval 'db.users.countDocuments({email: "anyone@blocked.example"})'`
+    returns 0.
+13. **After hook fires with the catalog payload (`session.create.after`)**:
+    log in as any verified user, then open `/hook-audit` (or
+    `db['hook-audit'].find().toArray()`). The `session.create.after` row
+    carries the catalog's payload shape (`payloadKeys: ['session', 'user']`),
+    `sessionUserIsNone: true` (`_user` is empty in a hook routine), and
+    `secretResolves: true` (`_secret` works).
+14. **`email.verified` fires its synthetic point**: the signup from
+    scenario 11 also produced an `email.verified` audit row
+    (`payloadKeys: ['user']`) written when the Mailpit link was clicked -
+    after the user write, which is why this hook reacts instead of
+    returning a record.
+15. **A throw in an after hook is an operational error, the write stands**:
+    sign up and verify `after-throw@example.test`, then log in. The audit
+    hook throws (deliberately, see `api/audit-login.yaml`) and the sign-in
+    call surfaces an error - but the session row was already committed:
+    `db['user-sessions'].find({}).sort({createdAt: -1}).limit(1)` shows it.
+    This is why fallible after-hook work belongs in `:try` - the audit
+    write itself is wrapped so an unreachable database never breaks login.
+16. **Build validation**: each of these edits to `auth.hooks` in
+    `lowdefy.yaml` fails the build (watch the dev server output):
+    - an unknown point, e.g. `point: organization.create.before`;
+    - an `endpointId` that does not exist, or one that points at a
+      `type: Api` endpoint;
+    - two entries binding the same `point`.
+
+Every scenario above is manual in phases 1-2; automate with the repo's e2e
 tooling as it grows.

--- a/apps/auth-reference/README.md
+++ b/apps/auth-reference/README.md
@@ -54,8 +54,9 @@ node scripts/dev.mjs --config-directory apps/auth-reference
 
 1. **Public page**: open `/home` logged out - it renders. `/dashboard`
    redirects to `/login?callbackUrl=/dashboard`.
-2. **Sign up (email/password)**: `/signup` → submit. The response carries
-   **no session** (check the Mailpit inbox); you land on `/check-email`.
+2. **Sign up (email/password)**: `/signup` → submit (the `SignUp` action,
+   email/password only). The response carries **no session** (check the
+   Mailpit inbox); you land on `/check-email`.
 3. **Unverified sign-in refused**: `/login` with the same credentials →
    sign-in fails (403 EMAIL_NOT_VERIFIED) until the email is verified.
 4. **Verify**: click the link in Mailpit → BetterAuth verifies and

--- a/apps/auth-reference/api/audit-login.yaml
+++ b/apps/auth-reference/api/audit-login.yaml
@@ -1,0 +1,49 @@
+# Bound to session.create.after (see auth.hooks in lowdefy.yaml).
+# _payload is { session, user } - the session just created and its user.
+# After hooks are fire-and-forget: the session is already committed, so
+# fallible work belongs in :try - a throw here surfaces as an operational
+# error on the sign-in call even though the session row exists.
+id: audit-login
+type: InternalApi
+routine:
+  # Deliberate throw demo (gate: a throw in an after hook surfaces as an
+  # operational error while the committed write stands). Sign in as
+  # after-throw@example.test to trigger it.
+  - ':if':
+      _eq:
+        - _payload: user.email
+        - after-throw@example.test
+    ':then':
+      - ':throw': Deliberate after-hook failure for the walkthrough.
+  - ':try':
+      - id: write_audit
+        type: MongoDBInsertOne
+        connectionId: audit_db
+        properties:
+          doc:
+            event: session.create.after
+            sessionId:
+              _payload: session.id
+            userId:
+              _payload: session.userId
+            email:
+              _payload: user.email
+            payloadKeys:
+              _object.keys:
+                _payload: true
+            # _user is empty in a hook routine - the caller is the auth
+            # engine, not a session user. The subject is in _payload.
+            sessionUserIsNone:
+              _eq:
+                - _user: id
+                - null
+            # _secret resolves normally in the system context.
+            secretResolves:
+              _eq:
+                - _secret: HOOK_AUDIT_KEY
+                - audit-secret-value
+            at:
+              _date: now
+    ':catch':
+      - ':log':
+          - 'audit-login hook failed to write the audit row'

--- a/apps/auth-reference/api/normalize-signup.yaml
+++ b/apps/auth-reference/api/normalize-signup.yaml
@@ -1,0 +1,29 @@
+# Bound to user.create.before (see auth.hooks in lowdefy.yaml).
+# _payload is { user } - the record BetterAuth is about to write.
+id: normalize-signup
+type: InternalApi
+routine:
+  # Veto: a :reject in a before hook aborts the write end to end - no user
+  # row is written and the signup call fails with the reject message.
+  - ':if':
+      _regex:
+        pattern: '@blocked\.example$'
+        on:
+          _payload: user.email
+    ':then':
+      - ':reject': Signups from blocked.example are not allowed.
+  # Replace the record BetterAuth writes - the plain :return value is the
+  # new record (the adapter wraps it as { data }).
+  - ':if':
+      _type:
+        type: string
+        on:
+          _payload: user.name
+    ':then':
+      - ':return':
+          _object.assign:
+            - _payload: user
+            - name:
+                _string.toUpperCase:
+                  _payload: user.name
+  # No :return - fall through, record written unchanged.

--- a/apps/auth-reference/api/on-email-verified.yaml
+++ b/apps/auth-reference/api/on-email-verified.yaml
@@ -1,0 +1,27 @@
+# Bound to email.verified (see auth.hooks in lowdefy.yaml) - a synthetic
+# point backed by BetterAuth's emailVerification.afterEmailVerification
+# callback, not a database hook. It fires after the user write, so a hook
+# here reacts (or updates explicitly); an inline :return is ignored.
+# _payload is { user } - the user whose email just became verified.
+id: on-email-verified
+type: InternalApi
+routine:
+  - ':try':
+      - id: write_audit
+        type: MongoDBInsertOne
+        connectionId: audit_db
+        properties:
+          doc:
+            event: email.verified
+            userId:
+              _payload: user.id
+            email:
+              _payload: user.email
+            payloadKeys:
+              _object.keys:
+                _payload: true
+            at:
+              _date: now
+    ':catch':
+      - ':log':
+          - 'on-email-verified hook failed to write the audit row'

--- a/apps/auth-reference/lowdefy.yaml
+++ b/apps/auth-reference/lowdefy.yaml
@@ -1,9 +1,10 @@
 name: auth-reference
 lowdefy: local
 
-# Reference app for the BetterAuth engine (auth-upgrade phase 1).
+# Reference app for the BetterAuth engine (auth-upgrade phases 1-2).
 # Exercises: email/password signup with email verification, magic link,
-# OAuth (Google), protected/public/role-gated pages, sign out, sessions.
+# OAuth (Google), protected/public/role-gated pages, sign out, sessions,
+# and auth hooks (user.create.before, session.create.after, email.verified).
 # See README.md for the full walkthrough and required environment variables.
 
 auth:
@@ -72,6 +73,20 @@ auth:
     signUp: /signup
     verifyEmail: /verify-email
 
+  # Each entry binds an auth lifecycle point to an InternalApi endpoint.
+  # The endpoint's routine is the hook body; it runs in a system context
+  # (_user empty, subject in _payload, _secret working).
+  hooks:
+    - id: normalize-signup
+      point: user.create.before
+      endpointId: normalize-signup
+    - id: audit-login
+      point: session.create.after
+      endpointId: audit-login
+    - id: on-email-verified
+      point: email.verified
+      endpointId: on-email-verified
+
   # Uncomment to exercise the wrong-roles opaque /404 redirect and the
   # pre-resolved dev caller (roles are authoritative; no engine runs):
   # dev:
@@ -80,6 +95,22 @@ auth:
   #     email: mock@example.com
   #     name: Mock User
   #     roles: []
+
+# The hooks write an audit trail here; the same database as auth so no
+# extra infrastructure is needed for the walkthrough.
+connections:
+  - id: audit_db
+    type: MongoDBCollection
+    properties:
+      databaseUri:
+        _secret: AUTH_DATABASE_URI
+      collection: hook-audit
+      write: true
+
+api:
+  - _ref: api/normalize-signup.yaml
+  - _ref: api/audit-login.yaml
+  - _ref: api/on-email-verified.yaml
 
 pages:
   - _ref: pages/home.yaml
@@ -90,3 +121,4 @@ pages:
   - _ref: pages/dashboard.yaml
   - _ref: pages/sessions.yaml
   - _ref: pages/admin.yaml
+  - _ref: pages/hook-audit.yaml

--- a/apps/auth-reference/pages/hook-audit.yaml
+++ b/apps/auth-reference/pages/hook-audit.yaml
@@ -1,0 +1,45 @@
+id: hook-audit
+type: Box
+properties:
+  style:
+    maxWidth: 640
+    margin: 60px auto
+requests:
+  - id: fetch_audit
+    type: MongoDBFind
+    connectionId: audit_db
+    properties:
+      query: {}
+      options:
+        sort:
+          at: -1
+        limit: 20
+events:
+  onInit:
+    - id: fetch
+      type: Request
+      params: fetch_audit
+blocks:
+  - id: hook_audit_title
+    type: Title
+    properties:
+      content: Hook audit trail (protected)
+      level: 2
+  - id: hook_audit_intro
+    type: Html
+    properties:
+      html: |
+        <p>The last 20 rows the auth hooks wrote to the <code>hook-audit</code>
+        collection - <code>session.create.after</code> rows from the
+        audit-login hook and <code>email.verified</code> rows from the
+        on-email-verified hook.</p>
+  - id: hook_audit_rows
+    type: Html
+    properties:
+      html:
+        _nunjucks:
+          template: |
+            <pre>{{ rows | dump(2) }}</pre>
+          on:
+            rows:
+              _request: fetch_audit

--- a/apps/auth-reference/pages/signup.yaml
+++ b/apps/auth-reference/pages/signup.yaml
@@ -32,9 +32,8 @@ blocks:
         # With requireEmailVerification the response carries no session -
         # verification precedes sign-in.
         - id: sign_up
-          type: Login
+          type: SignUp
           params:
-            signUp: true
             name:
               _state: name
             email:

--- a/packages/api/src/context/createSystemContext.js
+++ b/packages/api/src/context/createSystemContext.js
@@ -1,0 +1,74 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import createEvaluateOperators from './createEvaluateOperators.js';
+import createReadConfigFile from './createReadConfigFile.js';
+
+// Builds a fresh off-request context for a trusted system caller - an auth
+// hook fire. The caller is the auth engine, not a user: `user` is empty so
+// `_user` resolves to nothing (the hook's subject is in `_payload`), and the
+// target endpoint's auth is not re-checked against a session - InternalApi
+// already guarantees the endpoint is unreachable over HTTP.
+function createSystemContext({
+  agents,
+  appMeta,
+  buildDirectory,
+  config,
+  configDirectory,
+  connections,
+  createHandleError,
+  fileCache,
+  i18n,
+  jsMap,
+  logger,
+  operators,
+  rid,
+  secrets,
+  websockets,
+}) {
+  const context = {
+    rid,
+    agents,
+    appMeta,
+    buildDirectory,
+    config,
+    configDirectory,
+    connections,
+    fileCache,
+    headers: {},
+    i18n: i18n?.defaultLocale ? { ...i18n, active: i18n.defaultLocale } : undefined,
+    jsMap,
+    logger,
+    operators,
+    req: {
+      url: 'system:auth-hook',
+      method: null,
+      hostname: null,
+    },
+    secrets,
+    user: {},
+    websockets,
+  };
+  // System caller: trusted internal invocation - endpoint auth is not
+  // re-checked against a session.
+  context.authorize = () => true;
+  context.handleError = createHandleError({ context });
+  context.readConfigFile = createReadConfigFile(context);
+  context.evaluateOperators = createEvaluateOperators(context);
+  return context;
+}
+
+export default createSystemContext;

--- a/packages/api/src/context/createSystemContext.test.js
+++ b/packages/api/src/context/createSystemContext.test.js
@@ -1,0 +1,89 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+
+import createSystemContext from './createSystemContext.js';
+
+const logger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+function createTestSystemContext(overrides = {}) {
+  return createSystemContext({
+    agents: {},
+    appMeta: { name: 'Test App' },
+    buildDirectory: '/build',
+    config: {},
+    connections: {},
+    createHandleError: jest.fn(({ context }) => async (error) => context.logger.error(error)),
+    fileCache: new Map(),
+    i18n: undefined,
+    jsMap: {},
+    logger,
+    operators: { _test: () => 'test' },
+    rid: 'test-rid',
+    secrets: { KEY: 'value' },
+    websockets: {},
+    ...overrides,
+  });
+}
+
+test('createSystemContext runs with an empty user - the caller is the auth engine', () => {
+  const context = createTestSystemContext();
+  expect(context.user).toEqual({});
+});
+
+test('createSystemContext authorize allows any endpoint - auth is not re-checked against a session', () => {
+  const context = createTestSystemContext();
+  expect(context.authorize({ auth: { public: false, roles: ['admin'] } })).toBe(true);
+  expect(context.authorize({ auth: { public: false } })).toBe(true);
+});
+
+test('createSystemContext wires readConfigFile, evaluateOperators and handleError', () => {
+  const context = createTestSystemContext();
+  expect(context.readConfigFile).toBeInstanceOf(Function);
+  expect(context.evaluateOperators).toBeInstanceOf(Function);
+  expect(context.handleError).toBeInstanceOf(Function);
+});
+
+test('createSystemContext carries the singletons and per-fire fields', () => {
+  const context = createTestSystemContext();
+  expect(context.rid).toBe('test-rid');
+  expect(context.logger).toBe(logger);
+  expect(context.secrets).toEqual({ KEY: 'value' });
+  expect(context.buildDirectory).toBe('/build');
+  expect(context.headers).toEqual({});
+  expect(context.req.url).toBe('system:auth-hook');
+});
+
+test('createSystemContext activates the default locale when i18n is configured', () => {
+  const context = createTestSystemContext({
+    i18n: { defaultLocale: 'en', locales: ['en', 'de'] },
+  });
+  expect(context.i18n.active).toBe('en');
+  const noI18n = createTestSystemContext({ i18n: undefined });
+  expect(noI18n.i18n).toBeUndefined();
+});
+
+test('createSystemContext evaluateOperators resolves _secret and leaves _user empty', () => {
+  const context = createTestSystemContext();
+  expect(context.user).toEqual({});
+  expect(context.secrets.KEY).toBe('value');
+});

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -19,6 +19,7 @@ import callEndpoint from './routes/endpoints/callEndpoint.js';
 import callRequest from './routes/request/callRequest.js';
 import createApiContext from './context/createApiContext.js';
 import createChannelRegistry from './routes/websocket/createChannelRegistry.js';
+import createSystemContext from './context/createSystemContext.js';
 import createWebSocketConnection from './routes/websocket/createWebSocketConnection.js';
 import getBetterAuth from './routes/auth/getBetterAuth.js';
 import getBetterAuthConfig from './routes/auth/getBetterAuthConfig.js';
@@ -35,6 +36,7 @@ export {
   callRequest,
   createApiContext,
   createChannelRegistry,
+  createSystemContext,
   createWebSocketConnection,
   getBetterAuth,
   getBetterAuthConfig,

--- a/packages/api/src/routes/auth/getBetterAuth.js
+++ b/packages/api/src/routes/auth/getBetterAuth.js
@@ -22,10 +22,28 @@ let instance;
 
 // The BetterAuth instance is constructed once per process at first use -
 // it handles /api/auth/* and resolves sessions for every request.
-function getBetterAuth({ appMeta, authJson, config, dev, logger, plugins, secrets }) {
+function getBetterAuth({
+  appMeta,
+  authJson,
+  config,
+  createSystemContext,
+  dev,
+  logger,
+  plugins,
+  secrets,
+}) {
   if (instance) return instance;
   instance = betterAuth(
-    getBetterAuthConfig({ appMeta, authJson, config, dev, logger, plugins, secrets })
+    getBetterAuthConfig({
+      appMeta,
+      authJson,
+      config,
+      createSystemContext,
+      dev,
+      logger,
+      plugins,
+      secrets,
+    })
   );
   return instance;
 }

--- a/packages/api/src/routes/auth/getBetterAuthConfig.js
+++ b/packages/api/src/routes/auth/getBetterAuthConfig.js
@@ -21,6 +21,7 @@ import { _app, _secret } from '@lowdefy/operators-js/operators/server';
 import { type } from '@lowdefy/helpers';
 import { ConfigError } from '@lowdefy/errors';
 
+import buildHooks from './hooks/buildHooks.js';
 import buildProviders from './buildProviders.js';
 import createAuthLogger from './createAuthLogger.js';
 import createSendEmail from './createSendEmail.js';
@@ -31,7 +32,18 @@ import resolveCookiePrefix from './resolveCookiePrefix.js';
 // Build has validated the config and written all defaults, so this function
 // resolves the _secret operators and maps the Lowdefy surface onto
 // BetterAuth's options - no fallback defaults here.
-function getBetterAuthConfig({ appMeta, authJson, config = {}, dev = false, logger, plugins, secrets }) {
+// createSystemContext builds a fresh off-request context per hook fire - the
+// bridge a firing hook uses to invoke its InternalApi endpoint.
+function getBetterAuthConfig({
+  appMeta,
+  authJson,
+  config = {},
+  createSystemContext,
+  dev = false,
+  logger,
+  plugins,
+  secrets,
+}) {
   const operatorsParser = new ServerParser({
     lowdefyApp: appMeta,
     operators: { _app, _secret },
@@ -205,6 +217,21 @@ function getBetterAuthConfig({ appMeta, authJson, config = {}, dev = false, logg
   // impersonation (phase 6); its banned/banReason/banExpires fields land on
   // the user record.
   options.plugins.push(admin());
+
+  const { afterEmailVerification, databaseHooks } = buildHooks({
+    authConfig,
+    createSystemContext,
+    logger,
+  });
+  if (Object.keys(databaseHooks).length > 0) {
+    options.databaseHooks = databaseHooks;
+  }
+  if (afterEmailVerification) {
+    options.emailVerification = {
+      ...options.emailVerification,
+      afterEmailVerification,
+    };
+  }
 
   return options;
 }

--- a/packages/api/src/routes/auth/getBetterAuthConfig.test.js
+++ b/packages/api/src/routes/auth/getBetterAuthConfig.test.js
@@ -539,3 +539,54 @@ test('sets cookie prefix to lowdefy in production', () => {
   });
   expect(options.advanced.cookiePrefix).toBe('lowdefy');
 });
+
+test('assembles databaseHooks from auth.hooks bindings', () => {
+  const options = getBetterAuthConfig({
+    appMeta,
+    authJson: createAuthJson({
+      hooks: [
+        { id: 'normalize', point: 'user.create.before', endpointId: 'auth/normalize' },
+        { id: 'audit', point: 'session.create.after', endpointId: 'auth/audit' },
+      ],
+    }),
+    createSystemContext: jest.fn(),
+    logger: createLogger(),
+    plugins: createPlugins(),
+    secrets: baseSecrets,
+  });
+  expect(options.databaseHooks.user.create.before).toBeInstanceOf(Function);
+  expect(options.databaseHooks.session.create.after).toBeInstanceOf(Function);
+  expect(options.emailVerification?.afterEmailVerification).toBeUndefined();
+});
+
+test('does not set databaseHooks when no hooks are bound', () => {
+  const options = getBetterAuthConfig({
+    appMeta,
+    authJson: createAuthJson({ hooks: [] }),
+    createSystemContext: jest.fn(),
+    logger: createLogger(),
+    plugins: createPlugins(),
+    secrets: baseSecrets,
+  });
+  expect(options.databaseHooks).toBeUndefined();
+});
+
+test('an email.verified hook sets emailVerification.afterEmailVerification and preserves sendVerificationEmail', () => {
+  const options = getBetterAuthConfig({
+    appMeta,
+    authJson: createAuthJson({
+      email: {
+        from: 'noreply@example.com',
+        provider: { type: 'smtp', properties: { host: 'localhost', port: 1025 } },
+      },
+      hooks: [{ id: 'on-verified', point: 'email.verified', endpointId: 'auth/on-verified' }],
+    }),
+    createSystemContext: jest.fn(),
+    logger: createLogger(),
+    plugins: createPlugins(),
+    secrets: baseSecrets,
+  });
+  expect(options.emailVerification.afterEmailVerification).toBeInstanceOf(Function);
+  expect(options.emailVerification.sendVerificationEmail).toBeInstanceOf(Function);
+  expect(options.databaseHooks).toBeUndefined();
+});

--- a/packages/api/src/routes/auth/hooks/authHookPoints.js
+++ b/packages/api/src/routes/auth/hooks/authHookPoints.js
@@ -1,0 +1,137 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import findHookUser from './findHookUser.js';
+
+// The bindable auth hook points and what each hands the hook routine as
+// _payload - the contract between the hook mechanism and the hook author.
+// Build validation guarantees every configured point is in this catalog.
+//
+// Database points receive BetterAuth's databaseHooks record; session and
+// account writes carry only a userId, so the subject user is read through
+// BetterAuth's internal adapter. user.update deviates from the catalog by
+// what BetterAuth provides: the before hook receives only the changed fields
+// (no way to identify the subject), the after hook only the updated record.
+//
+// Synthetic points are backed by BetterAuth config callbacks, not database
+// hooks. "invitation.send" is accepted at build but its backing callback
+// ships with the organization plugin in a later phase.
+const authHookPoints = {
+  'user.create.before': {
+    kind: 'database',
+    model: 'user',
+    operation: 'create',
+    timing: 'before',
+    buildPayload: (data) => ({ user: data }),
+  },
+  'user.create.after': {
+    kind: 'database',
+    model: 'user',
+    operation: 'create',
+    timing: 'after',
+    buildPayload: (data) => ({ user: data }),
+  },
+  'user.update.before': {
+    kind: 'database',
+    model: 'user',
+    operation: 'update',
+    timing: 'before',
+    buildPayload: (data) => ({ user: null, changes: data }),
+  },
+  'user.update.after': {
+    kind: 'database',
+    model: 'user',
+    operation: 'update',
+    timing: 'after',
+    buildPayload: (data) => ({ user: data, changes: null }),
+  },
+  'session.create.before': {
+    kind: 'database',
+    model: 'session',
+    operation: 'create',
+    timing: 'before',
+    buildPayload: async (data, ctx) => ({
+      session: data,
+      user: await findHookUser({ ctx, userId: data.userId }),
+    }),
+  },
+  'session.create.after': {
+    kind: 'database',
+    model: 'session',
+    operation: 'create',
+    timing: 'after',
+    buildPayload: async (data, ctx) => ({
+      session: data,
+      user: await findHookUser({ ctx, userId: data.userId }),
+    }),
+  },
+  'session.delete.after': {
+    kind: 'database',
+    model: 'session',
+    operation: 'delete',
+    timing: 'after',
+    buildPayload: async (data, ctx) => ({
+      session: data,
+      user: await findHookUser({ ctx, userId: data.userId }),
+    }),
+  },
+  'account.create.before': {
+    kind: 'database',
+    model: 'account',
+    operation: 'create',
+    timing: 'before',
+    buildPayload: async (data, ctx) => ({
+      account: data,
+      user: await findHookUser({ ctx, userId: data.userId }),
+    }),
+  },
+  'account.create.after': {
+    kind: 'database',
+    model: 'account',
+    operation: 'create',
+    timing: 'after',
+    buildPayload: async (data, ctx) => ({
+      account: data,
+      user: await findHookUser({ ctx, userId: data.userId }),
+    }),
+  },
+  'verification.create.before': {
+    kind: 'database',
+    model: 'verification',
+    operation: 'create',
+    timing: 'before',
+    buildPayload: (data) => ({ verification: data }),
+  },
+  'verification.create.after': {
+    kind: 'database',
+    model: 'verification',
+    operation: 'create',
+    timing: 'after',
+    buildPayload: (data) => ({ verification: data }),
+  },
+  'email.verified': {
+    kind: 'synthetic',
+    timing: 'after',
+    buildPayload: (user) => ({ user }),
+  },
+  'invitation.send': {
+    kind: 'synthetic',
+    timing: 'after',
+    unwired: true,
+  },
+};
+
+export default authHookPoints;

--- a/packages/api/src/routes/auth/hooks/authHookPoints.test.js
+++ b/packages/api/src/routes/auth/hooks/authHookPoints.test.js
@@ -1,0 +1,85 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+
+import authHookPoints from './authHookPoints.js';
+
+test('the catalog covers the frozen launch point set', () => {
+  expect(Object.keys(authHookPoints).sort()).toEqual(
+    [
+      'user.create.before',
+      'user.create.after',
+      'user.update.before',
+      'user.update.after',
+      'session.create.before',
+      'session.create.after',
+      'session.delete.after',
+      'account.create.before',
+      'account.create.after',
+      'verification.create.before',
+      'verification.create.after',
+      'email.verified',
+      'invitation.send',
+    ].sort()
+  );
+});
+
+test('user.create points hand { user }', () => {
+  const user = { id: 'u1', email: 'a@b.c' };
+  expect(authHookPoints['user.create.before'].buildPayload(user)).toEqual({ user });
+  expect(authHookPoints['user.create.after'].buildPayload(user)).toEqual({ user });
+});
+
+test('user.update.before hands { user: null, changes } - BetterAuth provides only the changed fields', () => {
+  const changes = { name: 'New Name' };
+  expect(authHookPoints['user.update.before'].buildPayload(changes)).toEqual({
+    user: null,
+    changes,
+  });
+});
+
+test('user.update.after hands { user, changes: null } - BetterAuth provides only the updated record', () => {
+  const user = { id: 'u1', name: 'New Name' };
+  expect(authHookPoints['user.update.after'].buildPayload(user)).toEqual({ user, changes: null });
+});
+
+test('session and account points hand the record plus the fetched subject user', async () => {
+  const user = { id: 'u1', email: 'a@b.c' };
+  const findUserById = jest.fn(async () => user);
+  const ctx = { context: { internalAdapter: { findUserById } } };
+  const session = { id: 's1', userId: 'u1' };
+  const account = { id: 'acc1', userId: 'u1', providerId: 'google' };
+
+  await expect(
+    authHookPoints['session.create.before'].buildPayload(session, ctx)
+  ).resolves.toEqual({ session, user });
+  await expect(authHookPoints['session.delete.after'].buildPayload(session, ctx)).resolves.toEqual(
+    { session, user }
+  );
+  await expect(
+    authHookPoints['account.create.after'].buildPayload(account, ctx)
+  ).resolves.toEqual({ account, user });
+});
+
+test('verification points hand { verification } and email.verified hands { user }', () => {
+  const verification = { id: 'v1', identifier: 'a@b.c' };
+  expect(authHookPoints['verification.create.before'].buildPayload(verification)).toEqual({
+    verification,
+  });
+  const user = { id: 'u1' };
+  expect(authHookPoints['email.verified'].buildPayload(user)).toEqual({ user });
+});

--- a/packages/api/src/routes/auth/hooks/buildHooks.js
+++ b/packages/api/src/routes/auth/hooks/buildHooks.js
@@ -1,0 +1,85 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { set, type } from '@lowdefy/helpers';
+import { LowdefyInternalError } from '@lowdefy/errors';
+
+import authHookPoints from './authHookPoints.js';
+import composeAfterSlot from './composeAfterSlot.js';
+import composeBeforeSlot from './composeBeforeSlot.js';
+import createHookDispatch from './createHookDispatch.js';
+import createUserAfterHook from './createUserAfterHook.js';
+import createUserBeforeHook from './createUserBeforeHook.js';
+import engineHooks from './engineHooks.js';
+
+// Assembles BetterAuth's databaseHooks and the synthetic points' backing
+// callbacks from the engine-tier bindings and the validated auth.hooks
+// entries. Each point resolves to one composed slot with engine hooks first,
+// then the single user hook. Build validation guarantees every entry binds a
+// known point, at most once, to an existing InternalApi endpoint.
+function buildHooks({ authConfig, createSystemContext, logger }) {
+  const userHooks = {};
+  (authConfig.hooks ?? []).forEach((hook) => {
+    userHooks[hook.point] = hook;
+  });
+
+  if (Object.keys(userHooks).length > 0 && type.isNone(createSystemContext)) {
+    throw new LowdefyInternalError(
+      'Auth hooks are configured but no createSystemContext factory was provided to getBetterAuthConfig.'
+    );
+  }
+
+  const databaseHooks = {};
+  let afterEmailVerification;
+
+  const points = new Set([...Object.keys(engineHooks), ...Object.keys(userHooks)]);
+  points.forEach((point) => {
+    const pointDef = authHookPoints[point];
+    const userHook = userHooks[point];
+
+    if (pointDef.unwired === true) {
+      if (userHook) {
+        logger.warn(
+          `Auth hook "${userHook.id}" binds point "${point}", which has no backing callback yet - the organization plugin ships in a later phase. The hook will not fire.`
+        );
+      }
+      return;
+    }
+
+    const hooks = [...(engineHooks[point] ?? [])];
+    if (userHook) {
+      const dispatch = createHookDispatch({ createSystemContext, hook: userHook });
+      hooks.push(
+        pointDef.timing === 'before'
+          ? createUserBeforeHook({ dispatch, hook: userHook })
+          : createUserAfterHook({ dispatch })
+      );
+    }
+
+    if (pointDef.kind === 'database') {
+      const slot =
+        pointDef.timing === 'before' ? composeBeforeSlot({ hooks }) : composeAfterSlot({ hooks });
+      set(databaseHooks, `${pointDef.model}.${pointDef.operation}.${pointDef.timing}`, slot);
+    }
+    if (point === 'email.verified') {
+      afterEmailVerification = composeAfterSlot({ hooks });
+    }
+  });
+
+  return { afterEmailVerification, databaseHooks };
+}
+
+export default buildHooks;

--- a/packages/api/src/routes/auth/hooks/buildHooks.test.js
+++ b/packages/api/src/routes/auth/hooks/buildHooks.test.js
@@ -1,0 +1,341 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+import { APIError } from 'better-auth/api';
+import { operatorsServer } from '@lowdefy/operators-js';
+import { ConfigError, LowdefyInternalError } from '@lowdefy/errors';
+
+import buildHooks from './buildHooks.js';
+import createEvaluateOperators from '../../../context/createEvaluateOperators.js';
+import testContext from '../../../test/testContext.js';
+
+const operators = { ...operatorsServer };
+
+const logger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+function createMockReadConfigFile(endpointConfigs = {}) {
+  return jest.fn((path) => {
+    const match = path.match(/^api\/(.+)\.json$/);
+    if (match && endpointConfigs[match[1]]) {
+      const config = endpointConfigs[match[1]];
+      if (!config.auth) config.auth = { public: true };
+      return config;
+    }
+    return null;
+  });
+}
+
+// A factory producing a fresh system-like context per fire, the way the
+// servers' createSystemContext does - empty user, authorize bypassed.
+function createMockSystemContextFactory({ endpointConfigs = {} } = {}) {
+  return function createSystemContext() {
+    const context = testContext({
+      operators,
+      logger,
+      readConfigFile: createMockReadConfigFile(endpointConfigs),
+      user: {},
+      secrets: { HOOK_KEY: 'hook-secret-value' },
+    });
+    context.authorize = () => true;
+    context.evaluateOperators = createEvaluateOperators(context);
+    return context;
+  };
+}
+
+function buildTestHooks({ endpointConfigs, hooks }) {
+  return buildHooks({
+    authConfig: { hooks },
+    createSystemContext: createMockSystemContextFactory({ endpointConfigs }),
+    logger,
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('buildHooks returns empty databaseHooks and no afterEmailVerification when no hooks bound', () => {
+  const { afterEmailVerification, databaseHooks } = buildTestHooks({ hooks: [] });
+  expect(databaseHooks).toEqual({});
+  expect(afterEmailVerification).toBeUndefined();
+});
+
+test('buildHooks tolerates an authConfig without a hooks array', () => {
+  const { databaseHooks } = buildHooks({
+    authConfig: {},
+    createSystemContext: createMockSystemContextFactory(),
+    logger,
+  });
+  expect(databaseHooks).toEqual({});
+});
+
+test('buildHooks throws when hooks are configured without a createSystemContext factory', () => {
+  expect(() =>
+    buildHooks({
+      authConfig: { hooks: [{ id: 'h', point: 'user.create.before', endpointId: 'auth/h' }] },
+      logger,
+    })
+  ).toThrow(LowdefyInternalError);
+});
+
+test('a before hook :return replaces the record handed back as { data }', async () => {
+  const { databaseHooks } = buildTestHooks({
+    hooks: [{ id: 'normalize', point: 'user.create.before', endpointId: 'auth/normalize' }],
+    endpointConfigs: {
+      'auth/normalize': {
+        endpointId: 'auth/normalize',
+        type: 'InternalApi',
+        routine: { ':return': { name: 'Replaced Name', flagged: true } },
+      },
+    },
+  });
+  const result = await databaseHooks.user.create.before({ name: 'Original', email: 'a@b.c' });
+  expect(result).toEqual({ data: { name: 'Replaced Name', flagged: true } });
+});
+
+test('a before hook that falls through leaves the record unchanged', async () => {
+  const { databaseHooks } = buildTestHooks({
+    hooks: [{ id: 'noop', point: 'user.create.before', endpointId: 'auth/noop' }],
+    endpointConfigs: {
+      'auth/noop': {
+        endpointId: 'auth/noop',
+        type: 'InternalApi',
+        routine: [{ ':log': 'observed' }],
+      },
+    },
+  });
+  const record = { name: 'Original', email: 'a@b.c' };
+  const result = await databaseHooks.user.create.before(record);
+  expect(result).toEqual({ data: record });
+});
+
+test('a before hook :reject aborts the write with an APIError carrying the reject message', async () => {
+  const { databaseHooks } = buildTestHooks({
+    hooks: [{ id: 'veto', point: 'user.create.before', endpointId: 'auth/veto' }],
+    endpointConfigs: {
+      'auth/veto': {
+        endpointId: 'auth/veto',
+        type: 'InternalApi',
+        routine: { ':reject': 'Signups are closed.' },
+      },
+    },
+  });
+  await expect(databaseHooks.user.create.before({ email: 'a@b.c' })).rejects.toThrow(APIError);
+  await expect(databaseHooks.user.create.before({ email: 'a@b.c' })).rejects.toThrow(
+    'Signups are closed.'
+  );
+});
+
+test('a throw inside a before hook routine propagates and aborts the write', async () => {
+  const { databaseHooks } = buildTestHooks({
+    hooks: [{ id: 'boom', point: 'user.create.before', endpointId: 'auth/boom' }],
+    endpointConfigs: {
+      'auth/boom': {
+        endpointId: 'auth/boom',
+        type: 'InternalApi',
+        routine: { ':throw': 'boom' },
+      },
+    },
+  });
+  await expect(databaseHooks.user.create.before({ email: 'a@b.c' })).rejects.toThrow('boom');
+});
+
+test('a before hook :return that is not an object throws a ConfigError', async () => {
+  const { databaseHooks } = buildTestHooks({
+    hooks: [{ id: 'bad-return', point: 'user.create.before', endpointId: 'auth/bad' }],
+    endpointConfigs: {
+      'auth/bad': {
+        endpointId: 'auth/bad',
+        type: 'InternalApi',
+        routine: { ':return': 'not-an-object' },
+      },
+    },
+  });
+  await expect(databaseHooks.user.create.before({ email: 'a@b.c' })).rejects.toThrow(ConfigError);
+  await expect(databaseHooks.user.create.before({ email: 'a@b.c' })).rejects.toThrow(
+    'Auth hook "bad-return" at point "user.create.before" returned a string.'
+  );
+});
+
+test('the point payload reaches the routine as _payload - user.create.before hands { user }', async () => {
+  const { databaseHooks } = buildTestHooks({
+    hooks: [{ id: 'echo', point: 'user.create.before', endpointId: 'auth/echo' }],
+    endpointConfigs: {
+      'auth/echo': {
+        endpointId: 'auth/echo',
+        type: 'InternalApi',
+        routine: { ':return': { _payload: true } },
+      },
+    },
+  });
+  const result = await databaseHooks.user.create.before({ name: 'A', email: 'a@b.c' });
+  expect(result).toEqual({ data: { user: { name: 'A', email: 'a@b.c' } } });
+});
+
+test('inside a hook routine _user is empty and _secret resolves', async () => {
+  const { databaseHooks } = buildTestHooks({
+    hooks: [{ id: 'ops', point: 'user.create.before', endpointId: 'auth/ops' }],
+    endpointConfigs: {
+      'auth/ops': {
+        endpointId: 'auth/ops',
+        type: 'InternalApi',
+        routine: {
+          ':return': {
+            sessionUserId: { _user: 'id' },
+            secret: { _secret: 'HOOK_KEY' },
+          },
+        },
+      },
+    },
+  });
+  const result = await databaseHooks.user.create.before({ email: 'a@b.c' });
+  expect(result.data.sessionUserId).toBeNull();
+  expect(result.data.secret).toBe('hook-secret-value');
+});
+
+test('an after hook fires without affecting the result and ignores :return data', async () => {
+  const { databaseHooks } = buildTestHooks({
+    hooks: [{ id: 'audit', point: 'session.create.after', endpointId: 'auth/audit' }],
+    endpointConfigs: {
+      'auth/audit': {
+        endpointId: 'auth/audit',
+        type: 'InternalApi',
+        routine: { ':return': { ignored: true } },
+      },
+    },
+  });
+  await expect(
+    databaseHooks.session.create.after({ id: 'session_1', userId: 'user_1' })
+  ).resolves.toBeUndefined();
+  expect(logger.debug).toHaveBeenCalledWith(
+    expect.objectContaining({
+      event: 'debug_auth_hook',
+      hookId: 'audit',
+      point: 'session.create.after',
+      status: 'return',
+    })
+  );
+});
+
+test('a :reject in an after hook surfaces as an APIError on the operation', async () => {
+  const { databaseHooks } = buildTestHooks({
+    hooks: [{ id: 'audit', point: 'session.create.after', endpointId: 'auth/audit' }],
+    endpointConfigs: {
+      'auth/audit': {
+        endpointId: 'auth/audit',
+        type: 'InternalApi',
+        routine: { ':reject': 'audit failed' },
+      },
+    },
+  });
+  await expect(
+    databaseHooks.session.create.after({ id: 'session_1', userId: 'user_1' })
+  ).rejects.toThrow(APIError);
+});
+
+test('session points fetch the subject user through the internal adapter', async () => {
+  const { databaseHooks } = buildTestHooks({
+    hooks: [{ id: 'audit', point: 'session.create.after', endpointId: 'auth/audit' }],
+    endpointConfigs: {
+      'auth/audit': {
+        endpointId: 'auth/audit',
+        type: 'InternalApi',
+        routine: { ':reject': { '_string.concat': ['email:', { _payload: 'user.email' }] } },
+      },
+    },
+  });
+  const findUserById = jest.fn(async () => ({ id: 'user_1', email: 'a@b.c' }));
+  const ctx = { context: { internalAdapter: { findUserById } } };
+  await expect(
+    databaseHooks.session.create.after({ id: 'session_1', userId: 'user_1' }, ctx)
+  ).rejects.toThrow('email:a@b.c');
+  expect(findUserById).toHaveBeenCalledWith('user_1');
+});
+
+test('session points hand a null user when no endpoint context is available', async () => {
+  const { databaseHooks } = buildTestHooks({
+    hooks: [{ id: 'audit', point: 'session.create.after', endpointId: 'auth/audit' }],
+    endpointConfigs: {
+      'auth/audit': {
+        endpointId: 'auth/audit',
+        type: 'InternalApi',
+        routine: { ':reject': { _if_none: [{ _payload: 'user' }, 'user-is-null'] } },
+      },
+    },
+  });
+  await expect(
+    databaseHooks.session.create.after({ id: 'session_1', userId: 'user_1' }, null)
+  ).rejects.toThrow('user-is-null');
+});
+
+test('email.verified builds an afterEmailVerification callback, not a database hook', async () => {
+  const { afterEmailVerification, databaseHooks } = buildTestHooks({
+    hooks: [{ id: 'on-verified', point: 'email.verified', endpointId: 'auth/on-verified' }],
+    endpointConfigs: {
+      'auth/on-verified': {
+        endpointId: 'auth/on-verified',
+        type: 'InternalApi',
+        routine: { ':reject': { '_string.concat': ['verified:', { _payload: 'user.email' }] } },
+      },
+    },
+  });
+  expect(databaseHooks).toEqual({});
+  await expect(afterEmailVerification({ id: 'user_1', email: 'a@b.c' })).rejects.toThrow(
+    'verified:a@b.c'
+  );
+});
+
+test('invitation.send is accepted but not wired - a warning is logged and nothing assembles', () => {
+  const { afterEmailVerification, databaseHooks } = buildTestHooks({
+    hooks: [{ id: 'invite', point: 'invitation.send', endpointId: 'auth/invite' }],
+    endpointConfigs: {},
+  });
+  expect(databaseHooks).toEqual({});
+  expect(afterEmailVerification).toBeUndefined();
+  expect(logger.warn).toHaveBeenCalledWith(
+    expect.stringContaining('Auth hook "invite" binds point "invitation.send"')
+  );
+});
+
+test('multiple hooks assemble slots at their own points', async () => {
+  const { databaseHooks } = buildTestHooks({
+    hooks: [
+      { id: 'normalize', point: 'user.create.before', endpointId: 'auth/normalize' },
+      { id: 'audit', point: 'session.create.after', endpointId: 'auth/audit' },
+    ],
+    endpointConfigs: {
+      'auth/normalize': {
+        endpointId: 'auth/normalize',
+        type: 'InternalApi',
+        routine: { ':return': { name: 'N' } },
+      },
+      'auth/audit': {
+        endpointId: 'auth/audit',
+        type: 'InternalApi',
+        routine: [{ ':log': 'audit' }],
+      },
+    },
+  });
+  expect(databaseHooks.user.create.before).toBeInstanceOf(Function);
+  expect(databaseHooks.session.create.after).toBeInstanceOf(Function);
+  expect(databaseHooks.user.create.after).toBeUndefined();
+});

--- a/packages/api/src/routes/auth/hooks/composeAfterSlot.js
+++ b/packages/api/src/routes/auth/hooks/composeAfterSlot.js
@@ -1,0 +1,28 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// The composed slot for after and synthetic points - engine hooks first,
+// then the user hook, sequentially. Return values are ignored; a thrown
+// error propagates as an operational error on the underlying operation.
+function composeAfterSlot({ hooks }) {
+  return async function afterSlot(data, ctx) {
+    for (const hook of hooks) {
+      await hook(data, ctx);
+    }
+  };
+}
+
+export default composeAfterSlot;

--- a/packages/api/src/routes/auth/hooks/composeBeforeSlot.js
+++ b/packages/api/src/routes/auth/hooks/composeBeforeSlot.js
@@ -1,0 +1,42 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { type } from '@lowdefy/helpers';
+
+// BetterAuth exposes one callback per database point, so each point resolves
+// to a single composed slot - engine hooks first, then the user hook. The
+// slot threads the record: what one hook returns is passed to the next, and
+// the final record is handed back to BetterAuth as { data }. The first hook
+// to veto short-circuits - a returned false aborts the write, and a thrown
+// error propagates; there is no cross-hook transaction, so external
+// side-effects of earlier hooks are not rolled back.
+function composeBeforeSlot({ hooks }) {
+  return async function beforeSlot(data, ctx) {
+    let record = data;
+    for (const hook of hooks) {
+      const result = await hook(record, ctx);
+      if (result === false) {
+        return false;
+      }
+      if (type.isObject(result) && 'data' in result) {
+        record = result.data;
+      }
+    }
+    return { data: record };
+  };
+}
+
+export default composeBeforeSlot;

--- a/packages/api/src/routes/auth/hooks/composeBeforeSlot.test.js
+++ b/packages/api/src/routes/auth/hooks/composeBeforeSlot.test.js
@@ -1,0 +1,103 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+
+import composeAfterSlot from './composeAfterSlot.js';
+import composeBeforeSlot from './composeBeforeSlot.js';
+
+test('composeBeforeSlot threads the record - each hook sees the previous return', async () => {
+  const calls = [];
+  const slot = composeBeforeSlot({
+    hooks: [
+      async (record) => {
+        calls.push(record);
+        return { data: { ...record, engine: true } };
+      },
+      async (record) => {
+        calls.push(record);
+        return { data: { ...record, user: true } };
+      },
+    ],
+  });
+  const result = await slot({ name: 'A' });
+  expect(calls).toEqual([{ name: 'A' }, { name: 'A', engine: true }]);
+  expect(result).toEqual({ data: { name: 'A', engine: true, user: true } });
+});
+
+test('composeBeforeSlot passes the record on unchanged when a hook falls through', async () => {
+  const slot = composeBeforeSlot({
+    hooks: [async () => undefined, async (record) => ({ data: { ...record, touched: true } })],
+  });
+  const result = await slot({ name: 'A' });
+  expect(result).toEqual({ data: { name: 'A', touched: true } });
+});
+
+test('composeBeforeSlot short-circuits on the first hook returning false', async () => {
+  const second = jest.fn();
+  const slot = composeBeforeSlot({
+    hooks: [async () => false, second],
+  });
+  const result = await slot({ name: 'A' });
+  expect(result).toBe(false);
+  expect(second).not.toHaveBeenCalled();
+});
+
+test('composeBeforeSlot lets a thrown error propagate and skips later hooks', async () => {
+  const second = jest.fn();
+  const slot = composeBeforeSlot({
+    hooks: [
+      async () => {
+        throw new Error('veto');
+      },
+      second,
+    ],
+  });
+  await expect(slot({ name: 'A' })).rejects.toThrow('veto');
+  expect(second).not.toHaveBeenCalled();
+});
+
+test('composeAfterSlot runs hooks in order and ignores return values', async () => {
+  const calls = [];
+  const slot = composeAfterSlot({
+    hooks: [
+      async (data) => {
+        calls.push(['engine', data]);
+        return 'ignored';
+      },
+      async (data) => {
+        calls.push(['user', data]);
+      },
+    ],
+  });
+  const ctx = { context: {} };
+  await expect(slot({ id: 's1' }, ctx)).resolves.toBeUndefined();
+  expect(calls).toEqual([
+    ['engine', { id: 's1' }],
+    ['user', { id: 's1' }],
+  ]);
+});
+
+test('composeAfterSlot lets a thrown error propagate', async () => {
+  const slot = composeAfterSlot({
+    hooks: [
+      async () => {
+        throw new Error('audit failed');
+      },
+    ],
+  });
+  await expect(slot({ id: 's1' })).rejects.toThrow('audit failed');
+});

--- a/packages/api/src/routes/auth/hooks/createHookDispatch.js
+++ b/packages/api/src/routes/auth/hooks/createHookDispatch.js
@@ -1,0 +1,48 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import invokeEndpoint from '../../endpoints/invokeEndpoint.js';
+import authHookPoints from './authHookPoints.js';
+
+// Runs a user hook: builds the point's payload from the hook data, builds a
+// fresh system context, and invokes the bound InternalApi endpoint. Returns
+// the routine's terminal envelope ({ status, response?, error? }); the
+// translation to BetterAuth's hook contract lives in createUserBeforeHook /
+// createUserAfterHook.
+function createHookDispatch({ createSystemContext, hook }) {
+  const { buildPayload } = authHookPoints[hook.point];
+  return async function dispatchHook(data, ctx) {
+    const start = performance.now();
+    const payload = await buildPayload(data, ctx);
+    const context = createSystemContext();
+    const result = await invokeEndpoint(context, {
+      endpointId: hook.endpointId,
+      payload,
+      endpointDepth: 0,
+    });
+    context.logger.debug({
+      event: 'debug_auth_hook',
+      hookId: hook.id,
+      point: hook.point,
+      endpointId: hook.endpointId,
+      status: result.status,
+      elapsed_ms: Math.round((performance.now() - start) * 100) / 100,
+    });
+    return result;
+  };
+}
+
+export default createHookDispatch;

--- a/packages/api/src/routes/auth/hooks/createUserAfterHook.js
+++ b/packages/api/src/routes/auth/hooks/createUserAfterHook.js
@@ -1,0 +1,35 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { APIError } from 'better-auth/api';
+
+// Translates the routine's terminal control for after and synthetic points.
+// These fire after the write committed, so `:return` data is ignored and a
+// `:reject`/throw surfaces as an operational error on the underlying
+// operation - hook routines wrap fallible fire-and-forget work in `:try`.
+function createUserAfterHook({ dispatch }) {
+  return async function userAfterHook(data, ctx) {
+    const result = await dispatch(data, ctx);
+    if (result.status === 'reject') {
+      throw new APIError('BAD_REQUEST', { message: result.error.message });
+    }
+    if (result.status === 'error') {
+      throw result.error;
+    }
+  };
+}
+
+export default createUserAfterHook;

--- a/packages/api/src/routes/auth/hooks/createUserBeforeHook.js
+++ b/packages/api/src/routes/auth/hooks/createUserBeforeHook.js
@@ -1,0 +1,50 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { APIError } from 'better-auth/api';
+import { type } from '@lowdefy/helpers';
+import { ConfigError } from '@lowdefy/errors';
+
+// Translates the routine's terminal control into BetterAuth's before-hook
+// contract. The routine `:return`s plain data - the ceremony lives here:
+// returned data replaces the record ({ data } wrap), a fall-through leaves
+// the record unchanged, and `:reject`/throw aborts the write.
+function createUserBeforeHook({ dispatch, hook }) {
+  return async function userBeforeHook(data, ctx) {
+    const result = await dispatch(data, ctx);
+    if (result.status === 'return') {
+      if (!type.isObject(result.response)) {
+        throw new ConfigError(
+          `Auth hook "${hook.id}" at point "${hook.point}" returned a ${type.typeOf(
+            result.response
+          )}. A before hook ":return" value replaces the record being written, so it should be an object.`,
+          { received: result.response }
+        );
+      }
+      return { data: result.response };
+    }
+    if (result.status === 'reject') {
+      throw new APIError('BAD_REQUEST', { message: result.error.message });
+    }
+    if (result.status === 'error') {
+      throw result.error;
+    }
+    // The routine fell through without a terminal control - record unchanged.
+    return undefined;
+  };
+}
+
+export default createUserBeforeHook;

--- a/packages/api/src/routes/auth/hooks/createUserBeforeHook.test.js
+++ b/packages/api/src/routes/auth/hooks/createUserBeforeHook.test.js
@@ -1,0 +1,91 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { APIError } from 'better-auth/api';
+import { ConfigError } from '@lowdefy/errors';
+
+import createUserAfterHook from './createUserAfterHook.js';
+import createUserBeforeHook from './createUserBeforeHook.js';
+
+const hook = { id: 'test-hook', point: 'user.create.before', endpointId: 'auth/test' };
+
+test('before hook wraps :return data as { data }', async () => {
+  const userHook = createUserBeforeHook({
+    dispatch: async () => ({ status: 'return', response: { name: 'X' } }),
+    hook,
+  });
+  expect(await userHook({ name: 'A' })).toEqual({ data: { name: 'X' } });
+});
+
+test('before hook returns undefined when the routine falls through', async () => {
+  const userHook = createUserBeforeHook({
+    dispatch: async () => ({ status: 'continue' }),
+    hook,
+  });
+  expect(await userHook({ name: 'A' })).toBeUndefined();
+});
+
+test('before hook throws a ConfigError when :return data is not an object', async () => {
+  const userHook = createUserBeforeHook({
+    dispatch: async () => ({ status: 'return', response: 42 }),
+    hook,
+  });
+  await expect(userHook({ name: 'A' })).rejects.toThrow(ConfigError);
+  await expect(userHook({ name: 'A' })).rejects.toThrow(
+    'Auth hook "test-hook" at point "user.create.before" returned a number.'
+  );
+});
+
+test('before hook maps :reject to an APIError with the reject message', async () => {
+  const userHook = createUserBeforeHook({
+    dispatch: async () => ({ status: 'reject', error: new Error('blocked') }),
+    hook,
+  });
+  await expect(userHook({ name: 'A' })).rejects.toThrow(APIError);
+  await expect(userHook({ name: 'A' })).rejects.toThrow('blocked');
+});
+
+test('before hook rethrows the routine error on error status', async () => {
+  const routineError = new Error('exploded');
+  const userHook = createUserBeforeHook({
+    dispatch: async () => ({ status: 'error', error: routineError }),
+    hook,
+  });
+  await expect(userHook({ name: 'A' })).rejects.toBe(routineError);
+});
+
+test('after hook resolves undefined on return and continue', async () => {
+  const returned = createUserAfterHook({
+    dispatch: async () => ({ status: 'return', response: { ignored: true } }),
+  });
+  const fellThrough = createUserAfterHook({
+    dispatch: async () => ({ status: 'continue' }),
+  });
+  await expect(returned({ id: 's1' })).resolves.toBeUndefined();
+  await expect(fellThrough({ id: 's1' })).resolves.toBeUndefined();
+});
+
+test('after hook maps :reject to an APIError and rethrows routine errors', async () => {
+  const rejected = createUserAfterHook({
+    dispatch: async () => ({ status: 'reject', error: new Error('no') }),
+  });
+  const routineError = new Error('exploded');
+  const errored = createUserAfterHook({
+    dispatch: async () => ({ status: 'error', error: routineError }),
+  });
+  await expect(rejected({ id: 's1' })).rejects.toThrow(APIError);
+  await expect(errored({ id: 's1' })).rejects.toBe(routineError);
+});

--- a/packages/api/src/routes/auth/hooks/engineHooks.js
+++ b/packages/api/src/routes/auth/hooks/engineHooks.js
@@ -1,0 +1,25 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Engine-tier hook bindings - hard-coded framework behavior, not entries in
+// auth.hooks. Keyed by point; each point lists BetterAuth-native callbacks
+// (before: (data, ctx) => false | { data } | undefined, after: (data, ctx)).
+// Engine hooks run first in each composed slot, so the user hook sees the
+// engine-normalized record. The membership behaviors (auto-join, active-org
+// policy) register here in a later phase.
+const engineHooks = {};
+
+export default engineHooks;

--- a/packages/api/src/routes/auth/hooks/findHookUser.js
+++ b/packages/api/src/routes/auth/hooks/findHookUser.js
@@ -1,0 +1,31 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { type } from '@lowdefy/helpers';
+
+// Fetches the subject user for points whose payload catalog includes a user
+// the database hook does not receive directly (session and account writes
+// carry only a userId). Reads through BetterAuth's own internal adapter from
+// the hook's endpoint context; null when the write runs outside a request
+// lifecycle and no context is available.
+async function findHookUser({ ctx, userId }) {
+  if (type.isNone(userId) || type.isNone(ctx?.context?.internalAdapter?.findUserById)) {
+    return null;
+  }
+  return (await ctx.context.internalAdapter.findUserById(userId)) ?? null;
+}
+
+export default findHookUser;

--- a/packages/build/src/build/buildAuth/authHookPoints.js
+++ b/packages/build/src/build/buildAuth/authHookPoints.js
@@ -1,0 +1,38 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// The exhaustive launch set of bindable auth hook points. BetterAuth can hook
+// every model write, but unlisted points are deliberately not bindable -
+// adding a point later is an additive, non-breaking change.
+// "invitation.send" is accepted here per the frozen point set; its backing
+// callback ships with the organization plugin in a later phase.
+const authHookPoints = [
+  'user.create.before',
+  'user.create.after',
+  'user.update.before',
+  'user.update.after',
+  'session.create.before',
+  'session.create.after',
+  'session.delete.after',
+  'account.create.before',
+  'account.create.after',
+  'verification.create.before',
+  'verification.create.after',
+  'email.verified',
+  'invitation.send',
+];
+
+export default authHookPoints;

--- a/packages/build/src/build/buildAuth/buildAuth.js
+++ b/packages/build/src/build/buildAuth/buildAuth.js
@@ -17,6 +17,7 @@
 */
 
 import buildApiAuth from './buildApiAuth.js';
+import buildAuthHooks from './buildAuthHooks.js';
 import buildAuthPlugins from './buildAuthPlugins.js';
 import buildPageAuth from './buildPageAuth.js';
 import buildTrustedProviders from './buildTrustedProviders.js';
@@ -30,6 +31,7 @@ function buildAuth({ components, context }) {
   setAuthConfigured({ components, context });
   setAuthDefaults({ components, context });
   buildTrustedProviders({ components, context });
+  buildAuthHooks({ components, context });
   buildApiAuth({ components, context });
   buildWebsocketAuth({ components, context });
   buildPageAuth({ components, context });

--- a/packages/build/src/build/buildAuth/buildAuth.test.js
+++ b/packages/build/src/build/buildAuth/buildAuth.test.js
@@ -118,6 +118,7 @@ test('buildAuth fills in configured defaults for a minimal valid auth config', (
     websockets: { roles: {} },
     pages: { roles: {} },
     providers: [],
+    hooks: [],
     authPages: {
       signIn: '/login',
       signUp: '/signup',

--- a/packages/build/src/build/buildAuth/buildAuthHooks.js
+++ b/packages/build/src/build/buildAuth/buildAuthHooks.js
@@ -1,0 +1,64 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { type } from '@lowdefy/helpers';
+import { ConfigError } from '@lowdefy/errors';
+
+import authHookPoints from './authHookPoints.js';
+
+// Validates the auth.hooks bindings. Each entry binds an auth lifecycle point
+// to an InternalApi endpoint's routine. Runs before buildApi, so endpoints
+// still carry their raw id and declared type.
+function buildAuthHooks({ components }) {
+  const boundPoints = {};
+  (components.auth.hooks ?? []).forEach((hook) => {
+    const configKey = hook['~k'];
+    if (!authHookPoints.includes(hook.point)) {
+      throw new ConfigError(
+        `Auth hook "${hook.id}" binds unknown point "${
+          hook.point
+        }". Valid points are: ${authHookPoints.join(', ')}.`,
+        { received: hook.point, configKey }
+      );
+    }
+    if (!type.isNone(boundPoints[hook.point])) {
+      throw new ConfigError(
+        `Auth hooks "${boundPoints[hook.point]}" and "${hook.id}" both bind point "${
+          hook.point
+        }". At most one hook may bind a point.`,
+        { configKey }
+      );
+    }
+    boundPoints[hook.point] = hook.id;
+
+    const endpoint = (components.api ?? []).find((e) => e.id === hook.endpointId);
+    if (type.isNone(endpoint)) {
+      throw new ConfigError(
+        `Auth hook "${hook.id}" references endpoint "${hook.endpointId}" which does not exist.`,
+        { configKey }
+      );
+    }
+    if (endpoint.type !== 'InternalApi') {
+      throw new ConfigError(
+        `Auth hook "${hook.id}" endpoint "${hook.endpointId}" must be type "InternalApi" so it is not callable over HTTP.`,
+        { received: endpoint.type, configKey }
+      );
+    }
+  });
+  return components;
+}
+
+export default buildAuthHooks;

--- a/packages/build/src/build/buildAuth/buildAuthHooks.test.js
+++ b/packages/build/src/build/buildAuth/buildAuthHooks.test.js
@@ -1,0 +1,132 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import buildAuthHooks from './buildAuthHooks.js';
+
+test('buildAuthHooks returns components unchanged when hooks is undefined', () => {
+  const components = {
+    auth: {},
+  };
+  const res = buildAuthHooks({ components });
+  expect(res).toEqual({ auth: {} });
+});
+
+test('buildAuthHooks passes valid hooks bound to InternalApi endpoints', () => {
+  const components = {
+    auth: {
+      hooks: [
+        { id: 'link-contact', point: 'user.create.before', endpointId: 'auth/link-contact' },
+        { id: 'audit-login', point: 'session.create.after', endpointId: 'auth/audit-login' },
+      ],
+    },
+    api: [
+      { id: 'auth/link-contact', type: 'InternalApi', routine: [] },
+      { id: 'auth/audit-login', type: 'InternalApi', routine: [] },
+    ],
+  };
+  const res = buildAuthHooks({ components });
+  expect(res.auth.hooks).toEqual([
+    { id: 'link-contact', point: 'user.create.before', endpointId: 'auth/link-contact' },
+    { id: 'audit-login', point: 'session.create.after', endpointId: 'auth/audit-login' },
+  ]);
+});
+
+test('buildAuthHooks accepts every point in the frozen catalog', () => {
+  const points = [
+    'user.create.before',
+    'user.create.after',
+    'user.update.before',
+    'user.update.after',
+    'session.create.before',
+    'session.create.after',
+    'session.delete.after',
+    'account.create.before',
+    'account.create.after',
+    'verification.create.before',
+    'verification.create.after',
+    'email.verified',
+    'invitation.send',
+  ];
+  const components = {
+    auth: {
+      hooks: points.map((point, i) => ({ id: `hook-${i}`, point, endpointId: 'auth/hook' })),
+    },
+    api: [{ id: 'auth/hook', type: 'InternalApi', routine: [] }],
+  };
+  expect(() => buildAuthHooks({ components })).not.toThrow();
+});
+
+test('buildAuthHooks throws when a hook binds an unknown point', () => {
+  const components = {
+    auth: {
+      hooks: [{ id: 'bad-point', point: 'organization.create.before', endpointId: 'auth/hook' }],
+    },
+    api: [{ id: 'auth/hook', type: 'InternalApi', routine: [] }],
+  };
+  expect(() => buildAuthHooks({ components })).toThrow(
+    'Auth hook "bad-point" binds unknown point "organization.create.before". Valid points are: user.create.before'
+  );
+});
+
+test('buildAuthHooks throws when two hooks bind the same point', () => {
+  const components = {
+    auth: {
+      hooks: [
+        { id: 'first', point: 'user.create.before', endpointId: 'auth/hook' },
+        { id: 'second', point: 'user.create.before', endpointId: 'auth/hook' },
+      ],
+    },
+    api: [{ id: 'auth/hook', type: 'InternalApi', routine: [] }],
+  };
+  expect(() => buildAuthHooks({ components })).toThrow(
+    'Auth hooks "first" and "second" both bind point "user.create.before". At most one hook may bind a point.'
+  );
+});
+
+test('buildAuthHooks throws when the endpoint does not exist', () => {
+  const components = {
+    auth: {
+      hooks: [{ id: 'missing', point: 'user.create.before', endpointId: 'auth/nowhere' }],
+    },
+    api: [{ id: 'auth/hook', type: 'InternalApi', routine: [] }],
+  };
+  expect(() => buildAuthHooks({ components })).toThrow(
+    'Auth hook "missing" references endpoint "auth/nowhere" which does not exist.'
+  );
+});
+
+test('buildAuthHooks throws when the endpoint does not exist because api is undefined', () => {
+  const components = {
+    auth: {
+      hooks: [{ id: 'missing', point: 'user.create.before', endpointId: 'auth/nowhere' }],
+    },
+  };
+  expect(() => buildAuthHooks({ components })).toThrow(
+    'Auth hook "missing" references endpoint "auth/nowhere" which does not exist.'
+  );
+});
+
+test('buildAuthHooks throws when the endpoint is not type InternalApi', () => {
+  const components = {
+    auth: {
+      hooks: [{ id: 'public-target', point: 'user.create.before', endpointId: 'auth/hook' }],
+    },
+    api: [{ id: 'auth/hook', type: 'Api', routine: [] }],
+  };
+  expect(() => buildAuthHooks({ components })).toThrow(
+    'Auth hook "public-target" endpoint "auth/hook" must be type "InternalApi" so it is not callable over HTTP.'
+  );
+});

--- a/packages/build/src/build/buildAuth/setAuthDefaults.js
+++ b/packages/build/src/build/buildAuth/setAuthDefaults.js
@@ -44,6 +44,8 @@ function setAuthDefaults({ components }) {
     return components;
   }
 
+  setDefault(auth, 'hooks', []);
+
   setDefault(auth, 'authPages', {});
   setDefault(auth.authPages, 'signIn', '/login');
   setDefault(auth.authPages, 'signUp', '/signup');

--- a/packages/build/src/build/buildAuth/setAuthDefaults.test.js
+++ b/packages/build/src/build/buildAuth/setAuthDefaults.test.js
@@ -59,6 +59,7 @@ test('setAuthDefaults sets full defaults when auth is configured', () => {
       pages: { roles: {} },
       websockets: { roles: {} },
       providers: [],
+      hooks: [],
       authPages: {
         signIn: '/login',
         signUp: '/signup',

--- a/packages/build/src/build/buildAuth/validateAuthConfig.test.js
+++ b/packages/build/src/build/buildAuth/validateAuthConfig.test.js
@@ -303,3 +303,62 @@ test('validateAuthConfig throws when both protected and public websockets are se
     'Protected and public websockets are mutually exclusive. When protected websockets are listed, all unlisted websockets are public by default and vice versa.'
   );
 });
+
+test('validateAuthConfig passes a valid hooks array', () => {
+  const components = {
+    auth: {
+      secret: validSecret,
+      database: validDatabase,
+      emailAndPassword: { enabled: true },
+      hooks: [{ id: 'link-contact', point: 'user.create.before', endpointId: 'auth/link-contact' }],
+    },
+  };
+  expect(() => validateAuthConfig({ components, context })).not.toThrow();
+});
+
+test('validateAuthConfig throws when a hook entry is missing a required property', () => {
+  const components = {
+    auth: {
+      secret: validSecret,
+      database: validDatabase,
+      emailAndPassword: { enabled: true },
+      hooks: [{ id: 'link-contact', endpointId: 'auth/link-contact' }],
+    },
+  };
+  expect(() => validateAuthConfig({ components, context })).toThrow(
+    'Auth hook should have required property "point".'
+  );
+});
+
+test('validateAuthConfig throws when a hook entry contains an unknown property', () => {
+  const components = {
+    auth: {
+      secret: validSecret,
+      database: validDatabase,
+      emailAndPassword: { enabled: true },
+      hooks: [
+        {
+          id: 'link-contact',
+          point: 'user.create.before',
+          endpointId: 'auth/link-contact',
+          properties: {},
+        },
+      ],
+    },
+  };
+  expect(() => validateAuthConfig({ components, context })).toThrow();
+});
+
+test('validateAuthConfig throws when hooks is not an array', () => {
+  const components = {
+    auth: {
+      secret: validSecret,
+      database: validDatabase,
+      emailAndPassword: { enabled: true },
+      hooks: { id: 'link-contact' },
+    },
+  };
+  expect(() => validateAuthConfig({ components, context })).toThrow(
+    'Auth "hooks" should be an array.'
+  );
+});

--- a/packages/build/src/lowdefySchema.js
+++ b/packages/build/src/lowdefySchema.js
@@ -1044,6 +1044,48 @@ export default {
             type: 'Auth "authPages" should be an object.',
           },
         },
+        hooks: {
+          type: 'array',
+          errorMessage: {
+            type: 'Auth "hooks" should be an array.',
+          },
+          items: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['id', 'point', 'endpointId'],
+            properties: {
+              '~ignoreBuildChecks': {},
+              '~r': {},
+              '~l': {},
+              id: {
+                type: 'string',
+                errorMessage: {
+                  type: 'Auth hook "id" should be a string.',
+                },
+              },
+              point: {
+                type: 'string',
+                errorMessage: {
+                  type: 'Auth hook "point" should be a string.',
+                },
+              },
+              endpointId: {
+                type: 'string',
+                errorMessage: {
+                  type: 'Auth hook "endpointId" should be a string.',
+                },
+              },
+            },
+            errorMessage: {
+              type: 'Auth hook should be an object.',
+              required: {
+                id: 'Auth hook should have required property "id".',
+                point: 'Auth hook should have required property "point".',
+                endpointId: 'Auth hook should have required property "endpointId".',
+              },
+            },
+          },
+        },
         dev: {
           type: 'object',
           additionalProperties: false,

--- a/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
+++ b/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
@@ -93,6 +93,10 @@
       },
       "~k": "35"
     },
+    "hooks": {
+      "~arr": [],
+      "~k": "37"
+    },
     "authPages": {
       "signIn": "/login",
       "signUp": "/signup",
@@ -100,24 +104,24 @@
       "forgotPassword": "/forgot-password",
       "resetPassword": "/reset-password",
       "verifyEmail": "/verify-email",
-      "~k": "37"
+      "~k": "38"
     },
     "account": {
       "accountLinking": {
         "enabled": true,
         "trustedProviders": {
           "~arr": [],
-          "~k": "3a"
+          "~k": "3b"
         },
-        "~k": "39"
+        "~k": "3a"
       },
-      "~k": "38"
+      "~k": "39"
     },
     "rateLimit": {
       "enabled": true,
       "window": 60,
       "max": 100,
-      "~k": "3b"
+      "~k": "3c"
     },
     "~k": "5"
   },
@@ -315,216 +319,216 @@
       "~k_parent": "35"
     },
     "37": {
-      "key": "root.auth.authPages",
+      "key": "root.auth.hooks",
       "~k_parent": "5"
     },
     "38": {
-      "key": "root.auth.account",
+      "key": "root.auth.authPages",
       "~k_parent": "5"
     },
     "39": {
-      "key": "root.auth.account.accountLinking",
-      "~k_parent": "38"
+      "key": "root.auth.account",
+      "~k_parent": "5"
     },
     "40": {
-      "key": "root.pages[2:dashboard:Box].requests",
-      "~k_parent": "3t"
+      "key": "root.pages[2:dashboard:Box].subscriptions",
+      "~k_parent": "3u"
     },
     "41": {
-      "key": "root.pages[3:profile:Box]",
-      "~k_parent": "3g"
+      "key": "root.pages[2:dashboard:Box].requests",
+      "~k_parent": "3u"
     },
     "42": {
-      "key": "root.pages[3:profile:Box].auth",
-      "~k_parent": "41"
+      "key": "root.pages[3:profile:Box]",
+      "~k_parent": "3h"
     },
     "43": {
-      "key": "root.pages[3:profile:Box].slots",
-      "~k_parent": "41"
+      "key": "root.pages[3:profile:Box].auth",
+      "~k_parent": "42"
     },
     "44": {
-      "key": "root.pages[3:profile:Box].slots.content",
-      "~k_parent": "43"
+      "key": "root.pages[3:profile:Box].slots",
+      "~k_parent": "42"
     },
     "45": {
-      "key": "root.pages[3:profile:Box].subscriptions",
-      "~k_parent": "41"
+      "key": "root.pages[3:profile:Box].slots.content",
+      "~k_parent": "44"
     },
     "46": {
-      "key": "root.pages[3:profile:Box].requests",
-      "~k_parent": "41"
+      "key": "root.pages[3:profile:Box].subscriptions",
+      "~k_parent": "42"
     },
     "47": {
-      "key": "root.pages[4:settings:Box]",
-      "~k_parent": "3g"
+      "key": "root.pages[3:profile:Box].requests",
+      "~k_parent": "42"
     },
     "48": {
-      "key": "root.pages[4:settings:Box].auth",
-      "~k_parent": "47"
+      "key": "root.pages[4:settings:Box]",
+      "~k_parent": "3h"
     },
     "49": {
-      "key": "root.pages[4:settings:Box].slots",
-      "~k_parent": "47"
+      "key": "root.pages[4:settings:Box].auth",
+      "~k_parent": "48"
     },
     "50": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "4z"
+      "key": "root.types.blocks",
+      "~k_parent": "4o"
     },
     "51": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "50"
     },
     "52": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "50"
     },
     "53": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "50"
     },
     "54": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "50"
     },
     "55": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "50"
     },
     "56": {
-      "key": "root.types.blocks.Avatar",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "50"
     },
     "57": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Avatar",
+      "~k_parent": "50"
     },
     "58": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "50"
     },
     "59": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "50"
     },
     "60": {
-      "key": "root.imports.actions",
-      "~k_parent": "5z"
+      "key": "root.imports",
+      "~k_parent": "4"
     },
     "61": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "60"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "60"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "61"
     },
     "64": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "60"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "61"
     },
     "65": {
-      "key": "root.imports.agents",
-      "~k_parent": "5z"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "61"
     },
     "66": {
-      "key": "root.imports.auth",
-      "~k_parent": "5z"
+      "key": "root.imports.agents",
+      "~k_parent": "60"
     },
     "67": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "66"
+      "key": "root.imports.auth",
+      "~k_parent": "60"
     },
     "68": {
-      "key": "root.imports.auth.adapters[0]",
+      "key": "root.imports.auth.adapters",
       "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "66"
+      "key": "root.imports.auth.adapters[0]",
+      "~k_parent": "68"
     },
     "70": {
-      "key": "root.imports.blocks[24]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "6c"
     },
     "71": {
-      "key": "root.imports.connections",
-      "~k_parent": "5z"
+      "key": "root.imports.blocks[24]",
+      "~k_parent": "6c"
     },
     "72": {
-      "key": "root.imports.icons",
-      "~k_parent": "5z"
+      "key": "root.imports.connections",
+      "~k_parent": "60"
     },
     "73": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "72"
+      "key": "root.imports.icons",
+      "~k_parent": "60"
     },
     "74": {
-      "key": "root.imports.icons[0].icons",
+      "key": "root.imports.icons[0]",
       "~k_parent": "73"
     },
     "75": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[0].icons",
+      "~k_parent": "74"
     },
     "76": {
-      "key": "root.imports.icons[1].icons",
-      "~k_parent": "75"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "73"
     },
     "77": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[1].icons",
+      "~k_parent": "76"
     },
     "78": {
-      "key": "root.imports.icons[2].icons",
-      "~k_parent": "77"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "73"
     },
     "79": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[2].icons",
+      "~k_parent": "78"
     },
     "80": {
-      "key": "root.imports.icons[16].icons",
-      "~k_parent": "7z"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "73"
     },
     "81": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[16].icons",
+      "~k_parent": "80"
     },
     "82": {
-      "key": "root.imports.icons[17].icons",
-      "~k_parent": "81"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "73"
     },
     "83": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[17].icons",
+      "~k_parent": "82"
     },
     "84": {
-      "key": "root.imports.icons[18].icons",
-      "~k_parent": "83"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "73"
     },
     "85": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[18].icons",
+      "~k_parent": "84"
     },
     "86": {
-      "key": "root.imports.icons[19].icons",
-      "~k_parent": "85"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "73"
     },
     "87": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[19].icons",
+      "~k_parent": "86"
     },
     "88": {
-      "key": "root.imports.icons[20].icons",
-      "~k_parent": "87"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "73"
     },
     "89": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[20].icons",
+      "~k_parent": "88"
     },
     "a": {
       "key": "root.auth.providers[0:google:Google]",
@@ -928,608 +932,612 @@
       "~k_parent": "4"
     },
     "3a": {
-      "key": "root.auth.account.accountLinking.trustedProviders",
+      "key": "root.auth.account.accountLinking",
       "~k_parent": "39"
     },
     "3b": {
+      "key": "root.auth.account.accountLinking.trustedProviders",
+      "~k_parent": "3a"
+    },
+    "3c": {
       "key": "root.auth.rateLimit",
       "~k_parent": "5"
     },
-    "3c": {
+    "3d": {
       "key": "root.menus[0:default].links",
       "~k_parent": "i"
     },
-    "3d": {
+    "3e": {
       "key": "root.menus[0:default].links[0:dashboard:MenuLink].auth",
       "~k_parent": "k"
     },
-    "3e": {
+    "3f": {
       "key": "root.menus[0:default].links[1:profile:MenuLink].auth",
       "~k_parent": "m"
     },
-    "3f": {
+    "3g": {
       "key": "root.menus[0:default].links[2:settings:MenuLink].auth",
       "~k_parent": "o"
     },
-    "3g": {
+    "3h": {
       "key": "root.pages",
       "~k_parent": "4"
     },
-    "3h": {
-      "key": "root.pages[0:login:Result]",
-      "~k_parent": "3g"
-    },
     "3i": {
-      "key": "root.pages[0:login:Result].auth",
+      "key": "root.pages[0:login:Result]",
       "~k_parent": "3h"
     },
     "3j": {
+      "key": "root.pages[0:login:Result].auth",
+      "~k_parent": "3i"
+    },
+    "3k": {
       "key": "root.pages[0:login:Result].areas.extra.blocks[0:loginBtn:Button].events.onClick",
       "~k_parent": "y"
     },
-    "3k": {
-      "key": "root.pages[0:login:Result].areas.extra.blocks[0:loginBtn:Button].events.onClick.catch",
-      "~k_parent": "3j"
-    },
     "3l": {
-      "key": "root.pages[0:login:Result].subscriptions",
-      "~k_parent": "3h"
+      "key": "root.pages[0:login:Result].areas.extra.blocks[0:loginBtn:Button].events.onClick.catch",
+      "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.pages[0:login:Result].requests",
-      "~k_parent": "3h"
+      "key": "root.pages[0:login:Result].subscriptions",
+      "~k_parent": "3i"
     },
     "3n": {
-      "key": "root.pages[1:public-page:Box]",
-      "~k_parent": "3g"
+      "key": "root.pages[0:login:Result].requests",
+      "~k_parent": "3i"
     },
     "3o": {
-      "key": "root.pages[1:public-page:Box].auth",
-      "~k_parent": "3n"
+      "key": "root.pages[1:public-page:Box]",
+      "~k_parent": "3h"
     },
     "3p": {
-      "key": "root.pages[1:public-page:Box].slots",
-      "~k_parent": "3n"
+      "key": "root.pages[1:public-page:Box].auth",
+      "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.pages[1:public-page:Box].slots.content",
-      "~k_parent": "3p"
+      "key": "root.pages[1:public-page:Box].slots",
+      "~k_parent": "3o"
     },
     "3r": {
-      "key": "root.pages[1:public-page:Box].subscriptions",
-      "~k_parent": "3n"
+      "key": "root.pages[1:public-page:Box].slots.content",
+      "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.pages[1:public-page:Box].requests",
-      "~k_parent": "3n"
+      "key": "root.pages[1:public-page:Box].subscriptions",
+      "~k_parent": "3o"
     },
     "3t": {
-      "key": "root.pages[2:dashboard:Box]",
-      "~k_parent": "3g"
+      "key": "root.pages[1:public-page:Box].requests",
+      "~k_parent": "3o"
     },
     "3u": {
-      "key": "root.pages[2:dashboard:Box].auth",
-      "~k_parent": "3t"
+      "key": "root.pages[2:dashboard:Box]",
+      "~k_parent": "3h"
     },
     "3v": {
-      "key": "root.pages[2:dashboard:Box].slots",
-      "~k_parent": "3t"
+      "key": "root.pages[2:dashboard:Box].auth",
+      "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.pages[2:dashboard:Box].slots.content",
-      "~k_parent": "3v"
+      "key": "root.pages[2:dashboard:Box].slots",
+      "~k_parent": "3u"
     },
     "3x": {
+      "key": "root.pages[2:dashboard:Box].slots.content",
+      "~k_parent": "3w"
+    },
+    "3y": {
       "key": "root.pages[2:dashboard:Box].blocks[1:stats:Box].slots",
       "~k_parent": "1f"
     },
-    "3y": {
-      "key": "root.pages[2:dashboard:Box].blocks[1:stats:Box].slots.content",
-      "~k_parent": "3x"
-    },
     "3z": {
-      "key": "root.pages[2:dashboard:Box].subscriptions",
-      "~k_parent": "3t"
+      "key": "root.pages[2:dashboard:Box].blocks[1:stats:Box].slots.content",
+      "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.pages[4:settings:Box].slots.content",
-      "~k_parent": "49"
+      "key": "root.pages[4:settings:Box].slots",
+      "~k_parent": "48"
     },
     "4b": {
+      "key": "root.pages[4:settings:Box].slots.content",
+      "~k_parent": "4a"
+    },
+    "4c": {
       "key": "root.pages[4:settings:Box].blocks[3:logoutBtn:Button].events.onClick",
       "~k_parent": "2c"
     },
-    "4c": {
-      "key": "root.pages[4:settings:Box].blocks[3:logoutBtn:Button].events.onClick.catch",
-      "~k_parent": "4b"
-    },
     "4d": {
-      "key": "root.pages[4:settings:Box].subscriptions",
-      "~k_parent": "47"
+      "key": "root.pages[4:settings:Box].blocks[3:logoutBtn:Button].events.onClick.catch",
+      "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.pages[4:settings:Box].requests",
-      "~k_parent": "47"
+      "key": "root.pages[4:settings:Box].subscriptions",
+      "~k_parent": "48"
     },
     "4f": {
-      "key": "root.pages[5:404:Result]",
-      "~k_parent": "3g"
+      "key": "root.pages[4:settings:Box].requests",
+      "~k_parent": "48"
     },
     "4g": {
-      "key": "root.pages[5:404:Result].style",
-      "~k_parent": "4f"
+      "key": "root.pages[5:404:Result]",
+      "~k_parent": "3h"
     },
     "4h": {
-      "key": "root.pages[5:404:Result].style.block",
+      "key": "root.pages[5:404:Result].style",
       "~k_parent": "4g"
     },
     "4i": {
+      "key": "root.pages[5:404:Result].style.block",
+      "~k_parent": "4h"
+    },
+    "4j": {
       "key": "root.pages[5:404:Result].slots.extra.blocks[0:home:Button].events.onClick",
       "~k_parent": "2q"
     },
-    "4j": {
-      "key": "root.pages[5:404:Result].slots.extra.blocks[0:home:Button].events.onClick.catch",
-      "~k_parent": "4i"
-    },
     "4k": {
-      "key": "root.pages[5:404:Result].auth",
-      "~k_parent": "4f"
+      "key": "root.pages[5:404:Result].slots.extra.blocks[0:home:Button].events.onClick.catch",
+      "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.pages[5:404:Result].subscriptions",
-      "~k_parent": "4f"
+      "key": "root.pages[5:404:Result].auth",
+      "~k_parent": "4g"
     },
     "4m": {
-      "key": "root.pages[5:404:Result].requests",
-      "~k_parent": "4f"
+      "key": "root.pages[5:404:Result].subscriptions",
+      "~k_parent": "4g"
     },
     "4n": {
+      "key": "root.pages[5:404:Result].requests",
+      "~k_parent": "4g"
+    },
+    "4o": {
       "key": "root.types",
       "~k_parent": "4"
     },
-    "4o": {
-      "key": "root.types.actions",
-      "~k_parent": "4n"
-    },
     "4p": {
-      "key": "root.types.actions.Login",
+      "key": "root.types.actions",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.types.actions.Logout",
-      "~k_parent": "4o"
+      "key": "root.types.actions.Login",
+      "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.types.actions.Link",
-      "~k_parent": "4o"
+      "key": "root.types.actions.Logout",
+      "~k_parent": "4p"
     },
     "4s": {
-      "key": "root.types.actions.SetDarkMode",
-      "~k_parent": "4o"
+      "key": "root.types.actions.Link",
+      "~k_parent": "4p"
     },
     "4t": {
-      "key": "root.types.agents",
-      "~k_parent": "4n"
+      "key": "root.types.actions.SetDarkMode",
+      "~k_parent": "4p"
     },
     "4u": {
-      "key": "root.types.auth",
-      "~k_parent": "4n"
+      "key": "root.types.agents",
+      "~k_parent": "4o"
     },
     "4v": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "4u"
+      "key": "root.types.auth",
+      "~k_parent": "4o"
     },
     "4w": {
-      "key": "root.types.auth.adapters.MongoDBAuthAdapter",
+      "key": "root.types.auth.adapters",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "4u"
+      "key": "root.types.auth.adapters.MongoDBAuthAdapter",
+      "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.types.auth.providers.Google",
-      "~k_parent": "4x"
+      "key": "root.types.auth.providers",
+      "~k_parent": "4v"
     },
     "4z": {
-      "key": "root.types.blocks",
-      "~k_parent": "4n"
+      "key": "root.types.auth.providers.Google",
+      "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "50"
     },
     "5b": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "50"
     },
     "5c": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "50"
     },
     "5d": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "50"
     },
     "5e": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "50"
     },
     "5f": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.List",
+      "~k_parent": "50"
     },
     "5g": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "50"
     },
     "5h": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "50"
     },
     "5i": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "50"
     },
     "5j": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "50"
     },
     "5k": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "50"
     },
     "5l": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "50"
     },
     "5m": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "50"
     },
     "5n": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "50"
     },
     "5o": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "50"
     },
     "5p": {
-      "key": "root.types.connections",
-      "~k_parent": "4n"
+      "key": "root.types.blocks.Message",
+      "~k_parent": "50"
     },
     "5q": {
-      "key": "root.types.requests",
-      "~k_parent": "4n"
+      "key": "root.types.connections",
+      "~k_parent": "4o"
     },
     "5r": {
-      "key": "root.types.websockets",
-      "~k_parent": "4n"
+      "key": "root.types.requests",
+      "~k_parent": "4o"
     },
     "5s": {
-      "key": "root.types.api",
-      "~k_parent": "4n"
+      "key": "root.types.websockets",
+      "~k_parent": "4o"
     },
     "5t": {
-      "key": "root.types.operators",
-      "~k_parent": "4n"
+      "key": "root.types.api",
+      "~k_parent": "4o"
     },
     "5u": {
-      "key": "root.types.operators.client",
-      "~k_parent": "5t"
+      "key": "root.types.operators",
+      "~k_parent": "4o"
     },
     "5v": {
-      "key": "root.types.operators.client._user",
+      "key": "root.types.operators.client",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "5u"
+      "key": "root.types.operators.client._user",
+      "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "5u"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "5v"
     },
     "5y": {
-      "key": "root.types.operators.server",
-      "~k_parent": "5t"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "5v"
     },
     "5z": {
-      "key": "root.imports",
-      "~k_parent": "4"
+      "key": "root.types.operators.server",
+      "~k_parent": "5u"
     },
     "6a": {
-      "key": "root.imports.auth.providers[0]",
-      "~k_parent": "69"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "67"
     },
     "6b": {
-      "key": "root.imports.blocks",
-      "~k_parent": "5z"
+      "key": "root.imports.auth.providers[0]",
+      "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks",
+      "~k_parent": "60"
     },
     "6d": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "6c"
     },
     "6f": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "6c"
     },
     "6g": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "6c"
     },
     "6h": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "6c"
     },
     "6i": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "6c"
     },
     "6j": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "6c"
     },
     "6k": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "6c"
     },
     "6l": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "6c"
     },
     "6m": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "6c"
     },
     "6n": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "6c"
     },
     "6o": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "6c"
     },
     "6p": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "6c"
     },
     "6q": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "6c"
     },
     "6r": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "6c"
     },
     "6s": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "6c"
     },
     "6t": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "6c"
     },
     "6u": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "6c"
     },
     "6v": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "6c"
     },
     "6w": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "6c"
     },
     "6x": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "6c"
     },
     "6y": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "6c"
     },
     "6z": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "6b"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "6c"
     },
     "7a": {
-      "key": "root.imports.icons[3].icons",
-      "~k_parent": "79"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "73"
     },
     "7b": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[3].icons",
+      "~k_parent": "7a"
     },
     "7c": {
-      "key": "root.imports.icons[4].icons",
-      "~k_parent": "7b"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "73"
     },
     "7d": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[4].icons",
+      "~k_parent": "7c"
     },
     "7e": {
-      "key": "root.imports.icons[5].icons",
-      "~k_parent": "7d"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "73"
     },
     "7f": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[5].icons",
+      "~k_parent": "7e"
     },
     "7g": {
-      "key": "root.imports.icons[6].icons",
-      "~k_parent": "7f"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "73"
     },
     "7h": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[6].icons",
+      "~k_parent": "7g"
     },
     "7i": {
-      "key": "root.imports.icons[7].icons",
-      "~k_parent": "7h"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "73"
     },
     "7j": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[7].icons",
+      "~k_parent": "7i"
     },
     "7k": {
-      "key": "root.imports.icons[8].icons",
-      "~k_parent": "7j"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "73"
     },
     "7l": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[8].icons",
+      "~k_parent": "7k"
     },
     "7m": {
-      "key": "root.imports.icons[9].icons",
-      "~k_parent": "7l"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "73"
     },
     "7n": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[9].icons",
+      "~k_parent": "7m"
     },
     "7o": {
-      "key": "root.imports.icons[10].icons",
-      "~k_parent": "7n"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "73"
     },
     "7p": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[10].icons",
+      "~k_parent": "7o"
     },
     "7q": {
-      "key": "root.imports.icons[11].icons",
-      "~k_parent": "7p"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "73"
     },
     "7r": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[11].icons",
+      "~k_parent": "7q"
     },
     "7s": {
-      "key": "root.imports.icons[12].icons",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "73"
     },
     "7t": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[12].icons",
+      "~k_parent": "7s"
     },
     "7u": {
-      "key": "root.imports.icons[13].icons",
-      "~k_parent": "7t"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "73"
     },
     "7v": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[13].icons",
+      "~k_parent": "7u"
     },
     "7w": {
-      "key": "root.imports.icons[14].icons",
-      "~k_parent": "7v"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "73"
     },
     "7x": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[14].icons",
+      "~k_parent": "7w"
     },
     "7y": {
-      "key": "root.imports.icons[15].icons",
-      "~k_parent": "7x"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "73"
     },
     "7z": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[15].icons",
+      "~k_parent": "7y"
     },
     "8a": {
-      "key": "root.imports.icons[21].icons",
-      "~k_parent": "89"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "73"
     },
     "8b": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[21].icons",
+      "~k_parent": "8a"
     },
     "8c": {
-      "key": "root.imports.icons[22].icons",
-      "~k_parent": "8b"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "73"
     },
     "8d": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[22].icons",
+      "~k_parent": "8c"
     },
     "8e": {
-      "key": "root.imports.icons[23].icons",
-      "~k_parent": "8d"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "73"
     },
     "8f": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[23].icons",
+      "~k_parent": "8e"
     },
     "8g": {
-      "key": "root.imports.icons[24].icons",
-      "~k_parent": "8f"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "73"
     },
     "8h": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[24].icons",
+      "~k_parent": "8g"
     },
     "8i": {
-      "key": "root.imports.icons[25].icons",
-      "~k_parent": "8h"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "73"
     },
     "8j": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[25].icons",
+      "~k_parent": "8i"
     },
     "8k": {
-      "key": "root.imports.icons[26].icons",
-      "~k_parent": "8j"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "73"
     },
     "8l": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "72"
+      "key": "root.imports.icons[26].icons",
+      "~k_parent": "8k"
     },
     "8m": {
-      "key": "root.imports.icons[27].icons",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "73"
     },
     "8n": {
-      "key": "root.imports.requests",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "8m"
     },
     "8o": {
-      "key": "root.imports.websockets",
-      "~k_parent": "5z"
+      "key": "root.imports.requests",
+      "~k_parent": "60"
     },
     "8p": {
-      "key": "root.imports.operators",
-      "~k_parent": "5z"
+      "key": "root.imports.websockets",
+      "~k_parent": "60"
     },
     "8q": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "8p"
+      "key": "root.imports.operators",
+      "~k_parent": "60"
     },
     "8r": {
-      "key": "root.imports.operators.client[0]",
+      "key": "root.imports.operators.client",
       "~k_parent": "8q"
     },
     "8s": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "8q"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "8r"
     },
     "8t": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "8q"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "8r"
     },
     "8u": {
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "8r"
+    },
+    "8v": {
       "key": "root.imports.operators.server",
-      "~k_parent": "8p"
+      "~k_parent": "8q"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1553,7 +1561,7 @@
               },
               "auth": {
                 "public": false,
-                "~k": "3d"
+                "~k": "3e"
               },
               "menuItemId": "dashboard",
               "~k": "k"
@@ -1569,7 +1577,7 @@
               },
               "auth": {
                 "public": false,
-                "~k": "3e"
+                "~k": "3f"
               },
               "menuItemId": "profile",
               "~k": "m"
@@ -1585,13 +1593,13 @@
               },
               "auth": {
                 "public": false,
-                "~k": "3f"
+                "~k": "3g"
               },
               "menuItemId": "settings",
               "~k": "o"
             }
           ],
-          "~k": "3c"
+          "~k": "3d"
         },
         "menuId": "default",
         "~k": "i"
@@ -1606,9 +1614,9 @@
       "block": {
         "minHeight": "100vh",
         "background": "var(--ant-color-bg-layout)",
-        "~k": "4h"
+        "~k": "4i"
       },
-      "~k": "4g"
+      "~k": "4h"
     },
     "properties": {
       "status": "info",
@@ -1651,9 +1659,9 @@
                   },
                   "catch": {
                     "~arr": [],
-                    "~k": "4j"
+                    "~k": "4k"
                   },
-                  "~k": "4i"
+                  "~k": "4j"
                 },
                 "~k": "2q"
               },
@@ -1669,19 +1677,19 @@
     },
     "auth": {
       "public": true,
-      "~k": "4k"
+      "~k": "4l"
     },
     "pageId": "404",
     "blockId": "404",
     "subscriptions": {
       "~arr": [],
-      "~k": "4l"
+      "~k": "4m"
     },
     "requests": {
       "~arr": [],
-      "~k": "4m"
+      "~k": "4n"
     },
-    "~k": "4f"
+    "~k": "4g"
   },
   "pages/dashboard.json": {
     "id": "page:dashboard",
@@ -1692,7 +1700,7 @@
     },
     "auth": {
       "public": false,
-      "~k": "3u"
+      "~k": "3v"
     },
     "pageId": "dashboard",
     "blockId": "dashboard",
@@ -1750,28 +1758,28 @@
                     ],
                     "~k": "1g"
                   },
-                  "~k": "3y"
+                  "~k": "3z"
                 },
-                "~k": "3x"
+                "~k": "3y"
               },
               "~k": "1f"
             }
           ],
           "~k": "1a"
         },
-        "~k": "3w"
+        "~k": "3x"
       },
-      "~k": "3v"
+      "~k": "3w"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "3z"
+      "~k": "40"
     },
     "requests": {
       "~arr": [],
-      "~k": "40"
+      "~k": "41"
     },
-    "~k": "3t"
+    "~k": "3u"
   },
   "pages/login.json": {
     "id": "page:login",
@@ -1784,7 +1792,7 @@
     },
     "auth": {
       "public": true,
-      "~k": "3i"
+      "~k": "3j"
     },
     "pageId": "login",
     "blockId": "login",
@@ -1815,9 +1823,9 @@
                   },
                   "catch": {
                     "~arr": [],
-                    "~k": "3k"
+                    "~k": "3l"
                   },
-                  "~k": "3j"
+                  "~k": "3k"
                 },
                 "~k": "y"
               },
@@ -1833,13 +1841,13 @@
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "3l"
+      "~k": "3m"
     },
     "requests": {
       "~arr": [],
-      "~k": "3m"
+      "~k": "3n"
     },
-    "~k": "3h"
+    "~k": "3i"
   },
   "pages/profile.json": {
     "id": "page:profile",
@@ -1850,7 +1858,7 @@
     },
     "auth": {
       "public": false,
-      "~k": "42"
+      "~k": "43"
     },
     "pageId": "profile",
     "blockId": "profile",
@@ -1902,19 +1910,19 @@
           ],
           "~k": "1n"
         },
-        "~k": "44"
+        "~k": "45"
       },
-      "~k": "43"
+      "~k": "44"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "45"
+      "~k": "46"
     },
     "requests": {
       "~arr": [],
-      "~k": "46"
+      "~k": "47"
     },
-    "~k": "41"
+    "~k": "42"
   },
   "pages/public-page.json": {
     "id": "page:public-page",
@@ -1925,7 +1933,7 @@
     },
     "auth": {
       "public": true,
-      "~k": "3o"
+      "~k": "3p"
     },
     "pageId": "public-page",
     "blockId": "public-page",
@@ -1956,19 +1964,19 @@
           ],
           "~k": "13"
         },
-        "~k": "3q"
+        "~k": "3r"
       },
-      "~k": "3p"
+      "~k": "3q"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "3r"
+      "~k": "3s"
     },
     "requests": {
       "~arr": [],
-      "~k": "3s"
+      "~k": "3t"
     },
-    "~k": "3n"
+    "~k": "3o"
   },
   "pages/settings.json": {
     "id": "page:settings",
@@ -1979,7 +1987,7 @@
     },
     "auth": {
       "public": false,
-      "~k": "48"
+      "~k": "49"
     },
     "pageId": "settings",
     "blockId": "settings",
@@ -2059,9 +2067,9 @@
                   },
                   "catch": {
                     "~arr": [],
-                    "~k": "4c"
+                    "~k": "4d"
                   },
-                  "~k": "4b"
+                  "~k": "4c"
                 },
                 "~k": "2c"
               },
@@ -2071,19 +2079,19 @@
           ],
           "~k": "1z"
         },
-        "~k": "4a"
+        "~k": "4b"
       },
-      "~k": "49"
+      "~k": "4a"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "4d"
+      "~k": "4e"
     },
     "requests": {
       "~arr": [],
-      "~k": "4e"
+      "~k": "4f"
     },
-    "~k": "47"
+    "~k": "48"
   },
   "plugins/actionSchemas.json": {
     "Login": {
@@ -9186,30 +9194,30 @@
         "originalTypeName": "Login",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "4p"
+        "~k": "4q"
       },
       "Logout": {
         "originalTypeName": "Logout",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "4q"
+        "~k": "4r"
       },
       "Link": {
         "originalTypeName": "Link",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "4r"
+        "~k": "4s"
       },
       "SetDarkMode": {
         "originalTypeName": "SetDarkMode",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "4s"
+        "~k": "4t"
       },
-      "~k": "4o"
+      "~k": "4p"
     },
     "agents": {
-      "~k": "4t"
+      "~k": "4u"
     },
     "auth": {
       "adapters": {
@@ -9217,185 +9225,185 @@
           "originalTypeName": "MongoDBAuthAdapter",
           "package": "@lowdefy/connection-mongodb",
           "count": 1,
-          "~k": "4w"
+          "~k": "4x"
         },
-        "~k": "4v"
+        "~k": "4w"
       },
       "providers": {
         "Google": {
           "originalTypeName": "Google",
           "package": "@lowdefy/plugin-better-auth",
           "count": 1,
-          "~k": "4y"
+          "~k": "4z"
         },
-        "~k": "4x"
+        "~k": "4y"
       },
-      "~k": "4u"
+      "~k": "4v"
     },
     "blocks": {
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "50"
+        "~k": "51"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "51"
+        "~k": "52"
       },
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 6,
-        "~k": "52"
+        "~k": "53"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "53"
+        "~k": "54"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "54"
+        "~k": "55"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "55"
+        "~k": "56"
       },
       "Avatar": {
         "originalTypeName": "Avatar",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "56"
+        "~k": "57"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "57"
+        "~k": "58"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "58"
+        "~k": "59"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "59"
+        "~k": "5a"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5a"
+        "~k": "5b"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5b"
+        "~k": "5c"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5c"
+        "~k": "5d"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5d"
+        "~k": "5e"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5e"
+        "~k": "5f"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5f"
+        "~k": "5g"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5g"
+        "~k": "5h"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5h"
+        "~k": "5i"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5i"
+        "~k": "5j"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5j"
+        "~k": "5k"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5k"
+        "~k": "5l"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5l"
+        "~k": "5m"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5m"
+        "~k": "5n"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5n"
+        "~k": "5o"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "5o"
+        "~k": "5p"
       },
-      "~k": "4z"
+      "~k": "50"
     },
     "connections": {
-      "~k": "5p"
-    },
-    "requests": {
       "~k": "5q"
     },
-    "websockets": {
+    "requests": {
       "~k": "5r"
     },
-    "api": {
+    "websockets": {
       "~k": "5s"
+    },
+    "api": {
+      "~k": "5t"
     },
     "operators": {
       "client": {
@@ -9403,27 +9411,27 @@
           "originalTypeName": "_user",
           "package": "@lowdefy/operators-js",
           "count": 4,
-          "~k": "5v"
+          "~k": "5w"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5w"
+          "~k": "5x"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5x"
+          "~k": "5y"
         },
-        "~k": "5u"
+        "~k": "5v"
       },
       "server": {
-        "~k": "5y"
+        "~k": "5z"
       },
-      "~k": "5t"
+      "~k": "5u"
     },
-    "~k": "4n"
+    "~k": "4o"
   }
 }

--- a/packages/build/src/tests/success/36-auth-roles-app/snapshot.json
+++ b/packages/build/src/tests/success/36-auth-roles-app/snapshot.json
@@ -89,6 +89,10 @@
       "~arr": [],
       "~k": "2a"
     },
+    "hooks": {
+      "~arr": [],
+      "~k": "2b"
+    },
     "authPages": {
       "signIn": "/login",
       "signUp": "/signup",
@@ -96,7 +100,7 @@
       "forgotPassword": "/forgot-password",
       "resetPassword": "/reset-password",
       "verifyEmail": "/verify-email",
-      "~k": "2b"
+      "~k": "2c"
     },
     "session": {
       "expiresIn": 604800,
@@ -104,30 +108,30 @@
       "cookieCache": {
         "enabled": false,
         "maxAge": 300,
-        "~k": "2d"
+        "~k": "2e"
       },
       "crossSubDomainCookies": {
         "enabled": false,
-        "~k": "2e"
+        "~k": "2f"
       },
-      "~k": "2c"
+      "~k": "2d"
     },
     "account": {
       "accountLinking": {
         "enabled": true,
         "trustedProviders": {
           "~arr": [],
-          "~k": "2h"
+          "~k": "2i"
         },
-        "~k": "2g"
+        "~k": "2h"
       },
-      "~k": "2f"
+      "~k": "2g"
     },
     "rateLimit": {
       "enabled": true,
       "window": 60,
       "max": 100,
-      "~k": "2i"
+      "~k": "2j"
     },
     "~k": "5"
   },
@@ -263,244 +267,244 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.pages[2:profile:Box].slots",
-      "~k_parent": "2x"
+      "key": "root.pages[2:profile:Box].auth.roles",
+      "~k_parent": "2z"
     },
     "31": {
-      "key": "root.pages[2:profile:Box].slots.content",
-      "~k_parent": "30"
+      "key": "root.pages[2:profile:Box].slots",
+      "~k_parent": "2y"
     },
     "32": {
-      "key": "root.pages[2:profile:Box].subscriptions",
-      "~k_parent": "2x"
+      "key": "root.pages[2:profile:Box].slots.content",
+      "~k_parent": "31"
     },
     "33": {
-      "key": "root.pages[2:profile:Box].requests",
-      "~k_parent": "2x"
+      "key": "root.pages[2:profile:Box].subscriptions",
+      "~k_parent": "2y"
     },
     "34": {
-      "key": "root.pages[3:reports:Box]",
-      "~k_parent": "2j"
+      "key": "root.pages[2:profile:Box].requests",
+      "~k_parent": "2y"
     },
     "35": {
-      "key": "root.pages[3:reports:Box].auth",
-      "~k_parent": "34"
+      "key": "root.pages[3:reports:Box]",
+      "~k_parent": "2k"
     },
     "36": {
-      "key": "root.pages[3:reports:Box].auth.roles",
+      "key": "root.pages[3:reports:Box].auth",
       "~k_parent": "35"
     },
     "37": {
-      "key": "root.pages[3:reports:Box].slots",
-      "~k_parent": "34"
+      "key": "root.pages[3:reports:Box].auth.roles",
+      "~k_parent": "36"
     },
     "38": {
-      "key": "root.pages[3:reports:Box].slots.content",
-      "~k_parent": "37"
+      "key": "root.pages[3:reports:Box].slots",
+      "~k_parent": "35"
     },
     "39": {
-      "key": "root.pages[3:reports:Box].subscriptions",
-      "~k_parent": "34"
+      "key": "root.pages[3:reports:Box].slots.content",
+      "~k_parent": "38"
     },
     "40": {
-      "key": "root.pages[7:404:Result].slots.extra.blocks[0:home:Button].events.onClick.catch",
-      "~k_parent": "3z"
+      "key": "root.pages[7:404:Result].slots.extra.blocks[0:home:Button].events.onClick",
+      "~k_parent": "1w"
     },
     "41": {
-      "key": "root.pages[7:404:Result].auth",
-      "~k_parent": "3w"
+      "key": "root.pages[7:404:Result].slots.extra.blocks[0:home:Button].events.onClick.catch",
+      "~k_parent": "40"
     },
     "42": {
-      "key": "root.pages[7:404:Result].subscriptions",
-      "~k_parent": "3w"
+      "key": "root.pages[7:404:Result].auth",
+      "~k_parent": "3x"
     },
     "43": {
-      "key": "root.pages[7:404:Result].requests",
-      "~k_parent": "3w"
+      "key": "root.pages[7:404:Result].subscriptions",
+      "~k_parent": "3x"
     },
     "44": {
+      "key": "root.pages[7:404:Result].requests",
+      "~k_parent": "3x"
+    },
+    "45": {
       "key": "root.menus",
       "~k_parent": "4"
     },
-    "45": {
-      "key": "root.menus[0:default]",
-      "~k_parent": "44"
-    },
     "46": {
-      "key": "root.menus[0:default].links",
+      "key": "root.menus[0:default]",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.menus[0:default].links[0:0:MenuLink]",
+      "key": "root.menus[0:default].links",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.menus[0:default].links[0:0:MenuLink].auth",
+      "key": "root.menus[0:default].links[0:0:MenuLink]",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.menus[0:default].links[1:1:MenuLink]",
-      "~k_parent": "46"
+      "key": "root.menus[0:default].links[0:0:MenuLink].auth",
+      "~k_parent": "48"
     },
     "50": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "4x"
+      "key": "root.types.auth.adapters.MongoDBAuthAdapter",
+      "~k_parent": "4z"
     },
     "51": {
-      "key": "root.types.blocks",
-      "~k_parent": "4r"
+      "key": "root.types.auth.providers",
+      "~k_parent": "4y"
     },
     "52": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "51"
+      "key": "root.types.blocks",
+      "~k_parent": "4s"
     },
     "53": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "51"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "52"
     },
     "54": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "51"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "52"
     },
     "55": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "51"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "52"
     },
     "56": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "51"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "52"
     },
     "57": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "51"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "52"
     },
     "58": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "51"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "52"
     },
     "59": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "51"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "52"
     },
     "60": {
-      "key": "root.imports.agents",
-      "~k_parent": "5v"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "5x"
     },
     "61": {
-      "key": "root.imports.auth",
-      "~k_parent": "5v"
+      "key": "root.imports.agents",
+      "~k_parent": "5w"
     },
     "62": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "61"
+      "key": "root.imports.auth",
+      "~k_parent": "5w"
     },
     "63": {
-      "key": "root.imports.auth.adapters[0]",
+      "key": "root.imports.auth.adapters",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "61"
+      "key": "root.imports.auth.adapters[0]",
+      "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.blocks",
-      "~k_parent": "5v"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "62"
     },
     "66": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks",
+      "~k_parent": "5w"
     },
     "67": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "66"
     },
     "69": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "66"
     },
     "70": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[3].icons",
+      "~k_parent": "6z"
     },
     "71": {
-      "key": "root.imports.icons[4].icons",
-      "~k_parent": "70"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "6s"
     },
     "72": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[4].icons",
+      "~k_parent": "71"
     },
     "73": {
-      "key": "root.imports.icons[5].icons",
-      "~k_parent": "72"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "6s"
     },
     "74": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[5].icons",
+      "~k_parent": "73"
     },
     "75": {
-      "key": "root.imports.icons[6].icons",
-      "~k_parent": "74"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "6s"
     },
     "76": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[6].icons",
+      "~k_parent": "75"
     },
     "77": {
-      "key": "root.imports.icons[7].icons",
-      "~k_parent": "76"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "6s"
     },
     "78": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[7].icons",
+      "~k_parent": "77"
     },
     "79": {
-      "key": "root.imports.icons[8].icons",
-      "~k_parent": "78"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "6s"
     },
     "80": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[21].icons",
+      "~k_parent": "7z"
     },
     "81": {
-      "key": "root.imports.icons[22].icons",
-      "~k_parent": "80"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "6s"
     },
     "82": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[22].icons",
+      "~k_parent": "81"
     },
     "83": {
-      "key": "root.imports.icons[23].icons",
-      "~k_parent": "82"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "6s"
     },
     "84": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[23].icons",
+      "~k_parent": "83"
     },
     "85": {
-      "key": "root.imports.icons[24].icons",
-      "~k_parent": "84"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "6s"
     },
     "86": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[24].icons",
+      "~k_parent": "85"
     },
     "87": {
-      "key": "root.imports.icons[25].icons",
-      "~k_parent": "86"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "6s"
     },
     "88": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[25].icons",
+      "~k_parent": "87"
     },
     "89": {
-      "key": "root.imports.icons[26].icons",
-      "~k_parent": "88"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "6s"
     },
     "a": {
       "key": "root.auth.pages",
@@ -748,660 +752,664 @@
       "~k_parent": "5"
     },
     "2b": {
-      "key": "root.auth.authPages",
+      "key": "root.auth.hooks",
       "~k_parent": "5"
     },
     "2c": {
-      "key": "root.auth.session",
+      "key": "root.auth.authPages",
       "~k_parent": "5"
     },
     "2d": {
-      "key": "root.auth.session.cookieCache",
-      "~k_parent": "2c"
+      "key": "root.auth.session",
+      "~k_parent": "5"
     },
     "2e": {
-      "key": "root.auth.session.crossSubDomainCookies",
-      "~k_parent": "2c"
+      "key": "root.auth.session.cookieCache",
+      "~k_parent": "2d"
     },
     "2f": {
+      "key": "root.auth.session.crossSubDomainCookies",
+      "~k_parent": "2d"
+    },
+    "2g": {
       "key": "root.auth.account",
       "~k_parent": "5"
     },
-    "2g": {
-      "key": "root.auth.account.accountLinking",
-      "~k_parent": "2f"
-    },
     "2h": {
-      "key": "root.auth.account.accountLinking.trustedProviders",
+      "key": "root.auth.account.accountLinking",
       "~k_parent": "2g"
     },
     "2i": {
+      "key": "root.auth.account.accountLinking.trustedProviders",
+      "~k_parent": "2h"
+    },
+    "2j": {
       "key": "root.auth.rateLimit",
       "~k_parent": "5"
     },
-    "2j": {
+    "2k": {
       "key": "root.pages",
       "~k_parent": "4"
     },
-    "2k": {
-      "key": "root.pages[0:login:Result]",
-      "~k_parent": "2j"
-    },
     "2l": {
-      "key": "root.pages[0:login:Result].auth",
+      "key": "root.pages[0:login:Result]",
       "~k_parent": "2k"
     },
     "2m": {
+      "key": "root.pages[0:login:Result].auth",
+      "~k_parent": "2l"
+    },
+    "2n": {
       "key": "root.pages[0:login:Result].areas.extra.blocks[0:loginBtn:Button].events.onClick",
       "~k_parent": "o"
     },
-    "2n": {
-      "key": "root.pages[0:login:Result].areas.extra.blocks[0:loginBtn:Button].events.onClick.catch",
-      "~k_parent": "2m"
-    },
     "2o": {
-      "key": "root.pages[0:login:Result].subscriptions",
-      "~k_parent": "2k"
+      "key": "root.pages[0:login:Result].areas.extra.blocks[0:loginBtn:Button].events.onClick.catch",
+      "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.pages[0:login:Result].requests",
-      "~k_parent": "2k"
+      "key": "root.pages[0:login:Result].subscriptions",
+      "~k_parent": "2l"
     },
     "2q": {
-      "key": "root.pages[1:dashboard:Box]",
-      "~k_parent": "2j"
+      "key": "root.pages[0:login:Result].requests",
+      "~k_parent": "2l"
     },
     "2r": {
-      "key": "root.pages[1:dashboard:Box].auth",
-      "~k_parent": "2q"
+      "key": "root.pages[1:dashboard:Box]",
+      "~k_parent": "2k"
     },
     "2s": {
-      "key": "root.pages[1:dashboard:Box].auth.roles",
+      "key": "root.pages[1:dashboard:Box].auth",
       "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.pages[1:dashboard:Box].slots",
-      "~k_parent": "2q"
+      "key": "root.pages[1:dashboard:Box].auth.roles",
+      "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.pages[1:dashboard:Box].slots.content",
-      "~k_parent": "2t"
+      "key": "root.pages[1:dashboard:Box].slots",
+      "~k_parent": "2r"
     },
     "2v": {
-      "key": "root.pages[1:dashboard:Box].subscriptions",
-      "~k_parent": "2q"
+      "key": "root.pages[1:dashboard:Box].slots.content",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.pages[1:dashboard:Box].requests",
-      "~k_parent": "2q"
+      "key": "root.pages[1:dashboard:Box].subscriptions",
+      "~k_parent": "2r"
     },
     "2x": {
-      "key": "root.pages[2:profile:Box]",
-      "~k_parent": "2j"
+      "key": "root.pages[1:dashboard:Box].requests",
+      "~k_parent": "2r"
     },
     "2y": {
-      "key": "root.pages[2:profile:Box].auth",
-      "~k_parent": "2x"
+      "key": "root.pages[2:profile:Box]",
+      "~k_parent": "2k"
     },
     "2z": {
-      "key": "root.pages[2:profile:Box].auth.roles",
+      "key": "root.pages[2:profile:Box].auth",
       "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.pages[3:reports:Box].requests",
-      "~k_parent": "34"
+      "key": "root.pages[3:reports:Box].subscriptions",
+      "~k_parent": "35"
     },
     "3b": {
-      "key": "root.pages[4:team:Box]",
-      "~k_parent": "2j"
+      "key": "root.pages[3:reports:Box].requests",
+      "~k_parent": "35"
     },
     "3c": {
-      "key": "root.pages[4:team:Box].auth",
-      "~k_parent": "3b"
+      "key": "root.pages[4:team:Box]",
+      "~k_parent": "2k"
     },
     "3d": {
-      "key": "root.pages[4:team:Box].auth.roles",
+      "key": "root.pages[4:team:Box].auth",
       "~k_parent": "3c"
     },
     "3e": {
-      "key": "root.pages[4:team:Box].slots",
-      "~k_parent": "3b"
+      "key": "root.pages[4:team:Box].auth.roles",
+      "~k_parent": "3d"
     },
     "3f": {
-      "key": "root.pages[4:team:Box].slots.content",
-      "~k_parent": "3e"
+      "key": "root.pages[4:team:Box].slots",
+      "~k_parent": "3c"
     },
     "3g": {
-      "key": "root.pages[4:team:Box].subscriptions",
-      "~k_parent": "3b"
+      "key": "root.pages[4:team:Box].slots.content",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.pages[4:team:Box].requests",
-      "~k_parent": "3b"
+      "key": "root.pages[4:team:Box].subscriptions",
+      "~k_parent": "3c"
     },
     "3i": {
-      "key": "root.pages[5:admin-panel:Box]",
-      "~k_parent": "2j"
+      "key": "root.pages[4:team:Box].requests",
+      "~k_parent": "3c"
     },
     "3j": {
-      "key": "root.pages[5:admin-panel:Box].auth",
-      "~k_parent": "3i"
+      "key": "root.pages[5:admin-panel:Box]",
+      "~k_parent": "2k"
     },
     "3k": {
-      "key": "root.pages[5:admin-panel:Box].auth.roles",
+      "key": "root.pages[5:admin-panel:Box].auth",
       "~k_parent": "3j"
     },
     "3l": {
-      "key": "root.pages[5:admin-panel:Box].slots",
-      "~k_parent": "3i"
+      "key": "root.pages[5:admin-panel:Box].auth.roles",
+      "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.pages[5:admin-panel:Box].slots.content",
-      "~k_parent": "3l"
+      "key": "root.pages[5:admin-panel:Box].slots",
+      "~k_parent": "3j"
     },
     "3n": {
-      "key": "root.pages[5:admin-panel:Box].subscriptions",
-      "~k_parent": "3i"
+      "key": "root.pages[5:admin-panel:Box].slots.content",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.pages[5:admin-panel:Box].requests",
-      "~k_parent": "3i"
+      "key": "root.pages[5:admin-panel:Box].subscriptions",
+      "~k_parent": "3j"
     },
     "3p": {
-      "key": "root.pages[6:user-management:Box]",
-      "~k_parent": "2j"
+      "key": "root.pages[5:admin-panel:Box].requests",
+      "~k_parent": "3j"
     },
     "3q": {
-      "key": "root.pages[6:user-management:Box].auth",
-      "~k_parent": "3p"
+      "key": "root.pages[6:user-management:Box]",
+      "~k_parent": "2k"
     },
     "3r": {
-      "key": "root.pages[6:user-management:Box].auth.roles",
+      "key": "root.pages[6:user-management:Box].auth",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.pages[6:user-management:Box].slots",
-      "~k_parent": "3p"
+      "key": "root.pages[6:user-management:Box].auth.roles",
+      "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.pages[6:user-management:Box].slots.content",
-      "~k_parent": "3s"
+      "key": "root.pages[6:user-management:Box].slots",
+      "~k_parent": "3q"
     },
     "3u": {
-      "key": "root.pages[6:user-management:Box].subscriptions",
-      "~k_parent": "3p"
+      "key": "root.pages[6:user-management:Box].slots.content",
+      "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.pages[6:user-management:Box].requests",
-      "~k_parent": "3p"
+      "key": "root.pages[6:user-management:Box].subscriptions",
+      "~k_parent": "3q"
     },
     "3w": {
-      "key": "root.pages[7:404:Result]",
-      "~k_parent": "2j"
+      "key": "root.pages[6:user-management:Box].requests",
+      "~k_parent": "3q"
     },
     "3x": {
-      "key": "root.pages[7:404:Result].style",
-      "~k_parent": "3w"
+      "key": "root.pages[7:404:Result]",
+      "~k_parent": "2k"
     },
     "3y": {
-      "key": "root.pages[7:404:Result].style.block",
+      "key": "root.pages[7:404:Result].style",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.pages[7:404:Result].slots.extra.blocks[0:home:Button].events.onClick",
-      "~k_parent": "1w"
+      "key": "root.pages[7:404:Result].style.block",
+      "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.menus[0:default].links[1:1:MenuLink].auth",
-      "~k_parent": "49"
+      "key": "root.menus[0:default].links[1:1:MenuLink]",
+      "~k_parent": "47"
     },
     "4b": {
-      "key": "root.menus[0:default].links[1:1:MenuLink].auth.roles",
+      "key": "root.menus[0:default].links[1:1:MenuLink].auth",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.menus[0:default].links[2:2:MenuLink]",
-      "~k_parent": "46"
+      "key": "root.menus[0:default].links[1:1:MenuLink].auth.roles",
+      "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.menus[0:default].links[2:2:MenuLink].auth",
-      "~k_parent": "4c"
+      "key": "root.menus[0:default].links[2:2:MenuLink]",
+      "~k_parent": "47"
     },
     "4e": {
-      "key": "root.menus[0:default].links[2:2:MenuLink].auth.roles",
+      "key": "root.menus[0:default].links[2:2:MenuLink].auth",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.menus[0:default].links[3:3:MenuLink]",
-      "~k_parent": "46"
+      "key": "root.menus[0:default].links[2:2:MenuLink].auth.roles",
+      "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.menus[0:default].links[3:3:MenuLink].auth",
-      "~k_parent": "4f"
+      "key": "root.menus[0:default].links[3:3:MenuLink]",
+      "~k_parent": "47"
     },
     "4h": {
-      "key": "root.menus[0:default].links[3:3:MenuLink].auth.roles",
+      "key": "root.menus[0:default].links[3:3:MenuLink].auth",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.menus[0:default].links[4:4:MenuLink]",
-      "~k_parent": "46"
+      "key": "root.menus[0:default].links[3:3:MenuLink].auth.roles",
+      "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.menus[0:default].links[4:4:MenuLink].auth",
-      "~k_parent": "4i"
+      "key": "root.menus[0:default].links[4:4:MenuLink]",
+      "~k_parent": "47"
     },
     "4k": {
-      "key": "root.menus[0:default].links[4:4:MenuLink].auth.roles",
+      "key": "root.menus[0:default].links[4:4:MenuLink].auth",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.menus[0:default].links[5:5:MenuLink]",
-      "~k_parent": "46"
+      "key": "root.menus[0:default].links[4:4:MenuLink].auth.roles",
+      "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.menus[0:default].links[5:5:MenuLink].auth",
-      "~k_parent": "4l"
+      "key": "root.menus[0:default].links[5:5:MenuLink]",
+      "~k_parent": "47"
     },
     "4n": {
-      "key": "root.menus[0:default].links[5:5:MenuLink].auth.roles",
+      "key": "root.menus[0:default].links[5:5:MenuLink].auth",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.menus[0:default].links[6:6:MenuLink]",
-      "~k_parent": "46"
+      "key": "root.menus[0:default].links[5:5:MenuLink].auth.roles",
+      "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.menus[0:default].links[6:6:MenuLink].auth",
-      "~k_parent": "4o"
+      "key": "root.menus[0:default].links[6:6:MenuLink]",
+      "~k_parent": "47"
     },
     "4q": {
-      "key": "root.menus[0:default].links[6:6:MenuLink].auth.roles",
+      "key": "root.menus[0:default].links[6:6:MenuLink].auth",
       "~k_parent": "4p"
     },
     "4r": {
+      "key": "root.menus[0:default].links[6:6:MenuLink].auth.roles",
+      "~k_parent": "4q"
+    },
+    "4s": {
       "key": "root.types",
       "~k_parent": "4"
     },
-    "4s": {
-      "key": "root.types.actions",
-      "~k_parent": "4r"
-    },
     "4t": {
-      "key": "root.types.actions.Login",
+      "key": "root.types.actions",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.types.actions.Link",
-      "~k_parent": "4s"
+      "key": "root.types.actions.Login",
+      "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.types.actions.SetDarkMode",
-      "~k_parent": "4s"
+      "key": "root.types.actions.Link",
+      "~k_parent": "4t"
     },
     "4w": {
-      "key": "root.types.agents",
-      "~k_parent": "4r"
+      "key": "root.types.actions.SetDarkMode",
+      "~k_parent": "4t"
     },
     "4x": {
-      "key": "root.types.auth",
-      "~k_parent": "4r"
+      "key": "root.types.agents",
+      "~k_parent": "4s"
     },
     "4y": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "4x"
+      "key": "root.types.auth",
+      "~k_parent": "4s"
     },
     "4z": {
-      "key": "root.types.auth.adapters.MongoDBAuthAdapter",
+      "key": "root.types.auth.adapters",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "51"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "52"
     },
     "5b": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "51"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "52"
     },
     "5c": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "51"
+      "key": "root.types.blocks.List",
+      "~k_parent": "52"
     },
     "5d": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "51"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "52"
     },
     "5e": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "51"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "52"
     },
     "5f": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "51"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "52"
     },
     "5g": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "51"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "52"
     },
     "5h": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "51"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "52"
     },
     "5i": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "51"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "52"
     },
     "5j": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "51"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "52"
     },
     "5k": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "51"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "52"
     },
     "5l": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "51"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "52"
     },
     "5m": {
-      "key": "root.types.connections",
-      "~k_parent": "4r"
+      "key": "root.types.blocks.Message",
+      "~k_parent": "52"
     },
     "5n": {
-      "key": "root.types.requests",
-      "~k_parent": "4r"
+      "key": "root.types.connections",
+      "~k_parent": "4s"
     },
     "5o": {
-      "key": "root.types.websockets",
-      "~k_parent": "4r"
+      "key": "root.types.requests",
+      "~k_parent": "4s"
     },
     "5p": {
-      "key": "root.types.api",
-      "~k_parent": "4r"
+      "key": "root.types.websockets",
+      "~k_parent": "4s"
     },
     "5q": {
-      "key": "root.types.operators",
-      "~k_parent": "4r"
+      "key": "root.types.api",
+      "~k_parent": "4s"
     },
     "5r": {
-      "key": "root.types.operators.client",
-      "~k_parent": "5q"
+      "key": "root.types.operators",
+      "~k_parent": "4s"
     },
     "5s": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "5r"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.types.operators.server",
-      "~k_parent": "5q"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "5s"
     },
     "5v": {
+      "key": "root.types.operators.server",
+      "~k_parent": "5r"
+    },
+    "5w": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "5w": {
-      "key": "root.imports.actions",
-      "~k_parent": "5v"
-    },
     "5x": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "5w"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "5w"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "5x"
     },
     "6a": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "66"
     },
     "6b": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "66"
     },
     "6c": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "66"
     },
     "6d": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "66"
     },
     "6e": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "66"
     },
     "6f": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "66"
     },
     "6g": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "66"
     },
     "6h": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "66"
     },
     "6i": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "66"
     },
     "6j": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "66"
     },
     "6k": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "66"
     },
     "6l": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "66"
     },
     "6m": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "66"
     },
     "6n": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "66"
     },
     "6o": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "66"
     },
     "6p": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "65"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "66"
     },
     "6q": {
-      "key": "root.imports.connections",
-      "~k_parent": "5v"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "66"
     },
     "6r": {
-      "key": "root.imports.icons",
-      "~k_parent": "5v"
+      "key": "root.imports.connections",
+      "~k_parent": "5w"
     },
     "6s": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons",
+      "~k_parent": "5w"
     },
     "6t": {
-      "key": "root.imports.icons[0].icons",
+      "key": "root.imports.icons[0]",
       "~k_parent": "6s"
     },
     "6u": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[0].icons",
+      "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.imports.icons[1].icons",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "6s"
     },
     "6w": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[1].icons",
+      "~k_parent": "6v"
     },
     "6x": {
-      "key": "root.imports.icons[2].icons",
-      "~k_parent": "6w"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "6s"
     },
     "6y": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[2].icons",
+      "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.icons[3].icons",
-      "~k_parent": "6y"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "6s"
     },
     "7a": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[8].icons",
+      "~k_parent": "79"
     },
     "7b": {
-      "key": "root.imports.icons[9].icons",
-      "~k_parent": "7a"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "6s"
     },
     "7c": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[9].icons",
+      "~k_parent": "7b"
     },
     "7d": {
-      "key": "root.imports.icons[10].icons",
-      "~k_parent": "7c"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "6s"
     },
     "7e": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[10].icons",
+      "~k_parent": "7d"
     },
     "7f": {
-      "key": "root.imports.icons[11].icons",
-      "~k_parent": "7e"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "6s"
     },
     "7g": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[11].icons",
+      "~k_parent": "7f"
     },
     "7h": {
-      "key": "root.imports.icons[12].icons",
-      "~k_parent": "7g"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "6s"
     },
     "7i": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[12].icons",
+      "~k_parent": "7h"
     },
     "7j": {
-      "key": "root.imports.icons[13].icons",
-      "~k_parent": "7i"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "6s"
     },
     "7k": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[13].icons",
+      "~k_parent": "7j"
     },
     "7l": {
-      "key": "root.imports.icons[14].icons",
-      "~k_parent": "7k"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "6s"
     },
     "7m": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[14].icons",
+      "~k_parent": "7l"
     },
     "7n": {
-      "key": "root.imports.icons[15].icons",
-      "~k_parent": "7m"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "6s"
     },
     "7o": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[15].icons",
+      "~k_parent": "7n"
     },
     "7p": {
-      "key": "root.imports.icons[16].icons",
-      "~k_parent": "7o"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "6s"
     },
     "7q": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[16].icons",
+      "~k_parent": "7p"
     },
     "7r": {
-      "key": "root.imports.icons[17].icons",
-      "~k_parent": "7q"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "6s"
     },
     "7s": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[17].icons",
+      "~k_parent": "7r"
     },
     "7t": {
-      "key": "root.imports.icons[18].icons",
-      "~k_parent": "7s"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "6s"
     },
     "7u": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[18].icons",
+      "~k_parent": "7t"
     },
     "7v": {
-      "key": "root.imports.icons[19].icons",
-      "~k_parent": "7u"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "6s"
     },
     "7w": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[19].icons",
+      "~k_parent": "7v"
     },
     "7x": {
-      "key": "root.imports.icons[20].icons",
-      "~k_parent": "7w"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "6s"
     },
     "7y": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[20].icons",
+      "~k_parent": "7x"
     },
     "7z": {
-      "key": "root.imports.icons[21].icons",
-      "~k_parent": "7y"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "6s"
     },
     "8a": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "6r"
+      "key": "root.imports.icons[26].icons",
+      "~k_parent": "89"
     },
     "8b": {
-      "key": "root.imports.icons[27].icons",
-      "~k_parent": "8a"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "6s"
     },
     "8c": {
-      "key": "root.imports.requests",
-      "~k_parent": "5v"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "8b"
     },
     "8d": {
-      "key": "root.imports.websockets",
-      "~k_parent": "5v"
+      "key": "root.imports.requests",
+      "~k_parent": "5w"
     },
     "8e": {
-      "key": "root.imports.operators",
-      "~k_parent": "5v"
+      "key": "root.imports.websockets",
+      "~k_parent": "5w"
     },
     "8f": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "8e"
+      "key": "root.imports.operators",
+      "~k_parent": "5w"
     },
     "8g": {
-      "key": "root.imports.operators.client[0]",
+      "key": "root.imports.operators.client",
       "~k_parent": "8f"
     },
     "8h": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "8f"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "8g"
     },
     "8i": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "8g"
+    },
+    "8j": {
       "key": "root.imports.operators.server",
-      "~k_parent": "8e"
+      "~k_parent": "8f"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1420,10 +1428,10 @@
               "pageId": "login",
               "auth": {
                 "public": true,
-                "~k": "48"
+                "~k": "49"
               },
               "menuItemId": "0",
-              "~k": "47"
+              "~k": "48"
             },
             {
               "id": "menuitem:default:1",
@@ -1435,12 +1443,12 @@
                   "~arr": [
                     "user"
                   ],
-                  "~k": "4b"
+                  "~k": "4c"
                 },
-                "~k": "4a"
+                "~k": "4b"
               },
               "menuItemId": "1",
-              "~k": "49"
+              "~k": "4a"
             },
             {
               "id": "menuitem:default:2",
@@ -1452,12 +1460,12 @@
                   "~arr": [
                     "user"
                   ],
-                  "~k": "4e"
+                  "~k": "4f"
                 },
-                "~k": "4d"
+                "~k": "4e"
               },
               "menuItemId": "2",
-              "~k": "4c"
+              "~k": "4d"
             },
             {
               "id": "menuitem:default:3",
@@ -1469,12 +1477,12 @@
                   "~arr": [
                     "manager"
                   ],
-                  "~k": "4h"
+                  "~k": "4i"
                 },
-                "~k": "4g"
+                "~k": "4h"
               },
               "menuItemId": "3",
-              "~k": "4f"
+              "~k": "4g"
             },
             {
               "id": "menuitem:default:4",
@@ -1486,12 +1494,12 @@
                   "~arr": [
                     "manager"
                   ],
-                  "~k": "4k"
+                  "~k": "4l"
                 },
-                "~k": "4j"
+                "~k": "4k"
               },
               "menuItemId": "4",
-              "~k": "4i"
+              "~k": "4j"
             },
             {
               "id": "menuitem:default:5",
@@ -1503,12 +1511,12 @@
                   "~arr": [
                     "admin"
                   ],
-                  "~k": "4n"
+                  "~k": "4o"
                 },
-                "~k": "4m"
+                "~k": "4n"
               },
               "menuItemId": "5",
-              "~k": "4l"
+              "~k": "4m"
             },
             {
               "id": "menuitem:default:6",
@@ -1520,21 +1528,21 @@
                   "~arr": [
                     "admin"
                   ],
-                  "~k": "4q"
+                  "~k": "4r"
                 },
-                "~k": "4p"
+                "~k": "4q"
               },
               "menuItemId": "6",
-              "~k": "4o"
+              "~k": "4p"
             }
           ],
-          "~k": "46"
+          "~k": "47"
         },
         "menuId": "default",
-        "~k": "45"
+        "~k": "46"
       }
     ],
-    "~k": "44"
+    "~k": "45"
   },
   "pages/404.json": {
     "id": "page:404",
@@ -1543,9 +1551,9 @@
       "block": {
         "minHeight": "100vh",
         "background": "var(--ant-color-bg-layout)",
-        "~k": "3y"
+        "~k": "3z"
       },
-      "~k": "3x"
+      "~k": "3y"
     },
     "properties": {
       "status": "info",
@@ -1588,9 +1596,9 @@
                   },
                   "catch": {
                     "~arr": [],
-                    "~k": "40"
+                    "~k": "41"
                   },
-                  "~k": "3z"
+                  "~k": "40"
                 },
                 "~k": "1w"
               },
@@ -1606,19 +1614,19 @@
     },
     "auth": {
       "public": true,
-      "~k": "41"
+      "~k": "42"
     },
     "pageId": "404",
     "blockId": "404",
     "subscriptions": {
       "~arr": [],
-      "~k": "42"
+      "~k": "43"
     },
     "requests": {
       "~arr": [],
-      "~k": "43"
+      "~k": "44"
     },
-    "~k": "3w"
+    "~k": "3x"
   },
   "pages/admin-panel.json": {
     "id": "page:admin-panel",
@@ -1633,9 +1641,9 @@
         "~arr": [
           "admin"
         ],
-        "~k": "3k"
+        "~k": "3l"
       },
-      "~k": "3j"
+      "~k": "3k"
     },
     "pageId": "admin-panel",
     "blockId": "admin-panel",
@@ -1656,19 +1664,19 @@
           ],
           "~k": "1d"
         },
-        "~k": "3m"
+        "~k": "3n"
       },
-      "~k": "3l"
+      "~k": "3m"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "3n"
+      "~k": "3o"
     },
     "requests": {
       "~arr": [],
-      "~k": "3o"
+      "~k": "3p"
     },
-    "~k": "3i"
+    "~k": "3j"
   },
   "pages/dashboard.json": {
     "id": "page:dashboard",
@@ -1683,9 +1691,9 @@
         "~arr": [
           "user"
         ],
-        "~k": "2s"
+        "~k": "2t"
       },
-      "~k": "2r"
+      "~k": "2s"
     },
     "pageId": "dashboard",
     "blockId": "dashboard",
@@ -1706,19 +1714,19 @@
           ],
           "~k": "t"
         },
-        "~k": "2u"
+        "~k": "2v"
       },
-      "~k": "2t"
+      "~k": "2u"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "2v"
+      "~k": "2w"
     },
     "requests": {
       "~arr": [],
-      "~k": "2w"
+      "~k": "2x"
     },
-    "~k": "2q"
+    "~k": "2r"
   },
   "pages/login.json": {
     "id": "page:login",
@@ -1730,7 +1738,7 @@
     },
     "auth": {
       "public": true,
-      "~k": "2l"
+      "~k": "2m"
     },
     "pageId": "login",
     "blockId": "login",
@@ -1759,9 +1767,9 @@
                   },
                   "catch": {
                     "~arr": [],
-                    "~k": "2n"
+                    "~k": "2o"
                   },
-                  "~k": "2m"
+                  "~k": "2n"
                 },
                 "~k": "o"
               },
@@ -1777,13 +1785,13 @@
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "2o"
+      "~k": "2p"
     },
     "requests": {
       "~arr": [],
-      "~k": "2p"
+      "~k": "2q"
     },
-    "~k": "2k"
+    "~k": "2l"
   },
   "pages/profile.json": {
     "id": "page:profile",
@@ -1798,9 +1806,9 @@
         "~arr": [
           "user"
         ],
-        "~k": "2z"
+        "~k": "30"
       },
-      "~k": "2y"
+      "~k": "2z"
     },
     "pageId": "profile",
     "blockId": "profile",
@@ -1821,19 +1829,19 @@
           ],
           "~k": "y"
         },
-        "~k": "31"
+        "~k": "32"
       },
-      "~k": "30"
+      "~k": "31"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "32"
+      "~k": "33"
     },
     "requests": {
       "~arr": [],
-      "~k": "33"
+      "~k": "34"
     },
-    "~k": "2x"
+    "~k": "2y"
   },
   "pages/reports.json": {
     "id": "page:reports",
@@ -1848,9 +1856,9 @@
         "~arr": [
           "manager"
         ],
-        "~k": "36"
+        "~k": "37"
       },
-      "~k": "35"
+      "~k": "36"
     },
     "pageId": "reports",
     "blockId": "reports",
@@ -1871,19 +1879,19 @@
           ],
           "~k": "13"
         },
-        "~k": "38"
+        "~k": "39"
       },
-      "~k": "37"
+      "~k": "38"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "39"
+      "~k": "3a"
     },
     "requests": {
       "~arr": [],
-      "~k": "3a"
+      "~k": "3b"
     },
-    "~k": "34"
+    "~k": "35"
   },
   "pages/team.json": {
     "id": "page:team",
@@ -1898,9 +1906,9 @@
         "~arr": [
           "manager"
         ],
-        "~k": "3d"
+        "~k": "3e"
       },
-      "~k": "3c"
+      "~k": "3d"
     },
     "pageId": "team",
     "blockId": "team",
@@ -1921,19 +1929,19 @@
           ],
           "~k": "18"
         },
-        "~k": "3f"
+        "~k": "3g"
       },
-      "~k": "3e"
+      "~k": "3f"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "3g"
+      "~k": "3h"
     },
     "requests": {
       "~arr": [],
-      "~k": "3h"
+      "~k": "3i"
     },
-    "~k": "3b"
+    "~k": "3c"
   },
   "pages/user-management.json": {
     "id": "page:user-management",
@@ -1948,9 +1956,9 @@
         "~arr": [
           "admin"
         ],
-        "~k": "3r"
+        "~k": "3s"
       },
-      "~k": "3q"
+      "~k": "3r"
     },
     "pageId": "user-management",
     "blockId": "user-management",
@@ -1971,19 +1979,19 @@
           ],
           "~k": "1i"
         },
-        "~k": "3t"
+        "~k": "3u"
       },
-      "~k": "3s"
+      "~k": "3t"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "3u"
+      "~k": "3v"
     },
     "requests": {
       "~arr": [],
-      "~k": "3v"
+      "~k": "3w"
     },
-    "~k": "3p"
+    "~k": "3q"
   },
   "plugins/actionSchemas.json": {
     "Login": {
@@ -6537,24 +6545,24 @@
         "originalTypeName": "Login",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "4t"
+        "~k": "4u"
       },
       "Link": {
         "originalTypeName": "Link",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "4u"
+        "~k": "4v"
       },
       "SetDarkMode": {
         "originalTypeName": "SetDarkMode",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "4v"
+        "~k": "4w"
       },
-      "~k": "4s"
+      "~k": "4t"
     },
     "agents": {
-      "~k": "4w"
+      "~k": "4x"
     },
     "auth": {
       "adapters": {
@@ -6562,149 +6570,149 @@
           "originalTypeName": "MongoDBAuthAdapter",
           "package": "@lowdefy/connection-mongodb",
           "count": 1,
-          "~k": "4z"
+          "~k": "50"
         },
-        "~k": "4y"
+        "~k": "4z"
       },
       "providers": {
-        "~k": "50"
+        "~k": "51"
       },
-      "~k": "4x"
+      "~k": "4y"
     },
     "blocks": {
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "52"
+        "~k": "53"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "53"
+        "~k": "54"
       },
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "54"
+        "~k": "55"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 6,
-        "~k": "55"
+        "~k": "56"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "56"
+        "~k": "57"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "57"
+        "~k": "58"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "58"
+        "~k": "59"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "59"
+        "~k": "5a"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5a"
+        "~k": "5b"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5b"
+        "~k": "5c"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5c"
+        "~k": "5d"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5d"
+        "~k": "5e"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5e"
+        "~k": "5f"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5f"
+        "~k": "5g"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5g"
+        "~k": "5h"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5h"
+        "~k": "5i"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5i"
+        "~k": "5j"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5j"
+        "~k": "5k"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5k"
+        "~k": "5l"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "5l"
+        "~k": "5m"
       },
-      "~k": "51"
+      "~k": "52"
     },
     "connections": {
-      "~k": "5m"
-    },
-    "requests": {
       "~k": "5n"
     },
-    "websockets": {
+    "requests": {
       "~k": "5o"
     },
-    "api": {
+    "websockets": {
       "~k": "5p"
+    },
+    "api": {
+      "~k": "5q"
     },
     "operators": {
       "client": {
@@ -6712,21 +6720,21 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5s"
+          "~k": "5t"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5t"
+          "~k": "5u"
         },
-        "~k": "5r"
+        "~k": "5s"
       },
       "server": {
-        "~k": "5u"
+        "~k": "5v"
       },
-      "~k": "5q"
+      "~k": "5r"
     },
-    "~k": "4r"
+    "~k": "4s"
   }
 }

--- a/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
+++ b/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
@@ -114,6 +114,10 @@
       },
       "~k": "a8"
     },
+    "hooks": {
+      "~arr": [],
+      "~k": "aa"
+    },
     "authPages": {
       "signIn": "/login",
       "signUp": "/signup",
@@ -121,24 +125,24 @@
       "forgotPassword": "/forgot-password",
       "resetPassword": "/reset-password",
       "verifyEmail": "/verify-email",
-      "~k": "aa"
+      "~k": "ab"
     },
     "account": {
       "accountLinking": {
         "enabled": true,
         "trustedProviders": {
           "~arr": [],
-          "~k": "ad"
+          "~k": "ae"
         },
-        "~k": "ac"
+        "~k": "ad"
       },
-      "~k": "ab"
+      "~k": "ac"
     },
     "rateLimit": {
       "enabled": true,
       "window": 60,
       "max": 100,
-      "~k": "ae"
+      "~k": "af"
     },
     "~k": "e"
   },
@@ -2346,1292 +2350,1296 @@
       "~k_parent": "a8"
     },
     "aa": {
-      "key": "root.auth.authPages",
+      "key": "root.auth.hooks",
       "~k_parent": "e"
     },
     "ab": {
-      "key": "root.auth.account",
+      "key": "root.auth.authPages",
       "~k_parent": "e"
     },
     "ac": {
-      "key": "root.auth.account.accountLinking",
-      "~k_parent": "ab"
+      "key": "root.auth.account",
+      "~k_parent": "e"
     },
     "ad": {
-      "key": "root.auth.account.accountLinking.trustedProviders",
+      "key": "root.auth.account.accountLinking",
       "~k_parent": "ac"
     },
     "ae": {
+      "key": "root.auth.account.accountLinking.trustedProviders",
+      "~k_parent": "ad"
+    },
+    "af": {
       "key": "root.auth.rateLimit",
       "~k_parent": "e"
     },
-    "af": {
+    "ag": {
       "key": "root.menus[0:default].links",
       "~k_parent": "11"
     },
-    "ag": {
+    "ah": {
       "key": "root.menus[0:default].links[0:dashboard:MenuLink].auth",
       "~k_parent": "13"
     },
-    "ah": {
+    "ai": {
       "key": "root.menus[0:default].links[1:customers:MenuGroup].links",
       "~k_parent": "15"
     },
-    "ai": {
+    "aj": {
       "key": "root.menus[0:default].links[1:customers:MenuGroup].links[0:all-customers:MenuLink].auth",
       "~k_parent": "18"
     },
-    "aj": {
-      "key": "root.menus[0:default].links[1:customers:MenuGroup].links[0:all-customers:MenuLink].auth.roles",
-      "~k_parent": "ai"
-    },
     "ak": {
+      "key": "root.menus[0:default].links[1:customers:MenuGroup].links[0:all-customers:MenuLink].auth.roles",
+      "~k_parent": "aj"
+    },
+    "al": {
       "key": "root.menus[0:default].links[1:customers:MenuGroup].links[1:add-customer:MenuLink].auth",
       "~k_parent": "1a"
     },
-    "al": {
-      "key": "root.menus[0:default].links[1:customers:MenuGroup].links[1:add-customer:MenuLink].auth.roles",
-      "~k_parent": "ak"
-    },
     "am": {
+      "key": "root.menus[0:default].links[1:customers:MenuGroup].links[1:add-customer:MenuLink].auth.roles",
+      "~k_parent": "al"
+    },
+    "an": {
       "key": "root.menus[0:default].links[1:customers:MenuGroup].auth",
       "~k_parent": "15"
     },
-    "an": {
+    "ao": {
       "key": "root.menus[0:default].links[2:orders:MenuLink].auth",
       "~k_parent": "1c"
     },
-    "ao": {
-      "key": "root.menus[0:default].links[2:orders:MenuLink].auth.roles",
-      "~k_parent": "an"
-    },
     "ap": {
+      "key": "root.menus[0:default].links[2:orders:MenuLink].auth.roles",
+      "~k_parent": "ao"
+    },
+    "aq": {
       "key": "root.menus[0:default].links[3:reports:MenuLink].auth",
       "~k_parent": "1e"
     },
-    "aq": {
-      "key": "root.menus[0:default].links[3:reports:MenuLink].auth.roles",
-      "~k_parent": "ap"
-    },
     "ar": {
+      "key": "root.menus[0:default].links[3:reports:MenuLink].auth.roles",
+      "~k_parent": "aq"
+    },
+    "as": {
       "key": "root.menus[0:default].links[4:settings:MenuLink].auth",
       "~k_parent": "1g"
     },
-    "as": {
-      "key": "root.menus[0:default].links[4:settings:MenuLink].auth.roles",
-      "~k_parent": "ar"
-    },
     "at": {
+      "key": "root.menus[0:default].links[4:settings:MenuLink].auth.roles",
+      "~k_parent": "as"
+    },
+    "au": {
       "key": "root.pages",
       "~k_parent": "4"
     },
-    "au": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu]",
-      "~k_parent": "at"
-    },
     "av": {
+      "key": "root.pages[0:dashboard:PageHeaderMenu]",
+      "~k_parent": "au"
+    },
+    "aw": {
       "key": "root.pages[0:dashboard:PageHeaderMenu].events.onInitAsync",
       "~k_parent": "1o"
     },
-    "aw": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].events.onInitAsync.catch",
-      "~k_parent": "av"
-    },
     "ax": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].auth",
-      "~k_parent": "au"
+      "key": "root.pages[0:dashboard:PageHeaderMenu].events.onInitAsync.catch",
+      "~k_parent": "aw"
     },
     "ay": {
+      "key": "root.pages[0:dashboard:PageHeaderMenu].auth",
+      "~k_parent": "av"
+    },
+    "az": {
       "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].slots",
       "~k_parent": "1y"
     },
-    "az": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].slots.content",
-      "~k_parent": "ay"
-    },
     "b0": {
+      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].slots.content",
+      "~k_parent": "az"
+    },
+    "b1": {
       "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[0:totalCustomers:Card].slots",
       "~k_parent": "20"
     },
-    "b1": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[0:totalCustomers:Card].slots.content",
-      "~k_parent": "b0"
-    },
     "b2": {
+      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[0:totalCustomers:Card].slots.content",
+      "~k_parent": "b1"
+    },
+    "b3": {
       "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[1:totalOrders:Card].slots",
       "~k_parent": "26"
     },
-    "b3": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[1:totalOrders:Card].slots.content",
-      "~k_parent": "b2"
-    },
     "b4": {
+      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[1:totalOrders:Card].slots.content",
+      "~k_parent": "b3"
+    },
+    "b5": {
       "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[2:revenue:Card].slots",
       "~k_parent": "2c"
     },
-    "b5": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[2:revenue:Card].slots.content",
-      "~k_parent": "b4"
-    },
     "b6": {
+      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[2:revenue:Card].slots.content",
+      "~k_parent": "b5"
+    },
+    "b7": {
       "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[3:growth:Card].slots",
       "~k_parent": "2i"
     },
-    "b7": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[3:growth:Card].slots.content",
-      "~k_parent": "b6"
-    },
     "b8": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].subscriptions",
-      "~k_parent": "au"
+      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[3:growth:Card].slots.content",
+      "~k_parent": "b7"
     },
     "b9": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].requests",
-      "~k_parent": "au"
+      "key": "root.pages[0:dashboard:PageHeaderMenu].subscriptions",
+      "~k_parent": "av"
     },
     "ba": {
+      "key": "root.pages[0:dashboard:PageHeaderMenu].requests",
+      "~k_parent": "av"
+    },
+    "bb": {
       "key": "root.pages[0:dashboard:PageHeaderMenu].requests[0:api:AxiosHttp].payload",
       "~k_parent": "1m"
     },
-    "bb": {
+    "bc": {
       "key": "root.pages[0:dashboard:PageHeaderMenu].requests[0:api:AxiosHttp].auth",
       "~k_parent": "1m"
     },
-    "bc": {
-      "key": "root.pages[1:customers:PageHeaderMenu]",
-      "~k_parent": "at"
-    },
     "bd": {
+      "key": "root.pages[1:customers:PageHeaderMenu]",
+      "~k_parent": "au"
+    },
+    "be": {
       "key": "root.pages[1:customers:PageHeaderMenu].events.onInit",
       "~k_parent": "3e"
     },
-    "be": {
-      "key": "root.pages[1:customers:PageHeaderMenu].events.onInit.catch",
-      "~k_parent": "bd"
-    },
     "bf": {
-      "key": "root.pages[1:customers:PageHeaderMenu].auth",
-      "~k_parent": "bc"
+      "key": "root.pages[1:customers:PageHeaderMenu].events.onInit.catch",
+      "~k_parent": "be"
     },
     "bg": {
-      "key": "root.pages[1:customers:PageHeaderMenu].auth.roles",
-      "~k_parent": "bf"
+      "key": "root.pages[1:customers:PageHeaderMenu].auth",
+      "~k_parent": "bd"
     },
     "bh": {
+      "key": "root.pages[1:customers:PageHeaderMenu].auth.roles",
+      "~k_parent": "bg"
+    },
+    "bi": {
       "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].slots",
       "~k_parent": "3k"
     },
-    "bi": {
-      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].slots.content",
-      "~k_parent": "bh"
-    },
     "bj": {
+      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].slots.content",
+      "~k_parent": "bi"
+    },
+    "bk": {
       "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].blocks[0:searchQuery:TextInput].events.onChange.catch",
       "~k_parent": "3q"
     },
-    "bk": {
+    "bl": {
       "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].blocks[1:statusFilter:Selector].events.onChange",
       "~k_parent": "41"
     },
-    "bl": {
-      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].blocks[1:statusFilter:Selector].events.onChange.catch",
-      "~k_parent": "bk"
-    },
     "bm": {
+      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].blocks[1:statusFilter:Selector].events.onChange.catch",
+      "~k_parent": "bl"
+    },
+    "bn": {
       "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].blocks[2:addBtn:Button].events.onClick",
       "~k_parent": "47"
     },
-    "bn": {
-      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].blocks[2:addBtn:Button].events.onClick.catch",
-      "~k_parent": "bm"
-    },
     "bo": {
+      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].blocks[2:addBtn:Button].events.onClick.catch",
+      "~k_parent": "bn"
+    },
+    "bp": {
       "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].slots",
       "~k_parent": "4b"
     },
-    "bp": {
-      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].slots.content",
-      "~k_parent": "bo"
-    },
     "bq": {
+      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].slots.content",
+      "~k_parent": "bp"
+    },
+    "br": {
       "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].blocks[0:customerCard:Card].events.onClick",
       "~k_parent": "4i"
     },
-    "br": {
-      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].blocks[0:customerCard:Card].events.onClick.catch",
-      "~k_parent": "bq"
-    },
     "bs": {
+      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].blocks[0:customerCard:Card].events.onClick.catch",
+      "~k_parent": "br"
+    },
+    "bt": {
       "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].blocks[0:customerCard:Card].slots",
       "~k_parent": "4f"
     },
-    "bt": {
-      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].blocks[0:customerCard:Card].slots.content",
-      "~k_parent": "bs"
-    },
     "bu": {
-      "key": "root.pages[1:customers:PageHeaderMenu].subscriptions",
-      "~k_parent": "bc"
+      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].blocks[0:customerCard:Card].slots.content",
+      "~k_parent": "bt"
     },
     "bv": {
-      "key": "root.pages[1:customers:PageHeaderMenu].requests",
-      "~k_parent": "bc"
+      "key": "root.pages[1:customers:PageHeaderMenu].subscriptions",
+      "~k_parent": "bd"
     },
     "bw": {
+      "key": "root.pages[1:customers:PageHeaderMenu].requests",
+      "~k_parent": "bd"
+    },
+    "bx": {
       "key": "root.pages[1:customers:PageHeaderMenu].requests[0:db:MongoDBFind].auth",
       "~k_parent": "2r"
     },
-    "bx": {
-      "key": "root.pages[1:customers:PageHeaderMenu].requests[0:db:MongoDBFind].auth.roles",
-      "~k_parent": "bw"
-    },
     "by": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu]",
-      "~k_parent": "at"
+      "key": "root.pages[1:customers:PageHeaderMenu].requests[0:db:MongoDBFind].auth.roles",
+      "~k_parent": "bx"
     },
     "bz": {
+      "key": "root.pages[2:customer-detail:PageHeaderMenu]",
+      "~k_parent": "au"
+    },
+    "c0": {
       "key": "root.pages[2:customer-detail:PageHeaderMenu].events.onInit",
       "~k_parent": "5y"
     },
-    "c0": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].events.onInit.catch",
-      "~k_parent": "bz"
-    },
     "c1": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].auth",
-      "~k_parent": "by"
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].events.onInit.catch",
+      "~k_parent": "c0"
     },
     "c2": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].auth.roles",
-      "~k_parent": "c1"
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].auth",
+      "~k_parent": "bz"
     },
     "c3": {
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].auth.roles",
+      "~k_parent": "c2"
+    },
+    "c4": {
       "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].slots",
       "~k_parent": "6j"
     },
-    "c4": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].slots.content",
-      "~k_parent": "c3"
-    },
     "c5": {
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].slots.content",
+      "~k_parent": "c4"
+    },
+    "c6": {
       "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].slots",
       "~k_parent": "73"
     },
-    "c6": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].slots.content",
-      "~k_parent": "c5"
-    },
     "c7": {
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].slots.content",
+      "~k_parent": "c6"
+    },
+    "c8": {
       "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].blocks[0:saveBtn:Button].events.onClick",
       "~k_parent": "77"
     },
-    "c8": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].blocks[0:saveBtn:Button].events.onClick.catch",
-      "~k_parent": "c7"
-    },
     "c9": {
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].blocks[0:saveBtn:Button].events.onClick.catch",
+      "~k_parent": "c8"
+    },
+    "ca": {
       "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].blocks[1:cancelBtn:Button].events.onClick",
       "~k_parent": "7h"
     },
-    "ca": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].blocks[1:cancelBtn:Button].events.onClick.catch",
-      "~k_parent": "c9"
-    },
     "cb": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].subscriptions",
-      "~k_parent": "by"
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].blocks[1:cancelBtn:Button].events.onClick.catch",
+      "~k_parent": "ca"
     },
     "cc": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].requests",
-      "~k_parent": "by"
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].subscriptions",
+      "~k_parent": "bz"
     },
     "cd": {
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].requests",
+      "~k_parent": "bz"
+    },
+    "ce": {
       "key": "root.pages[2:customer-detail:PageHeaderMenu].requests[0:db:MongoDBFindOne].auth",
       "~k_parent": "58"
     },
-    "ce": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].requests[0:db:MongoDBFindOne].auth.roles",
-      "~k_parent": "cd"
-    },
     "cf": {
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].requests[0:db:MongoDBFindOne].auth.roles",
+      "~k_parent": "ce"
+    },
+    "cg": {
       "key": "root.pages[2:customer-detail:PageHeaderMenu].requests[1:db:MongoDBUpdateOne].auth",
       "~k_parent": "5e"
     },
-    "cg": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].requests[1:db:MongoDBUpdateOne].auth.roles",
-      "~k_parent": "cf"
-    },
     "ch": {
-      "key": "root.pages[3:orders:PageHeaderMenu]",
-      "~k_parent": "at"
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].requests[1:db:MongoDBUpdateOne].auth.roles",
+      "~k_parent": "cg"
     },
     "ci": {
-      "key": "root.pages[3:orders:PageHeaderMenu].auth",
-      "~k_parent": "ch"
+      "key": "root.pages[3:orders:PageHeaderMenu]",
+      "~k_parent": "au"
     },
     "cj": {
-      "key": "root.pages[3:orders:PageHeaderMenu].auth.roles",
+      "key": "root.pages[3:orders:PageHeaderMenu].auth",
       "~k_parent": "ci"
     },
     "ck": {
-      "key": "root.pages[3:orders:PageHeaderMenu].slots",
-      "~k_parent": "ch"
+      "key": "root.pages[3:orders:PageHeaderMenu].auth.roles",
+      "~k_parent": "cj"
     },
     "cl": {
-      "key": "root.pages[3:orders:PageHeaderMenu].slots.content",
-      "~k_parent": "ck"
+      "key": "root.pages[3:orders:PageHeaderMenu].slots",
+      "~k_parent": "ci"
     },
     "cm": {
-      "key": "root.pages[3:orders:PageHeaderMenu].subscriptions",
-      "~k_parent": "ch"
+      "key": "root.pages[3:orders:PageHeaderMenu].slots.content",
+      "~k_parent": "cl"
     },
     "cn": {
-      "key": "root.pages[3:orders:PageHeaderMenu].requests",
-      "~k_parent": "ch"
+      "key": "root.pages[3:orders:PageHeaderMenu].subscriptions",
+      "~k_parent": "ci"
     },
     "co": {
-      "key": "root.pages[4:reports:PageHeaderMenu]",
-      "~k_parent": "at"
+      "key": "root.pages[3:orders:PageHeaderMenu].requests",
+      "~k_parent": "ci"
     },
     "cp": {
-      "key": "root.pages[4:reports:PageHeaderMenu].auth",
-      "~k_parent": "co"
+      "key": "root.pages[4:reports:PageHeaderMenu]",
+      "~k_parent": "au"
     },
     "cq": {
-      "key": "root.pages[4:reports:PageHeaderMenu].auth.roles",
+      "key": "root.pages[4:reports:PageHeaderMenu].auth",
       "~k_parent": "cp"
     },
     "cr": {
-      "key": "root.pages[4:reports:PageHeaderMenu].slots",
-      "~k_parent": "co"
+      "key": "root.pages[4:reports:PageHeaderMenu].auth.roles",
+      "~k_parent": "cq"
     },
     "cs": {
-      "key": "root.pages[4:reports:PageHeaderMenu].slots.content",
-      "~k_parent": "cr"
+      "key": "root.pages[4:reports:PageHeaderMenu].slots",
+      "~k_parent": "cp"
     },
     "ct": {
-      "key": "root.pages[4:reports:PageHeaderMenu].subscriptions",
-      "~k_parent": "co"
+      "key": "root.pages[4:reports:PageHeaderMenu].slots.content",
+      "~k_parent": "cs"
     },
     "cu": {
-      "key": "root.pages[4:reports:PageHeaderMenu].requests",
-      "~k_parent": "co"
+      "key": "root.pages[4:reports:PageHeaderMenu].subscriptions",
+      "~k_parent": "cp"
     },
     "cv": {
-      "key": "root.pages[5:settings:PageHeaderMenu]",
-      "~k_parent": "at"
+      "key": "root.pages[4:reports:PageHeaderMenu].requests",
+      "~k_parent": "cp"
     },
     "cw": {
-      "key": "root.pages[5:settings:PageHeaderMenu].auth",
-      "~k_parent": "cv"
+      "key": "root.pages[5:settings:PageHeaderMenu]",
+      "~k_parent": "au"
     },
     "cx": {
-      "key": "root.pages[5:settings:PageHeaderMenu].auth.roles",
+      "key": "root.pages[5:settings:PageHeaderMenu].auth",
       "~k_parent": "cw"
     },
     "cy": {
-      "key": "root.pages[5:settings:PageHeaderMenu].slots",
-      "~k_parent": "cv"
+      "key": "root.pages[5:settings:PageHeaderMenu].auth.roles",
+      "~k_parent": "cx"
     },
     "cz": {
-      "key": "root.pages[5:settings:PageHeaderMenu].slots.content",
-      "~k_parent": "cy"
+      "key": "root.pages[5:settings:PageHeaderMenu].slots",
+      "~k_parent": "cw"
     },
     "d0": {
+      "key": "root.pages[5:settings:PageHeaderMenu].slots.content",
+      "~k_parent": "cz"
+    },
+    "d1": {
       "key": "root.pages[5:settings:PageHeaderMenu].blocks[1:settingsForm:Card].slots",
       "~k_parent": "84"
     },
-    "d1": {
-      "key": "root.pages[5:settings:PageHeaderMenu].blocks[1:settingsForm:Card].slots.content",
-      "~k_parent": "d0"
-    },
     "d2": {
+      "key": "root.pages[5:settings:PageHeaderMenu].blocks[1:settingsForm:Card].slots.content",
+      "~k_parent": "d1"
+    },
+    "d3": {
       "key": "root.pages[5:settings:PageHeaderMenu].blocks[1:settingsForm:Card].blocks[4:saveSettingsBtn:Button].events.onClick",
       "~k_parent": "8m"
     },
-    "d3": {
-      "key": "root.pages[5:settings:PageHeaderMenu].blocks[1:settingsForm:Card].blocks[4:saveSettingsBtn:Button].events.onClick.catch",
-      "~k_parent": "d2"
-    },
     "d4": {
-      "key": "root.pages[5:settings:PageHeaderMenu].subscriptions",
-      "~k_parent": "cv"
+      "key": "root.pages[5:settings:PageHeaderMenu].blocks[1:settingsForm:Card].blocks[4:saveSettingsBtn:Button].events.onClick.catch",
+      "~k_parent": "d3"
     },
     "d5": {
-      "key": "root.pages[5:settings:PageHeaderMenu].requests",
-      "~k_parent": "cv"
+      "key": "root.pages[5:settings:PageHeaderMenu].subscriptions",
+      "~k_parent": "cw"
     },
     "d6": {
-      "key": "root.pages[6:login:Result]",
-      "~k_parent": "at"
+      "key": "root.pages[5:settings:PageHeaderMenu].requests",
+      "~k_parent": "cw"
     },
     "d7": {
-      "key": "root.pages[6:login:Result].auth",
-      "~k_parent": "d6"
+      "key": "root.pages[6:login:Result]",
+      "~k_parent": "au"
     },
     "d8": {
+      "key": "root.pages[6:login:Result].auth",
+      "~k_parent": "d7"
+    },
+    "d9": {
       "key": "root.pages[6:login:Result].areas.extra.blocks[0:googleBtn:Button].events.onClick",
       "~k_parent": "92"
     },
-    "d9": {
-      "key": "root.pages[6:login:Result].areas.extra.blocks[0:googleBtn:Button].events.onClick.catch",
-      "~k_parent": "d8"
-    },
     "da": {
+      "key": "root.pages[6:login:Result].areas.extra.blocks[0:googleBtn:Button].events.onClick.catch",
+      "~k_parent": "d9"
+    },
+    "db": {
       "key": "root.pages[6:login:Result].areas.extra.blocks[4:credentialsBtn:Button].events.onClick",
       "~k_parent": "9e"
     },
-    "db": {
-      "key": "root.pages[6:login:Result].areas.extra.blocks[4:credentialsBtn:Button].events.onClick.catch",
-      "~k_parent": "da"
-    },
     "dc": {
-      "key": "root.pages[6:login:Result].subscriptions",
-      "~k_parent": "d6"
+      "key": "root.pages[6:login:Result].areas.extra.blocks[4:credentialsBtn:Button].events.onClick.catch",
+      "~k_parent": "db"
     },
     "dd": {
-      "key": "root.pages[6:login:Result].requests",
-      "~k_parent": "d6"
+      "key": "root.pages[6:login:Result].subscriptions",
+      "~k_parent": "d7"
     },
     "de": {
-      "key": "root.pages[7:404:Result]",
-      "~k_parent": "at"
+      "key": "root.pages[6:login:Result].requests",
+      "~k_parent": "d7"
     },
     "df": {
-      "key": "root.pages[7:404:Result].style",
-      "~k_parent": "de"
+      "key": "root.pages[7:404:Result]",
+      "~k_parent": "au"
     },
     "dg": {
-      "key": "root.pages[7:404:Result].style.block",
+      "key": "root.pages[7:404:Result].style",
       "~k_parent": "df"
     },
     "dh": {
+      "key": "root.pages[7:404:Result].style.block",
+      "~k_parent": "dg"
+    },
+    "di": {
       "key": "root.pages[7:404:Result].slots.extra.blocks[0:home:Button].events.onClick",
       "~k_parent": "9w"
     },
-    "di": {
-      "key": "root.pages[7:404:Result].slots.extra.blocks[0:home:Button].events.onClick.catch",
-      "~k_parent": "dh"
-    },
     "dj": {
-      "key": "root.pages[7:404:Result].auth",
-      "~k_parent": "de"
+      "key": "root.pages[7:404:Result].slots.extra.blocks[0:home:Button].events.onClick.catch",
+      "~k_parent": "di"
     },
     "dk": {
-      "key": "root.pages[7:404:Result].subscriptions",
-      "~k_parent": "de"
+      "key": "root.pages[7:404:Result].auth",
+      "~k_parent": "df"
     },
     "dl": {
-      "key": "root.pages[7:404:Result].requests",
-      "~k_parent": "de"
+      "key": "root.pages[7:404:Result].subscriptions",
+      "~k_parent": "df"
     },
     "dm": {
+      "key": "root.pages[7:404:Result].requests",
+      "~k_parent": "df"
+    },
+    "dn": {
       "key": "root.types",
       "~k_parent": "4"
     },
-    "dn": {
-      "key": "root.types.actions",
-      "~k_parent": "dm"
-    },
     "do": {
-      "key": "root.types.actions.Request",
+      "key": "root.types.actions",
       "~k_parent": "dn"
     },
     "dp": {
-      "key": "root.types.actions.Link",
-      "~k_parent": "dn"
+      "key": "root.types.actions.Request",
+      "~k_parent": "do"
     },
     "dq": {
-      "key": "root.types.actions.SetState",
-      "~k_parent": "dn"
+      "key": "root.types.actions.Link",
+      "~k_parent": "do"
     },
     "dr": {
-      "key": "root.types.actions.Validate",
-      "~k_parent": "dn"
+      "key": "root.types.actions.SetState",
+      "~k_parent": "do"
     },
     "ds": {
-      "key": "root.types.actions.DisplayMessage",
-      "~k_parent": "dn"
+      "key": "root.types.actions.Validate",
+      "~k_parent": "do"
     },
     "dt": {
-      "key": "root.types.actions.SetGlobal",
-      "~k_parent": "dn"
+      "key": "root.types.actions.DisplayMessage",
+      "~k_parent": "do"
     },
     "du": {
-      "key": "root.types.actions.Login",
-      "~k_parent": "dn"
+      "key": "root.types.actions.SetGlobal",
+      "~k_parent": "do"
     },
     "dv": {
-      "key": "root.types.actions.SetDarkMode",
-      "~k_parent": "dn"
+      "key": "root.types.actions.Login",
+      "~k_parent": "do"
     },
     "dw": {
-      "key": "root.types.agents",
-      "~k_parent": "dm"
+      "key": "root.types.actions.SetDarkMode",
+      "~k_parent": "do"
     },
     "dx": {
-      "key": "root.types.auth",
-      "~k_parent": "dm"
+      "key": "root.types.agents",
+      "~k_parent": "dn"
     },
     "dy": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "dx"
+      "key": "root.types.auth",
+      "~k_parent": "dn"
     },
     "dz": {
-      "key": "root.types.auth.adapters.MongoDBAuthAdapter",
+      "key": "root.types.auth.adapters",
       "~k_parent": "dy"
     },
     "e0": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "dx"
+      "key": "root.types.auth.adapters.MongoDBAuthAdapter",
+      "~k_parent": "dz"
     },
     "e1": {
-      "key": "root.types.auth.providers.Google",
-      "~k_parent": "e0"
+      "key": "root.types.auth.providers",
+      "~k_parent": "dy"
     },
     "e2": {
-      "key": "root.types.blocks",
-      "~k_parent": "dm"
+      "key": "root.types.auth.providers.Google",
+      "~k_parent": "e1"
     },
     "e3": {
-      "key": "root.types.blocks.PageHeaderMenu",
-      "~k_parent": "e2"
+      "key": "root.types.blocks",
+      "~k_parent": "dn"
     },
     "e4": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.PageHeaderMenu",
+      "~k_parent": "e3"
     },
     "e5": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "e3"
     },
     "e6": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "e3"
     },
     "e7": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "e3"
     },
     "e8": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "e3"
     },
     "e9": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "e3"
     },
     "ea": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "e3"
     },
     "eb": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "e3"
     },
     "ec": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.List",
+      "~k_parent": "e3"
     },
     "ed": {
-      "key": "root.types.blocks.Tag",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "e3"
     },
     "ee": {
-      "key": "root.types.blocks.TextArea",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Tag",
+      "~k_parent": "e3"
     },
     "ef": {
-      "key": "root.types.blocks.NumberInput",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.TextArea",
+      "~k_parent": "e3"
     },
     "eg": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.NumberInput",
+      "~k_parent": "e3"
     },
     "eh": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "e3"
     },
     "ei": {
-      "key": "root.types.blocks.Divider",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "e3"
     },
     "ej": {
-      "key": "root.types.blocks.PasswordInput",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Divider",
+      "~k_parent": "e3"
     },
     "ek": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.PasswordInput",
+      "~k_parent": "e3"
     },
     "el": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "e3"
     },
     "em": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "e3"
     },
     "en": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "e3"
     },
     "eo": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "e3"
     },
     "ep": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "e3"
     },
     "eq": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "e3"
     },
     "er": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "e3"
     },
     "es": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "e3"
     },
     "et": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "e3"
     },
     "eu": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "e3"
     },
     "ev": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "e3"
     },
     "ew": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "e3"
     },
     "ex": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "e3"
     },
     "ey": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "e2"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "e3"
     },
     "ez": {
-      "key": "root.types.connections",
-      "~k_parent": "dm"
+      "key": "root.types.blocks.Message",
+      "~k_parent": "e3"
     },
     "f0": {
-      "key": "root.types.connections.AxiosHttp",
-      "~k_parent": "ez"
+      "key": "root.types.connections",
+      "~k_parent": "dn"
     },
     "f1": {
-      "key": "root.types.connections.MongoDBCollection",
-      "~k_parent": "ez"
+      "key": "root.types.connections.AxiosHttp",
+      "~k_parent": "f0"
     },
     "f2": {
-      "key": "root.types.requests",
-      "~k_parent": "dm"
+      "key": "root.types.connections.MongoDBCollection",
+      "~k_parent": "f0"
     },
     "f3": {
-      "key": "root.types.requests.AxiosHttp",
-      "~k_parent": "f2"
+      "key": "root.types.requests",
+      "~k_parent": "dn"
     },
     "f4": {
-      "key": "root.types.requests.MongoDBFind",
-      "~k_parent": "f2"
+      "key": "root.types.requests.AxiosHttp",
+      "~k_parent": "f3"
     },
     "f5": {
-      "key": "root.types.requests.MongoDBFindOne",
-      "~k_parent": "f2"
+      "key": "root.types.requests.MongoDBFind",
+      "~k_parent": "f3"
     },
     "f6": {
-      "key": "root.types.requests.MongoDBUpdateOne",
-      "~k_parent": "f2"
+      "key": "root.types.requests.MongoDBFindOne",
+      "~k_parent": "f3"
     },
     "f7": {
-      "key": "root.types.websockets",
-      "~k_parent": "dm"
+      "key": "root.types.requests.MongoDBUpdateOne",
+      "~k_parent": "f3"
     },
     "f8": {
-      "key": "root.types.api",
-      "~k_parent": "dm"
+      "key": "root.types.websockets",
+      "~k_parent": "dn"
     },
     "f9": {
-      "key": "root.types.operators",
-      "~k_parent": "dm"
+      "key": "root.types.api",
+      "~k_parent": "dn"
     },
     "fa": {
-      "key": "root.types.operators.client",
-      "~k_parent": "f9"
+      "key": "root.types.operators",
+      "~k_parent": "dn"
     },
     "fb": {
-      "key": "root.types.operators.client._user",
+      "key": "root.types.operators.client",
       "~k_parent": "fa"
     },
     "fc": {
-      "key": "root.types.operators.client._request",
-      "~k_parent": "fa"
+      "key": "root.types.operators.client._user",
+      "~k_parent": "fb"
     },
     "fd": {
-      "key": "root.types.operators.client._state",
-      "~k_parent": "fa"
+      "key": "root.types.operators.client._request",
+      "~k_parent": "fb"
     },
     "fe": {
-      "key": "root.types.operators.client._if",
-      "~k_parent": "fa"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "fb"
     },
     "ff": {
-      "key": "root.types.operators.client._eq",
-      "~k_parent": "fa"
+      "key": "root.types.operators.client._if",
+      "~k_parent": "fb"
     },
     "fg": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "fa"
+      "key": "root.types.operators.client._eq",
+      "~k_parent": "fb"
     },
     "fh": {
-      "key": "root.types.operators.client._url_query",
-      "~k_parent": "fa"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "fb"
     },
     "fi": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "fa"
+      "key": "root.types.operators.client._url_query",
+      "~k_parent": "fb"
     },
     "fj": {
-      "key": "root.types.operators.server",
-      "~k_parent": "f9"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "fb"
     },
     "fk": {
-      "key": "root.types.operators.server._payload",
-      "~k_parent": "fj"
+      "key": "root.types.operators.server",
+      "~k_parent": "fa"
     },
     "fl": {
-      "key": "root.types.operators.server._if",
-      "~k_parent": "fj"
+      "key": "root.types.operators.server._payload",
+      "~k_parent": "fk"
     },
     "fm": {
-      "key": "root.types.operators.server._date",
-      "~k_parent": "fj"
+      "key": "root.types.operators.server._if",
+      "~k_parent": "fk"
     },
     "fn": {
+      "key": "root.types.operators.server._date",
+      "~k_parent": "fk"
+    },
+    "fo": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "fo": {
-      "key": "root.imports.actions",
-      "~k_parent": "fn"
-    },
     "fp": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "fo"
     },
     "fq": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "fo"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "fp"
     },
     "fr": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "fo"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "fp"
     },
     "fs": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "fo"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "fp"
     },
     "ft": {
-      "key": "root.imports.actions[4]",
-      "~k_parent": "fo"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "fp"
     },
     "fu": {
-      "key": "root.imports.actions[5]",
-      "~k_parent": "fo"
+      "key": "root.imports.actions[4]",
+      "~k_parent": "fp"
     },
     "fv": {
-      "key": "root.imports.actions[6]",
-      "~k_parent": "fo"
+      "key": "root.imports.actions[5]",
+      "~k_parent": "fp"
     },
     "fw": {
-      "key": "root.imports.actions[7]",
-      "~k_parent": "fo"
+      "key": "root.imports.actions[6]",
+      "~k_parent": "fp"
     },
     "fx": {
-      "key": "root.imports.agents",
-      "~k_parent": "fn"
+      "key": "root.imports.actions[7]",
+      "~k_parent": "fp"
     },
     "fy": {
-      "key": "root.imports.auth",
-      "~k_parent": "fn"
+      "key": "root.imports.agents",
+      "~k_parent": "fo"
     },
     "fz": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "fy"
+      "key": "root.imports.auth",
+      "~k_parent": "fo"
     },
     "g0": {
-      "key": "root.imports.auth.adapters[0]",
+      "key": "root.imports.auth.adapters",
       "~k_parent": "fz"
     },
     "g1": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "fy"
+      "key": "root.imports.auth.adapters[0]",
+      "~k_parent": "g0"
     },
     "g2": {
-      "key": "root.imports.auth.providers[0]",
-      "~k_parent": "g1"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "fz"
     },
     "g3": {
-      "key": "root.imports.blocks",
-      "~k_parent": "fn"
+      "key": "root.imports.auth.providers[0]",
+      "~k_parent": "g2"
     },
     "g4": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks",
+      "~k_parent": "fo"
     },
     "g5": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "g4"
     },
     "g6": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "g4"
     },
     "g7": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "g4"
     },
     "g8": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "g4"
     },
     "g9": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "g4"
     },
     "ga": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "g4"
     },
     "gb": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "g4"
     },
     "gc": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "g4"
     },
     "gd": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "g4"
     },
     "ge": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "g4"
     },
     "gf": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "g4"
     },
     "gg": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "g4"
     },
     "gh": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "g4"
     },
     "gi": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "g4"
     },
     "gj": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "g4"
     },
     "gk": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "g4"
     },
     "gl": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "g4"
     },
     "gm": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "g4"
     },
     "gn": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "g4"
     },
     "go": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "g4"
     },
     "gp": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "g4"
     },
     "gq": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "g4"
     },
     "gr": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "g4"
     },
     "gs": {
-      "key": "root.imports.blocks[24]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "g4"
     },
     "gt": {
-      "key": "root.imports.blocks[25]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[24]",
+      "~k_parent": "g4"
     },
     "gu": {
-      "key": "root.imports.blocks[26]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[25]",
+      "~k_parent": "g4"
     },
     "gv": {
-      "key": "root.imports.blocks[27]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[26]",
+      "~k_parent": "g4"
     },
     "gw": {
-      "key": "root.imports.blocks[28]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[27]",
+      "~k_parent": "g4"
     },
     "gx": {
-      "key": "root.imports.blocks[29]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[28]",
+      "~k_parent": "g4"
     },
     "gy": {
-      "key": "root.imports.blocks[30]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[29]",
+      "~k_parent": "g4"
     },
     "gz": {
-      "key": "root.imports.blocks[31]",
-      "~k_parent": "g3"
+      "key": "root.imports.blocks[30]",
+      "~k_parent": "g4"
     },
     "h0": {
-      "key": "root.imports.connections",
-      "~k_parent": "fn"
+      "key": "root.imports.blocks[31]",
+      "~k_parent": "g4"
     },
     "h1": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "h0"
+      "key": "root.imports.connections",
+      "~k_parent": "fo"
     },
     "h2": {
-      "key": "root.imports.connections[1]",
-      "~k_parent": "h0"
+      "key": "root.imports.connections[0]",
+      "~k_parent": "h1"
     },
     "h3": {
-      "key": "root.imports.icons",
-      "~k_parent": "fn"
+      "key": "root.imports.connections[1]",
+      "~k_parent": "h1"
     },
     "h4": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons",
+      "~k_parent": "fo"
     },
     "h5": {
-      "key": "root.imports.icons[0].icons",
+      "key": "root.imports.icons[0]",
       "~k_parent": "h4"
     },
     "h6": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[0].icons",
+      "~k_parent": "h5"
     },
     "h7": {
-      "key": "root.imports.icons[1].icons",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "h4"
     },
     "h8": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[1].icons",
+      "~k_parent": "h7"
     },
     "h9": {
-      "key": "root.imports.icons[2].icons",
-      "~k_parent": "h8"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "h4"
     },
     "ha": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[2].icons",
+      "~k_parent": "h9"
     },
     "hb": {
-      "key": "root.imports.icons[3].icons",
-      "~k_parent": "ha"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "h4"
     },
     "hc": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[3].icons",
+      "~k_parent": "hb"
     },
     "hd": {
-      "key": "root.imports.icons[4].icons",
-      "~k_parent": "hc"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "h4"
     },
     "he": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[4].icons",
+      "~k_parent": "hd"
     },
     "hf": {
-      "key": "root.imports.icons[5].icons",
-      "~k_parent": "he"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "h4"
     },
     "hg": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[5].icons",
+      "~k_parent": "hf"
     },
     "hh": {
-      "key": "root.imports.icons[6].icons",
-      "~k_parent": "hg"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "h4"
     },
     "hi": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[6].icons",
+      "~k_parent": "hh"
     },
     "hj": {
-      "key": "root.imports.icons[7].icons",
-      "~k_parent": "hi"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "h4"
     },
     "hk": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[7].icons",
+      "~k_parent": "hj"
     },
     "hl": {
-      "key": "root.imports.icons[8].icons",
-      "~k_parent": "hk"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "h4"
     },
     "hm": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[8].icons",
+      "~k_parent": "hl"
     },
     "hn": {
-      "key": "root.imports.icons[9].icons",
-      "~k_parent": "hm"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "h4"
     },
     "ho": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[9].icons",
+      "~k_parent": "hn"
     },
     "hp": {
-      "key": "root.imports.icons[10].icons",
-      "~k_parent": "ho"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "h4"
     },
     "hq": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[10].icons",
+      "~k_parent": "hp"
     },
     "hr": {
-      "key": "root.imports.icons[11].icons",
-      "~k_parent": "hq"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "h4"
     },
     "hs": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[11].icons",
+      "~k_parent": "hr"
     },
     "ht": {
-      "key": "root.imports.icons[12].icons",
-      "~k_parent": "hs"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "h4"
     },
     "hu": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[12].icons",
+      "~k_parent": "ht"
     },
     "hv": {
-      "key": "root.imports.icons[13].icons",
-      "~k_parent": "hu"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "h4"
     },
     "hw": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[13].icons",
+      "~k_parent": "hv"
     },
     "hx": {
-      "key": "root.imports.icons[14].icons",
-      "~k_parent": "hw"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "h4"
     },
     "hy": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[14].icons",
+      "~k_parent": "hx"
     },
     "hz": {
-      "key": "root.imports.icons[15].icons",
-      "~k_parent": "hy"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "h4"
     },
     "i0": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[15].icons",
+      "~k_parent": "hz"
     },
     "i1": {
-      "key": "root.imports.icons[16].icons",
-      "~k_parent": "i0"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "h4"
     },
     "i2": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[16].icons",
+      "~k_parent": "i1"
     },
     "i3": {
-      "key": "root.imports.icons[17].icons",
-      "~k_parent": "i2"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "h4"
     },
     "i4": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[17].icons",
+      "~k_parent": "i3"
     },
     "i5": {
-      "key": "root.imports.icons[18].icons",
-      "~k_parent": "i4"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "h4"
     },
     "i6": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[18].icons",
+      "~k_parent": "i5"
     },
     "i7": {
-      "key": "root.imports.icons[19].icons",
-      "~k_parent": "i6"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "h4"
     },
     "i8": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[19].icons",
+      "~k_parent": "i7"
     },
     "i9": {
-      "key": "root.imports.icons[20].icons",
-      "~k_parent": "i8"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "h4"
     },
     "ia": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[20].icons",
+      "~k_parent": "i9"
     },
     "ib": {
-      "key": "root.imports.icons[21].icons",
-      "~k_parent": "ia"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "h4"
     },
     "ic": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[21].icons",
+      "~k_parent": "ib"
     },
     "id": {
-      "key": "root.imports.icons[22].icons",
-      "~k_parent": "ic"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "h4"
     },
     "ie": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[22].icons",
+      "~k_parent": "id"
     },
     "if": {
-      "key": "root.imports.icons[23].icons",
-      "~k_parent": "ie"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "h4"
     },
     "ig": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[23].icons",
+      "~k_parent": "if"
     },
     "ih": {
-      "key": "root.imports.icons[24].icons",
-      "~k_parent": "ig"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "h4"
     },
     "ii": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[24].icons",
+      "~k_parent": "ih"
     },
     "ij": {
-      "key": "root.imports.icons[25].icons",
-      "~k_parent": "ii"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "h4"
     },
     "ik": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[25].icons",
+      "~k_parent": "ij"
     },
     "il": {
-      "key": "root.imports.icons[26].icons",
-      "~k_parent": "ik"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "h4"
     },
     "im": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "h3"
+      "key": "root.imports.icons[26].icons",
+      "~k_parent": "il"
     },
     "in": {
-      "key": "root.imports.icons[27].icons",
-      "~k_parent": "im"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "h4"
     },
     "io": {
-      "key": "root.imports.requests",
-      "~k_parent": "fn"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "in"
     },
     "ip": {
-      "key": "root.imports.requests[0]",
-      "~k_parent": "io"
+      "key": "root.imports.requests",
+      "~k_parent": "fo"
     },
     "iq": {
-      "key": "root.imports.requests[1]",
-      "~k_parent": "io"
+      "key": "root.imports.requests[0]",
+      "~k_parent": "ip"
     },
     "ir": {
-      "key": "root.imports.requests[2]",
-      "~k_parent": "io"
+      "key": "root.imports.requests[1]",
+      "~k_parent": "ip"
     },
     "is": {
-      "key": "root.imports.requests[3]",
-      "~k_parent": "io"
+      "key": "root.imports.requests[2]",
+      "~k_parent": "ip"
     },
     "it": {
-      "key": "root.imports.websockets",
-      "~k_parent": "fn"
+      "key": "root.imports.requests[3]",
+      "~k_parent": "ip"
     },
     "iu": {
-      "key": "root.imports.operators",
-      "~k_parent": "fn"
+      "key": "root.imports.websockets",
+      "~k_parent": "fo"
     },
     "iv": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "iu"
+      "key": "root.imports.operators",
+      "~k_parent": "fo"
     },
     "iw": {
-      "key": "root.imports.operators.client[0]",
+      "key": "root.imports.operators.client",
       "~k_parent": "iv"
     },
     "ix": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "iv"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "iw"
     },
     "iy": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "iv"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "iw"
     },
     "iz": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "iv"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "iw"
     },
     "j0": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "iv"
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "iw"
     },
     "j1": {
-      "key": "root.imports.operators.client[5]",
-      "~k_parent": "iv"
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "iw"
     },
     "j2": {
-      "key": "root.imports.operators.client[6]",
-      "~k_parent": "iv"
+      "key": "root.imports.operators.client[5]",
+      "~k_parent": "iw"
     },
     "j3": {
-      "key": "root.imports.operators.client[7]",
-      "~k_parent": "iv"
+      "key": "root.imports.operators.client[6]",
+      "~k_parent": "iw"
     },
     "j4": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "iu"
+      "key": "root.imports.operators.client[7]",
+      "~k_parent": "iw"
     },
     "j5": {
-      "key": "root.imports.operators.server[0]",
-      "~k_parent": "j4"
+      "key": "root.imports.operators.server",
+      "~k_parent": "iv"
     },
     "j6": {
-      "key": "root.imports.operators.server[1]",
-      "~k_parent": "j4"
+      "key": "root.imports.operators.server[0]",
+      "~k_parent": "j5"
     },
     "j7": {
+      "key": "root.imports.operators.server[1]",
+      "~k_parent": "j5"
+    },
+    "j8": {
       "key": "root.imports.operators.server[2]",
-      "~k_parent": "j4"
+      "~k_parent": "j5"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -3672,7 +3680,7 @@
               },
               "auth": {
                 "public": false,
-                "~k": "ag"
+                "~k": "ah"
               },
               "menuItemId": "dashboard",
               "~k": "13"
@@ -3701,9 +3709,9 @@
                         "~arr": [
                           "sales"
                         ],
-                        "~k": "aj"
+                        "~k": "ak"
                       },
-                      "~k": "ai"
+                      "~k": "aj"
                     },
                     "menuItemId": "all-customers",
                     "~k": "18"
@@ -3722,19 +3730,19 @@
                         "~arr": [
                           "sales"
                         ],
-                        "~k": "al"
+                        "~k": "am"
                       },
-                      "~k": "ak"
+                      "~k": "al"
                     },
                     "menuItemId": "add-customer",
                     "~k": "1a"
                   }
                 ],
-                "~k": "ah"
+                "~k": "ai"
               },
               "auth": {
                 "public": true,
-                "~k": "am"
+                "~k": "an"
               },
               "menuItemId": "customers",
               "~k": "15"
@@ -3754,9 +3762,9 @@
                   "~arr": [
                     "sales"
                   ],
-                  "~k": "ao"
+                  "~k": "ap"
                 },
-                "~k": "an"
+                "~k": "ao"
               },
               "menuItemId": "orders",
               "~k": "1c"
@@ -3776,9 +3784,9 @@
                   "~arr": [
                     "admin"
                   ],
-                  "~k": "aq"
+                  "~k": "ar"
                 },
-                "~k": "ap"
+                "~k": "aq"
               },
               "menuItemId": "reports",
               "~k": "1e"
@@ -3798,15 +3806,15 @@
                   "~arr": [
                     "admin"
                   ],
-                  "~k": "as"
+                  "~k": "at"
                 },
-                "~k": "ar"
+                "~k": "as"
               },
               "menuItemId": "settings",
               "~k": "1g"
             }
           ],
-          "~k": "af"
+          "~k": "ag"
         },
         "menuId": "default",
         "~k": "11"
@@ -3821,9 +3829,9 @@
       "block": {
         "minHeight": "100vh",
         "background": "var(--ant-color-bg-layout)",
-        "~k": "dg"
+        "~k": "dh"
       },
-      "~k": "df"
+      "~k": "dg"
     },
     "properties": {
       "status": "info",
@@ -3866,9 +3874,9 @@
                   },
                   "catch": {
                     "~arr": [],
-                    "~k": "di"
+                    "~k": "dj"
                   },
-                  "~k": "dh"
+                  "~k": "di"
                 },
                 "~k": "9w"
               },
@@ -3884,19 +3892,19 @@
     },
     "auth": {
       "public": true,
-      "~k": "dj"
+      "~k": "dk"
     },
     "pageId": "404",
     "blockId": "404",
     "subscriptions": {
       "~arr": [],
-      "~k": "dk"
+      "~k": "dl"
     },
     "requests": {
       "~arr": [],
-      "~k": "dl"
+      "~k": "dm"
     },
-    "~k": "de"
+    "~k": "df"
   },
   "pages/customer-detail.json": {
     "id": "page:customer-detail",
@@ -3978,9 +3986,9 @@
         },
         "catch": {
           "~arr": [],
-          "~k": "c0"
+          "~k": "c1"
         },
-        "~k": "bz"
+        "~k": "c0"
       },
       "~k": "5y"
     },
@@ -3990,9 +3998,9 @@
         "~arr": [
           "sales"
         ],
-        "~k": "c2"
+        "~k": "c3"
       },
-      "~k": "c1"
+      "~k": "c2"
     },
     "pageId": "customer-detail",
     "blockId": "customer-detail",
@@ -4151,9 +4159,9 @@
                                       },
                                       "catch": {
                                         "~arr": [],
-                                        "~k": "c8"
+                                        "~k": "c9"
                                       },
-                                      "~k": "c7"
+                                      "~k": "c8"
                                     },
                                     "~k": "77"
                                   },
@@ -4185,9 +4193,9 @@
                                       },
                                       "catch": {
                                         "~arr": [],
-                                        "~k": "ca"
+                                        "~k": "cb"
                                       },
-                                      "~k": "c9"
+                                      "~k": "ca"
                                     },
                                     "~k": "7h"
                                   },
@@ -4197,18 +4205,18 @@
                               ],
                               "~k": "74"
                             },
-                            "~k": "c6"
+                            "~k": "c7"
                           },
-                          "~k": "c5"
+                          "~k": "c6"
                         },
                         "~k": "73"
                       }
                     ],
                     "~k": "6o"
                   },
-                  "~k": "c4"
+                  "~k": "c5"
                 },
-                "~k": "c3"
+                "~k": "c4"
               },
               "~k": "6j"
             }
@@ -4221,7 +4229,7 @@
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "cb"
+      "~k": "cc"
     },
     "requests": {
       "~arr": [
@@ -4272,9 +4280,9 @@
           "~k": "5e"
         }
       ],
-      "~k": "cc"
+      "~k": "cd"
     },
-    "~k": "by"
+    "~k": "bz"
   },
   "pages/customer-detail/requests/getCustomer.json": {
     "id": "request:customer-detail:getCustomer",
@@ -4303,9 +4311,9 @@
         "~arr": [
           "sales"
         ],
-        "~k": "ce"
+        "~k": "cf"
       },
-      "~k": "cd"
+      "~k": "ce"
     },
     "requestId": "getCustomer",
     "pageId": "customer-detail",
@@ -4392,9 +4400,9 @@
         "~arr": [
           "sales"
         ],
-        "~k": "cg"
+        "~k": "ch"
       },
-      "~k": "cf"
+      "~k": "cg"
     },
     "requestId": "saveCustomer",
     "pageId": "customer-detail",
@@ -4422,9 +4430,9 @@
         },
         "catch": {
           "~arr": [],
-          "~k": "be"
+          "~k": "bf"
         },
-        "~k": "bd"
+        "~k": "be"
       },
       "~k": "3e"
     },
@@ -4434,9 +4442,9 @@
         "~arr": [
           "sales"
         ],
-        "~k": "bg"
+        "~k": "bh"
       },
-      "~k": "bf"
+      "~k": "bg"
     },
     "pageId": "customers",
     "blockId": "customers",
@@ -4483,7 +4491,7 @@
                             },
                             "catch": {
                               "~arr": [],
-                              "~k": "bj"
+                              "~k": "bk"
                             },
                             "~k": "3q"
                           },
@@ -4539,9 +4547,9 @@
                             },
                             "catch": {
                               "~arr": [],
-                              "~k": "bl"
+                              "~k": "bm"
                             },
-                            "~k": "bk"
+                            "~k": "bl"
                           },
                           "~k": "41"
                         },
@@ -4579,9 +4587,9 @@
                             },
                             "catch": {
                               "~arr": [],
-                              "~k": "bn"
+                              "~k": "bo"
                             },
-                            "~k": "bm"
+                            "~k": "bn"
                           },
                           "~k": "47"
                         },
@@ -4591,9 +4599,9 @@
                     ],
                     "~k": "3l"
                   },
-                  "~k": "bi"
+                  "~k": "bj"
                 },
-                "~k": "bh"
+                "~k": "bi"
               },
               "~k": "3k"
             },
@@ -4648,9 +4656,9 @@
                             },
                             "catch": {
                               "~arr": [],
-                              "~k": "br"
+                              "~k": "bs"
                             },
-                            "~k": "bq"
+                            "~k": "br"
                           },
                           "~k": "4i"
                         },
@@ -4729,18 +4737,18 @@
                               ],
                               "~k": "4o"
                             },
-                            "~k": "bt"
+                            "~k": "bu"
                           },
-                          "~k": "bs"
+                          "~k": "bt"
                         },
                         "~k": "4f"
                       }
                     ],
                     "~k": "4e"
                   },
-                  "~k": "bp"
+                  "~k": "bq"
                 },
-                "~k": "bo"
+                "~k": "bp"
               },
               "~k": "4b"
             }
@@ -4753,7 +4761,7 @@
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "bu"
+      "~k": "bv"
     },
     "requests": {
       "~arr": [
@@ -4775,9 +4783,9 @@
           "~k": "2r"
         }
       ],
-      "~k": "bv"
+      "~k": "bw"
     },
-    "~k": "bc"
+    "~k": "bd"
   },
   "pages/customers/requests/getCustomers.json": {
     "id": "request:customers:getCustomers",
@@ -4870,9 +4878,9 @@
         "~arr": [
           "sales"
         ],
-        "~k": "bx"
+        "~k": "by"
       },
-      "~k": "bw"
+      "~k": "bx"
     },
     "requestId": "getCustomers",
     "pageId": "customers",
@@ -4900,15 +4908,15 @@
         },
         "catch": {
           "~arr": [],
-          "~k": "aw"
+          "~k": "ax"
         },
-        "~k": "av"
+        "~k": "aw"
       },
       "~k": "1o"
     },
     "auth": {
       "public": false,
-      "~k": "ax"
+      "~k": "ay"
     },
     "pageId": "dashboard",
     "blockId": "dashboard",
@@ -4970,9 +4978,9 @@
                               ],
                               "~k": "22"
                             },
-                            "~k": "b1"
+                            "~k": "b2"
                           },
-                          "~k": "b0"
+                          "~k": "b1"
                         },
                         "~k": "20"
                       },
@@ -5005,9 +5013,9 @@
                               ],
                               "~k": "28"
                             },
-                            "~k": "b3"
+                            "~k": "b4"
                           },
-                          "~k": "b2"
+                          "~k": "b3"
                         },
                         "~k": "26"
                       },
@@ -5041,9 +5049,9 @@
                               ],
                               "~k": "2e"
                             },
-                            "~k": "b5"
+                            "~k": "b6"
                           },
-                          "~k": "b4"
+                          "~k": "b5"
                         },
                         "~k": "2c"
                       },
@@ -5077,18 +5085,18 @@
                               ],
                               "~k": "2k"
                             },
-                            "~k": "b7"
+                            "~k": "b8"
                           },
-                          "~k": "b6"
+                          "~k": "b7"
                         },
                         "~k": "2i"
                       }
                     ],
                     "~k": "1z"
                   },
-                  "~k": "az"
+                  "~k": "b0"
                 },
-                "~k": "ay"
+                "~k": "az"
               },
               "~k": "1y"
             }
@@ -5101,23 +5109,23 @@
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "b8"
+      "~k": "b9"
     },
     "requests": {
       "~arr": [
         {
           "id": "request:dashboard:getStats",
           "payload": {
-            "~k": "ba"
+            "~k": "bb"
           },
           "requestId": "getStats",
           "pageId": "dashboard",
           "~k": "1m"
         }
       ],
-      "~k": "b9"
+      "~k": "ba"
     },
-    "~k": "au"
+    "~k": "av"
   },
   "pages/dashboard/requests/getStats.json": {
     "id": "request:dashboard:getStats",
@@ -5128,11 +5136,11 @@
       "~k": "1n"
     },
     "payload": {
-      "~k": "ba"
+      "~k": "bb"
     },
     "auth": {
       "public": false,
-      "~k": "bb"
+      "~k": "bc"
     },
     "requestId": "getStats",
     "pageId": "dashboard",
@@ -5149,7 +5157,7 @@
     },
     "auth": {
       "public": true,
-      "~k": "d7"
+      "~k": "d8"
     },
     "pageId": "login",
     "blockId": "login",
@@ -5184,9 +5192,9 @@
                   },
                   "catch": {
                     "~arr": [],
-                    "~k": "d9"
+                    "~k": "da"
                   },
-                  "~k": "d8"
+                  "~k": "d9"
                 },
                 "~k": "92"
               },
@@ -5260,9 +5268,9 @@
                   },
                   "catch": {
                     "~arr": [],
-                    "~k": "db"
+                    "~k": "dc"
                   },
-                  "~k": "da"
+                  "~k": "db"
                 },
                 "~k": "9e"
               },
@@ -5278,13 +5286,13 @@
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "dc"
+      "~k": "dd"
     },
     "requests": {
       "~arr": [],
-      "~k": "dd"
+      "~k": "de"
     },
-    "~k": "d6"
+    "~k": "d7"
   },
   "pages/orders.json": {
     "id": "page:orders",
@@ -5299,9 +5307,9 @@
         "~arr": [
           "sales"
         ],
-        "~k": "cj"
+        "~k": "ck"
       },
-      "~k": "ci"
+      "~k": "cj"
     },
     "pageId": "orders",
     "blockId": "orders",
@@ -5332,19 +5340,19 @@
           ],
           "~k": "7n"
         },
-        "~k": "cl"
+        "~k": "cm"
       },
-      "~k": "ck"
+      "~k": "cl"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "cm"
+      "~k": "cn"
     },
     "requests": {
       "~arr": [],
-      "~k": "cn"
+      "~k": "co"
     },
-    "~k": "ch"
+    "~k": "ci"
   },
   "pages/reports.json": {
     "id": "page:reports",
@@ -5359,9 +5367,9 @@
         "~arr": [
           "admin"
         ],
-        "~k": "cq"
+        "~k": "cr"
       },
-      "~k": "cp"
+      "~k": "cq"
     },
     "pageId": "reports",
     "blockId": "reports",
@@ -5392,19 +5400,19 @@
           ],
           "~k": "7u"
         },
-        "~k": "cs"
+        "~k": "ct"
       },
-      "~k": "cr"
+      "~k": "cs"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "ct"
+      "~k": "cu"
     },
     "requests": {
       "~arr": [],
-      "~k": "cu"
+      "~k": "cv"
     },
-    "~k": "co"
+    "~k": "cp"
   },
   "pages/settings.json": {
     "id": "page:settings",
@@ -5419,9 +5427,9 @@
         "~arr": [
           "admin"
         ],
-        "~k": "cx"
+        "~k": "cy"
       },
-      "~k": "cw"
+      "~k": "cx"
     },
     "pageId": "settings",
     "blockId": "settings",
@@ -5564,9 +5572,9 @@
                             },
                             "catch": {
                               "~arr": [],
-                              "~k": "d3"
+                              "~k": "d4"
                             },
-                            "~k": "d2"
+                            "~k": "d3"
                           },
                           "~k": "8m"
                         },
@@ -5576,28 +5584,28 @@
                     ],
                     "~k": "86"
                   },
-                  "~k": "d1"
+                  "~k": "d2"
                 },
-                "~k": "d0"
+                "~k": "d1"
               },
               "~k": "84"
             }
           ],
           "~k": "81"
         },
-        "~k": "cz"
+        "~k": "d0"
       },
-      "~k": "cy"
+      "~k": "cz"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "d4"
+      "~k": "d5"
     },
     "requests": {
       "~arr": [],
-      "~k": "d5"
+      "~k": "d6"
     },
-    "~k": "cv"
+    "~k": "cw"
   },
   "plugins/actionSchemas.json": {
     "Request": {
@@ -17681,54 +17689,54 @@
         "originalTypeName": "Request",
         "package": "@lowdefy/actions-core",
         "count": 6,
-        "~k": "do"
+        "~k": "dp"
       },
       "Link": {
         "originalTypeName": "Link",
         "package": "@lowdefy/actions-core",
         "count": 5,
-        "~k": "dp"
+        "~k": "dq"
       },
       "SetState": {
         "originalTypeName": "SetState",
         "package": "@lowdefy/actions-core",
         "count": 2,
-        "~k": "dq"
+        "~k": "dr"
       },
       "Validate": {
         "originalTypeName": "Validate",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "dr"
+        "~k": "ds"
       },
       "DisplayMessage": {
         "originalTypeName": "DisplayMessage",
         "package": "@lowdefy/actions-core",
         "count": 2,
-        "~k": "ds"
+        "~k": "dt"
       },
       "SetGlobal": {
         "originalTypeName": "SetGlobal",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "dt"
+        "~k": "du"
       },
       "Login": {
         "originalTypeName": "Login",
         "package": "@lowdefy/actions-core",
         "count": 2,
-        "~k": "du"
+        "~k": "dv"
       },
       "SetDarkMode": {
         "originalTypeName": "SetDarkMode",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "dv"
+        "~k": "dw"
       },
-      "~k": "dn"
+      "~k": "do"
     },
     "agents": {
-      "~k": "dw"
+      "~k": "dx"
     },
     "auth": {
       "adapters": {
@@ -17736,263 +17744,263 @@
           "originalTypeName": "MongoDBAuthAdapter",
           "package": "@lowdefy/connection-mongodb",
           "count": 1,
-          "~k": "dz"
+          "~k": "e0"
         },
-        "~k": "dy"
+        "~k": "dz"
       },
       "providers": {
         "Google": {
           "originalTypeName": "Google",
           "package": "@lowdefy/plugin-better-auth",
           "count": 1,
-          "~k": "e1"
+          "~k": "e2"
         },
-        "~k": "e0"
+        "~k": "e1"
       },
-      "~k": "dx"
+      "~k": "dy"
     },
     "blocks": {
       "PageHeaderMenu": {
         "originalTypeName": "PageHeaderMenu",
         "package": "@lowdefy/blocks-antd",
         "count": 6,
-        "~k": "e3"
+        "~k": "e4"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "e4"
+        "~k": "e5"
       },
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "e5"
+        "~k": "e6"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 7,
-        "~k": "e6"
+        "~k": "e7"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 4,
-        "~k": "e7"
+        "~k": "e8"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 5,
-        "~k": "e8"
+        "~k": "e9"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "e9"
+        "~k": "ea"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "ea"
+        "~k": "eb"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "eb"
+        "~k": "ec"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "ec"
+        "~k": "ed"
       },
       "Tag": {
         "originalTypeName": "Tag",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "ed"
+        "~k": "ee"
       },
       "TextArea": {
         "originalTypeName": "TextArea",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "ee"
+        "~k": "ef"
       },
       "NumberInput": {
         "originalTypeName": "NumberInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "ef"
+        "~k": "eg"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "eg"
+        "~k": "eh"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "eh"
+        "~k": "ei"
       },
       "Divider": {
         "originalTypeName": "Divider",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "ei"
+        "~k": "ej"
       },
       "PasswordInput": {
         "originalTypeName": "PasswordInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "ej"
+        "~k": "ek"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "ek"
+        "~k": "el"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "el"
+        "~k": "em"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "em"
+        "~k": "en"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "en"
+        "~k": "eo"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "eo"
+        "~k": "ep"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "ep"
+        "~k": "eq"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "eq"
+        "~k": "er"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "er"
+        "~k": "es"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "es"
+        "~k": "et"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "et"
+        "~k": "eu"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "eu"
+        "~k": "ev"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "ev"
+        "~k": "ew"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "ew"
+        "~k": "ex"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "ex"
+        "~k": "ey"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "ey"
+        "~k": "ez"
       },
-      "~k": "e2"
+      "~k": "e3"
     },
     "connections": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 1,
-        "~k": "f0"
+        "~k": "f1"
       },
       "MongoDBCollection": {
         "originalTypeName": "MongoDBCollection",
         "package": "@lowdefy/connection-mongodb",
         "count": 2,
-        "~k": "f1"
+        "~k": "f2"
       },
-      "~k": "ez"
+      "~k": "f0"
     },
     "requests": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 1,
-        "~k": "f3"
+        "~k": "f4"
       },
       "MongoDBFind": {
         "originalTypeName": "MongoDBFind",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "f4"
+        "~k": "f5"
       },
       "MongoDBFindOne": {
         "originalTypeName": "MongoDBFindOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "f5"
+        "~k": "f6"
       },
       "MongoDBUpdateOne": {
         "originalTypeName": "MongoDBUpdateOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "f6"
+        "~k": "f7"
       },
-      "~k": "f2"
+      "~k": "f3"
     },
     "websockets": {
-      "~k": "f7"
+      "~k": "f8"
     },
     "api": {
-      "~k": "f8"
+      "~k": "f9"
     },
     "operators": {
       "client": {
@@ -18000,75 +18008,75 @@
           "originalTypeName": "_user",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "fb"
+          "~k": "fc"
         },
         "_request": {
           "originalTypeName": "_request",
           "package": "@lowdefy/operators-js",
           "count": 10,
-          "~k": "fc"
+          "~k": "fd"
         },
         "_state": {
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 18,
-          "~k": "fd"
+          "~k": "fe"
         },
         "_if": {
           "originalTypeName": "_if",
           "package": "@lowdefy/operators-js",
           "count": 3,
-          "~k": "fe"
+          "~k": "ff"
         },
         "_eq": {
           "originalTypeName": "_eq",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "ff"
+          "~k": "fg"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 4,
-          "~k": "fg"
+          "~k": "fh"
         },
         "_url_query": {
           "originalTypeName": "_url_query",
           "package": "@lowdefy/operators-js",
           "count": 5,
-          "~k": "fh"
+          "~k": "fi"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "fi"
+          "~k": "fj"
         },
-        "~k": "fa"
+        "~k": "fb"
       },
       "server": {
         "_payload": {
           "originalTypeName": "_payload",
           "package": "@lowdefy/operators-js",
           "count": 11,
-          "~k": "fk"
+          "~k": "fl"
         },
         "_if": {
           "originalTypeName": "_if",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "fl"
+          "~k": "fm"
         },
         "_date": {
           "originalTypeName": "_date",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "fm"
+          "~k": "fn"
         },
-        "~k": "fj"
+        "~k": "fk"
       },
-      "~k": "f9"
+      "~k": "fa"
     },
-    "~k": "dm"
+    "~k": "dn"
   }
 }

--- a/packages/client/src/auth/createAuthMethods.js
+++ b/packages/client/src/auth/createAuthMethods.js
@@ -75,16 +75,7 @@ async function unwrap(promise) {
 function createAuthMethods(lowdefy, auth) {
   // login and logout are Lowdefy functions that handle action params;
   // the auth object provides the BetterAuth client methods.
-  async function login({
-    callbackUrl,
-    email,
-    magicLink,
-    name,
-    password,
-    providerId,
-    signUp,
-    ...rest
-  } = {}) {
+  async function login({ callbackUrl, email, magicLink, password, providerId, ...rest } = {}) {
     const callbackURL = resolveCallbackURL({ lowdefy, callbackUrl });
     const providers = auth.authConfig?.providers ?? [];
 
@@ -110,11 +101,6 @@ function createAuthMethods(lowdefy, auth) {
       }
       return unwrap(auth.signInMagicLink({ email, callbackURL, ...rest }));
     }
-    if (signUp === true) {
-      // With requireEmailVerification the response carries no session - the
-      // page shows a "verify your email" message instead of navigating.
-      return unwrap(auth.signUpEmail({ email, password, name, callbackURL, ...rest }));
-    }
     if (!type.isNone(email) || !type.isNone(password)) {
       const data = await unwrap(auth.signInEmail({ email, password, ...rest }));
       const window = lowdefy._internal?.globals?.window;
@@ -124,8 +110,23 @@ function createAuthMethods(lowdefy, auth) {
       return data;
     }
     throw new Error(
-      'Login requires a "providerId", "email" and "password", "magicLink: true", or "signUp: true" param.'
+      'Login requires a "providerId", "email" and "password", or "magicLink: true" param.'
     );
+  }
+
+  // Creates an email/password account (BetterAuth's one signup endpoint).
+  // Social, magic-link and passkey have no separate signup - the account is
+  // created on first sign-in via login - so SignUp is email/password only.
+  async function signUp({ callbackUrl, email, name, password, ...rest } = {}) {
+    const callbackURL = resolveCallbackURL({ lowdefy, callbackUrl });
+    const data = await unwrap(auth.signUpEmail({ email, password, name, callbackURL, ...rest }));
+    // With requireEmailVerification the response carries no session - do not
+    // navigate; the page shows a "verify your email" message instead.
+    const window = lowdefy._internal?.globals?.window;
+    if (data?.token && callbackURL && window) {
+      window.location.assign(callbackURL);
+    }
+    return data;
   }
 
   async function logout({ callbackUrl } = {}) {
@@ -148,6 +149,7 @@ function createAuthMethods(lowdefy, auth) {
   return {
     login,
     logout,
+    signUp,
     updateSession,
   };
 }

--- a/packages/client/src/auth/createAuthMethods.test.js
+++ b/packages/client/src/auth/createAuthMethods.test.js
@@ -1,0 +1,95 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+import createAuthMethods from './createAuthMethods.js';
+
+function setup({ signUpResult } = {}) {
+  const assign = jest.fn();
+  const lowdefy = {
+    _internal: {
+      globals: { window: { location: { assign, search: '' } } },
+    },
+  };
+  const auth = {
+    authConfig: { providers: [] },
+    signInEmail: jest.fn(() => Promise.resolve({ data: { token: 't' }, error: null })),
+    signUpEmail: jest.fn(() =>
+      Promise.resolve({ data: signUpResult ?? { token: null, user: {} }, error: null })
+    ),
+  };
+  return { auth, lowdefy, assign };
+}
+
+test('signUp calls signUpEmail with email, password, name and callbackURL', async () => {
+  const { auth, lowdefy } = setup();
+  const { signUp } = createAuthMethods(lowdefy, auth);
+  await signUp({
+    email: 'user@example.com',
+    password: 'password123',
+    name: 'User',
+    callbackUrl: { url: '/verified' },
+  });
+  expect(auth.signUpEmail.mock.calls).toEqual([
+    [
+      {
+        email: 'user@example.com',
+        password: 'password123',
+        name: 'User',
+        callbackURL: '/verified',
+      },
+    ],
+  ]);
+});
+
+test('signUp does not navigate on a session-less response (verify-email state)', async () => {
+  const { auth, lowdefy, assign } = setup({ signUpResult: { token: null, user: {} } });
+  const { signUp } = createAuthMethods(lowdefy, auth);
+  const data = await signUp({
+    email: 'user@example.com',
+    password: 'password123',
+    callbackUrl: { url: '/verified' },
+  });
+  expect(assign).not.toHaveBeenCalled();
+  expect(data).toEqual({ token: null, user: {} });
+});
+
+test('signUp navigates to callbackURL when the response carries a session', async () => {
+  const { auth, lowdefy, assign } = setup({ signUpResult: { token: 'session-token', user: {} } });
+  const { signUp } = createAuthMethods(lowdefy, auth);
+  await signUp({
+    email: 'user@example.com',
+    password: 'password123',
+    callbackUrl: { url: '/verified' },
+  });
+  expect(assign.mock.calls).toEqual([['/verified']]);
+});
+
+test('signUp passes through rest params to signUpEmail', async () => {
+  const { auth, lowdefy } = setup();
+  const { signUp } = createAuthMethods(lowdefy, auth);
+  await signUp({ email: 'user@example.com', password: 'password123', rememberMe: true });
+  expect(auth.signUpEmail.mock.calls[0][0]).toMatchObject({ rememberMe: true });
+});
+
+test('login no longer handles signUp - a signUp-only call is rejected', async () => {
+  const { auth, lowdefy } = setup();
+  const { login } = createAuthMethods(lowdefy, auth);
+  await expect(login({ signUp: true, name: 'User' })).rejects.toThrow(
+    'Login requires a "providerId", "email" and "password", or "magicLink: true" param.'
+  );
+  expect(auth.signUpEmail).not.toHaveBeenCalled();
+});

--- a/packages/engine/src/actions/createSignUp.js
+++ b/packages/engine/src/actions/createSignUp.js
@@ -14,33 +14,10 @@
   limitations under the License.
 */
 
-export default {
-  actions: [
-    'CallAPI',
-    'CallMethod',
-    'CopyToClipboard',
-    'DisplayMessage',
-    'Fetch',
-    'GeolocationCurrentPosition',
-    'Link',
-    'Login',
-    'Logout',
-    'Publish',
-    'Request',
-    'Reset',
-    'ResetValidation',
-    'ScrollTo',
-    'SetDarkMode',
-    'SetFocus',
-    'SetGlobal',
-    'SetLocale',
-    'SetState',
-    'SignUp',
-    'Subscribe',
-    'Throw',
-    'Unsubscribe',
-    'UpdateSession',
-    'Validate',
-    'Wait',
-  ],
-};
+function createSignUp({ context }) {
+  return function signUp(params) {
+    return context._internal.lowdefy._internal.auth.signUp(params);
+  };
+}
+
+export default createSignUp;

--- a/packages/engine/src/actions/createSignUp.test.js
+++ b/packages/engine/src/actions/createSignUp.test.js
@@ -1,0 +1,82 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+import { jest } from '@jest/globals';
+
+import testContext from '../../test/testContext.js';
+
+const lowdefy = {
+  _internal: {
+    actions: {
+      SignUp: ({ methods: { signUp }, params }) => {
+        return signUp(params);
+      },
+    },
+    auth: {
+      signUp: jest.fn(),
+    },
+  },
+};
+
+const RealDate = Date;
+const mockDate = jest.fn(() => ({ date: 0 }));
+mockDate.now = jest.fn(() => 0);
+
+beforeEach(() => {
+  global.Date = mockDate;
+  lowdefy._internal.auth.signUp.mockReset();
+});
+
+afterAll(() => {
+  global.Date = RealDate;
+});
+
+test('SignUp', async () => {
+  const pageConfig = {
+    id: 'root',
+    type: 'Box',
+    blocks: [
+      {
+        id: 'button',
+        type: 'Button',
+        events: {
+          onClick: [
+            {
+              id: 'a',
+              type: 'SignUp',
+              params: { email: 'user@example.com', name: 'User', password: 'password123' },
+            },
+          ],
+        },
+      },
+    ],
+  };
+  const context = await testContext({
+    lowdefy,
+    pageConfig,
+  });
+  const button = context._internal.RootSlots.map['button'];
+  const res = await button.triggerEvent({ name: 'onClick' });
+  expect(lowdefy._internal.auth.signUp.mock.calls).toEqual([
+    [
+      {
+        email: 'user@example.com',
+        name: 'User',
+        password: 'password123',
+      },
+    ],
+  ]);
+  expect(res.success).toBe(true);
+});

--- a/packages/engine/src/actions/getActionMethods.js
+++ b/packages/engine/src/actions/getActionMethods.js
@@ -37,6 +37,7 @@ import createReset from './createReset.js';
 import createResetValidation from './createResetValidation.js';
 import createSetGlobal from './createSetGlobal.js';
 import createSetState from './createSetState.js';
+import createSignUp from './createSignUp.js';
 import createSubscribe from './createSubscribe.js';
 import createTranslate from './createTranslate.js';
 import createUnsubscribe from './createUnsubscribe.js';
@@ -68,6 +69,7 @@ function getActionMethods(props) {
     resetValidation: createResetValidation(props),
     setGlobal: createSetGlobal(props),
     setState: createSetState(props),
+    signUp: createSignUp(props),
     subscribe: createSubscribe(props),
     translate: createTranslate(props),
     unsubscribe: createUnsubscribe(props),

--- a/packages/plugins/actions/actions-core/src/actions.js
+++ b/packages/plugins/actions/actions-core/src/actions.js
@@ -33,6 +33,7 @@ export { default as SetFocus } from './actions/SetFocus/SetFocus.js';
 export { default as SetGlobal } from './actions/SetGlobal/SetGlobal.js';
 export { default as SetLocale } from './actions/SetLocale/SetLocale.js';
 export { default as SetState } from './actions/SetState/SetState.js';
+export { default as SignUp } from './actions/SignUp/SignUp.js';
 export { default as Subscribe } from './actions/Subscribe/Subscribe.js';
 export { default as Throw } from './actions/Throw/Throw.js';
 export { default as Unsubscribe } from './actions/Unsubscribe/Unsubscribe.js';

--- a/packages/plugins/actions/actions-core/src/actions/SignUp/SignUp.js
+++ b/packages/plugins/actions/actions-core/src/actions/SignUp/SignUp.js
@@ -14,33 +14,8 @@
   limitations under the License.
 */
 
-export default {
-  actions: [
-    'CallAPI',
-    'CallMethod',
-    'CopyToClipboard',
-    'DisplayMessage',
-    'Fetch',
-    'GeolocationCurrentPosition',
-    'Link',
-    'Login',
-    'Logout',
-    'Publish',
-    'Request',
-    'Reset',
-    'ResetValidation',
-    'ScrollTo',
-    'SetDarkMode',
-    'SetFocus',
-    'SetGlobal',
-    'SetLocale',
-    'SetState',
-    'SignUp',
-    'Subscribe',
-    'Throw',
-    'Unsubscribe',
-    'UpdateSession',
-    'Validate',
-    'Wait',
-  ],
-};
+function SignUp({ methods: { signUp }, params }) {
+  return signUp(params);
+}
+
+export default SignUp;

--- a/packages/plugins/actions/actions-core/src/actions/SignUp/SignUp.test.js
+++ b/packages/plugins/actions/actions-core/src/actions/SignUp/SignUp.test.js
@@ -14,33 +14,15 @@
   limitations under the License.
 */
 
-export default {
-  actions: [
-    'CallAPI',
-    'CallMethod',
-    'CopyToClipboard',
-    'DisplayMessage',
-    'Fetch',
-    'GeolocationCurrentPosition',
-    'Link',
-    'Login',
-    'Logout',
-    'Publish',
-    'Request',
-    'Reset',
-    'ResetValidation',
-    'ScrollTo',
-    'SetDarkMode',
-    'SetFocus',
-    'SetGlobal',
-    'SetLocale',
-    'SetState',
-    'SignUp',
-    'Subscribe',
-    'Throw',
-    'Unsubscribe',
-    'UpdateSession',
-    'Validate',
-    'Wait',
-  ],
-};
+import { jest } from '@jest/globals';
+import SignUp from './SignUp.js';
+
+const mockSignUp = jest.fn();
+const methods = { signUp: mockSignUp };
+
+test('SignUp action invocation', () => {
+  SignUp({ methods, params: { email: 'user@example.com', password: 'password123', name: 'User' } });
+  expect(mockSignUp.mock.calls).toEqual([
+    [{ email: 'user@example.com', password: 'password123', name: 'User' }],
+  ]);
+});

--- a/packages/plugins/actions/actions-core/src/actions/SignUp/schema.js
+++ b/packages/plugins/actions/actions-core/src/actions/SignUp/schema.js
@@ -1,0 +1,25 @@
+export default {
+  type: 'object',
+  params: {
+    type: 'object',
+    description: 'Parameters passed to the sign-up method (email/password only).',
+    properties: {
+      email: {
+        type: 'string',
+        description: 'Email address of the account to create.',
+      },
+      password: {
+        type: 'string',
+        description: 'Password for the new account.',
+      },
+      name: {
+        type: 'string',
+        description: 'Name of the user.',
+      },
+      callbackUrl: {
+        type: 'string',
+        description: 'URL to redirect to after email verification.',
+      },
+    },
+  },
+};

--- a/packages/plugins/actions/actions-core/src/schemas.js
+++ b/packages/plugins/actions/actions-core/src/schemas.js
@@ -33,6 +33,7 @@ export { default as SetFocus } from './actions/SetFocus/schema.js';
 export { default as SetGlobal } from './actions/SetGlobal/schema.js';
 export { default as SetLocale } from './actions/SetLocale/schema.js';
 export { default as SetState } from './actions/SetState/schema.js';
+export { default as SignUp } from './actions/SignUp/schema.js';
 export { default as Subscribe } from './actions/Subscribe/schema.js';
 export { default as Throw } from './actions/Throw/schema.js';
 export { default as Unsubscribe } from './actions/Unsubscribe/schema.js';

--- a/packages/servers/server-dev/lib/server/auth/createSystemContext.js
+++ b/packages/servers/server-dev/lib/server/auth/createSystemContext.js
@@ -1,0 +1,62 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import path from 'node:path';
+import { createSystemContext as buildSystemContext } from '@lowdefy/api';
+import { getSecretsFromEnv } from '@lowdefy/node-utils';
+import { v4 as uuid } from 'uuid';
+
+import agents from '../../../build/plugins/agents.js';
+import appMeta from '../../build/appMeta.js';
+import config from '../../build/config.js';
+import connections from '../../../build/plugins/connections.js';
+import createHandleError from '../log/createHandleError.js';
+import createLogger from '../log/createLogger.js';
+import fileCache from '../fileCache.js';
+import i18nConfig from '../../build/i18n.js';
+import loadDynamicJsMap from '../loadDynamicJsMap.js';
+import operators from '../../../build/plugins/operators/server.js';
+import websockets from '../../../build/plugins/websockets.js';
+
+const secrets = getSecretsFromEnv();
+
+// Builds a fresh system context per auth hook fire - the trusted internal
+// caller the BetterAuth engine uses to invoke hook endpoints. All fields are
+// startup singletons except the per-fire rid, logger, handleError, and the
+// dynamic jsMap re-read (JIT rebuilds rewrite serverJsMap.js).
+function createSystemContext() {
+  const rid = uuid();
+  const buildDirectory = path.join(process.cwd(), 'build');
+  return buildSystemContext({
+    rid,
+    agents,
+    appMeta,
+    buildDirectory,
+    config,
+    configDirectory: process.env.LOWDEFY_DIRECTORY_CONFIG || process.cwd(),
+    connections,
+    createHandleError,
+    fileCache,
+    i18n: i18nConfig,
+    jsMap: loadDynamicJsMap(buildDirectory),
+    logger: createLogger({ rid }),
+    operators,
+    secrets,
+    websockets,
+  });
+}
+
+export default createSystemContext;

--- a/packages/servers/server-dev/lib/server/auth/getAuth.js
+++ b/packages/servers/server-dev/lib/server/auth/getAuth.js
@@ -20,6 +20,7 @@ import { getSecretsFromEnv } from '@lowdefy/node-utils';
 import adapters from '../../../build/plugins/auth/adapters.js';
 import appMeta from '../../build/appMeta.js';
 import authJson from '../../build/auth.js';
+import createSystemContext from './createSystemContext.js';
 import lowdefyConfig from '../../build/config.js';
 import providers from '../../../build/plugins/auth/providers.js';
 
@@ -34,6 +35,7 @@ function getAuth({ logger }) {
     appMeta,
     authJson,
     config: lowdefyConfig,
+    createSystemContext,
     dev: true,
     logger,
     plugins: { adapters, providers },

--- a/packages/servers/server-dev/lib/server/loadDynamicJsMap.js
+++ b/packages/servers/server-dev/lib/server/loadDynamicJsMap.js
@@ -1,0 +1,47 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import staticJsMap from '../../build/plugins/operators/serverJsMap.js';
+
+// Dynamic JS map loading for JIT-built pages — the build rewrites
+// serverJsMap.js when a JIT page discovers new _js operators.
+let cachedJsMapMtime = null;
+let cachedJsMap = staticJsMap;
+
+function loadDynamicJsMap(buildDirectory) {
+  const jsMapPath = path.join(buildDirectory, 'plugins', 'operators', 'serverJsMap.js');
+  try {
+    const stat = fs.statSync(jsMapPath);
+    if (cachedJsMapMtime && stat.mtimeMs === cachedJsMapMtime) {
+      return cachedJsMap;
+    }
+    cachedJsMapMtime = stat.mtimeMs;
+    // For server-side, we can read and eval the JS file
+    const content = fs.readFileSync(jsMapPath, 'utf8');
+    const fn = new Function('exports', content.replace('export default', 'exports.default ='));
+    const exports = {};
+    fn(exports);
+    cachedJsMap = { ...staticJsMap, ...(exports.default ?? {}) };
+    return cachedJsMap;
+  } catch {
+    return cachedJsMap;
+  }
+}
+
+export default loadDynamicJsMap;

--- a/packages/servers/server-dev/manager/utils/createCustomPluginTypesMap.mjs
+++ b/packages/servers/server-dev/manager/utils/createCustomPluginTypesMap.mjs
@@ -42,8 +42,6 @@ async function createCustomPluginTypesMap({ directories, logger }) {
     agents: {},
     auth: {
       adapters: {},
-      callbacks: {},
-      events: {},
       providers: {},
     },
     blockMetas: {},

--- a/packages/servers/server-dev/src/middleware/apiContext.js
+++ b/packages/servers/server-dev/src/middleware/apiContext.js
@@ -14,7 +14,6 @@
   limitations under the License.
 */
 
-import fs from 'node:fs';
 import path from 'node:path';
 import { createApiContext, resolveAuthentication } from '@lowdefy/api';
 import { getSecretsFromEnv } from '@lowdefy/node-utils';
@@ -30,37 +29,12 @@ import fileCache from '../../lib/server/fileCache.js';
 import getAuth from '../../lib/server/auth/getAuth.js';
 import getMockUser from '../../lib/server/auth/getMockUser.js';
 import i18nConfig from '../../lib/build/i18n.js';
+import loadDynamicJsMap from '../../lib/server/loadDynamicJsMap.js';
 import logRequest from '../../lib/server/log/logRequest.js';
 import operators from '../../build/plugins/operators/server.js';
-import staticJsMap from '../../build/plugins/operators/serverJsMap.js';
 import websockets from '../../build/plugins/websockets.js';
 
 const secrets = getSecretsFromEnv();
-
-// Dynamic JS map loading for JIT-built pages — the build rewrites
-// serverJsMap.js when a JIT page discovers new _js operators.
-let cachedJsMapMtime = null;
-let cachedJsMap = staticJsMap;
-
-function loadDynamicJsMap(buildDirectory) {
-  const jsMapPath = path.join(buildDirectory, 'plugins', 'operators', 'serverJsMap.js');
-  try {
-    const stat = fs.statSync(jsMapPath);
-    if (cachedJsMapMtime && stat.mtimeMs === cachedJsMapMtime) {
-      return cachedJsMap;
-    }
-    cachedJsMapMtime = stat.mtimeMs;
-    // For server-side, we can read and eval the JS file
-    const content = fs.readFileSync(jsMapPath, 'utf8');
-    const fn = new Function('exports', content.replace('export default', 'exports.default ='));
-    const exports = {};
-    fn(exports);
-    cachedJsMap = { ...staticJsMap, ...(exports.default ?? {}) };
-    return cachedJsMap;
-  } catch {
-    return cachedJsMap;
-  }
-}
 
 // Replaces lib/server/apiWrapper.js. Errors thrown by handlers are routed by
 // Hono to the app-level error handler (src/middleware/errorHandler.js).

--- a/packages/servers/server-e2e/lowdefy/createCustomPluginTypesMap.mjs
+++ b/packages/servers/server-e2e/lowdefy/createCustomPluginTypesMap.mjs
@@ -42,8 +42,6 @@ async function createCustomPluginTypesMap({ directories }) {
     agents: {},
     auth: {
       adapters: {},
-      callbacks: {},
-      events: {},
       providers: {},
     },
     blockMetas: {},

--- a/packages/servers/server/lib/server/auth/createSystemContext.js
+++ b/packages/servers/server/lib/server/auth/createSystemContext.js
@@ -1,0 +1,59 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import path from 'node:path';
+import { createSystemContext as buildSystemContext } from '@lowdefy/api';
+import { getSecretsFromEnv } from '@lowdefy/node-utils';
+import { v4 as uuid } from 'uuid';
+
+import agents from '../../../build/plugins/agents.js';
+import appMeta from '../../build/appMeta.js';
+import config from '../../build/config.js';
+import connections from '../../../build/plugins/connections.js';
+import createHandleError from '../log/createHandleError.js';
+import createLogger from '../log/createLogger.js';
+import fileCache from '../fileCache.js';
+import i18nConfig from '../../build/i18n.js';
+import jsMap from '../../../build/plugins/operators/serverJsMap.js';
+import operators from '../../../build/plugins/operators/server.js';
+import websockets from '../../../build/plugins/websockets.js';
+
+const secrets = getSecretsFromEnv();
+
+// Builds a fresh system context per auth hook fire - the trusted internal
+// caller the BetterAuth engine uses to invoke hook endpoints. All fields are
+// startup singletons except the per-fire rid, logger, and handleError.
+function createSystemContext() {
+  const rid = uuid();
+  return buildSystemContext({
+    rid,
+    agents,
+    appMeta,
+    buildDirectory: path.join(process.cwd(), 'build'),
+    config,
+    connections,
+    createHandleError,
+    fileCache,
+    i18n: i18nConfig,
+    jsMap,
+    logger: createLogger({ rid }),
+    operators,
+    secrets,
+    websockets,
+  });
+}
+
+export default createSystemContext;

--- a/packages/servers/server/lib/server/auth/getAuth.js
+++ b/packages/servers/server/lib/server/auth/getAuth.js
@@ -20,6 +20,7 @@ import { getSecretsFromEnv } from '@lowdefy/node-utils';
 import adapters from '../../../build/plugins/auth/adapters.js';
 import appMeta from '../../build/appMeta.js';
 import authJson from '../../build/auth.js';
+import createSystemContext from './createSystemContext.js';
 import lowdefyConfig from '../../build/config.js';
 import providers from '../../../build/plugins/auth/providers.js';
 
@@ -34,6 +35,7 @@ function getAuth({ logger }) {
     appMeta,
     authJson,
     config: lowdefyConfig,
+    createSystemContext,
     logger,
     plugins: { adapters, providers },
     secrets: getSecretsFromEnv(),

--- a/packages/servers/server/lowdefy/createCustomPluginTypesMap.mjs
+++ b/packages/servers/server/lowdefy/createCustomPluginTypesMap.mjs
@@ -42,8 +42,6 @@ async function createCustomPluginTypesMap({ directories }) {
     agents: {},
     auth: {
       adapters: {},
-      callbacks: {},
-      events: {},
       providers: {},
     },
     blockMetas: {},


### PR DESCRIPTION
## Summary

Phase 2 of the auth upgrade: the user-tier hook system. Each `auth.hooks` entry binds an auth lifecycle point to an `InternalApi` endpoint whose routine is the hook body, invoked in a fresh system context with full Lowdefy access (connections, operators, control flow). Implements the binding model, the system-context bridge, the payload catalog, the return convention, and slot composition per [hooks/design.md](https://github.com/lowdefy/lowdefy-design/blob/main/designs/auth-upgrade/hooks/design.md); the `auth.hooks` surface per config-schema/design.md.

Stacked on #2215 (phase 1) — retargets to `auth-upgrade` when it merges.

## Changes

- **@lowdefy/build**: `hooks` registered in the `authConfig` schema (closed schema, `{ id, point, endpointId }`); new `buildAuthHooks` step validates known point (frozen 13-point catalog incl. `invitation.send`), endpointId resolves to an existing `type: InternalApi` endpoint, and one hook per point; `setAuthDefaults` writes `hooks: []`; `auth.json` carries the array. No retired callbacks/events discovery existed in build — nothing to remove there.
- **@lowdefy/api**: `createSystemContext` builds a fresh off-request context per hook fire (empty `user`, authorize bypassed — the auth engine is a trusted internal caller and `InternalApi` blocks HTTP). `getBetterAuthConfig` closes over the factory and assembles `databaseHooks` plus the `email.verified` → `afterEmailVerification` synthetic callback from `authJson.hooks`. One composed slot per point, engine bindings first (registry empty until phase 3), then the user hook. The dispatch adapter maps point data to the catalog payload, calls the shipped `invokeEndpoint` unchanged (depth-limited), and translates the routine envelope per the return convention: `:return` data wrapped as `{ data }` for database `before`, `:reject` → `APIError` carrying the reject message, throw → rethrow, returns ignored on `after`/synthetic. Each fire emits a `debug_auth_hook` log with `elapsed_ms`.
- **@lowdefy/server / server-dev**: each server assembles the `createSystemContext` factory over its own singletons and passes it into `getBetterAuth`; server-dev re-reads the dynamic jsMap per fire (loader extracted from the middleware). The retired `callbacks`/`events` keys removed from all `createCustomPluginTypesMap` templates (server, server-dev, server-e2e).
- **apps/auth-reference**: hook scenarios 11–16 in the README; `InternalApi` endpoints bound to `user.create.before` (record replace + domain veto), `session.create.after` (audit row via a MongoDB connection, proving payload shape / empty `_user` / `_secret`), `email.verified`; a protected `hook-audit` page lists the trail.

## Key Files

- `packages/api/src/context/createSystemContext.js` — the system-context bridge
- `packages/api/src/routes/auth/hooks/buildHooks.js` — slot assembly from engine + user bindings
- `packages/api/src/routes/auth/hooks/createUserBeforeHook.js` — return-convention translation
- `packages/api/src/routes/auth/hooks/authHookPoints.js` — runtime payload catalog
- `packages/build/src/build/buildAuth/buildAuthHooks.js` — build validation

## Gate

Verified two ways: unit tests (`pnpm test` green: build 1539, api 466, full suite exit 0) and an end-to-end harness driving the reference app's real build artifacts through a real BetterAuth 1.6.23 instance against MongoDB (memory server) and a live SMTP sink — 10/10 checks passed.

- ✅ Reference app binds `InternalApi` endpoints at a database `before` point (`user.create.before`), a database `after` point (`session.create.after`), and `email.verified`; each receives the catalog's payload shape (asserted via `payloadKeys` stored in the audit rows: `['user']`, `['session','user']`).
- ✅ A `user.create.before` hook's `:return` replaces the written record (name uppercased in the stored `users` row).
- ✅ A `:reject` in a `before` hook vetoes end to end — signup fails with the reject message, zero rows written.
- ✅ An `after` hook fires without affecting the committed write; a deliberate throw surfaces as an operational error while the session row stands (`:try` guidance documented in the app and README).
- ✅ Inside a hook routine `_user` is empty, `_payload` holds the subject, `_secret` resolves (asserted as stored booleans in the audit row).
- ✅ Build rejects: unknown `point`, missing `endpointId`, `endpointId` of `type: Api`, and two entries binding the same point — each verified against the real app build with clear `ConfigError`s.
- ✅ Unit tests for the dispatch adapter and return-convention translation (`buildHooks.test.js`, `createUserBeforeHook.test.js`, `composeBeforeSlot.test.js`, `authHookPoints.test.js`, `createSystemContext.test.js`); full suite passes.

## Report back — session.create hook latency

Measured on the e2e harness (M-series mac, local memory-server MongoDB):

- **No-op hook fire on `session.create` (context build + payload user fetch + `invokeEndpoint`): mean 0.25 ms, p50 0.23 ms, p95 0.32 ms (n=30).**
- `createSystemContext()` alone: ~0.3 µs per call.
- Sign-in wall time 40.83 ms with the hook vs 40.72 ms without (password hashing dominates) — the added cost is ~0.25 ms, ~0.6% of a login. No optimization warranted.

## Design learnings / escalations

1. **`user.update` payload deviation (catalog amendment recommended).** BetterAuth 1.6.23 hands `update.before` only the changed fields (no subject id — `updateWithHooks` passes the raw `data`) and `update.after` only the updated record. The catalog's `{ user, changes }` cannot be filled on both sides; shipped as `{ user: null, changes }` (before) and `{ user, changes: null }` (after). Recommend the payload catalog document exactly this. (Session/account points *do* get the full `user` — fetched via `internalAdapter.findUserById`, one extra read per fire, included in the latency number.)
2. **`:reject` maps to `APIError('BAD_REQUEST', { message })`** rather than bare `false`, per the design's "(or an `APIError`)" allowance — the routine's reject message surfaces inline to the client instead of BetterAuth's generic `FAILED_TO_CREATE_USER`.
3. **After-hook throws** propagate out of `auth.handler()` as a rejected promise (BetterAuth awaits queued after-transaction hooks inside the request chain), which Hono's error middleware turns into a 500 — the "operational error" of the convention. Confirmed against the installed source (`@better-auth/core` `runWithAdapter` awaits `pendingHooks` before returning).
4. `invitation.send` is accepted at build per the frozen point set; at runtime a startup warning states the binding will not fire until the org plugin lands (phase 3/6).
5. `code-docs/architecture/auth-system.md` predates phase 1 and still describes the NextAuth build; not updated here — flagging for a docs pass once the auth phases settle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)