### PR TITLE
feat(auth): Phase 4 - API auth strategies (apiKey, jwt)

### DIFF
--- a/apps/auth-reference/README.md
+++ b/apps/auth-reference/README.md
@@ -37,6 +37,9 @@ later phase grows this suite with a scenario.
   # Only for apps/auth-reference-tenant (its own database - tenants do not
   # mix with the pinned apps):
   LOWDEFY_SECRET_TENANT_DATABASE_URI=mongodb://localhost:27017/auth-reference-tenant
+  # Only needed for the phase-4 API strategy scenarios:
+  LOWDEFY_SECRET_PARTNER_KEY_ACME=partner-key-acme-0123456789abcdef
+  LOWDEFY_SECRET_JWT_SIGNING_SECRET=jwt-shared-secret-0123456789abcdef
   # The hook scenarios assert this exact value lands in the audit row:
   LOWDEFY_SECRET_HOOK_AUDIT_KEY=audit-secret-value
   # Only needed to exercise the OAuth scenario:
@@ -256,3 +259,56 @@ the old one) so pre-phase-3 users do not confuse the wall.
 Automation note: these scenarios are manual walkthroughs, like phases 1-2;
 they need live email verification loops and three side-by-side dev servers.
 Automate with the repo's e2e tooling as it grows.
+
+## Walkthrough (phase-4 gate - API strategies)
+
+The strategies-only scenarios (no database, JWKS, rejection matrix) live in
+the [auth-strategies fixture app](../auth-strategies/README.md); this
+section covers the scenarios that need a real login next to a strategy.
+Endpoints are POST-only with a JSON body:
+
+```sh
+call() { curl -s -X POST -H 'content-type: application/json' -d '{}' "$@"; }
+```
+
+29. **API key authenticates against a full auth app**:
+    `call -H "X-API-Key: partner-key-acme-0123456789abcdef"
+    http://localhost:3000/api/endpoints/partner-data` returns
+    `{"data":"partner-report","caller":"apiKey:partner-access:acme","branches":["north","east"]}`.
+    Without the header the same call returns `401` with one
+    `Unauthenticated request` warning line in the terminal - no structured
+    error log. With a session user lacking the `partner` role (log in, call
+    from the browser console with `credentials: 'include'`), it returns the
+    opaque `does not exist` error.
+30. **A logged-in session wins over a presented API key (no privilege
+    swap)**: sign in as a member, copy the session cookie from the browser
+    devtools, then present both credentials together:
+
+    ```sh
+    call -H "Cookie: <your lowdefy_auth-reference.session_token cookie>" \
+      -H "X-API-Key: partner-key-acme-0123456789abcdef" \
+      http://localhost:3000/api/endpoints/whoami
+    ```
+
+    The caller is the **session user** (your user id, member-resolved
+    roles, no `authMethod`/`strategyId` fields) - the session branch is
+    terminal, so the key is never consulted. Drop the Cookie header and the
+    same call resolves the **strategy caller**
+    (`id: "apiKey:partner-access:acme"`, `authMethod: "apiKey"`,
+    `strategyId: "partner-access"`, `roles: ["partner"]`,
+    `attributes: {"branches":["north","east"]}`).
+31. **A walled-out session does not fall through to strategies**: remove
+    your membership (`node scripts/set-member.mjs --email <you> --org org-a
+    --remove`), then repeat the two-credential call from 30. The caller is
+    `null` - the rejected session does not retry as an API caller, so a
+    removed member cannot re-admit themselves with a key. (Re-add your
+    membership afterwards.)
+32. **HMAC JWT with claim-derived roles**: mint a token with the shared
+    secret (`JWT_SIGNING_SECRET='jwt-shared-secret-0123456789abcdef'
+    node ../auth-strategies/scripts/mint-jwt.mjs --aud auth-reference-api
+    --roles partner` - note this app's audience) and present it as
+    `Authorization: Bearer` on `whoami`: the caller shows
+    `authMethod: "jwt"`, `strategyId: "service-jwt"`, and
+    `roles: ["partner"]` derived from the token's `roles` claim (the
+    strategy grants no static roles). The same token reaches
+    `partner-data`.

--- a/apps/auth-reference/api/partner-data.yaml
+++ b/apps/auth-reference/api/partner-data.yaml
@@ -1,0 +1,12 @@
+# Role-gated HTTP endpoint (auth.api.roles: partner) for the phase-4
+# strategy scenarios. A partner API key reaches it; a caller without the
+# partner role gets the opaque "does not exist"; no credentials gets 401.
+id: partner-data
+type: Api
+routine:
+  - ':return':
+      data: partner-report
+      caller:
+        _user: id
+      branches:
+        _user: attributes.branches

--- a/apps/auth-reference/api/whoami.yaml
+++ b/apps/auth-reference/api/whoami.yaml
@@ -1,0 +1,11 @@
+# Public HTTP endpoint echoing the resolved caller - the phase-4
+# walkthrough uses it to show session-vs-strategy precedence: a session
+# cookie and an API key presented together resolve to the session user
+# (the session branch is terminal), while the key alone resolves to the
+# strategy caller shape (id, authMethod, strategyId, roles, attributes).
+id: whoami
+type: Api
+routine:
+  - ':return':
+      user:
+        _user: true

--- a/apps/auth-reference/lowdefy.yaml
+++ b/apps/auth-reference/lowdefy.yaml
@@ -108,6 +108,46 @@ auth:
       point: email.verified
       endpointId: on-email-verified
 
+  # API auth strategies (phase 4) - external callers authenticate with a
+  # static API key or an HMAC-signed JWT. A logged-in session always wins
+  # over a presented credential, and strategy callers bypass the
+  # org-membership wall (they are members of no organization); their roles
+  # are deployment-global and check against auth.api.roles below.
+  strategies:
+    - id: partner-access
+      type: apiKey
+      properties:
+        keys:
+          - id: acme
+            value:
+              _secret: PARTNER_KEY_ACME
+      roles:
+        - partner
+      attributes:
+        branches: [north, east]
+    - id: service-jwt
+      type: jwt
+      properties:
+        secret:
+          _secret: JWT_SIGNING_SECRET
+        algorithms:
+          - HS256
+        issuer: https://auth.example.test
+        audience: auth-reference-api
+        claimMapping:
+          id: sub
+          roles: roles
+      roles: []
+
+  # HTTP API authorization. partner-data is role-gated; whoami is
+  # deliberately public - it echoes the resolved caller for the session-
+  # vs-strategy precedence scenarios (resolution runs on public endpoints
+  # too; only the authorization gate differs).
+  api:
+    roles:
+      partner:
+        - partner-data
+
   # Uncomment to exercise the wrong-roles opaque /404 redirect and the
   # pre-resolved dev caller (roles are authoritative; no engine runs):
   # dev:
@@ -151,6 +191,8 @@ api:
   - _ref: api/normalize-signup.yaml
   - _ref: api/audit-login.yaml
   - _ref: api/on-email-verified.yaml
+  - _ref: api/partner-data.yaml
+  - _ref: api/whoami.yaml
 
 pages:
   - _ref: pages/home.yaml

--- a/apps/auth-strategies/README.md
+++ b/apps/auth-strategies/README.md
@@ -1,0 +1,169 @@
+# Auth strategies reference app (strategies-only)
+
+The phase-4 fixture for [api-strategies](../../../lowdefy-design/designs/auth-upgrade/api-strategies/design.md):
+a pure API app with **no database and no login method**. External callers
+authenticate with a static API key (`X-API-Key` header) or a Bearer JWT
+(HMAC shared secret or JWKS). The BetterAuth instance runs stateless, so
+`getSession` resolves null on every request and authentication falls through
+to the strategies in config order.
+
+The session-wins-over-API-key scenario needs a real login and lives in the
+[auth-reference walkthrough](../auth-reference/README.md) (phase-4 section).
+
+## Prerequisites
+
+- **Secrets** — `.env` in this directory (no database URI - there is no
+  database):
+
+  ```sh
+  LOWDEFY_SECRET_BETTER_AUTH_SECRET=use-a-long-random-string-of-32-chars
+  LOWDEFY_SECRET_PARTNER_KEY_ACME=partner-key-acme-0123456789abcdef
+  LOWDEFY_SECRET_PARTNER_KEY_GLOBEX=partner-key-globex-0123456789abcd
+  LOWDEFY_SECRET_JWT_SIGNING_SECRET=jwt-shared-secret-0123456789abcdef
+  ```
+
+  Any values work; keys and secrets shorter than 32 characters log a startup
+  warning (never a build failure - secrets are opaque at build time).
+
+- **Mock IdP** — the `external-idp` (JWKS) scenarios need the bundled mock
+  IdP running; it generates an RSA key pair at boot, serves the JWKS, and
+  mints RS256 tokens:
+
+  ```sh
+  node scripts/jwks-server.mjs   # serves http://localhost:4100
+  ```
+
+## Run
+
+From the repo root:
+
+```sh
+node scripts/dev.mjs --config-directory apps/auth-strategies
+```
+
+The app builds and serves with no database configured - the terminal shows
+no adapter/connection activity, and the home page renders logged out.
+
+All API calls below run against `http://localhost:3000`. Endpoints are
+POST-only and expect a JSON body:
+
+```sh
+call() { curl -s -X POST -H 'content-type: application/json' -d '{}' "$@"; }
+```
+
+## Walkthrough (phase-4 gate - API strategies)
+
+1. **Public endpoint needs no credentials**: `call http://localhost:3000/api/endpoints/health`
+   returns `{"ok":true}` with no credentials presented.
+
+2. **No credentials on a protected endpoint → 401, one warning line**:
+   `call -i http://localhost:3000/api/endpoints/partner-data` returns
+   `401` with `{"name":"AuthenticationError",...}`. The server terminal
+   logs exactly **one warning line** (`Unauthenticated request: POST
+   /api/endpoints/partner-data`) - no structured error log, no Sentry
+   event, no stack trace.
+
+3. **API key authenticates**: present a configured key and the role-gated
+   endpoint answers:
+
+   ```sh
+   call -H "X-API-Key: partner-key-acme-0123456789abcdef" \
+     http://localhost:3000/api/endpoints/partner-data
+   ```
+
+   returns `{"data":"partner-report","caller":"apiKey:partner-access:acme","branches":["north","east"]}` -
+   the synthetic caller id carries the per-key audit identity (`acme`), and
+   the strategy's static `attributes.branches` surfaced through `_user`.
+   The terminal debug log records which strategy authenticated
+   (`auth_strategy_authenticated`, visible with log level debug).
+
+4. **Strategy caller shape on `_user`**:
+
+   ```sh
+   call -H "X-API-Key: partner-key-acme-0123456789abcdef" \
+     http://localhost:3000/api/endpoints/caller
+   ```
+
+   returns the full resolved caller:
+   `{"user":{"id":"apiKey:partner-access:acme","authMethod":"apiKey","strategyId":"partner-access","roles":["partner"],"attributes":{"branches":["north","east"]}}}`.
+
+5. **Valid credentials, wrong roles → opaque "does not exist"**: the same
+   partner key on the `api-user`-gated endpoint:
+
+   ```sh
+   call -i -H "X-API-Key: partner-key-acme-0123456789abcdef" \
+     http://localhost:3000/api/endpoints/service-data
+   ```
+
+   returns the opaque `API Endpoint "service-data" does not exist.` error
+   (a 500-shaped config error, not a 403) - authorization failures never
+   reveal which endpoints exist.
+
+6. **Wrong API key → 401**: an unconfigured key value on `partner-data`
+   returns `401` like step 2 - a failed match is not a caller.
+
+7. **JWT (HMAC) authenticates**: mint a token with the shared secret and
+   call the `api-user`-gated endpoint:
+
+   ```sh
+   TOKEN=$(JWT_SIGNING_SECRET='jwt-shared-secret-0123456789abcdef' \
+     node scripts/mint-jwt.mjs --email svc@example.test --roles reporting)
+   call -H "Authorization: Bearer $TOKEN" \
+     http://localhost:3000/api/endpoints/service-data
+   ```
+
+   returns `{"data":"service-report","caller":"service-1"}` - `_user.id` is
+   the token's `sub` claim. On `/api/endpoints/caller` the same token shows
+   `authMethod: jwt`, `strategyId: service-jwt`, and
+   `roles: ["api-user","reporting"]` - the strategy's static `api-user`
+   unioned with the claim-derived `reporting`.
+
+8. **JWT rejections** - each of these returns `401` (one warning line, as
+   in step 2), because the token fails verification and no other strategy
+   matches:
+
+   ```sh
+   node scripts/mint-jwt.mjs --bad exp    # expired
+   node scripts/mint-jwt.mjs --bad alg    # HS384, allowlist is [HS256]
+   node scripts/mint-jwt.mjs --bad iss    # wrong issuer
+   node scripts/mint-jwt.mjs --bad aud    # wrong audience
+   ```
+
+   (each with `JWT_SIGNING_SECRET` set, used as `Authorization: Bearer` on
+   `service-data`).
+
+9. **JWT (JWKS) authenticates**: with the mock IdP from Prerequisites
+   running:
+
+   ```sh
+   TOKEN=$(curl -s 'http://localhost:4100/token?roles=api-user&branches=west')
+   call -H "Authorization: Bearer $TOKEN" \
+     http://localhost:3000/api/endpoints/caller
+   ```
+
+   returns `authMethod: jwt`, `strategyId: external-idp`,
+   `roles: ["api-user"]` (claim-derived via the nested
+   `realm_access.roles` path - the strategy grants no static roles), and
+   `attributes: {"branches":["west"]}` (claim-mapped via
+   `attributes.branches`). That token also reaches `service-data`.
+
+10. **JWKS rejections**: `curl -s 'http://localhost:4100/token?bad=key'`
+    (signed by a rogue key), `?bad=exp`, `?bad=iss`, and `?bad=aud` all
+    return `401` when presented as Bearer tokens.
+
+11. **Strategy order and header separation**: present both a valid API key
+    and a valid Bearer token on `/api/endpoints/caller` - the caller is the
+    API key's (`strategyId: partner-access`), because strategies resolve in
+    config order and `partner-access` is listed first. The two credentials
+    never compete for one header: `apiKey` reads `X-API-Key`, `jwt` reads
+    `Authorization`.
+
+## Notes
+
+- **Brute-force surface**: strategy endpoints have no built-in rate
+  limiting (BetterAuth's rate limiter covers `/api/auth/*` session routes,
+  which a strategies-only app never exercises). Put a reverse proxy with
+  per-IP rate limiting in front of a deployment that exposes API keys -
+  per-key rate limiting arrives with the future `dynamicApiKey` strategy.
+- Every scenario above is manual; automate with the repo's e2e tooling as
+  it grows.

--- a/apps/auth-strategies/lowdefy.yaml
+++ b/apps/auth-strategies/lowdefy.yaml
@@ -1,0 +1,124 @@
+name: auth-strategies
+lowdefy: local
+
+# Strategies-only reference app for auth-upgrade phase 4 (API auth
+# strategies). No database and no login method are configured - external
+# callers authenticate with a static API key (X-API-Key) or a Bearer JWT
+# (HMAC shared secret or JWKS). The BetterAuth instance runs stateless, so
+# getSession resolves null on every request and resolution falls through to
+# the strategies. See README.md for the full walkthrough.
+
+auth:
+  secret:
+    _secret: BETTER_AUTH_SECRET
+
+  strategies:
+    # Static API keys - config-defined, no database needed.
+    - id: partner-access
+      type: apiKey
+      properties:
+        headerName: X-API-Key
+        keys:
+          - id: acme
+            value:
+              _secret: PARTNER_KEY_ACME
+          - id: globex
+            value:
+              _secret: PARTNER_KEY_GLOBEX
+      roles:
+        - partner
+      attributes:
+        branches: [north, east]
+
+    # JWT verified with an HMAC shared secret.
+    - id: service-jwt
+      type: jwt
+      properties:
+        secret:
+          _secret: JWT_SIGNING_SECRET
+        algorithms:
+          - HS256
+        issuer: https://auth.example.test
+        audience: auth-strategies-api
+        claimMapping:
+          id: sub
+          email: email
+          roles: roles
+      roles:
+        - api-user
+
+    # JWT verified against a JWKS endpoint - scripts/jwks-server.mjs plays
+    # the external IdP and mints RS256 tokens for the walkthrough.
+    - id: external-idp
+      type: jwt
+      properties:
+        jwksUri: http://localhost:4100/jwks.json
+        algorithms:
+          - RS256
+        issuer: http://localhost:4100
+        audience: auth-strategies-api
+        claimMapping:
+          id: sub
+          roles: realm_access.roles
+          attributes.branches: resource_access.branches
+      roles: []
+
+  api:
+    protected: true
+    public:
+      - health
+    roles:
+      partner:
+        - partner-data
+      api-user:
+        - service-data
+
+api:
+  - id: health
+    type: Api
+    routine:
+      - ':return':
+          ok: true
+
+  # Role-gated per auth.api.roles - a partner key reaches this; a service
+  # JWT gets the opaque "does not exist".
+  - id: partner-data
+    type: Api
+    routine:
+      - ':return':
+          data: partner-report
+          caller:
+            _user: id
+          branches:
+            _user: attributes.branches
+
+  - id: service-data
+    type: Api
+    routine:
+      - ':return':
+          data: service-report
+          caller:
+            _user: id
+
+  # Protected but not role-gated - any authenticated caller may call it.
+  # Returns the resolved caller so the walkthrough can assert the strategy
+  # caller shape (id, authMethod, strategyId, roles, attributes).
+  - id: caller
+    type: Api
+    routine:
+      - ':return':
+          user:
+            _user: true
+
+pages:
+  - id: home
+    type: Box
+    blocks:
+      - id: title
+        type: Title
+        properties:
+          content: Strategies-only reference app
+      - id: info
+        type: Paragraph
+        properties:
+          content: This app has no login method - see README.md for the API walkthrough.

--- a/apps/auth-strategies/scripts/jwks-server.mjs
+++ b/apps/auth-strategies/scripts/jwks-server.mjs
@@ -1,0 +1,99 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/*
+  Plays the external IdP for the JWKS walkthrough scenarios: generates an
+  RSA key pair at boot, serves the public key set on /jwks.json, and mints
+  RS256 tokens on /token.
+
+  Usage: node scripts/jwks-server.mjs   (from apps/auth-strategies)
+
+    GET /jwks.json          the JWKS the app's external-idp strategy reads
+    GET /token              a valid token (sub=idp-user-1)
+    GET /token?sub=x&roles=a,b&branches=n,e
+                            custom subject, realm_access.roles and
+                            resource_access.branches claims
+    GET /token?bad=key      signed with a rogue key (must be rejected)
+    GET /token?bad=exp      already expired (must be rejected)
+    GET /token?bad=iss      wrong issuer (must be rejected)
+    GET /token?bad=aud      wrong audience (must be rejected)
+*/
+
+import http from 'node:http';
+import { createRequire } from 'node:module';
+
+// jose is not hoisted to the repo root - resolve it through the plugin
+// package that depends on it.
+const requireFromPlugin = createRequire(
+  new URL(
+    '../../../packages/plugins/plugins/plugin-better-auth/package.json',
+    import.meta.url
+  )
+);
+const { exportJWK, generateKeyPair, SignJWT } = await import(requireFromPlugin.resolve('jose'));
+
+const port = Number(process.env.JWKS_PORT ?? 4100);
+const issuer = `http://localhost:${port}`;
+const audience = 'auth-strategies-api';
+
+const { publicKey, privateKey } = await generateKeyPair('RS256');
+const rogue = await generateKeyPair('RS256');
+const jwk = await exportJWK(publicKey);
+jwk.alg = 'RS256';
+jwk.use = 'sig';
+jwk.kid = 'reference-key';
+
+async function mintToken(query) {
+  const bad = query.get('bad');
+  const payload = { sub: query.get('sub') ?? 'idp-user-1' };
+  const roles = query.get('roles');
+  if (roles) {
+    payload.realm_access = { roles: roles.split(',') };
+  }
+  const branches = query.get('branches');
+  if (branches) {
+    payload.resource_access = { branches: branches.split(',') };
+  }
+  const builder = new SignJWT(payload)
+    .setProtectedHeader({ alg: 'RS256', kid: 'reference-key' })
+    .setIssuedAt()
+    .setIssuer(bad === 'iss' ? 'http://evil.example.test' : issuer)
+    .setAudience(bad === 'aud' ? 'other-api' : audience)
+    .setExpirationTime(bad === 'exp' ? Math.floor(Date.now() / 1000) - 60 : '15m');
+  return builder.sign(bad === 'key' ? rogue.privateKey : privateKey);
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, issuer);
+  if (url.pathname === '/jwks.json') {
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ keys: [jwk] }));
+    return;
+  }
+  if (url.pathname === '/token') {
+    res.setHeader('content-type', 'text/plain');
+    res.end(await mintToken(url.searchParams));
+    return;
+  }
+  res.statusCode = 404;
+  res.end('Not found');
+});
+
+server.listen(port, () => {
+  console.log(`Mock IdP listening on ${issuer}`);
+  console.log(`  JWKS:  ${issuer}/jwks.json`);
+  console.log(`  Token: ${issuer}/token`);
+});

--- a/apps/auth-strategies/scripts/mint-jwt.mjs
+++ b/apps/auth-strategies/scripts/mint-jwt.mjs
@@ -1,0 +1,79 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/*
+  Mints an HMAC (HS256) token for the service-jwt strategy walkthrough
+  scenarios, signed with the same shared secret the app reads through
+  _secret: JWT_SIGNING_SECRET.
+
+  Usage: JWT_SIGNING_SECRET='...' node scripts/mint-jwt.mjs [flags]
+
+    --sub <id>        subject claim              (default service-1)
+    --email <email>   email claim                (default none)
+    --roles <a,b>     roles claim                (default none)
+    --aud <audience>  audience claim             (default auth-strategies-api)
+    --bad exp         already expired            (must be rejected)
+    --bad alg         signed with HS384          (must be rejected)
+    --bad iss         wrong issuer               (must be rejected)
+    --bad aud         wrong audience             (must be rejected)
+*/
+
+import { createRequire } from 'node:module';
+import { parseArgs } from 'node:util';
+
+// jose is not hoisted to the repo root - resolve it through the plugin
+// package that depends on it.
+const requireFromPlugin = createRequire(
+  new URL(
+    '../../../packages/plugins/plugins/plugin-better-auth/package.json',
+    import.meta.url
+  )
+);
+const { SignJWT } = await import(requireFromPlugin.resolve('jose'));
+
+const secret = process.env.JWT_SIGNING_SECRET;
+if (!secret) {
+  console.error('Set JWT_SIGNING_SECRET to the shared secret the app is configured with.');
+  process.exit(1);
+}
+
+const { values } = parseArgs({
+  options: {
+    sub: { type: 'string', default: 'service-1' },
+    email: { type: 'string' },
+    roles: { type: 'string' },
+    aud: { type: 'string', default: 'auth-strategies-api' },
+    bad: { type: 'string' },
+  },
+});
+
+const payload = { sub: values.sub };
+if (values.email) {
+  payload.email = values.email;
+}
+if (values.roles) {
+  payload.roles = values.roles.split(',');
+}
+
+const token = await new SignJWT(payload)
+  .setProtectedHeader({ alg: values.bad === 'alg' ? 'HS384' : 'HS256' })
+  .setIssuedAt()
+  .setIssuer(values.bad === 'iss' ? 'https://evil.example.test' : 'https://auth.example.test')
+  .setAudience(values.bad === 'aud' ? 'other-api' : values.aud)
+  .setExpirationTime(values.bad === 'exp' ? Math.floor(Date.now() / 1000) - 60 : '15m')
+  .sign(new TextEncoder().encode(secret));
+
+console.log(token);

--- a/packages/api/src/context/resolveAuthentication.js
+++ b/packages/api/src/context/resolveAuthentication.js
@@ -18,9 +18,14 @@
 
 import { type } from '@lowdefy/helpers';
 
+import resolveStrategyCaller from './resolveStrategyCaller.js';
+
 // resolveAuthentication is the single writer of context.user - nothing
-// downstream rewrites it. API strategies (no-session callers) resolve on a
-// separate path in a later phase; the session branch is terminal.
+// downstream rewrites it. The session and strategy branches are disjoint
+// ways to become a caller: a resolved session is terminal - it never falls
+// through to strategies, so a walled-out member cannot be silently
+// re-admitted by an apiKey/jwt strategy carrying config-granted roles. API
+// strategies are tried, in config order, only when no session resolves.
 //
 // The active member row is the hard membership wall and the role source in
 // one indexed read ({ userId, organizationId } on the member model), live on
@@ -37,14 +42,18 @@ import { type } from '@lowdefy/helpers';
 // the one merged bag of authorization inputs: user.attributes (global) and
 // the active member's attributes (per-org), shallow per-key merge where the
 // member value wins - nested objects replace, never deep-merge.
-async function resolveAuthentication(context, { auth, headers }) {
+async function resolveAuthentication(context, { auth, headers, strategies }) {
   if (type.isNone(auth)) {
     context.user = null;
     return;
   }
   const session = await auth.api.getSession({ headers });
   if (type.isNone(session)) {
-    context.user = null;
+    context.user = await resolveStrategyCaller({
+      headers,
+      logger: context.logger,
+      strategies,
+    });
     return;
   }
   const activeOrganizationId = session.session.activeOrganizationId;

--- a/packages/api/src/context/resolveAuthentication.test.js
+++ b/packages/api/src/context/resolveAuthentication.test.js
@@ -176,3 +176,83 @@ test('does not mutate the original session user object', async () => {
   expect(sessionUser).toEqual({ id: 'user_1' });
   expect(context.user).not.toBe(sessionUser);
 });
+
+function mockStrategy({ attributes = {}, id, match = null, roles = [], type = 'apiKey' }) {
+  return { attributes, id, roles, type, verify: jest.fn().mockResolvedValue(match) };
+}
+
+function mockLogger() {
+  return { debug: jest.fn(), warn: jest.fn() };
+}
+
+test('resolves a strategy caller when no session resolves', async () => {
+  const { auth } = mockAuth({ session: null });
+  const context = { logger: mockLogger() };
+  const strategies = [
+    mockStrategy({
+      id: 'partner-access',
+      match: { user: { id: 'apiKey:partner-access:acme' } },
+      roles: ['partner'],
+    }),
+  ];
+
+  await resolveAuthentication(context, { auth, headers: {}, strategies });
+
+  expect(context.user).toEqual({
+    id: 'apiKey:partner-access:acme',
+    authMethod: 'apiKey',
+    strategyId: 'partner-access',
+    roles: ['partner'],
+    attributes: {},
+  });
+});
+
+test('sets context.user to null when no session resolves and no strategy matches', async () => {
+  const { auth } = mockAuth({ session: null });
+  const context = { logger: mockLogger() };
+  const strategies = [mockStrategy({ id: 'partner-access' })];
+
+  await resolveAuthentication(context, { auth, headers: {}, strategies });
+
+  expect(context.user).toBe(null);
+  expect(strategies[0].verify).toHaveBeenCalled();
+});
+
+test('a resolved session wins over a presented strategy credential', async () => {
+  const { auth } = mockAuth({
+    session: {
+      user: { id: 'user_1' },
+      session: { id: 'sess_1', activeOrganizationId: 'org_1' },
+    },
+    member: { id: 'member_1', role: 'member' },
+  });
+  const context = { logger: mockLogger() };
+  const strategies = [
+    mockStrategy({ id: 'partner-access', match: { user: { id: 'apiKey:partner-access:acme' } } }),
+  ];
+
+  await resolveAuthentication(context, { auth, headers: {}, strategies });
+
+  expect(context.user.id).toBe('user_1');
+  expect(context.user.authMethod).toBeUndefined();
+  expect(strategies[0].verify).not.toHaveBeenCalled();
+});
+
+test('a session rejected by the membership wall does not fall through to strategies', async () => {
+  const { auth } = mockAuth({
+    session: {
+      user: { id: 'user_1' },
+      session: { id: 'sess_1', activeOrganizationId: 'org_1' },
+    },
+    member: null,
+  });
+  const context = { logger: mockLogger() };
+  const strategies = [
+    mockStrategy({ id: 'partner-access', match: { user: { id: 'apiKey:partner-access:acme' } } }),
+  ];
+
+  await resolveAuthentication(context, { auth, headers: {}, strategies });
+
+  expect(context.user).toBe(null);
+  expect(strategies[0].verify).not.toHaveBeenCalled();
+});

--- a/packages/api/src/context/resolveStrategyCaller.js
+++ b/packages/api/src/context/resolveStrategyCaller.js
@@ -1,0 +1,48 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { type } from '@lowdefy/helpers';
+
+// Tries the configured API auth strategies in config order; the first
+// verifier match wins. A strategy caller is a config-derived, org-less
+// principal: roles are the strategy's static grant unioned with any
+// claim-derived roles, and attributes are the static bag shallow-merged
+// with claim-mapped values (claim wins), so _user.attributes reads the same
+// for session and strategy callers.
+async function resolveStrategyCaller({ headers, logger, strategies }) {
+  for (const strategy of strategies ?? []) {
+    const match = await strategy.verify({ headers, logger });
+    if (type.isNone(match)) {
+      continue;
+    }
+    const roles = [...new Set([...strategy.roles, ...(match.roles ?? [])])];
+    const attributes = { ...strategy.attributes, ...(match.attributes ?? {}) };
+    logger.debug(
+      { event: 'auth_strategy_authenticated', authMethod: strategy.type, strategyId: strategy.id },
+      `Request authenticated by auth strategy "${strategy.id}" (${strategy.type}).`
+    );
+    return {
+      ...match.user,
+      authMethod: strategy.type,
+      strategyId: strategy.id,
+      roles,
+      attributes,
+    };
+  }
+  return null;
+}
+
+export default resolveStrategyCaller;

--- a/packages/api/src/context/resolveStrategyCaller.test.js
+++ b/packages/api/src/context/resolveStrategyCaller.test.js
@@ -1,0 +1,147 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+
+import resolveStrategyCaller from './resolveStrategyCaller.js';
+
+function mockLogger() {
+  return { debug: jest.fn(), warn: jest.fn() };
+}
+
+function mockStrategy({ attributes = {}, id, match = null, roles = [], type = 'apiKey' }) {
+  return { attributes, id, roles, type, verify: jest.fn().mockResolvedValue(match) };
+}
+
+test('resolveStrategyCaller returns null when no strategies are configured', async () => {
+  const logger = mockLogger();
+  expect(await resolveStrategyCaller({ headers: {}, logger, strategies: undefined })).toBe(null);
+  expect(await resolveStrategyCaller({ headers: {}, logger, strategies: [] })).toBe(null);
+});
+
+test('resolveStrategyCaller returns null when no strategy matches', async () => {
+  const logger = mockLogger();
+  const strategies = [mockStrategy({ id: 'a' }), mockStrategy({ id: 'b' })];
+  expect(await resolveStrategyCaller({ headers: {}, logger, strategies })).toBe(null);
+  expect(strategies[0].verify).toHaveBeenCalled();
+  expect(strategies[1].verify).toHaveBeenCalled();
+});
+
+test('resolveStrategyCaller tries strategies in config order and the first match wins', async () => {
+  const logger = mockLogger();
+  const strategies = [
+    mockStrategy({ id: 'first', match: null }),
+    mockStrategy({ id: 'second', match: { user: { id: 'caller-2' } }, roles: ['partner'] }),
+    mockStrategy({ id: 'third', match: { user: { id: 'caller-3' } } }),
+  ];
+  const caller = await resolveStrategyCaller({ headers: {}, logger, strategies });
+  expect(caller.id).toBe('caller-2');
+  expect(caller.strategyId).toBe('second');
+  expect(strategies[2].verify).not.toHaveBeenCalled();
+});
+
+test('resolveStrategyCaller builds the apiKey caller shape from static grants', async () => {
+  const logger = mockLogger();
+  const strategies = [
+    mockStrategy({
+      id: 'partner-access',
+      match: { user: { id: 'apiKey:partner-access:acme' } },
+      roles: ['partner'],
+      attributes: { branches: ['north', 'east'] },
+    }),
+  ];
+  const caller = await resolveStrategyCaller({ headers: {}, logger, strategies });
+  expect(caller).toEqual({
+    id: 'apiKey:partner-access:acme',
+    authMethod: 'apiKey',
+    strategyId: 'partner-access',
+    roles: ['partner'],
+    attributes: { branches: ['north', 'east'] },
+  });
+});
+
+test('resolveStrategyCaller unions static and claim-derived roles deduplicated', async () => {
+  const logger = mockLogger();
+  const strategies = [
+    mockStrategy({
+      id: 'service-jwt',
+      type: 'jwt',
+      match: { user: { id: 'svc' }, roles: ['api-user', 'reporting'] },
+      roles: ['api-user', 'partner'],
+    }),
+  ];
+  const caller = await resolveStrategyCaller({ headers: {}, logger, strategies });
+  expect(caller.roles).toEqual(['api-user', 'partner', 'reporting']);
+});
+
+test('resolveStrategyCaller merges static attributes with claim-mapped attributes where the claim wins', async () => {
+  const logger = mockLogger();
+  const strategies = [
+    mockStrategy({
+      id: 'service-jwt',
+      type: 'jwt',
+      match: { user: { id: 'svc' }, attributes: { branches: ['claim'], region: 'eu' } },
+      attributes: { branches: ['static'], team: 'ops' },
+    }),
+  ];
+  const caller = await resolveStrategyCaller({ headers: {}, logger, strategies });
+  expect(caller.attributes).toEqual({ branches: ['claim'], region: 'eu', team: 'ops' });
+});
+
+test('resolveStrategyCaller does not let mapped user fields clobber authMethod, strategyId, roles or attributes', async () => {
+  const logger = mockLogger();
+  const strategies = [
+    mockStrategy({
+      id: 'service-jwt',
+      type: 'jwt',
+      match: {
+        user: {
+          id: 'svc',
+          authMethod: 'spoofed',
+          strategyId: 'spoofed',
+          roles: ['spoofed'],
+          attributes: { spoofed: true },
+        },
+      },
+      roles: ['api-user'],
+    }),
+  ];
+  const caller = await resolveStrategyCaller({ headers: {}, logger, strategies });
+  expect(caller.authMethod).toBe('jwt');
+  expect(caller.strategyId).toBe('service-jwt');
+  expect(caller.roles).toEqual(['api-user']);
+  expect(caller.attributes).toEqual({});
+});
+
+test('resolveStrategyCaller logs which strategy authenticated the request', async () => {
+  const logger = mockLogger();
+  const strategies = [
+    mockStrategy({ id: 'partner-access', match: { user: { id: 'apiKey:partner-access:acme' } } }),
+  ];
+  await resolveStrategyCaller({ headers: {}, logger, strategies });
+  expect(logger.debug).toHaveBeenCalledWith(
+    { event: 'auth_strategy_authenticated', authMethod: 'apiKey', strategyId: 'partner-access' },
+    'Request authenticated by auth strategy "partner-access" (apiKey).'
+  );
+});
+
+test('resolveStrategyCaller passes headers and logger to each verifier', async () => {
+  const logger = mockLogger();
+  const headers = { get: () => null };
+  const strategies = [mockStrategy({ id: 'a' })];
+  await resolveStrategyCaller({ headers, logger, strategies });
+  expect(strategies[0].verify).toHaveBeenCalledWith({ headers, logger });
+});

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -21,6 +21,7 @@ import createApiContext from './context/createApiContext.js';
 import createChannelRegistry from './routes/websocket/createChannelRegistry.js';
 import createSystemContext from './context/createSystemContext.js';
 import createWebSocketConnection from './routes/websocket/createWebSocketConnection.js';
+import getAuthStrategies from './routes/auth/strategies/getAuthStrategies.js';
 import getBetterAuth from './routes/auth/getBetterAuth.js';
 import getBetterAuthConfig from './routes/auth/getBetterAuthConfig.js';
 import getHomeAndMenus from './routes/rootConfig/getHomeAndMenus.js';
@@ -38,6 +39,7 @@ export {
   createChannelRegistry,
   createSystemContext,
   createWebSocketConnection,
+  getAuthStrategies,
   getBetterAuth,
   getBetterAuthConfig,
   getHomeAndMenus,

--- a/packages/api/src/routes/auth/getBetterAuth.js
+++ b/packages/api/src/routes/auth/getBetterAuth.js
@@ -53,8 +53,10 @@ function getBetterAuth({
 
   // Ensure the pinned organization exists at startup - created if missing,
   // untouched otherwise. The engine hooks await the same memoized ensure per
-  // fire, so a failure here only defers seeding to the first sign-in.
-  if (authJson.organizations?.policy === 'pinned') {
+  // fire, so a failure here only defers seeding to the first sign-in. A
+  // strategies-only app has no database - seeding an in-memory org would be
+  // meaningless, and no session user can ever reach the membership wall.
+  if (authJson.organizations?.policy === 'pinned' && authJson.database) {
     ensureOrganization({ auth: instance, slug: authJson.organizations.org }).catch((error) => {
       logger.warn(
         { err: error },

--- a/packages/api/src/routes/auth/getBetterAuthConfig.js
+++ b/packages/api/src/routes/auth/getBetterAuthConfig.js
@@ -84,12 +84,19 @@ function getBetterAuthConfig({
     );
   }
 
-  const adapterPlugin = plugins.adapters[authConfig.database.type];
-  if (type.isNone(adapterPlugin)) {
-    throw new ConfigError(
-      `Auth database adapter type "${authConfig.database.type}" not found at database "${authConfig.database.id}".`,
-      { configKey: authConfig.database['~k'] }
-    );
+  // A strategies-only app configures no database - BetterAuth is constructed
+  // without an adapter (its stateless mode, backed by a memory adapter), so
+  // getSession runs guard-free and returns null on every request.
+  let database;
+  if (!type.isNone(authConfig.database)) {
+    const adapterPlugin = plugins.adapters[authConfig.database.type];
+    if (type.isNone(adapterPlugin)) {
+      throw new ConfigError(
+        `Auth database adapter type "${authConfig.database.type}" not found at database "${authConfig.database.id}".`,
+        { configKey: authConfig.database['~k'] }
+      );
+    }
+    database = adapterPlugin({ properties: authConfig.database.properties ?? {} });
   }
 
   const { socialProviders, genericOAuthConfigs } = buildProviders({ authConfig, plugins });
@@ -105,7 +112,6 @@ function getBetterAuthConfig({
     baseURL: { allowedHosts: ['*'], protocol: dev ? 'http' : 'auto' },
     basePath: `${config.basePath ?? ''}/api/auth`,
     secret: authConfig.secret,
-    database: adapterPlugin({ properties: authConfig.database.properties ?? {} }),
     telemetry: { enabled: false },
     logger: createAuthLogger({ logger }),
     user: {
@@ -145,6 +151,10 @@ function getBetterAuthConfig({
     },
     plugins: [],
   };
+
+  if (!type.isNone(database)) {
+    options.database = database;
+  }
 
   if (authConfig.session.crossSubDomainCookies.enabled === true) {
     options.advanced.crossSubDomainCookies = {

--- a/packages/api/src/routes/auth/getBetterAuthConfig.test.js
+++ b/packages/api/src/routes/auth/getBetterAuthConfig.test.js
@@ -181,6 +181,33 @@ test('resolves the database adapter using the matching plugin and resolved secre
   expect(options.database).toBe('adapter-instance');
 });
 
+test('constructs a stateless instance without a database for a strategies-only app', () => {
+  const adapterPlugin = jest.fn(() => 'adapter-instance');
+  const options = getBetterAuthConfig({
+    appMeta,
+    authJson: createAuthJson({
+      database: undefined,
+      emailAndPassword: undefined,
+      strategies: [
+        {
+          id: 'partner-access',
+          type: 'apiKey',
+          properties: { headerName: 'X-API-Key', keys: [{ id: 'acme', value: 'k'.repeat(32) }] },
+          roles: ['partner'],
+          attributes: {},
+        },
+      ],
+    }),
+    getAuth,
+    logger: createLogger(),
+    plugins: createPlugins({ adapters: { MongoDBAuthAdapter: adapterPlugin } }),
+    secrets: baseSecrets,
+  });
+  expect(adapterPlugin).not.toHaveBeenCalled();
+  expect(options.database).toBeUndefined();
+  expect(options.secret).toBe(baseSecrets.BETTER_AUTH_SECRET);
+});
+
 test('throws ConfigError when the database adapter type is not found', () => {
   const authJson = createAuthJson({
     database: {

--- a/packages/api/src/routes/auth/strategies/createAuthStrategies.js
+++ b/packages/api/src/routes/auth/strategies/createAuthStrategies.js
@@ -1,0 +1,77 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ServerParser } from '@lowdefy/operators';
+import { _app, _secret } from '@lowdefy/operators-js/operators/server';
+import { type } from '@lowdefy/helpers';
+import { ConfigError } from '@lowdefy/errors';
+
+// Builds the API auth strategy verifiers from the auth.json build artifact.
+// Build has validated the config and written all defaults, so this resolves
+// the _secret operators and constructs each strategy type's verifier.
+// Verifier factories warn on short static keys at construction, so key
+// strength surfaces at startup, never as a build failure.
+function createAuthStrategies({ appMeta, authJson, logger, plugins, secrets }) {
+  if (!type.isArray(authJson.strategies) || authJson.strategies.length === 0) {
+    return [];
+  }
+
+  const operatorsParser = new ServerParser({
+    lowdefyApp: appMeta,
+    operators: { _app, _secret },
+    secrets,
+    user: {},
+  });
+
+  const { output: strategiesConfig, errors: operatorErrors } = operatorsParser.parse({
+    input: authJson.strategies,
+    location: 'auth.strategies',
+    payload: {},
+  });
+
+  if (operatorErrors.length > 0) {
+    throw operatorErrors[0];
+  }
+
+  return strategiesConfig.map((strategy) => {
+    const strategyPlugin = plugins.strategies[strategy.type];
+    if (type.isNone(strategyPlugin)) {
+      throw new ConfigError(
+        `Auth strategy type "${strategy.type}" not found at strategy "${strategy.id}".`,
+        { configKey: strategy['~k'] }
+      );
+    }
+    let verify;
+    try {
+      verify = strategyPlugin({
+        logger,
+        properties: strategy.properties,
+        strategyId: strategy.id,
+      });
+    } catch (error) {
+      throw new ConfigError(error.message, { cause: error, configKey: strategy['~k'] });
+    }
+    return {
+      attributes: strategy.attributes,
+      id: strategy.id,
+      roles: strategy.roles,
+      type: strategy.type,
+      verify,
+    };
+  });
+}
+
+export default createAuthStrategies;

--- a/packages/api/src/routes/auth/strategies/createAuthStrategies.test.js
+++ b/packages/api/src/routes/auth/strategies/createAuthStrategies.test.js
@@ -1,0 +1,166 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+import { ConfigError } from '@lowdefy/errors';
+
+import createAuthStrategies from './createAuthStrategies.js';
+
+const appMeta = { name: 'Test App', slug: 'test-app' };
+
+function mockLogger() {
+  return { debug: jest.fn(), warn: jest.fn() };
+}
+
+test('createAuthStrategies returns an empty list when no strategies are configured', () => {
+  const logger = mockLogger();
+  expect(
+    createAuthStrategies({
+      appMeta,
+      authJson: { configured: true, strategies: [] },
+      logger,
+      plugins: { strategies: {} },
+      secrets: {},
+    })
+  ).toEqual([]);
+  expect(
+    createAuthStrategies({
+      appMeta,
+      authJson: { configured: true },
+      logger,
+      plugins: { strategies: {} },
+      secrets: {},
+    })
+  ).toEqual([]);
+});
+
+test('createAuthStrategies resolves _secret operators and constructs verifiers', () => {
+  const logger = mockLogger();
+  const verify = async () => null;
+  const apiKey = jest.fn(() => verify);
+  const strategies = createAuthStrategies({
+    appMeta,
+    authJson: {
+      configured: true,
+      strategies: [
+        {
+          id: 'partner-access',
+          type: 'apiKey',
+          properties: {
+            headerName: 'X-API-Key',
+            keys: [{ id: 'acme', value: { _secret: 'PARTNER_KEY_ACME' } }],
+          },
+          roles: ['partner'],
+          attributes: { branches: ['north'] },
+        },
+      ],
+    },
+    logger,
+    plugins: { strategies: { apiKey } },
+    secrets: { PARTNER_KEY_ACME: 'resolved-key-value' },
+  });
+  expect(apiKey).toHaveBeenCalledWith({
+    logger,
+    properties: {
+      headerName: 'X-API-Key',
+      keys: [{ id: 'acme', value: 'resolved-key-value' }],
+    },
+    strategyId: 'partner-access',
+  });
+  expect(strategies).toEqual([
+    {
+      attributes: { branches: ['north'] },
+      id: 'partner-access',
+      roles: ['partner'],
+      type: 'apiKey',
+      verify,
+    },
+  ]);
+});
+
+test('createAuthStrategies keeps strategies in config order', () => {
+  const logger = mockLogger();
+  const strategies = createAuthStrategies({
+    appMeta,
+    authJson: {
+      configured: true,
+      strategies: [
+        { id: 'a', type: 'apiKey', properties: {}, roles: [], attributes: {} },
+        { id: 'b', type: 'jwt', properties: {}, roles: [], attributes: {} },
+      ],
+    },
+    logger,
+    plugins: { strategies: { apiKey: () => 'verify-a', jwt: () => 'verify-b' } },
+    secrets: {},
+  });
+  expect(strategies.map((strategy) => strategy.id)).toEqual(['a', 'b']);
+});
+
+test('createAuthStrategies throws a ConfigError for an unknown strategy type', () => {
+  const logger = mockLogger();
+  expect(() =>
+    createAuthStrategies({
+      appMeta,
+      authJson: {
+        configured: true,
+        strategies: [{ id: 'x', type: 'unknown', properties: {}, roles: [], attributes: {} }],
+      },
+      logger,
+      plugins: { strategies: {} },
+      secrets: {},
+    })
+  ).toThrow(new ConfigError('Auth strategy type "unknown" not found at strategy "x".'));
+});
+
+test('createAuthStrategies wraps verifier construction errors in a ConfigError', () => {
+  const logger = mockLogger();
+  let thrown;
+  try {
+    createAuthStrategies({
+      appMeta,
+      authJson: {
+        configured: true,
+        strategies: [
+          {
+            id: 'partner-access',
+            type: 'apiKey',
+            properties: { headerName: 'X-API-Key', keys: [{ id: 'acme', value: undefined }] },
+            roles: [],
+            attributes: {},
+          },
+        ],
+      },
+      logger,
+      plugins: {
+        strategies: {
+          apiKey: () => {
+            throw new Error(
+              'Auth strategy "partner-access" key "acme" did not resolve to a string.'
+            );
+          },
+        },
+      },
+      secrets: {},
+    });
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toBeInstanceOf(ConfigError);
+  expect(thrown.message).toBe(
+    'Auth strategy "partner-access" key "acme" did not resolve to a string.'
+  );
+  expect(thrown.cause).toBeInstanceOf(Error);
+});

--- a/packages/api/src/routes/auth/strategies/getAuthStrategies.js
+++ b/packages/api/src/routes/auth/strategies/getAuthStrategies.js
@@ -1,0 +1,30 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import createAuthStrategies from './createAuthStrategies.js';
+
+let strategies;
+
+// The strategy verifiers are constructed once per process at first use -
+// resolveAuthentication tries them in config order on every request that
+// resolves no session.
+function getAuthStrategies({ appMeta, authJson, logger, plugins, secrets }) {
+  if (strategies) return strategies;
+  strategies = createAuthStrategies({ appMeta, authJson, logger, plugins, secrets });
+  return strategies;
+}
+
+export default getAuthStrategies;

--- a/packages/api/src/routes/endpoints/authorizeApiEndpoint.js
+++ b/packages/api/src/routes/endpoints/authorizeApiEndpoint.js
@@ -14,15 +14,23 @@
   limitations under the License.
 */
 
-import { ConfigError } from '@lowdefy/errors';
+import { AuthenticationError, ConfigError } from '@lowdefy/errors';
+import { type } from '@lowdefy/helpers';
 
-function authorizeApiEndpoint({ authorize, logger }, { endpointConfig }) {
+function authorizeApiEndpoint({ authorize, logger, user }, { endpointConfig }) {
   if (!authorize(endpointConfig)) {
     logger.debug({
       event: 'debug_api_authorize',
       authorized: false,
       auth_config: endpointConfig.auth,
     });
+    // Unauthenticated on a protected endpoint - 401 tells the caller to fix
+    // its credentials. Wrong roles stay opaque below.
+    if (type.isNone(user)) {
+      throw new AuthenticationError(
+        `Authentication required for API endpoint "${endpointConfig.endpointId}".`
+      );
+    }
     throw new ConfigError(`API Endpoint "${endpointConfig.endpointId}" does not exist.`);
   }
   logger.debug({

--- a/packages/api/src/routes/request/authorizeRequest.js
+++ b/packages/api/src/routes/request/authorizeRequest.js
@@ -14,15 +14,23 @@
   limitations under the License.
 */
 
-import { ConfigError } from '@lowdefy/errors';
+import { AuthenticationError, ConfigError } from '@lowdefy/errors';
+import { type } from '@lowdefy/helpers';
 
-function authorizeRequest({ authorize, logger }, { requestConfig }) {
+function authorizeRequest({ authorize, logger, user }, { requestConfig }) {
   if (!authorize(requestConfig)) {
     logger.debug({
       event: 'debug_request_authorize',
       authorized: false,
       auth_config: requestConfig.auth,
     });
+    // Unauthenticated on a protected request - 401 tells the caller to fix
+    // its credentials. Wrong roles stay opaque below.
+    if (type.isNone(user)) {
+      throw new AuthenticationError(
+        `Authentication required for request "${requestConfig.requestId}".`
+      );
+    }
     // Throw does not exist error to avoid leaking information that request exists to unauthorized users
     throw new ConfigError(`Request "${requestConfig.requestId}" does not exist.`, {
       configKey: requestConfig['~k'],

--- a/packages/api/src/routes/request/callRequest.test.js
+++ b/packages/api/src/routes/request/callRequest.test.js
@@ -19,7 +19,7 @@ import { operatorsServer } from '@lowdefy/operators-js';
 import callRequest from './callRequest.js';
 import testContext from '../../test/testContext.js';
 
-import { ConfigError, RequestError } from '@lowdefy/errors';
+import { AuthenticationError, ConfigError, RequestError } from '@lowdefy/errors';
 
 const { _date, _payload, _secret, _user } = operatorsServer;
 
@@ -203,7 +203,7 @@ test('call request, protected auth with user', async () => {
   });
 });
 
-test('call request, protected auth without user', async () => {
+test('call request, protected auth without user throws AuthenticationError', async () => {
   mockReadConfigFile.mockImplementation(
     defaultReadConfigImp({
       requestConfig: {
@@ -220,8 +220,31 @@ test('call request, protected auth without user', async () => {
   );
   mockTestRequest.mockImplementation(defaultResolverImp);
 
-  await expect(callRequest(context, defaultParams)).rejects.toThrow(ConfigError);
+  await expect(callRequest(context, defaultParams)).rejects.toThrow(AuthenticationError);
   await expect(callRequest(context, defaultParams)).rejects.toThrow(
+    'Authentication required for request "requestId".'
+  );
+});
+
+test('call request, protected auth with user missing the required roles stays opaque', async () => {
+  mockReadConfigFile.mockImplementation(
+    defaultReadConfigImp({
+      requestConfig: {
+        id: 'request:pageId:requestId',
+        type: 'TestRequest',
+        requestId: 'requestId',
+        connectionId: 'testConnection',
+        auth: { public: false, roles: ['admin'] },
+        properties: {
+          requestProperty: 'requestProperty',
+        },
+      },
+    })
+  );
+  mockTestRequest.mockImplementation(defaultResolverImp);
+
+  await expect(callRequest(authenticatedContext, defaultParams)).rejects.toThrow(ConfigError);
+  await expect(callRequest(authenticatedContext, defaultParams)).rejects.toThrow(
     'Request "requestId" does not exist.'
   );
 });

--- a/packages/build/src/build/buildAuth/buildAuth.js
+++ b/packages/build/src/build/buildAuth/buildAuth.js
@@ -19,6 +19,7 @@
 import buildApiAuth from './buildApiAuth.js';
 import buildAuthHooks from './buildAuthHooks.js';
 import buildAuthPlugins from './buildAuthPlugins.js';
+import buildAuthStrategies from './buildAuthStrategies.js';
 import buildPageAuth from './buildPageAuth.js';
 import buildRoleCatalog from './buildRoleCatalog.js';
 import buildTrustedProviders from './buildTrustedProviders.js';
@@ -34,6 +35,7 @@ function buildAuth({ components, context }) {
   buildRoleCatalog({ components, context });
   buildTrustedProviders({ components, context });
   buildAuthHooks({ components, context });
+  buildAuthStrategies({ components, context });
   buildApiAuth({ components, context });
   buildWebsocketAuth({ components, context });
   buildPageAuth({ components, context });

--- a/packages/build/src/build/buildAuth/buildAuth.test.js
+++ b/packages/build/src/build/buildAuth/buildAuth.test.js
@@ -122,6 +122,7 @@ test('buildAuth fills in configured defaults for a minimal valid auth config', (
     providers: [],
     roles: [],
     hooks: [],
+    strategies: [],
     organizations: {
       policy: 'pinned',
       org: 'default',

--- a/packages/build/src/build/buildAuth/buildAuthPlugins.js
+++ b/packages/build/src/build/buildAuth/buildAuthPlugins.js
@@ -21,12 +21,15 @@ import { type } from '@lowdefy/helpers';
 // Shapes are already validated by validateAuthConfig before this step runs.
 function buildAuthPlugins({ components, context }) {
   const counters = context.typeCounters.auth;
-  const { database, providers } = components.auth;
+  const { database, providers, strategies } = components.auth;
   if (!type.isNone(database)) {
     counters.adapters.increment(database.type, database['~k']);
   }
   (providers ?? []).forEach((provider) => {
     counters.providers.increment(provider.type, provider['~k']);
+  });
+  (strategies ?? []).forEach((strategy) => {
+    counters.strategies.increment(strategy.type, strategy['~k']);
   });
 }
 

--- a/packages/build/src/build/buildAuth/buildAuthPlugins.test.js
+++ b/packages/build/src/build/buildAuth/buildAuthPlugins.test.js
@@ -81,6 +81,34 @@ test('buildAuthPlugins does not count providers when the list is absent', () => 
   expect(context.typeCounters.auth.providers.getCounts()).toEqual({});
 });
 
+test('buildAuthPlugins counts each strategy type with its config location', () => {
+  const context = testContext();
+  const components = {
+    auth: {
+      strategies: [
+        { id: 'partner-access', type: 'apiKey', properties: {}, '~k': 'k-api-key' },
+        { id: 'service-jwt', type: 'jwt', properties: {}, '~k': 'k-jwt' },
+      ],
+    },
+  };
+  buildAuthPlugins({ components, context });
+  expect(context.typeCounters.auth.strategies.getCounts()).toEqual({
+    apiKey: 1,
+    jwt: 1,
+  });
+  expect(context.typeCounters.auth.strategies.getLocation('apiKey')).toBe('k-api-key');
+  expect(context.typeCounters.auth.strategies.getLocation('jwt')).toBe('k-jwt');
+});
+
+test('buildAuthPlugins does not count strategies when the list is absent', () => {
+  const context = testContext();
+  const components = {
+    auth: {},
+  };
+  buildAuthPlugins({ components, context });
+  expect(context.typeCounters.auth.strategies.getCounts()).toEqual({});
+});
+
 test('buildAuthPlugins counts both database and provider types together', () => {
   const context = testContext();
   const components = {

--- a/packages/build/src/build/buildAuth/buildAuthStrategies.js
+++ b/packages/build/src/build/buildAuth/buildAuthStrategies.js
@@ -1,0 +1,104 @@
+/* eslint-disable no-param-reassign */
+
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { type } from '@lowdefy/helpers';
+import { ConfigError } from '@lowdefy/errors';
+
+const strategyTypes = ['apiKey', 'jwt'];
+
+function setDefault(object, key, value) {
+  if (type.isNone(object[key])) {
+    object[key] = value;
+  }
+}
+
+function validateApiKeyStrategy({ strategy, configKey }) {
+  const properties = strategy.properties ?? {};
+  if (!type.isArray(properties.keys) || properties.keys.length === 0) {
+    throw new ConfigError(
+      `Auth strategy "${strategy.id}" requires "properties.keys" to be a non-empty array of keys.`,
+      { configKey }
+    );
+  }
+  properties.keys.forEach((key, index) => {
+    if (type.isNone(key.value)) {
+      throw new ConfigError(
+        `Auth strategy "${strategy.id}" key at index ${index} is missing "value". Reference the key with the _secret operator.`,
+        { configKey }
+      );
+    }
+  });
+}
+
+function validateJwtStrategy({ strategy, configKey }) {
+  const properties = strategy.properties ?? {};
+  const hasSecret = !type.isNone(properties.secret);
+  const hasJwksUri = !type.isNone(properties.jwksUri);
+  if (hasSecret === hasJwksUri) {
+    throw new ConfigError(
+      `Auth strategy "${strategy.id}" requires exactly one of "properties.secret" or "properties.jwksUri" to verify token signatures.`,
+      { configKey }
+    );
+  }
+  // The algorithms allowlist restricts which signing algorithms are accepted,
+  // preventing "alg: none" and algorithm-confusion downgrade attacks.
+  if (!type.isArray(properties.algorithms) || properties.algorithms.length === 0) {
+    throw new ConfigError(
+      `Auth strategy "${strategy.id}" requires "properties.algorithms" to be a non-empty array restricting the accepted signing algorithms.`,
+      { configKey }
+    );
+  }
+}
+
+// Validates auth.strategies and writes per-entry defaults so the runtime
+// never falls back. Objects are mutated in place to preserve ~k markers.
+function buildAuthStrategies({ components }) {
+  const seenIds = {};
+  (components.auth.strategies ?? []).forEach((strategy) => {
+    const configKey = strategy['~k'];
+    if (seenIds[strategy.id] === true) {
+      throw new ConfigError(`Duplicate auth strategy id "${strategy.id}".`, { configKey });
+    }
+    seenIds[strategy.id] = true;
+
+    if (!strategyTypes.includes(strategy.type)) {
+      throw new ConfigError(
+        `Auth strategy "${strategy.id}" has unknown type "${
+          strategy.type
+        }". Valid types are: ${strategyTypes.join(', ')}.`,
+        { received: strategy.type, configKey }
+      );
+    }
+
+    if (strategy.type === 'apiKey') {
+      validateApiKeyStrategy({ strategy, configKey });
+    }
+    if (strategy.type === 'jwt') {
+      validateJwtStrategy({ strategy, configKey });
+    }
+
+    setDefault(strategy, 'roles', []);
+    setDefault(strategy, 'attributes', {});
+    if (strategy.type === 'apiKey') {
+      setDefault(strategy.properties, 'headerName', 'X-API-Key');
+    }
+  });
+  return components;
+}
+
+export default buildAuthStrategies;

--- a/packages/build/src/build/buildAuth/buildAuthStrategies.test.js
+++ b/packages/build/src/build/buildAuth/buildAuthStrategies.test.js
@@ -1,0 +1,306 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import buildAuthStrategies from './buildAuthStrategies.js';
+
+test('buildAuthStrategies returns components unchanged when strategies is undefined', () => {
+  const components = {
+    auth: {},
+  };
+  const res = buildAuthStrategies({ components });
+  expect(res).toEqual({ auth: {} });
+});
+
+test('buildAuthStrategies is a no-op for an empty strategies array', () => {
+  const components = {
+    auth: {
+      strategies: [],
+    },
+  };
+  const res = buildAuthStrategies({ components });
+  expect(res).toEqual({ auth: { strategies: [] } });
+});
+
+test('buildAuthStrategies passes a valid apiKey strategy and writes defaults', () => {
+  const components = {
+    auth: {
+      strategies: [
+        {
+          id: 'partner-access',
+          type: 'apiKey',
+          properties: {
+            keys: [{ id: 'acme', value: { _secret: 'PARTNER_KEY_ACME' } }],
+          },
+        },
+      ],
+    },
+  };
+  const res = buildAuthStrategies({ components });
+  expect(res.auth.strategies).toEqual([
+    {
+      id: 'partner-access',
+      type: 'apiKey',
+      properties: {
+        headerName: 'X-API-Key',
+        keys: [{ id: 'acme', value: { _secret: 'PARTNER_KEY_ACME' } }],
+      },
+      roles: [],
+      attributes: {},
+    },
+  ]);
+});
+
+test('buildAuthStrategies passes a valid jwt strategy with an HMAC secret and writes defaults', () => {
+  const components = {
+    auth: {
+      strategies: [
+        {
+          id: 'service-jwt',
+          type: 'jwt',
+          properties: {
+            secret: { _secret: 'JWT_SIGNING_SECRET' },
+            algorithms: ['HS256'],
+          },
+        },
+      ],
+    },
+  };
+  const res = buildAuthStrategies({ components });
+  expect(res.auth.strategies).toEqual([
+    {
+      id: 'service-jwt',
+      type: 'jwt',
+      properties: {
+        secret: { _secret: 'JWT_SIGNING_SECRET' },
+        algorithms: ['HS256'],
+      },
+      roles: [],
+      attributes: {},
+    },
+  ]);
+});
+
+test('buildAuthStrategies passes a valid jwt strategy with a jwksUri and writes defaults', () => {
+  const components = {
+    auth: {
+      strategies: [
+        {
+          id: 'idp-jwt',
+          type: 'jwt',
+          properties: {
+            jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+            algorithms: ['RS256'],
+            issuer: 'https://auth.example.com',
+            audience: 'my-lowdefy-api',
+          },
+        },
+      ],
+    },
+  };
+  const res = buildAuthStrategies({ components });
+  expect(res.auth.strategies).toEqual([
+    {
+      id: 'idp-jwt',
+      type: 'jwt',
+      properties: {
+        jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+        algorithms: ['RS256'],
+        issuer: 'https://auth.example.com',
+        audience: 'my-lowdefy-api',
+      },
+      roles: [],
+      attributes: {},
+    },
+  ]);
+});
+
+test('buildAuthStrategies preserves explicit roles, attributes and headerName', () => {
+  const components = {
+    auth: {
+      strategies: [
+        {
+          id: 'partner-access',
+          type: 'apiKey',
+          properties: {
+            headerName: 'X-Partner-Key',
+            keys: [{ value: { _secret: 'PARTNER_KEY' } }],
+          },
+          roles: ['partner'],
+          attributes: { branches: ['north', 'east'] },
+        },
+      ],
+    },
+  };
+  const res = buildAuthStrategies({ components });
+  expect(res.auth.strategies).toEqual([
+    {
+      id: 'partner-access',
+      type: 'apiKey',
+      properties: {
+        headerName: 'X-Partner-Key',
+        keys: [{ value: { _secret: 'PARTNER_KEY' } }],
+      },
+      roles: ['partner'],
+      attributes: { branches: ['north', 'east'] },
+    },
+  ]);
+});
+
+test('buildAuthStrategies throws when two strategies share an id', () => {
+  const components = {
+    auth: {
+      strategies: [
+        {
+          id: 'partner-access',
+          type: 'apiKey',
+          properties: { keys: [{ value: { _secret: 'KEY_A' } }] },
+        },
+        {
+          id: 'partner-access',
+          type: 'jwt',
+          properties: { secret: { _secret: 'JWT_SECRET' }, algorithms: ['HS256'] },
+        },
+      ],
+    },
+  };
+  expect(() => buildAuthStrategies({ components })).toThrow(
+    'Duplicate auth strategy id "partner-access".'
+  );
+});
+
+test('buildAuthStrategies throws when a strategy has an unknown type', () => {
+  const components = {
+    auth: {
+      strategies: [{ id: 'basic-auth', type: 'basic', properties: {} }],
+    },
+  };
+  expect(() => buildAuthStrategies({ components })).toThrow(
+    'Auth strategy "basic-auth" has unknown type "basic". Valid types are: apiKey, jwt.'
+  );
+});
+
+test('buildAuthStrategies throws when an apiKey strategy has no keys', () => {
+  const components = {
+    auth: {
+      strategies: [{ id: 'partner-access', type: 'apiKey', properties: {} }],
+    },
+  };
+  expect(() => buildAuthStrategies({ components })).toThrow(
+    'Auth strategy "partner-access" requires "properties.keys" to be a non-empty array of keys.'
+  );
+});
+
+test('buildAuthStrategies throws when an apiKey strategy has an empty keys array', () => {
+  const components = {
+    auth: {
+      strategies: [{ id: 'partner-access', type: 'apiKey', properties: { keys: [] } }],
+    },
+  };
+  expect(() => buildAuthStrategies({ components })).toThrow(
+    'Auth strategy "partner-access" requires "properties.keys" to be a non-empty array of keys.'
+  );
+});
+
+test('buildAuthStrategies throws when an apiKey key entry is missing a value', () => {
+  const components = {
+    auth: {
+      strategies: [
+        {
+          id: 'partner-access',
+          type: 'apiKey',
+          properties: {
+            keys: [{ id: 'acme', value: { _secret: 'PARTNER_KEY_ACME' } }, { id: 'globex' }],
+          },
+        },
+      ],
+    },
+  };
+  expect(() => buildAuthStrategies({ components })).toThrow(
+    'Auth strategy "partner-access" key at index 1 is missing "value". Reference the key with the _secret operator.'
+  );
+});
+
+test('buildAuthStrategies throws when a jwt strategy sets both secret and jwksUri', () => {
+  const components = {
+    auth: {
+      strategies: [
+        {
+          id: 'service-jwt',
+          type: 'jwt',
+          properties: {
+            secret: { _secret: 'JWT_SIGNING_SECRET' },
+            jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+            algorithms: ['HS256'],
+          },
+        },
+      ],
+    },
+  };
+  expect(() => buildAuthStrategies({ components })).toThrow(
+    'Auth strategy "service-jwt" requires exactly one of "properties.secret" or "properties.jwksUri" to verify token signatures.'
+  );
+});
+
+test('buildAuthStrategies throws when a jwt strategy sets neither secret nor jwksUri', () => {
+  const components = {
+    auth: {
+      strategies: [
+        {
+          id: 'service-jwt',
+          type: 'jwt',
+          properties: { algorithms: ['HS256'] },
+        },
+      ],
+    },
+  };
+  expect(() => buildAuthStrategies({ components })).toThrow(
+    'Auth strategy "service-jwt" requires exactly one of "properties.secret" or "properties.jwksUri" to verify token signatures.'
+  );
+});
+
+test('buildAuthStrategies throws when a jwt strategy has no algorithms', () => {
+  const components = {
+    auth: {
+      strategies: [
+        {
+          id: 'service-jwt',
+          type: 'jwt',
+          properties: { secret: { _secret: 'JWT_SIGNING_SECRET' } },
+        },
+      ],
+    },
+  };
+  expect(() => buildAuthStrategies({ components })).toThrow(
+    'Auth strategy "service-jwt" requires "properties.algorithms" to be a non-empty array restricting the accepted signing algorithms.'
+  );
+});
+
+test('buildAuthStrategies throws when a jwt strategy has an empty algorithms array', () => {
+  const components = {
+    auth: {
+      strategies: [
+        {
+          id: 'service-jwt',
+          type: 'jwt',
+          properties: { secret: { _secret: 'JWT_SIGNING_SECRET' }, algorithms: [] },
+        },
+      ],
+    },
+  };
+  expect(() => buildAuthStrategies({ components })).toThrow(
+    'Auth strategy "service-jwt" requires "properties.algorithms" to be a non-empty array restricting the accepted signing algorithms.'
+  );
+});

--- a/packages/build/src/build/buildAuth/setAuthDefaults.js
+++ b/packages/build/src/build/buildAuth/setAuthDefaults.js
@@ -45,6 +45,7 @@ function setAuthDefaults({ components }) {
   }
 
   setDefault(auth, 'hooks', []);
+  setDefault(auth, 'strategies', []);
 
   // Organizations are always on - an app that sets nothing gets one
   // auto-seeded organization (slug "default") pinned as the active org,

--- a/packages/build/src/build/buildAuth/setAuthDefaults.test.js
+++ b/packages/build/src/build/buildAuth/setAuthDefaults.test.js
@@ -60,6 +60,7 @@ test('setAuthDefaults sets full defaults when auth is configured', () => {
       websockets: { roles: {} },
       providers: [],
       hooks: [],
+      strategies: [],
       organizations: {
         policy: 'pinned',
         org: 'default',
@@ -85,6 +86,26 @@ test('setAuthDefaults sets full defaults when auth is configured', () => {
       rateLimit: { enabled: true, window: 60, max: 100 },
     },
   });
+});
+
+test('setAuthDefaults sets strategies to an empty array when auth is configured', () => {
+  const components = {
+    auth: {
+      configured: true,
+    },
+  };
+  const res = setAuthDefaults({ components });
+  expect(res.auth.strategies).toEqual([]);
+});
+
+test('setAuthDefaults does not set strategies when auth is not configured', () => {
+  const components = {
+    auth: {
+      configured: false,
+    },
+  };
+  const res = setAuthDefaults({ components });
+  expect(res.auth.strategies).toBeUndefined();
 });
 
 test('setAuthDefaults does not overwrite explicitly provided values', () => {

--- a/packages/build/src/build/buildAuth/validateAuthConfig.js
+++ b/packages/build/src/build/buildAuth/validateAuthConfig.js
@@ -79,12 +79,13 @@ function validateAuthConfig({ components }) {
   const magicLinkEnabled = auth.magicLink?.enabled === true;
   const hasProviders = type.isArray(auth.providers) && auth.providers.length > 0;
   const hasLoginMethod = emailAndPasswordEnabled || magicLinkEnabled || hasProviders;
+  const hasStrategies = type.isArray(auth.strategies) && auth.strategies.length > 0;
 
   // dev.mockUser is a server-dev-only bypass, not a mechanism - a block whose
   // only substance is dev.mockUser still fails this check.
-  if (!hasLoginMethod) {
+  if (!hasLoginMethod && !hasStrategies) {
     throw new ConfigError(
-      'Auth is configured without an authentication mechanism. Configure a login method ("emailAndPassword.enabled: true" or "magicLink.enabled: true") or an OAuth provider in "providers".',
+      'Auth is configured without an authentication mechanism. Configure a login method ("emailAndPassword.enabled: true" or "magicLink.enabled: true"), or an OAuth provider in "providers", or an API auth strategy in "strategies".',
       { configKey }
     );
   }

--- a/packages/build/src/build/buildAuth/validateAuthConfig.test.js
+++ b/packages/build/src/build/buildAuth/validateAuthConfig.test.js
@@ -50,9 +50,7 @@ test('validateAuthConfig throws when auth contains an unknown key', () => {
       notAKnownAuthKey: true,
     },
   };
-  expect(() => validateAuthConfig({ components, context })).toThrow(
-    /contains an unknown property/
-  );
+  expect(() => validateAuthConfig({ components, context })).toThrow(/contains an unknown property/);
 });
 
 test('validateAuthConfig throws when configured without an authentication mechanism', () => {
@@ -62,7 +60,64 @@ test('validateAuthConfig throws when configured without an authentication mechan
     },
   };
   expect(() => validateAuthConfig({ components, context })).toThrow(
-    'Auth is configured without an authentication mechanism. Configure a login method ("emailAndPassword.enabled: true" or "magicLink.enabled: true") or an OAuth provider in "providers".'
+    'Auth is configured without an authentication mechanism. Configure a login method ("emailAndPassword.enabled: true" or "magicLink.enabled: true"), or an OAuth provider in "providers", or an API auth strategy in "strategies".'
+  );
+});
+
+test('validateAuthConfig passes a strategies-only auth block without a database or login method', () => {
+  const components = {
+    auth: {
+      secret: validSecret,
+      strategies: [
+        {
+          id: 'partner-access',
+          type: 'apiKey',
+          properties: { keys: [{ value: { _secret: 'PARTNER_KEY' } }] },
+        },
+      ],
+    },
+  };
+  expect(() => validateAuthConfig({ components, context })).not.toThrow();
+});
+
+test('validateAuthConfig throws when a strategies-only auth block is missing secret', () => {
+  const components = {
+    auth: {
+      strategies: [
+        {
+          id: 'partner-access',
+          type: 'apiKey',
+          properties: { keys: [{ value: { _secret: 'PARTNER_KEY' } }] },
+        },
+      ],
+    },
+  };
+  expect(() => validateAuthConfig({ components, context })).toThrow(
+    'Auth "secret" is required when auth is configured. Reference it with the _secret operator.'
+  );
+});
+
+test('validateAuthConfig throws when a strategy entry is missing a required property', () => {
+  const components = {
+    auth: {
+      secret: validSecret,
+      strategies: [{ id: 'partner-access' }],
+    },
+  };
+  expect(() => validateAuthConfig({ components, context })).toThrow(
+    'Auth strategy should have required property "type".'
+  );
+});
+
+test('validateAuthConfig throws when strategies is not an array', () => {
+  const components = {
+    auth: {
+      secret: validSecret,
+      strategies: { id: 'partner-access' },
+    },
+  };
+  expect(() => validateAuthConfig({ components, context })).toThrow(
+    'Auth "strategies" should be an array.'
   );
 });
 
@@ -464,7 +519,5 @@ test('validateAuthConfig throws when organizations contains an unknown property'
       organizations: { enabled: true },
     },
   };
-  expect(() => validateAuthConfig({ components, context })).toThrow(
-    /contains an unknown property/
-  );
+  expect(() => validateAuthConfig({ components, context })).toThrow(/contains an unknown property/);
 });

--- a/packages/build/src/build/buildImports/buildImportsDev.js
+++ b/packages/build/src/build/buildImports/buildImportsDev.js
@@ -29,6 +29,7 @@ function getPluginPackages({ components }) {
   getPackages(components.types.agents);
   getPackages(components.types.auth.adapters);
   getPackages(components.types.auth.providers);
+  getPackages(components.types.auth.strategies);
   getPackages(components.types.blocks);
   getPackages(components.types.connections);
   getPackages(components.types.requests);
@@ -57,6 +58,7 @@ function buildImportsDev({ components, context }) {
     auth: {
       adapters: buildImportClassDev({ pluginPackages, map: context.typesMap.auth.adapters }),
       providers: buildImportClassDev({ pluginPackages, map: context.typesMap.auth.providers }),
+      strategies: buildImportClassDev({ pluginPackages, map: context.typesMap.auth.strategies }),
     },
     blocks,
     connections: buildImportClassDev({ pluginPackages, map: context.typesMap.connections }),

--- a/packages/build/src/build/buildImports/buildImportsProd.js
+++ b/packages/build/src/build/buildImports/buildImportsProd.js
@@ -33,6 +33,7 @@ function buildImportsProd({ components, context }) {
     auth: {
       adapters: buildImportClassProd(components.types.auth.adapters),
       providers: buildImportClassProd(components.types.auth.providers),
+      strategies: buildImportClassProd(components.types.auth.strategies),
     },
     blocks,
     connections: buildImportClassProd(components.types.connections),

--- a/packages/build/src/build/buildTypes.js
+++ b/packages/build/src/build/buildTypes.js
@@ -71,6 +71,7 @@ function buildTypes({ components, context }) {
     auth: {
       adapters: {},
       providers: {},
+      strategies: {},
     },
     blocks: {},
     connections: {},
@@ -109,6 +110,13 @@ function buildTypes({ components, context }) {
     definitions: context.typesMap.auth.providers,
     store: components.types.auth.providers,
     typeClass: 'Auth provider',
+  });
+
+  buildTypeClass(context, {
+    counter: typeCounters.auth.strategies,
+    definitions: context.typesMap.auth.strategies,
+    store: components.types.auth.strategies,
+    typeClass: 'Auth strategy',
   });
 
   buildTypeClass(context, {

--- a/packages/build/src/build/writePluginImports/writeAuthImports.js
+++ b/packages/build/src/build/writePluginImports/writeAuthImports.js
@@ -31,6 +31,13 @@ async function writeAuthImports({ components, context }) {
       importPath: 'auth/providers',
     })
   );
+  await context.writeBuildArtifact(
+    'plugins/auth/strategies.js',
+    generateImportFile({
+      imports: components.imports.auth.strategies,
+      importPath: 'auth/strategies',
+    })
+  );
 }
 
 export default writeAuthImports;

--- a/packages/build/src/createContext.js
+++ b/packages/build/src/createContext.js
@@ -58,6 +58,7 @@ function createContext({
       auth: {
         adapters: createCounter(),
         providers: createCounter(),
+        strategies: createCounter(),
       },
       blocks: createCounter(),
       connections: createCounter(),

--- a/packages/build/src/defaultTypesMap.js
+++ b/packages/build/src/defaultTypesMap.js
@@ -4,6 +4,7 @@ const defaultTypesMap = {
   auth: {
     adapters: {},
     providers: {},
+    strategies: {},
   },
   blockMetas: {},
   blocks: {},

--- a/packages/build/src/lowdefySchema.js
+++ b/packages/build/src/lowdefySchema.js
@@ -1086,6 +1086,65 @@ export default {
             },
           },
         },
+        strategies: {
+          type: 'array',
+          errorMessage: {
+            type: 'Auth "strategies" should be an array.',
+          },
+          items: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['id', 'type'],
+            properties: {
+              '~ignoreBuildChecks': {},
+              '~r': {},
+              '~l': {},
+              id: {
+                type: 'string',
+                errorMessage: {
+                  type: 'Auth strategy "id" should be a string.',
+                },
+              },
+              type: {
+                type: 'string',
+                errorMessage: {
+                  type: 'Auth strategy "type" should be a string.',
+                },
+              },
+              properties: {
+                type: 'object',
+                errorMessage: {
+                  type: 'Auth strategy "properties" should be an object.',
+                },
+              },
+              roles: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  errorMessage: {
+                    type: 'Auth strategy "roles" should be an array of role names.',
+                  },
+                },
+                errorMessage: {
+                  type: 'Auth strategy "roles" should be an array of role names.',
+                },
+              },
+              attributes: {
+                type: 'object',
+                errorMessage: {
+                  type: 'Auth strategy "attributes" should be an object.',
+                },
+              },
+            },
+            errorMessage: {
+              type: 'Auth strategy should be an object.',
+              required: {
+                id: 'Auth strategy should have required property "id".',
+                type: 'Auth strategy should have required property "type".',
+              },
+            },
+          },
+        },
         organizations: {
           type: 'object',
           additionalProperties: false,

--- a/packages/build/src/scripts/generateDefaultTypes.js
+++ b/packages/build/src/scripts/generateDefaultTypes.js
@@ -29,6 +29,7 @@ async function generateDefaultTypesMap() {
     auth: {
       adapters: {},
       providers: {},
+      strategies: {},
     },
     blockMetas: {},
     blocks: {},

--- a/packages/build/src/test-utils/runBuildForSnapshots.js
+++ b/packages/build/src/test-utils/runBuildForSnapshots.js
@@ -161,6 +161,10 @@ const snapshotTypesMap = {
       GitHub: { package: '@lowdefy/plugin-better-auth' },
       GenericOAuth: { package: '@lowdefy/plugin-better-auth' },
     },
+    strategies: {
+      apiKey: { package: '@lowdefy/plugin-better-auth' },
+      jwt: { package: '@lowdefy/plugin-better-auth' },
+    },
   },
   operators: {
     client: {

--- a/packages/build/src/test-utils/testContext.js
+++ b/packages/build/src/test-utils/testContext.js
@@ -37,6 +37,7 @@ function testContext({ writeBuildArtifact, configDirectory, readConfigFile, logg
       auth: {
         adapters: createCounter(),
         providers: createCounter(),
+        strategies: createCounter(),
       },
       blocks: createCounter(),
       connections: createCounter(),

--- a/packages/build/src/tests/success/01-minimal-config/snapshot.json
+++ b/packages/build/src/tests/success/01-minimal-config/snapshot.json
@@ -127,144 +127,152 @@
       "~k_parent": "18"
     },
     "20": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1s"
     },
     "21": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1s"
     },
     "22": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1s"
     },
     "23": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1s"
     },
     "24": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1s"
     },
     "25": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1s"
     },
     "26": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1s"
     },
     "27": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1s"
     },
     "28": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1s"
     },
     "29": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1s"
     },
     "30": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2u"
     },
     "31": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2u"
     },
     "32": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2u"
     },
     "33": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2u"
     },
     "34": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2u"
     },
     "35": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2u"
     },
     "36": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2u"
     },
     "37": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2u"
     },
     "38": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2u"
     },
     "39": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2u"
     },
     "40": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3f"
     },
     "41": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3f"
     },
     "43": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3f"
     },
     "45": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3f"
     },
     "47": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3f"
     },
     "49": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.operators",
-      "~k_parent": "2k"
+      "key": "root.imports.requests",
+      "~k_parent": "2l"
     },
     "51": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "50"
+      "key": "root.imports.websockets",
+      "~k_parent": "2l"
     },
     "52": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "51"
+      "key": "root.imports.operators",
+      "~k_parent": "2l"
     },
     "53": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "51"
+      "key": "root.imports.operators.client",
+      "~k_parent": "52"
     },
     "54": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "53"
+    },
+    "55": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "53"
+    },
+    "56": {
       "key": "root.imports.operators.server",
-      "~k_parent": "50"
+      "~k_parent": "52"
     },
     "a": {
       "key": "root.pages[1:404:Result].style",
@@ -435,352 +443,352 @@
       "~k_parent": "1o"
     },
     "1r": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1o"
+    },
+    "1s": {
       "key": "root.types.blocks",
       "~k_parent": "1j"
     },
-    "1s": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1r"
-    },
     "1t": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1s"
     },
     "1u": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1s"
     },
     "1w": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1s"
     },
     "1x": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1s"
     },
     "1y": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1s"
     },
     "1z": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1s"
     },
     "2a": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1s"
     },
     "2b": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1s"
+    },
+    "2c": {
       "key": "root.types.connections",
       "~k_parent": "1j"
     },
-    "2c": {
+    "2d": {
       "key": "root.types.requests",
       "~k_parent": "1j"
     },
-    "2d": {
+    "2e": {
       "key": "root.types.websockets",
       "~k_parent": "1j"
     },
-    "2e": {
+    "2f": {
       "key": "root.types.api",
       "~k_parent": "1j"
     },
-    "2f": {
+    "2g": {
       "key": "root.types.operators",
       "~k_parent": "1j"
     },
-    "2g": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2f"
-    },
     "2h": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2g"
     },
     "2i": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2g"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2h"
     },
     "2j": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2f"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2h"
     },
     "2k": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2g"
+    },
+    "2l": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2l": {
-      "key": "root.imports.actions",
-      "~k_parent": "2k"
-    },
     "2m": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2l"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.imports.agents",
-      "~k_parent": "2k"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2m"
     },
     "2p": {
-      "key": "root.imports.auth",
-      "~k_parent": "2k"
+      "key": "root.imports.agents",
+      "~k_parent": "2l"
     },
     "2q": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2p"
+      "key": "root.imports.auth",
+      "~k_parent": "2l"
     },
     "2r": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2p"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2k"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2q"
     },
     "2t": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2s"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2q"
     },
     "2u": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks",
+      "~k_parent": "2l"
     },
     "2v": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2u"
     },
     "2y": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2u"
     },
     "2z": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2u"
     },
     "3b": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2u"
     },
     "3c": {
-      "key": "root.imports.connections",
-      "~k_parent": "2k"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2u"
     },
     "3d": {
-      "key": "root.imports.icons",
-      "~k_parent": "2k"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "2u"
     },
     "3e": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3d"
+      "key": "root.imports.connections",
+      "~k_parent": "2l"
     },
     "3f": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3e"
+      "key": "root.imports.icons",
+      "~k_parent": "2l"
     },
     "3g": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3f"
     },
     "3n": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3f"
     },
     "3r": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3f"
     },
     "3t": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3f"
     },
     "3v": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3f"
     },
     "3x": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3f"
     },
     "3z": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3f"
     },
     "4b": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3f"
     },
     "4d": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3f"
     },
     "4f": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3f"
     },
     "4h": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3f"
     },
     "4j": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3f"
     },
     "4l": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3f"
     },
     "4n": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3f"
     },
     "4p": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3f"
     },
     "4r": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3f"
     },
     "4t": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3f"
     },
     "4v": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3f"
     },
     "4x": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.requests",
-      "~k_parent": "2k"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3f"
     },
     "4z": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2k"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4y"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -977,6 +985,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5471,6 +5480,9 @@
       "providers": {
         "~k": "1q"
       },
+      "strategies": {
+        "~k": "1r"
+      },
       "~k": "1o"
     },
     "blocks": {
@@ -5478,129 +5490,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1s"
+        "~k": "1t"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1t"
+        "~k": "1u"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1u"
+        "~k": "1v"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1v"
+        "~k": "1w"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1w"
+        "~k": "1x"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
-      "~k": "1r"
+      "~k": "1s"
     },
     "connections": {
-      "~k": "2b"
-    },
-    "requests": {
       "~k": "2c"
     },
-    "websockets": {
+    "requests": {
       "~k": "2d"
     },
-    "api": {
+    "websockets": {
       "~k": "2e"
+    },
+    "api": {
+      "~k": "2f"
     },
     "operators": {
       "client": {
@@ -5608,20 +5620,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2h"
+          "~k": "2i"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2i"
+          "~k": "2j"
         },
-        "~k": "2g"
+        "~k": "2h"
       },
       "server": {
-        "~k": "2j"
+        "~k": "2k"
       },
-      "~k": "2f"
+      "~k": "2g"
     },
     "~k": "1j"
   }

--- a/packages/build/src/tests/success/02-minimal-with-name/snapshot.json
+++ b/packages/build/src/tests/success/02-minimal-with-name/snapshot.json
@@ -127,144 +127,152 @@
       "~k_parent": "18"
     },
     "20": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1s"
     },
     "21": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1s"
     },
     "22": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1s"
     },
     "23": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1s"
     },
     "24": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1s"
     },
     "25": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1s"
     },
     "26": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1s"
     },
     "27": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1s"
     },
     "28": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1s"
     },
     "29": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1s"
     },
     "30": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2u"
     },
     "31": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2u"
     },
     "32": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2u"
     },
     "33": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2u"
     },
     "34": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2u"
     },
     "35": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2u"
     },
     "36": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2u"
     },
     "37": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2u"
     },
     "38": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2u"
     },
     "39": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2u"
     },
     "40": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3f"
     },
     "41": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3f"
     },
     "43": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3f"
     },
     "45": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3f"
     },
     "47": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3f"
     },
     "49": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.operators",
-      "~k_parent": "2k"
+      "key": "root.imports.requests",
+      "~k_parent": "2l"
     },
     "51": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "50"
+      "key": "root.imports.websockets",
+      "~k_parent": "2l"
     },
     "52": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "51"
+      "key": "root.imports.operators",
+      "~k_parent": "2l"
     },
     "53": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "51"
+      "key": "root.imports.operators.client",
+      "~k_parent": "52"
     },
     "54": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "53"
+    },
+    "55": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "53"
+    },
+    "56": {
       "key": "root.imports.operators.server",
-      "~k_parent": "50"
+      "~k_parent": "52"
     },
     "a": {
       "key": "root.pages[1:404:Result].style",
@@ -435,352 +443,352 @@
       "~k_parent": "1o"
     },
     "1r": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1o"
+    },
+    "1s": {
       "key": "root.types.blocks",
       "~k_parent": "1j"
     },
-    "1s": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1r"
-    },
     "1t": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1s"
     },
     "1u": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1s"
     },
     "1w": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1s"
     },
     "1x": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1s"
     },
     "1y": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1s"
     },
     "1z": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1s"
     },
     "2a": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1s"
     },
     "2b": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1s"
+    },
+    "2c": {
       "key": "root.types.connections",
       "~k_parent": "1j"
     },
-    "2c": {
+    "2d": {
       "key": "root.types.requests",
       "~k_parent": "1j"
     },
-    "2d": {
+    "2e": {
       "key": "root.types.websockets",
       "~k_parent": "1j"
     },
-    "2e": {
+    "2f": {
       "key": "root.types.api",
       "~k_parent": "1j"
     },
-    "2f": {
+    "2g": {
       "key": "root.types.operators",
       "~k_parent": "1j"
     },
-    "2g": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2f"
-    },
     "2h": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2g"
     },
     "2i": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2g"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2h"
     },
     "2j": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2f"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2h"
     },
     "2k": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2g"
+    },
+    "2l": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2l": {
-      "key": "root.imports.actions",
-      "~k_parent": "2k"
-    },
     "2m": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2l"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.imports.agents",
-      "~k_parent": "2k"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2m"
     },
     "2p": {
-      "key": "root.imports.auth",
-      "~k_parent": "2k"
+      "key": "root.imports.agents",
+      "~k_parent": "2l"
     },
     "2q": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2p"
+      "key": "root.imports.auth",
+      "~k_parent": "2l"
     },
     "2r": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2p"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2k"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2q"
     },
     "2t": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2s"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2q"
     },
     "2u": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks",
+      "~k_parent": "2l"
     },
     "2v": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2u"
     },
     "2y": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2u"
     },
     "2z": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2u"
     },
     "3b": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2u"
     },
     "3c": {
-      "key": "root.imports.connections",
-      "~k_parent": "2k"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2u"
     },
     "3d": {
-      "key": "root.imports.icons",
-      "~k_parent": "2k"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "2u"
     },
     "3e": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3d"
+      "key": "root.imports.connections",
+      "~k_parent": "2l"
     },
     "3f": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3e"
+      "key": "root.imports.icons",
+      "~k_parent": "2l"
     },
     "3g": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3f"
     },
     "3n": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3f"
     },
     "3r": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3f"
     },
     "3t": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3f"
     },
     "3v": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3f"
     },
     "3x": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3f"
     },
     "3z": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3f"
     },
     "4b": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3f"
     },
     "4d": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3f"
     },
     "4f": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3f"
     },
     "4h": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3f"
     },
     "4j": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3f"
     },
     "4l": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3f"
     },
     "4n": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3f"
     },
     "4p": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3f"
     },
     "4r": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3f"
     },
     "4t": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3f"
     },
     "4v": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3f"
     },
     "4x": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.requests",
-      "~k_parent": "2k"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3f"
     },
     "4z": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2k"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4y"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -977,6 +985,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5471,6 +5480,9 @@
       "providers": {
         "~k": "1q"
       },
+      "strategies": {
+        "~k": "1r"
+      },
       "~k": "1o"
     },
     "blocks": {
@@ -5478,129 +5490,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1s"
+        "~k": "1t"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1t"
+        "~k": "1u"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1u"
+        "~k": "1v"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1v"
+        "~k": "1w"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1w"
+        "~k": "1x"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
-      "~k": "1r"
+      "~k": "1s"
     },
     "connections": {
-      "~k": "2b"
-    },
-    "requests": {
       "~k": "2c"
     },
-    "websockets": {
+    "requests": {
       "~k": "2d"
     },
-    "api": {
+    "websockets": {
       "~k": "2e"
+    },
+    "api": {
+      "~k": "2f"
     },
     "operators": {
       "client": {
@@ -5608,20 +5620,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2h"
+          "~k": "2i"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2i"
+          "~k": "2j"
         },
-        "~k": "2g"
+        "~k": "2h"
       },
       "server": {
-        "~k": "2j"
+        "~k": "2k"
       },
-      "~k": "2f"
+      "~k": "2g"
     },
     "~k": "1j"
   }

--- a/packages/build/src/tests/success/03-minimal-with-version/snapshot.json
+++ b/packages/build/src/tests/success/03-minimal-with-version/snapshot.json
@@ -127,144 +127,152 @@
       "~k_parent": "18"
     },
     "20": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1s"
     },
     "21": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1s"
     },
     "22": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1s"
     },
     "23": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1s"
     },
     "24": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1s"
     },
     "25": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1s"
     },
     "26": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1s"
     },
     "27": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1s"
     },
     "28": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1s"
     },
     "29": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1s"
     },
     "30": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2u"
     },
     "31": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2u"
     },
     "32": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2u"
     },
     "33": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2u"
     },
     "34": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2u"
     },
     "35": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2u"
     },
     "36": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2u"
     },
     "37": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2u"
     },
     "38": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2u"
     },
     "39": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2u"
     },
     "40": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3f"
     },
     "41": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3f"
     },
     "43": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3f"
     },
     "45": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3f"
     },
     "47": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3f"
     },
     "49": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.operators",
-      "~k_parent": "2k"
+      "key": "root.imports.requests",
+      "~k_parent": "2l"
     },
     "51": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "50"
+      "key": "root.imports.websockets",
+      "~k_parent": "2l"
     },
     "52": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "51"
+      "key": "root.imports.operators",
+      "~k_parent": "2l"
     },
     "53": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "51"
+      "key": "root.imports.operators.client",
+      "~k_parent": "52"
     },
     "54": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "53"
+    },
+    "55": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "53"
+    },
+    "56": {
       "key": "root.imports.operators.server",
-      "~k_parent": "50"
+      "~k_parent": "52"
     },
     "a": {
       "key": "root.pages[1:404:Result].style",
@@ -435,352 +443,352 @@
       "~k_parent": "1o"
     },
     "1r": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1o"
+    },
+    "1s": {
       "key": "root.types.blocks",
       "~k_parent": "1j"
     },
-    "1s": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1r"
-    },
     "1t": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1s"
     },
     "1u": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1s"
     },
     "1w": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1s"
     },
     "1x": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1s"
     },
     "1y": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1s"
     },
     "1z": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1s"
     },
     "2a": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1s"
     },
     "2b": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1s"
+    },
+    "2c": {
       "key": "root.types.connections",
       "~k_parent": "1j"
     },
-    "2c": {
+    "2d": {
       "key": "root.types.requests",
       "~k_parent": "1j"
     },
-    "2d": {
+    "2e": {
       "key": "root.types.websockets",
       "~k_parent": "1j"
     },
-    "2e": {
+    "2f": {
       "key": "root.types.api",
       "~k_parent": "1j"
     },
-    "2f": {
+    "2g": {
       "key": "root.types.operators",
       "~k_parent": "1j"
     },
-    "2g": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2f"
-    },
     "2h": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2g"
     },
     "2i": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2g"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2h"
     },
     "2j": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2f"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2h"
     },
     "2k": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2g"
+    },
+    "2l": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2l": {
-      "key": "root.imports.actions",
-      "~k_parent": "2k"
-    },
     "2m": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2l"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.imports.agents",
-      "~k_parent": "2k"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2m"
     },
     "2p": {
-      "key": "root.imports.auth",
-      "~k_parent": "2k"
+      "key": "root.imports.agents",
+      "~k_parent": "2l"
     },
     "2q": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2p"
+      "key": "root.imports.auth",
+      "~k_parent": "2l"
     },
     "2r": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2p"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2k"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2q"
     },
     "2t": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2s"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2q"
     },
     "2u": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks",
+      "~k_parent": "2l"
     },
     "2v": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2u"
     },
     "2y": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2u"
     },
     "2z": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2u"
     },
     "3b": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2u"
     },
     "3c": {
-      "key": "root.imports.connections",
-      "~k_parent": "2k"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2u"
     },
     "3d": {
-      "key": "root.imports.icons",
-      "~k_parent": "2k"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "2u"
     },
     "3e": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3d"
+      "key": "root.imports.connections",
+      "~k_parent": "2l"
     },
     "3f": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3e"
+      "key": "root.imports.icons",
+      "~k_parent": "2l"
     },
     "3g": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3f"
     },
     "3n": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3f"
     },
     "3r": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3f"
     },
     "3t": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3f"
     },
     "3v": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3f"
     },
     "3x": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3f"
     },
     "3z": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3f"
     },
     "4b": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3f"
     },
     "4d": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3f"
     },
     "4f": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3f"
     },
     "4h": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3f"
     },
     "4j": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3f"
     },
     "4l": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3f"
     },
     "4n": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3f"
     },
     "4p": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3f"
     },
     "4r": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3f"
     },
     "4t": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3f"
     },
     "4v": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3f"
     },
     "4x": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.requests",
-      "~k_parent": "2k"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3f"
     },
     "4z": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2k"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4y"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -977,6 +985,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5471,6 +5480,9 @@
       "providers": {
         "~k": "1q"
       },
+      "strategies": {
+        "~k": "1r"
+      },
       "~k": "1o"
     },
     "blocks": {
@@ -5478,129 +5490,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1s"
+        "~k": "1t"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1t"
+        "~k": "1u"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1u"
+        "~k": "1v"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1v"
+        "~k": "1w"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1w"
+        "~k": "1x"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
-      "~k": "1r"
+      "~k": "1s"
     },
     "connections": {
-      "~k": "2b"
-    },
-    "requests": {
       "~k": "2c"
     },
-    "websockets": {
+    "requests": {
       "~k": "2d"
     },
-    "api": {
+    "websockets": {
       "~k": "2e"
+    },
+    "api": {
+      "~k": "2f"
     },
     "operators": {
       "client": {
@@ -5608,20 +5620,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2h"
+          "~k": "2i"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2i"
+          "~k": "2j"
         },
-        "~k": "2g"
+        "~k": "2h"
       },
       "server": {
-        "~k": "2j"
+        "~k": "2k"
       },
-      "~k": "2f"
+      "~k": "2g"
     },
     "~k": "1j"
   }

--- a/packages/build/src/tests/success/04-minimal-with-license/snapshot.json
+++ b/packages/build/src/tests/success/04-minimal-with-license/snapshot.json
@@ -127,144 +127,152 @@
       "~k_parent": "18"
     },
     "20": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1s"
     },
     "21": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1s"
     },
     "22": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1s"
     },
     "23": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1s"
     },
     "24": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1s"
     },
     "25": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1s"
     },
     "26": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1s"
     },
     "27": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1s"
     },
     "28": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1s"
     },
     "29": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1s"
     },
     "30": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2u"
     },
     "31": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2u"
     },
     "32": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2u"
     },
     "33": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2u"
     },
     "34": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2u"
     },
     "35": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2u"
     },
     "36": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2u"
     },
     "37": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2u"
     },
     "38": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2u"
     },
     "39": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2u"
     },
     "40": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3f"
     },
     "41": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3f"
     },
     "43": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3f"
     },
     "45": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3f"
     },
     "47": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3f"
     },
     "49": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.operators",
-      "~k_parent": "2k"
+      "key": "root.imports.requests",
+      "~k_parent": "2l"
     },
     "51": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "50"
+      "key": "root.imports.websockets",
+      "~k_parent": "2l"
     },
     "52": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "51"
+      "key": "root.imports.operators",
+      "~k_parent": "2l"
     },
     "53": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "51"
+      "key": "root.imports.operators.client",
+      "~k_parent": "52"
     },
     "54": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "53"
+    },
+    "55": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "53"
+    },
+    "56": {
       "key": "root.imports.operators.server",
-      "~k_parent": "50"
+      "~k_parent": "52"
     },
     "a": {
       "key": "root.pages[1:404:Result].style",
@@ -435,352 +443,352 @@
       "~k_parent": "1o"
     },
     "1r": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1o"
+    },
+    "1s": {
       "key": "root.types.blocks",
       "~k_parent": "1j"
     },
-    "1s": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1r"
-    },
     "1t": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1s"
     },
     "1u": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1s"
     },
     "1w": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1s"
     },
     "1x": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1s"
     },
     "1y": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1s"
     },
     "1z": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1s"
     },
     "2a": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1s"
     },
     "2b": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1s"
+    },
+    "2c": {
       "key": "root.types.connections",
       "~k_parent": "1j"
     },
-    "2c": {
+    "2d": {
       "key": "root.types.requests",
       "~k_parent": "1j"
     },
-    "2d": {
+    "2e": {
       "key": "root.types.websockets",
       "~k_parent": "1j"
     },
-    "2e": {
+    "2f": {
       "key": "root.types.api",
       "~k_parent": "1j"
     },
-    "2f": {
+    "2g": {
       "key": "root.types.operators",
       "~k_parent": "1j"
     },
-    "2g": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2f"
-    },
     "2h": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2g"
     },
     "2i": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2g"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2h"
     },
     "2j": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2f"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2h"
     },
     "2k": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2g"
+    },
+    "2l": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2l": {
-      "key": "root.imports.actions",
-      "~k_parent": "2k"
-    },
     "2m": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2l"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.imports.agents",
-      "~k_parent": "2k"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2m"
     },
     "2p": {
-      "key": "root.imports.auth",
-      "~k_parent": "2k"
+      "key": "root.imports.agents",
+      "~k_parent": "2l"
     },
     "2q": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2p"
+      "key": "root.imports.auth",
+      "~k_parent": "2l"
     },
     "2r": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2p"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2k"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2q"
     },
     "2t": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2s"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2q"
     },
     "2u": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks",
+      "~k_parent": "2l"
     },
     "2v": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2u"
     },
     "2y": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2u"
     },
     "2z": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2u"
     },
     "3b": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2u"
     },
     "3c": {
-      "key": "root.imports.connections",
-      "~k_parent": "2k"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2u"
     },
     "3d": {
-      "key": "root.imports.icons",
-      "~k_parent": "2k"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "2u"
     },
     "3e": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3d"
+      "key": "root.imports.connections",
+      "~k_parent": "2l"
     },
     "3f": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3e"
+      "key": "root.imports.icons",
+      "~k_parent": "2l"
     },
     "3g": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3f"
     },
     "3n": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3f"
     },
     "3r": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3f"
     },
     "3t": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3f"
     },
     "3v": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3f"
     },
     "3x": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3f"
     },
     "3z": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3f"
     },
     "4b": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3f"
     },
     "4d": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3f"
     },
     "4f": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3f"
     },
     "4h": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3f"
     },
     "4j": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3f"
     },
     "4l": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3f"
     },
     "4n": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3f"
     },
     "4p": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3f"
     },
     "4r": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3f"
     },
     "4t": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3f"
     },
     "4v": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3f"
     },
     "4x": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.requests",
-      "~k_parent": "2k"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3f"
     },
     "4z": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2k"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4y"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -977,6 +985,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5471,6 +5480,9 @@
       "providers": {
         "~k": "1q"
       },
+      "strategies": {
+        "~k": "1r"
+      },
       "~k": "1o"
     },
     "blocks": {
@@ -5478,129 +5490,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1s"
+        "~k": "1t"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1t"
+        "~k": "1u"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1u"
+        "~k": "1v"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1v"
+        "~k": "1w"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1w"
+        "~k": "1x"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
-      "~k": "1r"
+      "~k": "1s"
     },
     "connections": {
-      "~k": "2b"
-    },
-    "requests": {
       "~k": "2c"
     },
-    "websockets": {
+    "requests": {
       "~k": "2d"
     },
-    "api": {
+    "websockets": {
       "~k": "2e"
+    },
+    "api": {
+      "~k": "2f"
     },
     "operators": {
       "client": {
@@ -5608,20 +5620,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2h"
+          "~k": "2i"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2i"
+          "~k": "2j"
         },
-        "~k": "2g"
+        "~k": "2h"
       },
       "server": {
-        "~k": "2j"
+        "~k": "2k"
       },
-      "~k": "2f"
+      "~k": "2g"
     },
     "~k": "1j"
   }

--- a/packages/build/src/tests/success/05-empty-pages-array/snapshot.json
+++ b/packages/build/src/tests/success/05-empty-pages-array/snapshot.json
@@ -126,124 +126,124 @@
       "~k_parent": "4"
     },
     "20": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1l"
     },
     "21": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1l"
     },
     "22": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1l"
     },
     "23": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1l"
     },
     "24": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1l"
+    },
+    "25": {
       "key": "root.types.connections",
       "~k_parent": "1c"
     },
-    "25": {
+    "26": {
       "key": "root.types.requests",
       "~k_parent": "1c"
     },
-    "26": {
+    "27": {
       "key": "root.types.websockets",
       "~k_parent": "1c"
     },
-    "27": {
+    "28": {
       "key": "root.types.api",
       "~k_parent": "1c"
     },
-    "28": {
+    "29": {
       "key": "root.types.operators",
       "~k_parent": "1c"
     },
-    "29": {
-      "key": "root.types.operators.client",
-      "~k_parent": "28"
-    },
     "30": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2n"
     },
     "31": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2n"
     },
     "32": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2n"
     },
     "33": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2n"
     },
     "34": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2n"
     },
     "35": {
-      "key": "root.imports.connections",
-      "~k_parent": "2d"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2n"
     },
     "36": {
-      "key": "root.imports.icons",
-      "~k_parent": "2d"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "2n"
     },
     "37": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "36"
+      "key": "root.imports.connections",
+      "~k_parent": "2e"
     },
     "38": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "37"
+      "key": "root.imports.icons",
+      "~k_parent": "2e"
     },
     "39": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "38"
     },
     "40": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "38"
     },
     "42": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "38"
     },
     "44": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "38"
     },
     "46": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "38"
     },
     "48": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "38"
     },
     "a": {
       "key": "root.pages[0:404:Result].properties",
@@ -386,372 +386,380 @@
       "~k_parent": "1h"
     },
     "1k": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1h"
+    },
+    "1l": {
       "key": "root.types.blocks",
       "~k_parent": "1c"
     },
-    "1l": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1k"
-    },
     "1m": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1l"
     },
     "1n": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1l"
     },
     "1o": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1l"
     },
     "1p": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1l"
     },
     "1q": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1l"
     },
     "1r": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1l"
     },
     "1s": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1l"
     },
     "1t": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1l"
     },
     "1u": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1l"
     },
     "1v": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1l"
     },
     "1w": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1l"
     },
     "1x": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1l"
     },
     "1y": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1l"
     },
     "1z": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1k"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1l"
     },
     "2a": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "29"
     },
     "2b": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "29"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2a"
     },
     "2c": {
-      "key": "root.types.operators.server",
-      "~k_parent": "28"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2a"
     },
     "2d": {
+      "key": "root.types.operators.server",
+      "~k_parent": "29"
+    },
+    "2e": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2e": {
-      "key": "root.imports.actions",
-      "~k_parent": "2d"
-    },
     "2f": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2e"
     },
     "2g": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2e"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2f"
     },
     "2h": {
-      "key": "root.imports.agents",
-      "~k_parent": "2d"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2f"
     },
     "2i": {
-      "key": "root.imports.auth",
-      "~k_parent": "2d"
+      "key": "root.imports.agents",
+      "~k_parent": "2e"
     },
     "2j": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2i"
+      "key": "root.imports.auth",
+      "~k_parent": "2e"
     },
     "2k": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2i"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2j"
     },
     "2l": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2d"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2j"
     },
     "2m": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2l"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2j"
     },
     "2n": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks",
+      "~k_parent": "2e"
     },
     "2o": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2n"
     },
     "2q": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2n"
     },
     "2r": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2n"
     },
     "2s": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2n"
     },
     "2t": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2n"
     },
     "2u": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2n"
     },
     "2v": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2n"
     },
     "2w": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2n"
     },
     "2x": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2n"
     },
     "2y": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2n"
     },
     "2z": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2n"
     },
     "3a": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "39"
     },
     "3b": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "38"
     },
     "3c": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "38"
     },
     "3e": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3d"
     },
     "3f": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "38"
     },
     "3g": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "38"
     },
     "3i": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "38"
     },
     "3k": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3j"
     },
     "3l": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "38"
     },
     "3m": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3l"
     },
     "3n": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "38"
     },
     "3o": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "38"
     },
     "3q": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "38"
     },
     "3s": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "38"
     },
     "3u": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "38"
     },
     "3w": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "38"
     },
     "3y": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "38"
     },
     "4a": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "38"
     },
     "4c": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "38"
     },
     "4e": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "38"
     },
     "4g": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "38"
     },
     "4i": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "38"
     },
     "4k": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "38"
     },
     "4m": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "38"
     },
     "4o": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "36"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "38"
     },
     "4q": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.requests",
-      "~k_parent": "2d"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "38"
     },
     "4s": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2d"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.operators",
-      "~k_parent": "2d"
+      "key": "root.imports.requests",
+      "~k_parent": "2e"
     },
     "4u": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "4t"
+      "key": "root.imports.websockets",
+      "~k_parent": "2e"
     },
     "4v": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "4u"
+      "key": "root.imports.operators",
+      "~k_parent": "2e"
     },
     "4w": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "4u"
+      "key": "root.imports.operators.client",
+      "~k_parent": "4v"
     },
     "4x": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "4w"
+    },
+    "4y": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "4w"
+    },
+    "4z": {
       "key": "root.imports.operators.server",
-      "~k_parent": "4t"
+      "~k_parent": "4v"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -917,6 +925,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Result": {
       "category": "container"
@@ -5411,6 +5420,9 @@
       "providers": {
         "~k": "1j"
       },
+      "strategies": {
+        "~k": "1k"
+      },
       "~k": "1h"
     },
     "blocks": {
@@ -5418,129 +5430,129 @@
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1l"
+        "~k": "1m"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1m"
+        "~k": "1n"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1n"
+        "~k": "1o"
       },
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1o"
+        "~k": "1p"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1p"
+        "~k": "1q"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1q"
+        "~k": "1r"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1r"
+        "~k": "1s"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1s"
+        "~k": "1t"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1t"
+        "~k": "1u"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1u"
+        "~k": "1v"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1v"
+        "~k": "1w"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1w"
+        "~k": "1x"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1x"
+        "~k": "1y"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
-      "~k": "1k"
+      "~k": "1l"
     },
     "connections": {
-      "~k": "24"
-    },
-    "requests": {
       "~k": "25"
     },
-    "websockets": {
+    "requests": {
       "~k": "26"
     },
-    "api": {
+    "websockets": {
       "~k": "27"
+    },
+    "api": {
+      "~k": "28"
     },
     "operators": {
       "client": {
@@ -5548,20 +5560,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2a"
+          "~k": "2b"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2b"
+          "~k": "2c"
         },
-        "~k": "29"
+        "~k": "2a"
       },
       "server": {
-        "~k": "2c"
+        "~k": "2d"
       },
-      "~k": "28"
+      "~k": "29"
     },
     "~k": "1c"
   }

--- a/packages/build/src/tests/success/06-single-page-minimal/snapshot.json
+++ b/packages/build/src/tests/success/06-single-page-minimal/snapshot.json
@@ -127,144 +127,152 @@
       "~k_parent": "18"
     },
     "20": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1s"
     },
     "21": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1s"
     },
     "22": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1s"
     },
     "23": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1s"
     },
     "24": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1s"
     },
     "25": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1s"
     },
     "26": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1s"
     },
     "27": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1s"
     },
     "28": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1s"
     },
     "29": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1s"
     },
     "30": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2u"
     },
     "31": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2u"
     },
     "32": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2u"
     },
     "33": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2u"
     },
     "34": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2u"
     },
     "35": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2u"
     },
     "36": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2u"
     },
     "37": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2u"
     },
     "38": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2u"
     },
     "39": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2u"
     },
     "40": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3f"
     },
     "41": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3f"
     },
     "43": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3f"
     },
     "45": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3f"
     },
     "47": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3f"
     },
     "49": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.operators",
-      "~k_parent": "2k"
+      "key": "root.imports.requests",
+      "~k_parent": "2l"
     },
     "51": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "50"
+      "key": "root.imports.websockets",
+      "~k_parent": "2l"
     },
     "52": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "51"
+      "key": "root.imports.operators",
+      "~k_parent": "2l"
     },
     "53": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "51"
+      "key": "root.imports.operators.client",
+      "~k_parent": "52"
     },
     "54": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "53"
+    },
+    "55": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "53"
+    },
+    "56": {
       "key": "root.imports.operators.server",
-      "~k_parent": "50"
+      "~k_parent": "52"
     },
     "a": {
       "key": "root.pages[1:404:Result].style",
@@ -435,352 +443,352 @@
       "~k_parent": "1o"
     },
     "1r": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1o"
+    },
+    "1s": {
       "key": "root.types.blocks",
       "~k_parent": "1j"
     },
-    "1s": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1r"
-    },
     "1t": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1s"
     },
     "1u": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1s"
     },
     "1w": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1s"
     },
     "1x": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1s"
     },
     "1y": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1s"
     },
     "1z": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1s"
     },
     "2a": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1s"
     },
     "2b": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1s"
+    },
+    "2c": {
       "key": "root.types.connections",
       "~k_parent": "1j"
     },
-    "2c": {
+    "2d": {
       "key": "root.types.requests",
       "~k_parent": "1j"
     },
-    "2d": {
+    "2e": {
       "key": "root.types.websockets",
       "~k_parent": "1j"
     },
-    "2e": {
+    "2f": {
       "key": "root.types.api",
       "~k_parent": "1j"
     },
-    "2f": {
+    "2g": {
       "key": "root.types.operators",
       "~k_parent": "1j"
     },
-    "2g": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2f"
-    },
     "2h": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2g"
     },
     "2i": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2g"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2h"
     },
     "2j": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2f"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2h"
     },
     "2k": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2g"
+    },
+    "2l": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2l": {
-      "key": "root.imports.actions",
-      "~k_parent": "2k"
-    },
     "2m": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2l"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.imports.agents",
-      "~k_parent": "2k"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2m"
     },
     "2p": {
-      "key": "root.imports.auth",
-      "~k_parent": "2k"
+      "key": "root.imports.agents",
+      "~k_parent": "2l"
     },
     "2q": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2p"
+      "key": "root.imports.auth",
+      "~k_parent": "2l"
     },
     "2r": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2p"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2k"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2q"
     },
     "2t": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2s"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2q"
     },
     "2u": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks",
+      "~k_parent": "2l"
     },
     "2v": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2u"
     },
     "2y": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2u"
     },
     "2z": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2u"
     },
     "3b": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2u"
     },
     "3c": {
-      "key": "root.imports.connections",
-      "~k_parent": "2k"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2u"
     },
     "3d": {
-      "key": "root.imports.icons",
-      "~k_parent": "2k"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "2u"
     },
     "3e": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3d"
+      "key": "root.imports.connections",
+      "~k_parent": "2l"
     },
     "3f": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3e"
+      "key": "root.imports.icons",
+      "~k_parent": "2l"
     },
     "3g": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3f"
     },
     "3n": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3f"
     },
     "3r": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3f"
     },
     "3t": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3f"
     },
     "3v": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3f"
     },
     "3x": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3f"
     },
     "3z": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3f"
     },
     "4b": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3f"
     },
     "4d": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3f"
     },
     "4f": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3f"
     },
     "4h": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3f"
     },
     "4j": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3f"
     },
     "4l": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3f"
     },
     "4n": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3f"
     },
     "4p": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3f"
     },
     "4r": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3f"
     },
     "4t": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3f"
     },
     "4v": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3f"
     },
     "4x": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.requests",
-      "~k_parent": "2k"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3f"
     },
     "4z": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2k"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4y"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -977,6 +985,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5471,6 +5480,9 @@
       "providers": {
         "~k": "1q"
       },
+      "strategies": {
+        "~k": "1r"
+      },
       "~k": "1o"
     },
     "blocks": {
@@ -5478,129 +5490,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1s"
+        "~k": "1t"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1t"
+        "~k": "1u"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1u"
+        "~k": "1v"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1v"
+        "~k": "1w"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1w"
+        "~k": "1x"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
-      "~k": "1r"
+      "~k": "1s"
     },
     "connections": {
-      "~k": "2b"
-    },
-    "requests": {
       "~k": "2c"
     },
-    "websockets": {
+    "requests": {
       "~k": "2d"
     },
-    "api": {
+    "websockets": {
       "~k": "2e"
+    },
+    "api": {
+      "~k": "2f"
     },
     "operators": {
       "client": {
@@ -5608,20 +5620,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2h"
+          "~k": "2i"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2i"
+          "~k": "2j"
         },
-        "~k": "2g"
+        "~k": "2h"
       },
       "server": {
-        "~k": "2j"
+        "~k": "2k"
       },
-      "~k": "2f"
+      "~k": "2g"
     },
     "~k": "1j"
   }

--- a/packages/build/src/tests/success/07-single-page-with-title/snapshot.json
+++ b/packages/build/src/tests/success/07-single-page-with-title/snapshot.json
@@ -128,148 +128,156 @@
       "~k_parent": "16"
     },
     "20": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1t"
     },
     "21": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1t"
     },
     "22": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1t"
     },
     "23": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1t"
     },
     "24": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1t"
     },
     "25": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1t"
     },
     "26": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1t"
     },
     "27": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1t"
     },
     "28": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1t"
     },
     "29": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1t"
     },
     "30": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2v"
     },
     "31": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2v"
     },
     "32": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2v"
     },
     "33": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2v"
     },
     "34": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2v"
     },
     "35": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2v"
     },
     "36": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2v"
     },
     "37": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2v"
     },
     "38": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2v"
     },
     "39": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2v"
     },
     "40": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3g"
     },
     "42": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3g"
     },
     "44": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3g"
     },
     "46": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3g"
     },
     "48": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3g"
     },
     "50": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2l"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.operators",
-      "~k_parent": "2l"
+      "key": "root.imports.requests",
+      "~k_parent": "2m"
     },
     "52": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "51"
+      "key": "root.imports.websockets",
+      "~k_parent": "2m"
     },
     "53": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "52"
+      "key": "root.imports.operators",
+      "~k_parent": "2m"
     },
     "54": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "52"
+      "key": "root.imports.operators.client",
+      "~k_parent": "53"
     },
     "55": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "54"
+    },
+    "56": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "54"
+    },
+    "57": {
       "key": "root.imports.operators.server",
-      "~k_parent": "51"
+      "~k_parent": "53"
     },
     "a": {
       "key": "root.pages[1:404:Result]",
@@ -444,348 +452,348 @@
       "~k_parent": "1p"
     },
     "1s": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1p"
+    },
+    "1t": {
       "key": "root.types.blocks",
       "~k_parent": "1k"
     },
-    "1t": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1s"
-    },
     "1u": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1t"
     },
     "1v": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1t"
     },
     "1w": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1t"
     },
     "1x": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1t"
     },
     "1y": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1t"
     },
     "1z": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1t"
     },
     "2a": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1t"
     },
     "2b": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1s"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1t"
     },
     "2c": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1t"
+    },
+    "2d": {
       "key": "root.types.connections",
       "~k_parent": "1k"
     },
-    "2d": {
+    "2e": {
       "key": "root.types.requests",
       "~k_parent": "1k"
     },
-    "2e": {
+    "2f": {
       "key": "root.types.websockets",
       "~k_parent": "1k"
     },
-    "2f": {
+    "2g": {
       "key": "root.types.api",
       "~k_parent": "1k"
     },
-    "2g": {
+    "2h": {
       "key": "root.types.operators",
       "~k_parent": "1k"
     },
-    "2h": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2g"
-    },
     "2i": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2h"
     },
     "2j": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2h"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2i"
     },
     "2k": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2g"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2i"
     },
     "2l": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2h"
+    },
+    "2m": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2m": {
-      "key": "root.imports.actions",
-      "~k_parent": "2l"
-    },
     "2n": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2m"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.imports.agents",
-      "~k_parent": "2l"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2n"
     },
     "2q": {
-      "key": "root.imports.auth",
-      "~k_parent": "2l"
+      "key": "root.imports.agents",
+      "~k_parent": "2m"
     },
     "2r": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2q"
+      "key": "root.imports.auth",
+      "~k_parent": "2m"
     },
     "2s": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2q"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2l"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2r"
     },
     "2u": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2t"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2r"
     },
     "2v": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks",
+      "~k_parent": "2m"
     },
     "2w": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2v"
     },
     "2x": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2v"
     },
     "2y": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2v"
     },
     "2z": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2v"
     },
     "3a": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2v"
     },
     "3b": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2v"
     },
     "3c": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2v"
     },
     "3d": {
-      "key": "root.imports.connections",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2v"
     },
     "3e": {
-      "key": "root.imports.icons",
-      "~k_parent": "2l"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "2v"
     },
     "3f": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3e"
+      "key": "root.imports.connections",
+      "~k_parent": "2m"
     },
     "3g": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3f"
+      "key": "root.imports.icons",
+      "~k_parent": "2m"
     },
     "3h": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3g"
     },
     "3k": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3j"
     },
     "3l": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3g"
     },
     "3m": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3l"
     },
     "3n": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3g"
     },
     "3o": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3g"
     },
     "3q": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3g"
     },
     "3s": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3g"
     },
     "3u": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3g"
     },
     "3w": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3g"
     },
     "3y": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3g"
     },
     "4a": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3g"
     },
     "4c": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3g"
     },
     "4e": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3g"
     },
     "4g": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3g"
     },
     "4i": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3g"
     },
     "4k": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3g"
     },
     "4m": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3g"
     },
     "4o": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3g"
     },
     "4q": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3g"
     },
     "4s": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3g"
     },
     "4u": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3g"
     },
     "4w": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3g"
     },
     "4y": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.requests",
-      "~k_parent": "2l"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3g"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -986,6 +994,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5480,6 +5489,9 @@
       "providers": {
         "~k": "1r"
       },
+      "strategies": {
+        "~k": "1s"
+      },
       "~k": "1p"
     },
     "blocks": {
@@ -5487,129 +5499,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1t"
+        "~k": "1u"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1u"
+        "~k": "1v"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1v"
+        "~k": "1w"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1w"
+        "~k": "1x"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
-      "~k": "1s"
+      "~k": "1t"
     },
     "connections": {
-      "~k": "2c"
-    },
-    "requests": {
       "~k": "2d"
     },
-    "websockets": {
+    "requests": {
       "~k": "2e"
     },
-    "api": {
+    "websockets": {
       "~k": "2f"
+    },
+    "api": {
+      "~k": "2g"
     },
     "operators": {
       "client": {
@@ -5617,20 +5629,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2i"
+          "~k": "2j"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2j"
+          "~k": "2k"
         },
-        "~k": "2h"
+        "~k": "2i"
       },
       "server": {
-        "~k": "2k"
+        "~k": "2l"
       },
-      "~k": "2g"
+      "~k": "2h"
     },
     "~k": "1k"
   }

--- a/packages/build/src/tests/success/08-page-with-single-block/snapshot.json
+++ b/packages/build/src/tests/success/08-page-with-single-block/snapshot.json
@@ -134,164 +134,164 @@
       "~k_parent": "12"
     },
     "20": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1x"
     },
     "21": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1x"
     },
     "22": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1x"
     },
     "23": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1x"
     },
     "24": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1x"
     },
     "25": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1x"
     },
     "26": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1x"
     },
     "27": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1x"
     },
     "28": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1x"
     },
     "29": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1x"
     },
     "30": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks",
+      "~k_parent": "2r"
     },
     "31": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "30"
     },
     "32": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "30"
     },
     "33": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "30"
     },
     "34": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "30"
     },
     "35": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "30"
     },
     "36": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "30"
     },
     "37": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "30"
     },
     "38": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "30"
     },
     "39": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "30"
     },
     "40": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3m"
     },
     "42": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3m"
     },
     "44": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3m"
     },
     "46": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3m"
     },
     "48": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3m"
     },
     "50": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3m"
     },
     "52": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3m"
     },
     "54": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.requests",
-      "~k_parent": "2q"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3m"
     },
     "56": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2q"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.operators",
-      "~k_parent": "2q"
+      "key": "root.imports.requests",
+      "~k_parent": "2r"
     },
     "58": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "57"
+      "key": "root.imports.websockets",
+      "~k_parent": "2r"
     },
     "59": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "58"
+      "key": "root.imports.operators",
+      "~k_parent": "2r"
     },
     "b": {
       "key": "root.pages",
@@ -478,340 +478,348 @@
       "~k_parent": "1t"
     },
     "1w": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1t"
+    },
+    "1x": {
       "key": "root.types.blocks",
       "~k_parent": "1o"
     },
-    "1x": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1w"
-    },
     "1y": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1x"
     },
     "1z": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "1x"
     },
     "2a": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1x"
     },
     "2b": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1x"
     },
     "2c": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1x"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1x"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1x"
     },
     "2f": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1x"
     },
     "2g": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1x"
     },
     "2h": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1x"
+    },
+    "2i": {
       "key": "root.types.connections",
       "~k_parent": "1o"
     },
-    "2i": {
+    "2j": {
       "key": "root.types.requests",
       "~k_parent": "1o"
     },
-    "2j": {
+    "2k": {
       "key": "root.types.websockets",
       "~k_parent": "1o"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.api",
       "~k_parent": "1o"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.operators",
       "~k_parent": "1o"
     },
-    "2m": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2l"
-    },
     "2n": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2m"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2l"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2n"
     },
     "2q": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2m"
+    },
+    "2r": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2r": {
-      "key": "root.imports.actions",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2r"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.imports.agents",
-      "~k_parent": "2q"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2s"
     },
     "2v": {
-      "key": "root.imports.auth",
-      "~k_parent": "2q"
+      "key": "root.imports.agents",
+      "~k_parent": "2r"
     },
     "2w": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2v"
+      "key": "root.imports.auth",
+      "~k_parent": "2r"
     },
     "2x": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2v"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2q"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2w"
     },
     "2z": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2y"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2w"
     },
     "3a": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "30"
     },
     "3b": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "30"
     },
     "3c": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "30"
     },
     "3d": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "30"
     },
     "3e": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "30"
     },
     "3f": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "30"
     },
     "3g": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "30"
     },
     "3h": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "30"
     },
     "3i": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "30"
     },
     "3j": {
-      "key": "root.imports.connections",
-      "~k_parent": "2q"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "30"
     },
     "3k": {
-      "key": "root.imports.icons",
-      "~k_parent": "2q"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "30"
     },
     "3l": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3k"
+      "key": "root.imports.connections",
+      "~k_parent": "2r"
     },
     "3m": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3l"
+      "key": "root.imports.icons",
+      "~k_parent": "2r"
     },
     "3n": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3m"
     },
     "3u": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3m"
     },
     "3w": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3m"
     },
     "3y": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3m"
     },
     "4a": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3m"
     },
     "4c": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3m"
     },
     "4e": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3m"
     },
     "4g": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3m"
     },
     "4i": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3m"
     },
     "4k": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3m"
     },
     "4m": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3m"
     },
     "4o": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3m"
     },
     "4q": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3m"
     },
     "4s": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3m"
     },
     "4u": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3m"
     },
     "4w": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3m"
     },
     "4y": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3m"
     },
     "5a": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "58"
+      "key": "root.imports.operators.client",
+      "~k_parent": "59"
     },
     "5b": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5a"
+    },
+    "5c": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5a"
+    },
+    "5d": {
       "key": "root.imports.operators.server",
-      "~k_parent": "57"
+      "~k_parent": "59"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1029,6 +1037,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5523,6 +5532,9 @@
       "providers": {
         "~k": "1v"
       },
+      "strategies": {
+        "~k": "1w"
+      },
       "~k": "1t"
     },
     "blocks": {
@@ -5530,135 +5542,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
-      "~k": "1w"
+      "~k": "1x"
     },
     "connections": {
-      "~k": "2h"
-    },
-    "requests": {
       "~k": "2i"
     },
-    "websockets": {
+    "requests": {
       "~k": "2j"
     },
-    "api": {
+    "websockets": {
       "~k": "2k"
+    },
+    "api": {
+      "~k": "2l"
     },
     "operators": {
       "client": {
@@ -5666,20 +5678,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2n"
+          "~k": "2o"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2o"
+          "~k": "2p"
         },
-        "~k": "2m"
+        "~k": "2n"
       },
       "server": {
-        "~k": "2p"
+        "~k": "2q"
       },
-      "~k": "2l"
+      "~k": "2m"
     },
     "~k": "1o"
   }

--- a/packages/build/src/tests/success/09-page-with-multiple-blocks/snapshot.json
+++ b/packages/build/src/tests/success/09-page-with-multiple-blocks/snapshot.json
@@ -134,164 +134,164 @@
       "~k_parent": "p"
     },
     "20": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1x"
+    },
+    "21": {
       "key": "root.types.blocks",
       "~k_parent": "1s"
     },
-    "21": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "20"
-    },
     "22": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "21"
     },
     "23": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "21"
     },
     "24": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "21"
     },
     "25": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "21"
     },
     "26": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "21"
     },
     "27": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "21"
     },
     "28": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "20"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "21"
     },
     "29": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "21"
     },
     "30": {
-      "key": "root.imports.auth",
-      "~k_parent": "2v"
+      "key": "root.imports.agents",
+      "~k_parent": "2w"
     },
     "31": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "30"
+      "key": "root.imports.auth",
+      "~k_parent": "2w"
     },
     "32": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "30"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "31"
     },
     "33": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2v"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "31"
     },
     "34": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "33"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "31"
     },
     "35": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks",
+      "~k_parent": "2w"
     },
     "36": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "35"
     },
     "37": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "35"
     },
     "38": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "35"
     },
     "39": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "35"
     },
     "40": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3s"
     },
     "42": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3s"
     },
     "44": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3s"
     },
     "46": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3s"
     },
     "48": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3s"
     },
     "50": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3s"
     },
     "52": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3s"
     },
     "54": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3s"
     },
     "56": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3s"
     },
     "58": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3s"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[1:intro:Paragraph]",
@@ -498,348 +498,356 @@
       "~k_parent": "1x"
     },
     "2a": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "21"
     },
     "2b": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "21"
     },
     "2c": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "20"
+      "key": "root.types.blocks.List",
+      "~k_parent": "21"
     },
     "2d": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "21"
     },
     "2e": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "21"
     },
     "2f": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "20"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "21"
     },
     "2g": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "21"
     },
     "2h": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "21"
     },
     "2i": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "21"
     },
     "2j": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "21"
     },
     "2k": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "21"
     },
     "2l": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "21"
     },
     "2m": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "21"
+    },
+    "2n": {
       "key": "root.types.connections",
       "~k_parent": "1s"
     },
-    "2n": {
+    "2o": {
       "key": "root.types.requests",
       "~k_parent": "1s"
     },
-    "2o": {
+    "2p": {
       "key": "root.types.websockets",
       "~k_parent": "1s"
     },
-    "2p": {
+    "2q": {
       "key": "root.types.api",
       "~k_parent": "1s"
     },
-    "2q": {
+    "2r": {
       "key": "root.types.operators",
       "~k_parent": "1s"
     },
-    "2r": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2r"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2q"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2s"
     },
     "2v": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2r"
+    },
+    "2w": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2w": {
-      "key": "root.imports.actions",
-      "~k_parent": "2v"
-    },
     "2x": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2w"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.agents",
-      "~k_parent": "2v"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2x"
     },
     "3a": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "35"
     },
     "3b": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "35"
     },
     "3c": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "35"
     },
     "3d": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "35"
     },
     "3e": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "35"
     },
     "3f": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "35"
     },
     "3g": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "35"
     },
     "3h": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "35"
     },
     "3i": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "35"
     },
     "3j": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "35"
     },
     "3k": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "35"
     },
     "3l": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "35"
     },
     "3m": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "35"
     },
     "3n": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "35"
     },
     "3o": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "35"
     },
     "3p": {
-      "key": "root.imports.connections",
-      "~k_parent": "2v"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "35"
     },
     "3q": {
-      "key": "root.imports.icons",
-      "~k_parent": "2v"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "35"
     },
     "3r": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3q"
+      "key": "root.imports.connections",
+      "~k_parent": "2w"
     },
     "3s": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3r"
+      "key": "root.imports.icons",
+      "~k_parent": "2w"
     },
     "3t": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3s"
     },
     "3w": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3s"
     },
     "3y": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3s"
     },
     "4a": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3s"
     },
     "4c": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3s"
     },
     "4e": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3s"
     },
     "4g": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3s"
     },
     "4i": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3s"
     },
     "4k": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3s"
     },
     "4m": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3s"
     },
     "4o": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3s"
     },
     "4q": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3s"
     },
     "4s": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3s"
     },
     "4u": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3s"
     },
     "4w": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3s"
     },
     "4y": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3s"
     },
     "5a": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.requests",
-      "~k_parent": "2v"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3s"
     },
     "5c": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2v"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.operators",
-      "~k_parent": "2v"
+      "key": "root.imports.requests",
+      "~k_parent": "2w"
     },
     "5e": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5d"
+      "key": "root.imports.websockets",
+      "~k_parent": "2w"
     },
     "5f": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5e"
+      "key": "root.imports.operators",
+      "~k_parent": "2w"
     },
     "5g": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5e"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5f"
     },
     "5h": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5g"
+    },
+    "5i": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5g"
+    },
+    "5j": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5d"
+      "~k_parent": "5f"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1077,6 +1085,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5571,6 +5580,9 @@
       "providers": {
         "~k": "1z"
       },
+      "strategies": {
+        "~k": "20"
+      },
       "~k": "1x"
     },
     "blocks": {
@@ -5578,141 +5590,141 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "21"
+        "~k": "22"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "24"
+        "~k": "25"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
-      "~k": "20"
+      "~k": "21"
     },
     "connections": {
-      "~k": "2m"
-    },
-    "requests": {
       "~k": "2n"
     },
-    "websockets": {
+    "requests": {
       "~k": "2o"
     },
-    "api": {
+    "websockets": {
       "~k": "2p"
+    },
+    "api": {
+      "~k": "2q"
     },
     "operators": {
       "client": {
@@ -5720,20 +5732,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2s"
+          "~k": "2t"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2t"
+          "~k": "2u"
         },
-        "~k": "2r"
+        "~k": "2s"
       },
       "server": {
-        "~k": "2u"
+        "~k": "2v"
       },
-      "~k": "2q"
+      "~k": "2r"
     },
     "~k": "1s"
   }

--- a/packages/build/src/tests/success/10-page-with-nested-blocks/snapshot.json
+++ b/packages/build/src/tests/success/10-page-with-nested-blocks/snapshot.json
@@ -154,140 +154,140 @@
       "~k_parent": "23"
     },
     "26": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "23"
+    },
+    "27": {
       "key": "root.types.blocks",
       "~k_parent": "1y"
     },
-    "27": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "26"
-    },
     "28": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "27"
     },
     "29": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "27"
     },
     "30": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2w"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2y"
     },
     "31": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2x"
+    },
+    "32": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "32": {
-      "key": "root.imports.actions",
-      "~k_parent": "31"
-    },
     "33": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "32"
     },
     "34": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "32"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "33"
     },
     "35": {
-      "key": "root.imports.agents",
-      "~k_parent": "31"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "33"
     },
     "36": {
-      "key": "root.imports.auth",
-      "~k_parent": "31"
+      "key": "root.imports.agents",
+      "~k_parent": "32"
     },
     "37": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "36"
+      "key": "root.imports.auth",
+      "~k_parent": "32"
     },
     "38": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "36"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "37"
     },
     "39": {
-      "key": "root.imports.blocks",
-      "~k_parent": "31"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "37"
     },
     "40": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3y"
     },
     "42": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3y"
     },
     "44": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3y"
     },
     "46": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3y"
     },
     "48": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3y"
     },
     "50": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3y"
     },
     "52": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3y"
     },
     "54": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3y"
     },
     "56": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3y"
     },
     "58": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3y"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[0:container:Box].blocks[0:inner1:Title]",
@@ -500,372 +500,380 @@
       "~k_parent": "1y"
     },
     "2a": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "27"
     },
     "2b": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "27"
     },
     "2c": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "27"
     },
     "2d": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "27"
     },
     "2e": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "26"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "27"
     },
     "2f": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "27"
     },
     "2g": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "27"
     },
     "2h": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "27"
     },
     "2i": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "26"
+      "key": "root.types.blocks.List",
+      "~k_parent": "27"
     },
     "2j": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "27"
     },
     "2k": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "27"
     },
     "2l": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "26"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "27"
     },
     "2m": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "27"
     },
     "2n": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "26"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "27"
     },
     "2o": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "26"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "27"
     },
     "2p": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "26"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "27"
     },
     "2q": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "26"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "27"
     },
     "2r": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "26"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "27"
     },
     "2s": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "27"
+    },
+    "2t": {
       "key": "root.types.connections",
       "~k_parent": "1y"
     },
-    "2t": {
+    "2u": {
       "key": "root.types.requests",
       "~k_parent": "1y"
     },
-    "2u": {
+    "2v": {
       "key": "root.types.websockets",
       "~k_parent": "1y"
     },
-    "2v": {
+    "2w": {
       "key": "root.types.api",
       "~k_parent": "1y"
     },
-    "2w": {
+    "2x": {
       "key": "root.types.operators",
       "~k_parent": "1y"
     },
-    "2x": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2w"
-    },
     "2y": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2x"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "39"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "37"
     },
     "3b": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks",
+      "~k_parent": "32"
     },
     "3c": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3b"
     },
     "3e": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3b"
     },
     "3f": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3b"
     },
     "3g": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3b"
     },
     "3h": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3b"
     },
     "3i": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3b"
     },
     "3j": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3b"
     },
     "3k": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3b"
     },
     "3l": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3b"
     },
     "3m": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3b"
     },
     "3n": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3b"
     },
     "3o": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3b"
     },
     "3p": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3b"
     },
     "3q": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3b"
     },
     "3r": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3b"
     },
     "3s": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3b"
     },
     "3t": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3b"
     },
     "3u": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3b"
     },
     "3v": {
-      "key": "root.imports.connections",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3b"
     },
     "3w": {
-      "key": "root.imports.icons",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "3b"
     },
     "3x": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3w"
+      "key": "root.imports.connections",
+      "~k_parent": "32"
     },
     "3y": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3x"
+      "key": "root.imports.icons",
+      "~k_parent": "32"
     },
     "3z": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3y"
     },
     "4c": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3y"
     },
     "4e": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3y"
     },
     "4g": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3y"
     },
     "4i": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3y"
     },
     "4k": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3y"
     },
     "4m": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3y"
     },
     "4o": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3y"
     },
     "4q": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3y"
     },
     "4s": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3y"
     },
     "4u": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3y"
     },
     "4w": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3y"
     },
     "4y": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3y"
     },
     "5a": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3y"
     },
     "5c": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3y"
     },
     "5e": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3y"
     },
     "5g": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.requests",
-      "~k_parent": "31"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3y"
     },
     "5i": {
-      "key": "root.imports.websockets",
-      "~k_parent": "31"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.operators",
-      "~k_parent": "31"
+      "key": "root.imports.requests",
+      "~k_parent": "32"
     },
     "5k": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5j"
+      "key": "root.imports.websockets",
+      "~k_parent": "32"
     },
     "5l": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5k"
+      "key": "root.imports.operators",
+      "~k_parent": "32"
     },
     "5m": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5k"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5l"
     },
     "5n": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5m"
+    },
+    "5o": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5m"
+    },
+    "5p": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5j"
+      "~k_parent": "5l"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1127,6 +1135,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5621,6 +5630,9 @@
       "providers": {
         "~k": "25"
       },
+      "strategies": {
+        "~k": "26"
+      },
       "~k": "23"
     },
     "blocks": {
@@ -5628,141 +5640,141 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "27"
+        "~k": "28"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
-      "~k": "26"
+      "~k": "27"
     },
     "connections": {
-      "~k": "2s"
-    },
-    "requests": {
       "~k": "2t"
     },
-    "websockets": {
+    "requests": {
       "~k": "2u"
     },
-    "api": {
+    "websockets": {
       "~k": "2v"
+    },
+    "api": {
+      "~k": "2w"
     },
     "operators": {
       "client": {
@@ -5770,20 +5782,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2y"
+          "~k": "2z"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2z"
+          "~k": "30"
         },
-        "~k": "2x"
+        "~k": "2y"
       },
       "server": {
-        "~k": "30"
+        "~k": "31"
       },
-      "~k": "2w"
+      "~k": "2x"
     },
     "~k": "1y"
   }

--- a/packages/build/src/tests/success/11-page-with-areas/snapshot.json
+++ b/packages/build/src/tests/success/11-page-with-areas/snapshot.json
@@ -130,164 +130,164 @@
       "~k_parent": "r"
     },
     "20": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1x"
+    },
+    "21": {
       "key": "root.types.blocks",
       "~k_parent": "1s"
     },
-    "21": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "20"
-    },
     "22": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "21"
     },
     "23": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "21"
     },
     "24": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "21"
     },
     "25": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "21"
     },
     "26": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "21"
     },
     "27": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "21"
     },
     "28": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "21"
     },
     "29": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "20"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "21"
     },
     "30": {
-      "key": "root.imports.agents",
-      "~k_parent": "2w"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2y"
     },
     "31": {
-      "key": "root.imports.auth",
-      "~k_parent": "2w"
+      "key": "root.imports.agents",
+      "~k_parent": "2x"
     },
     "32": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "31"
+      "key": "root.imports.auth",
+      "~k_parent": "2x"
     },
     "33": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "31"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2w"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "32"
     },
     "35": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "34"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "32"
     },
     "36": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks",
+      "~k_parent": "2x"
     },
     "37": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "36"
     },
     "38": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "36"
     },
     "39": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "36"
     },
     "40": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3u"
     },
     "42": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3u"
     },
     "44": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3u"
     },
     "46": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3u"
     },
     "48": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3u"
     },
     "50": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3u"
     },
     "52": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3u"
     },
     "54": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3u"
     },
     "56": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3u"
     },
     "58": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3u"
     },
     "a": {
       "key": "root.pages[0:home:Card].areas.title.blocks[0:cardTitle:Title]",
@@ -500,356 +500,364 @@
       "~k_parent": "1x"
     },
     "2a": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "21"
     },
     "2b": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "21"
     },
     "2c": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "21"
     },
     "2d": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "20"
+      "key": "root.types.blocks.List",
+      "~k_parent": "21"
     },
     "2e": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "21"
     },
     "2f": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "21"
     },
     "2g": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "20"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "21"
     },
     "2h": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "21"
     },
     "2i": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "21"
     },
     "2j": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "21"
     },
     "2k": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "21"
     },
     "2l": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "21"
     },
     "2m": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "21"
     },
     "2n": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "21"
+    },
+    "2o": {
       "key": "root.types.connections",
       "~k_parent": "1s"
     },
-    "2o": {
+    "2p": {
       "key": "root.types.requests",
       "~k_parent": "1s"
     },
-    "2p": {
+    "2q": {
       "key": "root.types.websockets",
       "~k_parent": "1s"
     },
-    "2q": {
+    "2r": {
       "key": "root.types.api",
       "~k_parent": "1s"
     },
-    "2r": {
+    "2s": {
       "key": "root.types.operators",
       "~k_parent": "1s"
     },
-    "2s": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2r"
-    },
     "2t": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2s"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2r"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2t"
     },
     "2w": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2s"
+    },
+    "2x": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2x": {
-      "key": "root.imports.actions",
-      "~k_parent": "2w"
-    },
     "2y": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2x"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "36"
     },
     "3b": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "36"
     },
     "3c": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "36"
     },
     "3d": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "36"
     },
     "3e": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "36"
     },
     "3f": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "36"
     },
     "3g": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "36"
     },
     "3h": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "36"
     },
     "3i": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "36"
     },
     "3j": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "36"
     },
     "3k": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "36"
     },
     "3l": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "36"
     },
     "3m": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "36"
     },
     "3n": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "36"
     },
     "3o": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "36"
     },
     "3p": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "36"
     },
     "3q": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "36"
     },
     "3r": {
-      "key": "root.imports.connections",
-      "~k_parent": "2w"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "36"
     },
     "3s": {
-      "key": "root.imports.icons",
-      "~k_parent": "2w"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "36"
     },
     "3t": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3s"
+      "key": "root.imports.connections",
+      "~k_parent": "2x"
     },
     "3u": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3t"
+      "key": "root.imports.icons",
+      "~k_parent": "2x"
     },
     "3v": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3u"
     },
     "3y": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3u"
     },
     "4a": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3u"
     },
     "4c": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3u"
     },
     "4e": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3u"
     },
     "4g": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3u"
     },
     "4i": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3u"
     },
     "4k": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3u"
     },
     "4m": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3u"
     },
     "4o": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3u"
     },
     "4q": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3u"
     },
     "4s": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3u"
     },
     "4u": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3u"
     },
     "4w": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3u"
     },
     "4y": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3u"
     },
     "5a": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3u"
     },
     "5c": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.requests",
-      "~k_parent": "2w"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3u"
     },
     "5e": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2w"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.operators",
-      "~k_parent": "2w"
+      "key": "root.imports.requests",
+      "~k_parent": "2x"
     },
     "5g": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5f"
+      "key": "root.imports.websockets",
+      "~k_parent": "2x"
     },
     "5h": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5g"
+      "key": "root.imports.operators",
+      "~k_parent": "2x"
     },
     "5i": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5g"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5h"
     },
     "5j": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5i"
+    },
+    "5k": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5i"
+    },
+    "5l": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5f"
+      "~k_parent": "5h"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1085,6 +1093,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Card": {
       "category": "container"
@@ -6069,6 +6078,9 @@
       "providers": {
         "~k": "1z"
       },
+      "strategies": {
+        "~k": "20"
+      },
       "~k": "1x"
     },
     "blocks": {
@@ -6076,147 +6088,147 @@
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
-      "~k": "20"
+      "~k": "21"
     },
     "connections": {
-      "~k": "2n"
-    },
-    "requests": {
       "~k": "2o"
     },
-    "websockets": {
+    "requests": {
       "~k": "2p"
     },
-    "api": {
+    "websockets": {
       "~k": "2q"
+    },
+    "api": {
+      "~k": "2r"
     },
     "operators": {
       "client": {
@@ -6224,20 +6236,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2t"
+          "~k": "2u"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2u"
+          "~k": "2v"
         },
-        "~k": "2s"
+        "~k": "2t"
       },
       "server": {
-        "~k": "2v"
+        "~k": "2w"
       },
-      "~k": "2r"
+      "~k": "2s"
     },
     "~k": "1s"
   }

--- a/packages/build/src/tests/success/12-page-with-content-area/snapshot.json
+++ b/packages/build/src/tests/success/12-page-with-content-area/snapshot.json
@@ -134,164 +134,164 @@
       "~k_parent": "12"
     },
     "20": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1x"
     },
     "21": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1x"
     },
     "22": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1x"
     },
     "23": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1x"
     },
     "24": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1x"
     },
     "25": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1x"
     },
     "26": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1x"
     },
     "27": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1x"
     },
     "28": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1x"
     },
     "29": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1x"
     },
     "30": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks",
+      "~k_parent": "2r"
     },
     "31": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "30"
     },
     "32": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "30"
     },
     "33": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "30"
     },
     "34": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "30"
     },
     "35": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "30"
     },
     "36": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "30"
     },
     "37": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "30"
     },
     "38": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "30"
     },
     "39": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "30"
     },
     "40": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3m"
     },
     "42": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3m"
     },
     "44": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3m"
     },
     "46": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3m"
     },
     "48": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3m"
     },
     "50": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3m"
     },
     "52": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3m"
     },
     "54": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.requests",
-      "~k_parent": "2q"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3m"
     },
     "56": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2q"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.operators",
-      "~k_parent": "2q"
+      "key": "root.imports.requests",
+      "~k_parent": "2r"
     },
     "58": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "57"
+      "key": "root.imports.websockets",
+      "~k_parent": "2r"
     },
     "59": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "58"
+      "key": "root.imports.operators",
+      "~k_parent": "2r"
     },
     "a": {
       "key": "root.pages[0:home:Box].areas.content.blocks[0:mainContent:Paragraph]",
@@ -480,340 +480,348 @@
       "~k_parent": "1t"
     },
     "1w": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1t"
+    },
+    "1x": {
       "key": "root.types.blocks",
       "~k_parent": "1o"
     },
-    "1x": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1w"
-    },
     "1y": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1x"
     },
     "1z": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "1x"
     },
     "2a": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1x"
     },
     "2b": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1x"
     },
     "2c": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1x"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1x"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1x"
     },
     "2f": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1x"
     },
     "2g": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1x"
     },
     "2h": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1x"
+    },
+    "2i": {
       "key": "root.types.connections",
       "~k_parent": "1o"
     },
-    "2i": {
+    "2j": {
       "key": "root.types.requests",
       "~k_parent": "1o"
     },
-    "2j": {
+    "2k": {
       "key": "root.types.websockets",
       "~k_parent": "1o"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.api",
       "~k_parent": "1o"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.operators",
       "~k_parent": "1o"
     },
-    "2m": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2l"
-    },
     "2n": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2m"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2l"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2n"
     },
     "2q": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2m"
+    },
+    "2r": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2r": {
-      "key": "root.imports.actions",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2r"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.imports.agents",
-      "~k_parent": "2q"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2s"
     },
     "2v": {
-      "key": "root.imports.auth",
-      "~k_parent": "2q"
+      "key": "root.imports.agents",
+      "~k_parent": "2r"
     },
     "2w": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2v"
+      "key": "root.imports.auth",
+      "~k_parent": "2r"
     },
     "2x": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2v"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2q"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2w"
     },
     "2z": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2y"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2w"
     },
     "3a": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "30"
     },
     "3b": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "30"
     },
     "3c": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "30"
     },
     "3d": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "30"
     },
     "3e": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "30"
     },
     "3f": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "30"
     },
     "3g": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "30"
     },
     "3h": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "30"
     },
     "3i": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "30"
     },
     "3j": {
-      "key": "root.imports.connections",
-      "~k_parent": "2q"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "30"
     },
     "3k": {
-      "key": "root.imports.icons",
-      "~k_parent": "2q"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "30"
     },
     "3l": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3k"
+      "key": "root.imports.connections",
+      "~k_parent": "2r"
     },
     "3m": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3l"
+      "key": "root.imports.icons",
+      "~k_parent": "2r"
     },
     "3n": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3m"
     },
     "3u": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3m"
     },
     "3w": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3m"
     },
     "3y": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3m"
     },
     "4a": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3m"
     },
     "4c": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3m"
     },
     "4e": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3m"
     },
     "4g": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3m"
     },
     "4i": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3m"
     },
     "4k": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3m"
     },
     "4m": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3m"
     },
     "4o": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3m"
     },
     "4q": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3m"
     },
     "4s": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3m"
     },
     "4u": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3m"
     },
     "4w": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3m"
     },
     "4y": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3m"
     },
     "5a": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "58"
+      "key": "root.imports.operators.client",
+      "~k_parent": "59"
     },
     "5b": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5a"
+    },
+    "5c": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5a"
+    },
+    "5d": {
       "key": "root.imports.operators.server",
-      "~k_parent": "57"
+      "~k_parent": "59"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1031,6 +1039,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5525,6 +5534,9 @@
       "providers": {
         "~k": "1v"
       },
+      "strategies": {
+        "~k": "1w"
+      },
       "~k": "1t"
     },
     "blocks": {
@@ -5532,135 +5544,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
-      "~k": "1w"
+      "~k": "1x"
     },
     "connections": {
-      "~k": "2h"
-    },
-    "requests": {
       "~k": "2i"
     },
-    "websockets": {
+    "requests": {
       "~k": "2j"
     },
-    "api": {
+    "websockets": {
       "~k": "2k"
+    },
+    "api": {
+      "~k": "2l"
     },
     "operators": {
       "client": {
@@ -5668,20 +5680,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2n"
+          "~k": "2o"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2o"
+          "~k": "2p"
         },
-        "~k": "2m"
+        "~k": "2n"
       },
       "server": {
-        "~k": "2p"
+        "~k": "2q"
       },
-      "~k": "2l"
+      "~k": "2m"
     },
     "~k": "1o"
   }

--- a/packages/build/src/tests/success/13-page-with-multiple-areas/snapshot.json
+++ b/packages/build/src/tests/success/13-page-with-multiple-areas/snapshot.json
@@ -146,148 +146,148 @@
       "~k_parent": "21"
     },
     "24": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "21"
+    },
+    "25": {
       "key": "root.types.blocks",
       "~k_parent": "1w"
     },
-    "25": {
-      "key": "root.types.blocks.PageHeaderMenu",
-      "~k_parent": "24"
-    },
     "26": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "24"
+      "key": "root.types.blocks.PageHeaderMenu",
+      "~k_parent": "25"
     },
     "27": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "25"
     },
     "28": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "25"
     },
     "29": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "25"
     },
     "30": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2w"
+    },
+    "31": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "31": {
-      "key": "root.imports.actions",
-      "~k_parent": "30"
-    },
     "32": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "31"
     },
     "33": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "31"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.imports.agents",
-      "~k_parent": "30"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "32"
     },
     "35": {
-      "key": "root.imports.auth",
-      "~k_parent": "30"
+      "key": "root.imports.agents",
+      "~k_parent": "31"
     },
     "36": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "35"
+      "key": "root.imports.auth",
+      "~k_parent": "31"
     },
     "37": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "35"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "36"
     },
     "38": {
-      "key": "root.imports.blocks",
-      "~k_parent": "30"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "36"
     },
     "39": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "38"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "36"
     },
     "40": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3y"
     },
     "42": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3y"
     },
     "44": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3y"
     },
     "46": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3y"
     },
     "48": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3y"
     },
     "50": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3y"
     },
     "52": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3y"
     },
     "54": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3y"
     },
     "56": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3y"
     },
     "58": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3y"
     },
     "a": {
       "key": "root.pages[0:home:PageHeaderMenu].areas.header.blocks[0:logo:Title]",
@@ -504,372 +504,380 @@
       "~k_parent": "1x"
     },
     "2a": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "25"
     },
     "2b": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "25"
     },
     "2c": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "25"
     },
     "2d": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "24"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "25"
     },
     "2e": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "25"
     },
     "2f": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "25"
     },
     "2g": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "25"
     },
     "2h": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "24"
+      "key": "root.types.blocks.List",
+      "~k_parent": "25"
     },
     "2i": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "25"
     },
     "2j": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "25"
     },
     "2k": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "24"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "25"
     },
     "2l": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "25"
     },
     "2m": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "24"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "25"
     },
     "2n": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "24"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "25"
     },
     "2o": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "24"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "25"
     },
     "2p": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "24"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "25"
     },
     "2q": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "25"
     },
     "2r": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "25"
+    },
+    "2s": {
       "key": "root.types.connections",
       "~k_parent": "1w"
     },
-    "2s": {
+    "2t": {
       "key": "root.types.requests",
       "~k_parent": "1w"
     },
-    "2t": {
+    "2u": {
       "key": "root.types.websockets",
       "~k_parent": "1w"
     },
-    "2u": {
+    "2v": {
       "key": "root.types.api",
       "~k_parent": "1w"
     },
-    "2v": {
+    "2w": {
       "key": "root.types.operators",
       "~k_parent": "1w"
     },
-    "2w": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2v"
-    },
     "2x": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2w"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2v"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2x"
     },
     "3a": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks",
+      "~k_parent": "31"
     },
     "3b": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3a"
     },
     "3c": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3a"
     },
     "3d": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3a"
     },
     "3e": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3a"
     },
     "3f": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3a"
     },
     "3g": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3a"
     },
     "3h": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3a"
     },
     "3i": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3a"
     },
     "3j": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3a"
     },
     "3k": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3a"
     },
     "3l": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3a"
     },
     "3m": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3a"
     },
     "3n": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3a"
     },
     "3o": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3a"
     },
     "3p": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3a"
     },
     "3q": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3a"
     },
     "3r": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3a"
     },
     "3s": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3a"
     },
     "3t": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3a"
     },
     "3u": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "38"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3a"
     },
     "3v": {
-      "key": "root.imports.connections",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "3a"
     },
     "3w": {
-      "key": "root.imports.icons",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "3a"
     },
     "3x": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3w"
+      "key": "root.imports.connections",
+      "~k_parent": "31"
     },
     "3y": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3x"
+      "key": "root.imports.icons",
+      "~k_parent": "31"
     },
     "3z": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3y"
     },
     "4c": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3y"
     },
     "4e": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3y"
     },
     "4g": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3y"
     },
     "4i": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3y"
     },
     "4k": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3y"
     },
     "4m": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3y"
     },
     "4o": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3y"
     },
     "4q": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3y"
     },
     "4s": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3y"
     },
     "4u": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3y"
     },
     "4w": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3y"
     },
     "4y": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3y"
     },
     "5a": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3y"
     },
     "5c": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3y"
     },
     "5e": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3y"
     },
     "5g": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.requests",
-      "~k_parent": "30"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3y"
     },
     "5i": {
-      "key": "root.imports.websockets",
-      "~k_parent": "30"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.operators",
-      "~k_parent": "30"
+      "key": "root.imports.requests",
+      "~k_parent": "31"
     },
     "5k": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5j"
+      "key": "root.imports.websockets",
+      "~k_parent": "31"
     },
     "5l": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5k"
+      "key": "root.imports.operators",
+      "~k_parent": "31"
     },
     "5m": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5k"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5l"
     },
     "5n": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5m"
+    },
+    "5o": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5m"
+    },
+    "5p": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5j"
+      "~k_parent": "5l"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1123,6 +1131,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "PageHeaderMenu": {
       "category": "container"
@@ -6926,6 +6935,9 @@
       "providers": {
         "~k": "23"
       },
+      "strategies": {
+        "~k": "24"
+      },
       "~k": "21"
     },
     "blocks": {
@@ -6933,147 +6945,147 @@
         "originalTypeName": "PageHeaderMenu",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "27"
+        "~k": "28"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
-      "~k": "24"
+      "~k": "25"
     },
     "connections": {
-      "~k": "2r"
-    },
-    "requests": {
       "~k": "2s"
     },
-    "websockets": {
+    "requests": {
       "~k": "2t"
     },
-    "api": {
+    "websockets": {
       "~k": "2u"
+    },
+    "api": {
+      "~k": "2v"
     },
     "operators": {
       "client": {
@@ -7081,20 +7093,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2x"
+          "~k": "2y"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2y"
+          "~k": "2z"
         },
-        "~k": "2w"
+        "~k": "2x"
       },
       "server": {
-        "~k": "2z"
+        "~k": "30"
       },
-      "~k": "2v"
+      "~k": "2w"
     },
     "~k": "1w"
   }

--- a/packages/build/src/tests/success/14-page-with-events-onInit/snapshot.json
+++ b/packages/build/src/tests/success/14-page-with-events-onInit/snapshot.json
@@ -134,164 +134,164 @@
       "~k_parent": "13"
     },
     "20": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1z"
     },
     "21": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1z"
     },
     "22": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1z"
     },
     "23": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1z"
     },
     "24": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1z"
     },
     "25": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1z"
     },
     "26": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1z"
     },
     "27": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1z"
     },
     "28": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1z"
     },
     "29": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1z"
     },
     "30": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2r"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2y"
     },
     "31": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "30"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2y"
     },
     "32": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks",
+      "~k_parent": "2s"
     },
     "33": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "32"
     },
     "35": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "32"
     },
     "36": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "32"
     },
     "37": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "32"
     },
     "38": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "32"
     },
     "39": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "32"
     },
     "40": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3n"
     },
     "41": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3n"
     },
     "43": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3n"
     },
     "45": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3n"
     },
     "47": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3n"
     },
     "49": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3n"
     },
     "51": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3n"
     },
     "53": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3n"
     },
     "55": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.requests",
-      "~k_parent": "2r"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3n"
     },
     "57": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2r"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.operators",
-      "~k_parent": "2r"
+      "key": "root.imports.requests",
+      "~k_parent": "2s"
     },
     "59": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "58"
+      "key": "root.imports.websockets",
+      "~k_parent": "2s"
     },
     "a": {
       "key": "root.pages[0:home:Box].events.onInit[0:initState:SetState].params",
@@ -487,336 +487,344 @@
       "~k_parent": "1v"
     },
     "1y": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1v"
+    },
+    "1z": {
       "key": "root.types.blocks",
       "~k_parent": "1p"
     },
-    "1z": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1y"
-    },
     "2a": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1z"
     },
     "2b": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1z"
     },
     "2c": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1z"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1z"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1z"
     },
     "2f": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1z"
     },
     "2g": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1z"
     },
     "2h": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1z"
     },
     "2i": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1z"
+    },
+    "2j": {
       "key": "root.types.connections",
       "~k_parent": "1p"
     },
-    "2j": {
+    "2k": {
       "key": "root.types.requests",
       "~k_parent": "1p"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.websockets",
       "~k_parent": "1p"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.api",
       "~k_parent": "1p"
     },
-    "2m": {
+    "2n": {
       "key": "root.types.operators",
       "~k_parent": "1p"
     },
-    "2n": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2m"
-    },
     "2o": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2n"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2o"
     },
     "2q": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2m"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2o"
     },
     "2r": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2n"
+    },
+    "2s": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2s": {
-      "key": "root.imports.actions",
-      "~k_parent": "2r"
-    },
     "2t": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "2s"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2t"
     },
     "2w": {
-      "key": "root.imports.agents",
-      "~k_parent": "2r"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "2t"
     },
     "2x": {
-      "key": "root.imports.auth",
-      "~k_parent": "2r"
+      "key": "root.imports.agents",
+      "~k_parent": "2s"
     },
     "2y": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2x"
+      "key": "root.imports.auth",
+      "~k_parent": "2s"
     },
     "2z": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2x"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "32"
     },
     "3b": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "32"
     },
     "3c": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "32"
     },
     "3d": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "32"
     },
     "3e": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "32"
     },
     "3f": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "32"
     },
     "3g": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "32"
     },
     "3h": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "32"
     },
     "3i": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "32"
     },
     "3j": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "32"
     },
     "3k": {
-      "key": "root.imports.connections",
-      "~k_parent": "2r"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "32"
     },
     "3l": {
-      "key": "root.imports.icons",
-      "~k_parent": "2r"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "32"
     },
     "3m": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3l"
+      "key": "root.imports.connections",
+      "~k_parent": "2s"
     },
     "3n": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3m"
+      "key": "root.imports.icons",
+      "~k_parent": "2s"
     },
     "3o": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3n"
     },
     "3r": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3n"
     },
     "3t": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3n"
     },
     "3v": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3n"
     },
     "3x": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3n"
     },
     "3z": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3n"
     },
     "4b": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3n"
     },
     "4d": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3n"
     },
     "4f": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3n"
     },
     "4h": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3n"
     },
     "4j": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3n"
     },
     "4l": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3n"
     },
     "4n": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3n"
     },
     "4p": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3n"
     },
     "4r": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3n"
     },
     "4t": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3n"
     },
     "4v": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3n"
     },
     "4x": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3n"
     },
     "4z": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "59"
+      "key": "root.imports.operators",
+      "~k_parent": "2s"
     },
     "5b": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "59"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5a"
     },
     "5c": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5b"
+    },
+    "5d": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5b"
+    },
+    "5e": {
       "key": "root.imports.operators.server",
-      "~k_parent": "58"
+      "~k_parent": "5a"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1044,6 +1052,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5544,6 +5553,9 @@
       "providers": {
         "~k": "1x"
       },
+      "strategies": {
+        "~k": "1y"
+      },
       "~k": "1v"
     },
     "blocks": {
@@ -5551,129 +5563,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1z"
+        "~k": "20"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
-      "~k": "1y"
+      "~k": "1z"
     },
     "connections": {
-      "~k": "2i"
-    },
-    "requests": {
       "~k": "2j"
     },
-    "websockets": {
+    "requests": {
       "~k": "2k"
     },
-    "api": {
+    "websockets": {
       "~k": "2l"
+    },
+    "api": {
+      "~k": "2m"
     },
     "operators": {
       "client": {
@@ -5681,20 +5693,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2o"
+          "~k": "2p"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2p"
+          "~k": "2q"
         },
-        "~k": "2n"
+        "~k": "2o"
       },
       "server": {
-        "~k": "2q"
+        "~k": "2r"
       },
-      "~k": "2m"
+      "~k": "2n"
     },
     "~k": "1p"
   }

--- a/packages/build/src/tests/success/15-page-with-events-onMount/snapshot.json
+++ b/packages/build/src/tests/success/15-page-with-events-onMount/snapshot.json
@@ -146,152 +146,152 @@
       "~k_parent": "20"
     },
     "23": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "20"
+    },
+    "24": {
       "key": "root.types.blocks",
       "~k_parent": "1u"
     },
-    "24": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "23"
-    },
     "25": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "24"
     },
     "26": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "24"
     },
     "27": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "24"
     },
     "28": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "24"
     },
     "29": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "23"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "24"
     },
     "30": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "2x"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2y"
     },
     "31": {
-      "key": "root.imports.agents",
-      "~k_parent": "2w"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "2y"
     },
     "32": {
-      "key": "root.imports.auth",
-      "~k_parent": "2w"
+      "key": "root.imports.agents",
+      "~k_parent": "2x"
     },
     "33": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "32"
+      "key": "root.imports.auth",
+      "~k_parent": "2x"
     },
     "34": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "32"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "33"
     },
     "35": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2w"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "33"
     },
     "36": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "35"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "33"
     },
     "37": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks",
+      "~k_parent": "2x"
     },
     "38": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "37"
     },
     "39": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "37"
     },
     "40": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3s"
     },
     "42": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3s"
     },
     "44": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3s"
     },
     "46": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3s"
     },
     "48": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3s"
     },
     "50": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3s"
     },
     "52": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3s"
     },
     "54": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3s"
     },
     "56": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3s"
     },
     "58": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3s"
     },
     "a": {
       "key": "root.pages[0:home:Box].events.onMount[0:mountAction:SetState].params",
@@ -498,348 +498,356 @@
       "~k_parent": "1u"
     },
     "2a": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "24"
     },
     "2b": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "24"
     },
     "2c": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "24"
     },
     "2d": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "23"
+      "key": "root.types.blocks.List",
+      "~k_parent": "24"
     },
     "2e": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "24"
     },
     "2f": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "24"
     },
     "2g": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "23"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "24"
     },
     "2h": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "24"
     },
     "2i": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "23"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "24"
     },
     "2j": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "23"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "24"
     },
     "2k": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "23"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "24"
     },
     "2l": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "23"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "24"
     },
     "2m": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "24"
     },
     "2n": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "24"
+    },
+    "2o": {
       "key": "root.types.connections",
       "~k_parent": "1u"
     },
-    "2o": {
+    "2p": {
       "key": "root.types.requests",
       "~k_parent": "1u"
     },
-    "2p": {
+    "2q": {
       "key": "root.types.websockets",
       "~k_parent": "1u"
     },
-    "2q": {
+    "2r": {
       "key": "root.types.api",
       "~k_parent": "1u"
     },
-    "2r": {
+    "2s": {
       "key": "root.types.operators",
       "~k_parent": "1u"
     },
-    "2s": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2r"
-    },
     "2t": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2s"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2r"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2t"
     },
     "2w": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2s"
+    },
+    "2x": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2x": {
-      "key": "root.imports.actions",
-      "~k_parent": "2w"
-    },
     "2y": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2x"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "37"
     },
     "3b": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "37"
     },
     "3c": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "37"
     },
     "3d": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "37"
     },
     "3e": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "37"
     },
     "3f": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "37"
     },
     "3g": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "37"
     },
     "3h": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "37"
     },
     "3i": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "37"
     },
     "3j": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "37"
     },
     "3k": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "37"
     },
     "3l": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "37"
     },
     "3m": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "37"
     },
     "3n": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "37"
     },
     "3o": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "37"
     },
     "3p": {
-      "key": "root.imports.connections",
-      "~k_parent": "2w"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "37"
     },
     "3q": {
-      "key": "root.imports.icons",
-      "~k_parent": "2w"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "37"
     },
     "3r": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3q"
+      "key": "root.imports.connections",
+      "~k_parent": "2x"
     },
     "3s": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3r"
+      "key": "root.imports.icons",
+      "~k_parent": "2x"
     },
     "3t": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3s"
     },
     "3w": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3s"
     },
     "3y": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3s"
     },
     "4a": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3s"
     },
     "4c": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3s"
     },
     "4e": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3s"
     },
     "4g": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3s"
     },
     "4i": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3s"
     },
     "4k": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3s"
     },
     "4m": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3s"
     },
     "4o": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3s"
     },
     "4q": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3s"
     },
     "4s": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3s"
     },
     "4u": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3s"
     },
     "4w": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3s"
     },
     "4y": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3s"
     },
     "5a": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.requests",
-      "~k_parent": "2w"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3s"
     },
     "5c": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2w"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.operators",
-      "~k_parent": "2w"
+      "key": "root.imports.requests",
+      "~k_parent": "2x"
     },
     "5e": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5d"
+      "key": "root.imports.websockets",
+      "~k_parent": "2x"
     },
     "5f": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5e"
+      "key": "root.imports.operators",
+      "~k_parent": "2x"
     },
     "5g": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5e"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5f"
     },
     "5h": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5g"
+    },
+    "5i": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5g"
+    },
+    "5j": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5d"
+      "~k_parent": "5f"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1088,6 +1096,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5588,6 +5597,9 @@
       "providers": {
         "~k": "22"
       },
+      "strategies": {
+        "~k": "23"
+      },
       "~k": "20"
     },
     "blocks": {
@@ -5595,129 +5607,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "24"
+        "~k": "25"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
-      "~k": "23"
+      "~k": "24"
     },
     "connections": {
-      "~k": "2n"
-    },
-    "requests": {
       "~k": "2o"
     },
-    "websockets": {
+    "requests": {
       "~k": "2p"
     },
-    "api": {
+    "websockets": {
       "~k": "2q"
+    },
+    "api": {
+      "~k": "2r"
     },
     "operators": {
       "client": {
@@ -5725,20 +5737,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2t"
+          "~k": "2u"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2u"
+          "~k": "2v"
         },
-        "~k": "2s"
+        "~k": "2t"
       },
       "server": {
-        "~k": "2v"
+        "~k": "2w"
       },
-      "~k": "2r"
+      "~k": "2s"
     },
     "~k": "1u"
   }

--- a/packages/build/src/tests/success/16-page-with-layout-span/snapshot.json
+++ b/packages/build/src/tests/success/16-page-with-layout-span/snapshot.json
@@ -134,164 +134,164 @@
       "~k_parent": "14"
     },
     "20": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1z"
     },
     "21": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1z"
     },
     "22": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1z"
     },
     "23": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1z"
     },
     "24": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1z"
     },
     "25": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1z"
     },
     "26": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1z"
     },
     "27": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1z"
     },
     "28": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1z"
     },
     "29": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1z"
     },
     "30": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2z"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2x"
     },
     "31": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks",
+      "~k_parent": "2s"
     },
     "32": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "31"
     },
     "33": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "31"
     },
     "34": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "31"
     },
     "35": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "31"
     },
     "36": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "31"
     },
     "37": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "31"
     },
     "38": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "31"
     },
     "39": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "31"
     },
     "40": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3m"
     },
     "42": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3m"
     },
     "44": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3m"
     },
     "46": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3m"
     },
     "48": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3m"
     },
     "50": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3m"
     },
     "52": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3m"
     },
     "54": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.requests",
-      "~k_parent": "2r"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3m"
     },
     "56": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2r"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.operators",
-      "~k_parent": "2r"
+      "key": "root.imports.requests",
+      "~k_parent": "2s"
     },
     "58": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "57"
+      "key": "root.imports.websockets",
+      "~k_parent": "2s"
     },
     "59": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "58"
+      "key": "root.imports.operators",
+      "~k_parent": "2s"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[1:col2:Box]",
@@ -488,332 +488,340 @@
       "~k_parent": "1v"
     },
     "1y": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1v"
+    },
+    "1z": {
       "key": "root.types.blocks",
       "~k_parent": "1q"
     },
-    "1z": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1y"
-    },
     "2a": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1z"
     },
     "2b": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1z"
     },
     "2c": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1z"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1z"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1z"
     },
     "2f": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1z"
     },
     "2g": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1z"
     },
     "2h": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1z"
     },
     "2i": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1z"
+    },
+    "2j": {
       "key": "root.types.connections",
       "~k_parent": "1q"
     },
-    "2j": {
+    "2k": {
       "key": "root.types.requests",
       "~k_parent": "1q"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.websockets",
       "~k_parent": "1q"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.api",
       "~k_parent": "1q"
     },
-    "2m": {
+    "2n": {
       "key": "root.types.operators",
       "~k_parent": "1q"
     },
-    "2n": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2m"
-    },
     "2o": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2n"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2o"
     },
     "2q": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2m"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2o"
     },
     "2r": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2n"
+    },
+    "2s": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2s": {
-      "key": "root.imports.actions",
-      "~k_parent": "2r"
-    },
     "2t": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.imports.agents",
-      "~k_parent": "2r"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2t"
     },
     "2w": {
-      "key": "root.imports.auth",
-      "~k_parent": "2r"
+      "key": "root.imports.agents",
+      "~k_parent": "2s"
     },
     "2x": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2w"
+      "key": "root.imports.auth",
+      "~k_parent": "2s"
     },
     "2y": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2w"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2r"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2x"
     },
     "3a": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "31"
     },
     "3b": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "31"
     },
     "3c": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "31"
     },
     "3d": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "31"
     },
     "3e": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "31"
     },
     "3f": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "31"
     },
     "3g": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "31"
     },
     "3h": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "31"
     },
     "3i": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "31"
     },
     "3j": {
-      "key": "root.imports.connections",
-      "~k_parent": "2r"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "31"
     },
     "3k": {
-      "key": "root.imports.icons",
-      "~k_parent": "2r"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "31"
     },
     "3l": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3k"
+      "key": "root.imports.connections",
+      "~k_parent": "2s"
     },
     "3m": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3l"
+      "key": "root.imports.icons",
+      "~k_parent": "2s"
     },
     "3n": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3m"
     },
     "3u": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3m"
     },
     "3w": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3m"
     },
     "3y": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3m"
     },
     "4a": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3m"
     },
     "4c": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3m"
     },
     "4e": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3m"
     },
     "4g": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3m"
     },
     "4i": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3m"
     },
     "4k": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3m"
     },
     "4m": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3m"
     },
     "4o": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3m"
     },
     "4q": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3m"
     },
     "4s": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3m"
     },
     "4u": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3m"
     },
     "4w": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3m"
     },
     "4y": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3m"
     },
     "5a": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "58"
+      "key": "root.imports.operators.client",
+      "~k_parent": "59"
     },
     "5b": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5a"
+    },
+    "5c": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5a"
+    },
+    "5d": {
       "key": "root.imports.operators.server",
-      "~k_parent": "57"
+      "~k_parent": "59"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1041,6 +1049,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5535,6 +5544,9 @@
       "providers": {
         "~k": "1x"
       },
+      "strategies": {
+        "~k": "1y"
+      },
       "~k": "1v"
     },
     "blocks": {
@@ -5542,129 +5554,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "1z"
+        "~k": "20"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
-      "~k": "1y"
+      "~k": "1z"
     },
     "connections": {
-      "~k": "2i"
-    },
-    "requests": {
       "~k": "2j"
     },
-    "websockets": {
+    "requests": {
       "~k": "2k"
     },
-    "api": {
+    "websockets": {
       "~k": "2l"
+    },
+    "api": {
+      "~k": "2m"
     },
     "operators": {
       "client": {
@@ -5672,20 +5684,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2o"
+          "~k": "2p"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2p"
+          "~k": "2q"
         },
-        "~k": "2n"
+        "~k": "2o"
       },
       "server": {
-        "~k": "2q"
+        "~k": "2r"
       },
-      "~k": "2m"
+      "~k": "2n"
     },
     "~k": "1q"
   }

--- a/packages/build/src/tests/success/17-page-with-layout-responsive/snapshot.json
+++ b/packages/build/src/tests/success/17-page-with-layout-responsive/snapshot.json
@@ -134,164 +134,164 @@
       "~k_parent": "p"
     },
     "20": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1x"
+    },
+    "21": {
       "key": "root.types.blocks",
       "~k_parent": "1s"
     },
-    "21": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "20"
-    },
     "22": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "21"
     },
     "23": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "21"
     },
     "24": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "21"
     },
     "25": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "21"
     },
     "26": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "20"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "21"
     },
     "27": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "21"
     },
     "28": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "21"
     },
     "29": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "21"
     },
     "30": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2y"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2z"
     },
     "31": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2t"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2z"
     },
     "32": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "31"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2z"
     },
     "33": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks",
+      "~k_parent": "2u"
     },
     "34": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "33"
     },
     "35": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "33"
     },
     "36": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "33"
     },
     "37": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "33"
     },
     "38": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "33"
     },
     "39": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "33"
     },
     "40": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3o"
     },
     "42": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3o"
     },
     "44": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3o"
     },
     "46": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3o"
     },
     "48": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3o"
     },
     "50": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3o"
     },
     "52": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3o"
     },
     "54": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3o"
     },
     "56": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.requests",
-      "~k_parent": "2t"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3o"
     },
     "58": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2t"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.operators",
-      "~k_parent": "2t"
+      "key": "root.imports.requests",
+      "~k_parent": "2u"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[0:responsive:Box].layout.sm",
@@ -498,332 +498,340 @@
       "~k_parent": "1x"
     },
     "2a": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "20"
+      "key": "root.types.blocks.List",
+      "~k_parent": "21"
     },
     "2b": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "21"
     },
     "2c": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "21"
     },
     "2d": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "20"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "21"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "21"
     },
     "2f": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "21"
     },
     "2g": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "21"
     },
     "2h": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "21"
     },
     "2i": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "20"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "21"
     },
     "2j": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "20"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "21"
     },
     "2k": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "21"
+    },
+    "2l": {
       "key": "root.types.connections",
       "~k_parent": "1s"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.requests",
       "~k_parent": "1s"
     },
-    "2m": {
+    "2n": {
       "key": "root.types.websockets",
       "~k_parent": "1s"
     },
-    "2n": {
+    "2o": {
       "key": "root.types.api",
       "~k_parent": "1s"
     },
-    "2o": {
+    "2p": {
       "key": "root.types.operators",
       "~k_parent": "1s"
     },
-    "2p": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2o"
-    },
     "2q": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2p"
     },
     "2r": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2p"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2o"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2q"
     },
     "2t": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2p"
+    },
+    "2u": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2u": {
-      "key": "root.imports.actions",
-      "~k_parent": "2t"
-    },
     "2v": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2u"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2v"
     },
     "2x": {
-      "key": "root.imports.agents",
-      "~k_parent": "2t"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2v"
     },
     "2y": {
-      "key": "root.imports.auth",
-      "~k_parent": "2t"
+      "key": "root.imports.agents",
+      "~k_parent": "2u"
     },
     "2z": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2y"
+      "key": "root.imports.auth",
+      "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "33"
     },
     "3b": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "33"
     },
     "3c": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "33"
     },
     "3d": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "33"
     },
     "3e": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "33"
     },
     "3f": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "33"
     },
     "3g": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "33"
     },
     "3h": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "33"
     },
     "3i": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "33"
     },
     "3j": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "33"
     },
     "3k": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "33"
     },
     "3l": {
-      "key": "root.imports.connections",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "33"
     },
     "3m": {
-      "key": "root.imports.icons",
-      "~k_parent": "2t"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "33"
     },
     "3n": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3m"
+      "key": "root.imports.connections",
+      "~k_parent": "2u"
     },
     "3o": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3n"
+      "key": "root.imports.icons",
+      "~k_parent": "2u"
     },
     "3p": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3o"
     },
     "3s": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3o"
     },
     "3u": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3o"
     },
     "3w": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3o"
     },
     "3y": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3o"
     },
     "4a": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3o"
     },
     "4c": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3o"
     },
     "4e": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3o"
     },
     "4g": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3o"
     },
     "4i": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3o"
     },
     "4k": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3o"
     },
     "4m": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3o"
     },
     "4o": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3o"
     },
     "4q": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3o"
     },
     "4s": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3o"
     },
     "4u": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3o"
     },
     "4w": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3o"
     },
     "4y": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3o"
     },
     "5a": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "59"
+      "key": "root.imports.websockets",
+      "~k_parent": "2u"
     },
     "5b": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5a"
+      "key": "root.imports.operators",
+      "~k_parent": "2u"
     },
     "5c": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5a"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5b"
     },
     "5d": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5c"
+    },
+    "5e": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5c"
+    },
+    "5f": {
       "key": "root.imports.operators.server",
-      "~k_parent": "59"
+      "~k_parent": "5b"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1057,6 +1065,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5551,6 +5560,9 @@
       "providers": {
         "~k": "1z"
       },
+      "strategies": {
+        "~k": "20"
+      },
       "~k": "1x"
     },
     "blocks": {
@@ -5558,129 +5570,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "21"
+        "~k": "22"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
-      "~k": "20"
+      "~k": "21"
     },
     "connections": {
-      "~k": "2k"
-    },
-    "requests": {
       "~k": "2l"
     },
-    "websockets": {
+    "requests": {
       "~k": "2m"
     },
-    "api": {
+    "websockets": {
       "~k": "2n"
+    },
+    "api": {
+      "~k": "2o"
     },
     "operators": {
       "client": {
@@ -5688,20 +5700,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2q"
+          "~k": "2r"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2r"
+          "~k": "2s"
         },
-        "~k": "2p"
+        "~k": "2q"
       },
       "server": {
-        "~k": "2s"
+        "~k": "2t"
       },
-      "~k": "2o"
+      "~k": "2p"
     },
     "~k": "1s"
   }

--- a/packages/build/src/tests/success/18-page-with-style/snapshot.json
+++ b/packages/build/src/tests/success/18-page-with-style/snapshot.json
@@ -142,156 +142,156 @@
       "~k_parent": "1z"
     },
     "22": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1z"
+    },
+    "23": {
       "key": "root.types.blocks",
       "~k_parent": "1u"
     },
-    "23": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "22"
-    },
     "24": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "23"
     },
     "25": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "23"
     },
     "26": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "23"
     },
     "27": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "23"
     },
     "28": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "23"
     },
     "29": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "22"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "23"
     },
     "30": {
-      "key": "root.imports.agents",
-      "~k_parent": "2w"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2y"
     },
     "31": {
-      "key": "root.imports.auth",
-      "~k_parent": "2w"
+      "key": "root.imports.agents",
+      "~k_parent": "2x"
     },
     "32": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "31"
+      "key": "root.imports.auth",
+      "~k_parent": "2x"
     },
     "33": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "31"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2w"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "32"
     },
     "35": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "34"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "32"
     },
     "36": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks",
+      "~k_parent": "2x"
     },
     "37": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "36"
     },
     "38": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "36"
     },
     "39": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "36"
     },
     "40": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3s"
     },
     "42": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3s"
     },
     "44": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3s"
     },
     "46": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3s"
     },
     "48": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3s"
     },
     "50": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3s"
     },
     "52": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3s"
     },
     "54": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3s"
     },
     "56": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3s"
     },
     "58": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3s"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[0:styled:Title].style",
@@ -496,348 +496,356 @@
       "~k_parent": "1u"
     },
     "2a": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "23"
     },
     "2b": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "23"
     },
     "2c": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "23"
     },
     "2d": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "22"
+      "key": "root.types.blocks.List",
+      "~k_parent": "23"
     },
     "2e": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "23"
     },
     "2f": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "23"
     },
     "2g": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "22"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "23"
     },
     "2h": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "23"
     },
     "2i": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "22"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "23"
     },
     "2j": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "22"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "23"
     },
     "2k": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "22"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "23"
     },
     "2l": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "22"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "23"
     },
     "2m": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "23"
     },
     "2n": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "23"
+    },
+    "2o": {
       "key": "root.types.connections",
       "~k_parent": "1u"
     },
-    "2o": {
+    "2p": {
       "key": "root.types.requests",
       "~k_parent": "1u"
     },
-    "2p": {
+    "2q": {
       "key": "root.types.websockets",
       "~k_parent": "1u"
     },
-    "2q": {
+    "2r": {
       "key": "root.types.api",
       "~k_parent": "1u"
     },
-    "2r": {
+    "2s": {
       "key": "root.types.operators",
       "~k_parent": "1u"
     },
-    "2s": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2r"
-    },
     "2t": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2s"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2r"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2t"
     },
     "2w": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2s"
+    },
+    "2x": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2x": {
-      "key": "root.imports.actions",
-      "~k_parent": "2w"
-    },
     "2y": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2x"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "36"
     },
     "3b": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "36"
     },
     "3c": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "36"
     },
     "3d": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "36"
     },
     "3e": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "36"
     },
     "3f": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "36"
     },
     "3g": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "36"
     },
     "3h": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "36"
     },
     "3i": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "36"
     },
     "3j": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "36"
     },
     "3k": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "36"
     },
     "3l": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "36"
     },
     "3m": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "36"
     },
     "3n": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "36"
     },
     "3o": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "36"
     },
     "3p": {
-      "key": "root.imports.connections",
-      "~k_parent": "2w"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "36"
     },
     "3q": {
-      "key": "root.imports.icons",
-      "~k_parent": "2w"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "36"
     },
     "3r": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3q"
+      "key": "root.imports.connections",
+      "~k_parent": "2x"
     },
     "3s": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3r"
+      "key": "root.imports.icons",
+      "~k_parent": "2x"
     },
     "3t": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3s"
     },
     "3w": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3s"
     },
     "3y": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3s"
     },
     "4a": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3s"
     },
     "4c": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3s"
     },
     "4e": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3s"
     },
     "4g": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3s"
     },
     "4i": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3s"
     },
     "4k": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3s"
     },
     "4m": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3s"
     },
     "4o": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3s"
     },
     "4q": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3s"
     },
     "4s": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3s"
     },
     "4u": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3s"
     },
     "4w": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3s"
     },
     "4y": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3s"
     },
     "5a": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.requests",
-      "~k_parent": "2w"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3s"
     },
     "5c": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2w"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.operators",
-      "~k_parent": "2w"
+      "key": "root.imports.requests",
+      "~k_parent": "2x"
     },
     "5e": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5d"
+      "key": "root.imports.websockets",
+      "~k_parent": "2x"
     },
     "5f": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5e"
+      "key": "root.imports.operators",
+      "~k_parent": "2x"
     },
     "5g": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5e"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5f"
     },
     "5h": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5g"
+    },
+    "5i": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5g"
+    },
+    "5j": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5d"
+      "~k_parent": "5f"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1072,6 +1080,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5566,6 +5575,9 @@
       "providers": {
         "~k": "21"
       },
+      "strategies": {
+        "~k": "22"
+      },
       "~k": "1z"
     },
     "blocks": {
@@ -5573,135 +5585,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "23"
+        "~k": "24"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
-      "~k": "22"
+      "~k": "23"
     },
     "connections": {
-      "~k": "2n"
-    },
-    "requests": {
       "~k": "2o"
     },
-    "websockets": {
+    "requests": {
       "~k": "2p"
     },
-    "api": {
+    "websockets": {
       "~k": "2q"
+    },
+    "api": {
+      "~k": "2r"
     },
     "operators": {
       "client": {
@@ -5709,20 +5721,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2t"
+          "~k": "2u"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2u"
+          "~k": "2v"
         },
-        "~k": "2s"
+        "~k": "2t"
       },
       "server": {
-        "~k": "2v"
+        "~k": "2w"
       },
-      "~k": "2r"
+      "~k": "2s"
     },
     "~k": "1u"
   }

--- a/packages/build/src/tests/success/19-page-with-visible/snapshot.json
+++ b/packages/build/src/tests/success/19-page-with-visible/snapshot.json
@@ -134,164 +134,164 @@
       "~k_parent": "14"
     },
     "20": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1z"
     },
     "21": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "1z"
     },
     "22": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1z"
     },
     "23": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1z"
     },
     "24": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1z"
     },
     "25": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1z"
     },
     "26": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1z"
     },
     "27": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1z"
     },
     "28": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1z"
     },
     "29": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1z"
     },
     "30": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2s"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2y"
     },
     "31": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "30"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2y"
     },
     "32": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks",
+      "~k_parent": "2t"
     },
     "33": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "32"
     },
     "35": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "32"
     },
     "36": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "32"
     },
     "37": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "32"
     },
     "38": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "32"
     },
     "39": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "32"
     },
     "40": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3o"
     },
     "42": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3o"
     },
     "44": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3o"
     },
     "46": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3o"
     },
     "48": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3o"
     },
     "50": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3o"
     },
     "52": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3o"
     },
     "54": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3o"
     },
     "56": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.requests",
-      "~k_parent": "2s"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3o"
     },
     "58": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2s"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.operators",
-      "~k_parent": "2s"
+      "key": "root.imports.requests",
+      "~k_parent": "2t"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[1:hidden:Paragraph]",
@@ -488,340 +488,348 @@
       "~k_parent": "1v"
     },
     "1y": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1v"
+    },
+    "1z": {
       "key": "root.types.blocks",
       "~k_parent": "1q"
     },
-    "1z": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1y"
-    },
     "2a": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1z"
     },
     "2b": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1z"
     },
     "2c": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1z"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1z"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1z"
     },
     "2f": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1z"
     },
     "2g": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1z"
     },
     "2h": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1z"
     },
     "2i": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1z"
     },
     "2j": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1z"
+    },
+    "2k": {
       "key": "root.types.connections",
       "~k_parent": "1q"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.requests",
       "~k_parent": "1q"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.websockets",
       "~k_parent": "1q"
     },
-    "2m": {
+    "2n": {
       "key": "root.types.api",
       "~k_parent": "1q"
     },
-    "2n": {
+    "2o": {
       "key": "root.types.operators",
       "~k_parent": "1q"
     },
-    "2o": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2n"
-    },
     "2p": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2o"
     },
     "2q": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2o"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2p"
     },
     "2r": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2n"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2p"
     },
     "2s": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2o"
+    },
+    "2t": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2t": {
-      "key": "root.imports.actions",
-      "~k_parent": "2s"
-    },
     "2u": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2t"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.imports.agents",
-      "~k_parent": "2s"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.imports.auth",
-      "~k_parent": "2s"
+      "key": "root.imports.agents",
+      "~k_parent": "2t"
     },
     "2y": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2x"
+      "key": "root.imports.auth",
+      "~k_parent": "2t"
     },
     "2z": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2x"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "32"
     },
     "3b": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "32"
     },
     "3c": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "32"
     },
     "3d": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "32"
     },
     "3e": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "32"
     },
     "3f": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "32"
     },
     "3g": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "32"
     },
     "3h": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "32"
     },
     "3i": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "32"
     },
     "3j": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "32"
     },
     "3k": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "32"
     },
     "3l": {
-      "key": "root.imports.connections",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "32"
     },
     "3m": {
-      "key": "root.imports.icons",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "32"
     },
     "3n": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3m"
+      "key": "root.imports.connections",
+      "~k_parent": "2t"
     },
     "3o": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3n"
+      "key": "root.imports.icons",
+      "~k_parent": "2t"
     },
     "3p": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3o"
     },
     "3s": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3o"
     },
     "3u": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3o"
     },
     "3w": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3o"
     },
     "3y": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3o"
     },
     "4a": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3o"
     },
     "4c": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3o"
     },
     "4e": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3o"
     },
     "4g": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3o"
     },
     "4i": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3o"
     },
     "4k": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3o"
     },
     "4m": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3o"
     },
     "4o": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3o"
     },
     "4q": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3o"
     },
     "4s": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3o"
     },
     "4u": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3o"
     },
     "4w": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3o"
     },
     "4y": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3o"
     },
     "5a": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "59"
+      "key": "root.imports.websockets",
+      "~k_parent": "2t"
     },
     "5b": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5a"
+      "key": "root.imports.operators",
+      "~k_parent": "2t"
     },
     "5c": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5a"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5b"
     },
     "5d": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5c"
+    },
+    "5e": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5c"
+    },
+    "5f": {
       "key": "root.imports.operators.server",
-      "~k_parent": "59"
+      "~k_parent": "5b"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1051,6 +1059,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5545,6 +5554,9 @@
       "providers": {
         "~k": "1x"
       },
+      "strategies": {
+        "~k": "1y"
+      },
       "~k": "1v"
     },
     "blocks": {
@@ -5552,135 +5564,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1z"
+        "~k": "20"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "20"
+        "~k": "21"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
-      "~k": "1y"
+      "~k": "1z"
     },
     "connections": {
-      "~k": "2j"
-    },
-    "requests": {
       "~k": "2k"
     },
-    "websockets": {
+    "requests": {
       "~k": "2l"
     },
-    "api": {
+    "websockets": {
       "~k": "2m"
+    },
+    "api": {
+      "~k": "2n"
     },
     "operators": {
       "client": {
@@ -5688,20 +5700,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2p"
+          "~k": "2q"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2q"
+          "~k": "2r"
         },
-        "~k": "2o"
+        "~k": "2p"
       },
       "server": {
-        "~k": "2r"
+        "~k": "2s"
       },
-      "~k": "2n"
+      "~k": "2o"
     },
     "~k": "1q"
   }

--- a/packages/build/src/tests/success/20-page-with-properties/snapshot.json
+++ b/packages/build/src/tests/success/20-page-with-properties/snapshot.json
@@ -134,164 +134,164 @@
       "~k_parent": "13"
     },
     "20": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1y"
     },
     "21": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1y"
     },
     "22": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1y"
     },
     "23": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1y"
     },
     "24": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1y"
     },
     "25": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1y"
     },
     "26": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1y"
     },
     "27": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1y"
     },
     "28": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1y"
     },
     "29": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1y"
     },
     "30": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks",
+      "~k_parent": "2r"
     },
     "31": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "30"
     },
     "32": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "30"
     },
     "33": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "30"
     },
     "34": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "30"
     },
     "35": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "30"
     },
     "36": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "30"
     },
     "37": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "30"
     },
     "38": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "30"
     },
     "39": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "30"
     },
     "40": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3l"
     },
     "41": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3l"
     },
     "43": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3l"
     },
     "45": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3l"
     },
     "47": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3l"
     },
     "49": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3l"
     },
     "51": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3l"
     },
     "53": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.requests",
-      "~k_parent": "2q"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3l"
     },
     "55": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2q"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.operators",
-      "~k_parent": "2q"
+      "key": "root.imports.requests",
+      "~k_parent": "2r"
     },
     "57": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "56"
+      "key": "root.imports.websockets",
+      "~k_parent": "2r"
     },
     "58": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "57"
+      "key": "root.imports.operators",
+      "~k_parent": "2r"
     },
     "59": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "57"
+      "key": "root.imports.operators.client",
+      "~k_parent": "58"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[0:button:Button].properties",
@@ -483,332 +483,340 @@
       "~k_parent": "1u"
     },
     "1x": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1u"
+    },
+    "1y": {
       "key": "root.types.blocks",
       "~k_parent": "1p"
     },
-    "1y": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1x"
-    },
     "1z": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1y"
     },
     "2a": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1y"
     },
     "2b": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1y"
     },
     "2c": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1y"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1y"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1y"
     },
     "2f": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1y"
     },
     "2g": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1y"
     },
     "2h": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1y"
+    },
+    "2i": {
       "key": "root.types.connections",
       "~k_parent": "1p"
     },
-    "2i": {
+    "2j": {
       "key": "root.types.requests",
       "~k_parent": "1p"
     },
-    "2j": {
+    "2k": {
       "key": "root.types.websockets",
       "~k_parent": "1p"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.api",
       "~k_parent": "1p"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.operators",
       "~k_parent": "1p"
     },
-    "2m": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2l"
-    },
     "2n": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2m"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2l"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2n"
     },
     "2q": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2m"
+    },
+    "2r": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2r": {
-      "key": "root.imports.actions",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2r"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.imports.agents",
-      "~k_parent": "2q"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2s"
     },
     "2v": {
-      "key": "root.imports.auth",
-      "~k_parent": "2q"
+      "key": "root.imports.agents",
+      "~k_parent": "2r"
     },
     "2w": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2v"
+      "key": "root.imports.auth",
+      "~k_parent": "2r"
     },
     "2x": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2v"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2q"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2w"
     },
     "2z": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2y"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2w"
     },
     "3a": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "30"
     },
     "3b": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "30"
     },
     "3c": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "30"
     },
     "3d": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "30"
     },
     "3e": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "30"
     },
     "3f": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "30"
     },
     "3g": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "30"
     },
     "3h": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "30"
     },
     "3i": {
-      "key": "root.imports.connections",
-      "~k_parent": "2q"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "30"
     },
     "3j": {
-      "key": "root.imports.icons",
-      "~k_parent": "2q"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "30"
     },
     "3k": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3j"
+      "key": "root.imports.connections",
+      "~k_parent": "2r"
     },
     "3l": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3k"
+      "key": "root.imports.icons",
+      "~k_parent": "2r"
     },
     "3m": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3l"
     },
     "3n": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3l"
     },
     "3p": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3l"
     },
     "3r": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3l"
     },
     "3t": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3l"
     },
     "3v": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3l"
     },
     "3x": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3l"
     },
     "3z": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3l"
     },
     "4b": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3l"
     },
     "4d": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3l"
     },
     "4f": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3l"
     },
     "4h": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3l"
     },
     "4j": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3l"
     },
     "4l": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3l"
     },
     "4n": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3l"
     },
     "4p": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3l"
     },
     "4r": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3l"
     },
     "4t": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3l"
     },
     "4v": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3l"
     },
     "4x": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3j"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3l"
     },
     "4z": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4y"
     },
     "5a": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "59"
+    },
+    "5b": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "59"
+    },
+    "5c": {
       "key": "root.imports.operators.server",
-      "~k_parent": "56"
+      "~k_parent": "58"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1035,6 +1043,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5529,6 +5538,9 @@
       "providers": {
         "~k": "1w"
       },
+      "strategies": {
+        "~k": "1x"
+      },
       "~k": "1u"
     },
     "blocks": {
@@ -5536,129 +5548,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1z"
+        "~k": "20"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
-      "~k": "1x"
+      "~k": "1y"
     },
     "connections": {
-      "~k": "2h"
-    },
-    "requests": {
       "~k": "2i"
     },
-    "websockets": {
+    "requests": {
       "~k": "2j"
     },
-    "api": {
+    "websockets": {
       "~k": "2k"
+    },
+    "api": {
+      "~k": "2l"
     },
     "operators": {
       "client": {
@@ -5666,20 +5678,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2n"
+          "~k": "2o"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2o"
+          "~k": "2p"
         },
-        "~k": "2m"
+        "~k": "2n"
       },
       "server": {
-        "~k": "2p"
+        "~k": "2q"
       },
-      "~k": "2l"
+      "~k": "2m"
     },
     "~k": "1p"
   }

--- a/packages/build/src/tests/success/21-multiple-pages/snapshot.json
+++ b/packages/build/src/tests/success/21-multiple-pages/snapshot.json
@@ -170,132 +170,140 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2p"
     },
     "31": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2p"
     },
     "32": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2p"
     },
     "33": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2p"
     },
     "34": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2p"
     },
     "35": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2p"
     },
     "36": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2p"
     },
     "37": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2p"
     },
     "38": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2p"
+    },
+    "39": {
       "key": "root.types.connections",
       "~k_parent": "2g"
     },
-    "39": {
-      "key": "root.types.requests",
-      "~k_parent": "2g"
-    },
     "40": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3r"
     },
     "41": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3r"
     },
     "42": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3r"
     },
     "43": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3r"
     },
     "44": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3r"
     },
     "45": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3r"
     },
     "46": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3r"
     },
     "47": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3r"
     },
     "48": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3r"
     },
     "49": {
-      "key": "root.imports.connections",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3r"
     },
     "50": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4c"
     },
     "52": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4c"
     },
     "54": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4c"
     },
     "56": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4c"
     },
     "58": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4c"
     },
     "60": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5y"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5z"
     },
     "61": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "60"
+    },
+    "62": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "60"
+    },
+    "63": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5x"
+      "~k_parent": "5z"
     },
     "a": {
       "key": "root.pages[2:contact:Box]",
@@ -564,364 +572,364 @@
       "~k_parent": "2l"
     },
     "2o": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2l"
+    },
+    "2p": {
       "key": "root.types.blocks",
       "~k_parent": "2g"
     },
-    "2p": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2o"
-    },
     "2q": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2p"
     },
     "2r": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2p"
     },
     "2s": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2p"
     },
     "2t": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2p"
     },
     "2u": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2p"
     },
     "2v": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2p"
     },
     "2w": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2p"
     },
     "2x": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2p"
     },
     "2y": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2p"
     },
     "2z": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2p"
     },
     "3a": {
-      "key": "root.types.websockets",
+      "key": "root.types.requests",
       "~k_parent": "2g"
     },
     "3b": {
-      "key": "root.types.api",
+      "key": "root.types.websockets",
       "~k_parent": "2g"
     },
     "3c": {
-      "key": "root.types.operators",
+      "key": "root.types.api",
       "~k_parent": "2g"
     },
     "3d": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3c"
+      "key": "root.types.operators",
+      "~k_parent": "2g"
     },
     "3e": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3d"
     },
     "3f": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3d"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3c"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3e"
     },
     "3h": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3d"
+    },
+    "3i": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "3i": {
-      "key": "root.imports.actions",
-      "~k_parent": "3h"
-    },
     "3j": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3i"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3j"
     },
     "3l": {
-      "key": "root.imports.agents",
-      "~k_parent": "3h"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3j"
     },
     "3m": {
-      "key": "root.imports.auth",
-      "~k_parent": "3h"
+      "key": "root.imports.agents",
+      "~k_parent": "3i"
     },
     "3n": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3m"
+      "key": "root.imports.auth",
+      "~k_parent": "3i"
     },
     "3o": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3m"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3h"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3n"
     },
     "3q": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3p"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3n"
     },
     "3r": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks",
+      "~k_parent": "3i"
     },
     "3s": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3r"
     },
     "3u": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3r"
     },
     "3v": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3r"
     },
     "3w": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3r"
     },
     "3x": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3r"
     },
     "3y": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3r"
     },
     "3z": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3r"
     },
     "4a": {
-      "key": "root.imports.icons",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3r"
     },
     "4b": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4a"
+      "key": "root.imports.connections",
+      "~k_parent": "3i"
     },
     "4c": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4b"
+      "key": "root.imports.icons",
+      "~k_parent": "3i"
     },
     "4d": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4c"
     },
     "4g": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4c"
     },
     "4i": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4c"
     },
     "4k": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4c"
     },
     "4m": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4c"
     },
     "4o": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4c"
     },
     "4q": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4c"
     },
     "4s": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4c"
     },
     "4u": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4c"
     },
     "4w": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4c"
     },
     "4y": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4c"
     },
     "5a": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4c"
     },
     "5c": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4c"
     },
     "5e": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4c"
     },
     "5g": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4c"
     },
     "5i": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4c"
     },
     "5k": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4c"
     },
     "5m": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4c"
     },
     "5o": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4c"
     },
     "5q": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4c"
     },
     "5s": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4a"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4c"
     },
     "5u": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.requests",
-      "~k_parent": "3h"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4c"
     },
     "5w": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3h"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.operators",
-      "~k_parent": "3h"
+      "key": "root.imports.requests",
+      "~k_parent": "3i"
     },
     "5y": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5x"
+      "key": "root.imports.websockets",
+      "~k_parent": "3i"
     },
     "5z": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5y"
+      "key": "root.imports.operators",
+      "~k_parent": "3i"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1258,6 +1266,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5752,6 +5761,9 @@
       "providers": {
         "~k": "2n"
       },
+      "strategies": {
+        "~k": "2o"
+      },
       "~k": "2l"
     },
     "blocks": {
@@ -5759,129 +5771,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 6,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
-      "~k": "2o"
+      "~k": "2p"
     },
     "connections": {
-      "~k": "38"
-    },
-    "requests": {
       "~k": "39"
     },
-    "websockets": {
+    "requests": {
       "~k": "3a"
     },
-    "api": {
+    "websockets": {
       "~k": "3b"
+    },
+    "api": {
+      "~k": "3c"
     },
     "operators": {
       "client": {
@@ -5889,20 +5901,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3e"
+          "~k": "3f"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3f"
+          "~k": "3g"
         },
-        "~k": "3d"
+        "~k": "3e"
       },
       "server": {
-        "~k": "3g"
+        "~k": "3h"
       },
-      "~k": "3c"
+      "~k": "3d"
     },
     "~k": "2g"
   }

--- a/packages/build/src/tests/success/22-page-404-auto-generated/snapshot.json
+++ b/packages/build/src/tests/success/22-page-404-auto-generated/snapshot.json
@@ -127,144 +127,152 @@
       "~k_parent": "18"
     },
     "20": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1s"
     },
     "21": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1s"
     },
     "22": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1s"
     },
     "23": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1s"
     },
     "24": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1s"
     },
     "25": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1s"
     },
     "26": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1s"
     },
     "27": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1s"
     },
     "28": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1s"
     },
     "29": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1s"
     },
     "30": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2u"
     },
     "31": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2u"
     },
     "32": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2u"
     },
     "33": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2u"
     },
     "34": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2u"
     },
     "35": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2u"
     },
     "36": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2u"
     },
     "37": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2u"
     },
     "38": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2u"
     },
     "39": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2u"
     },
     "40": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3f"
     },
     "41": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3f"
     },
     "43": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3f"
     },
     "45": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3f"
     },
     "47": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3f"
     },
     "49": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.operators",
-      "~k_parent": "2k"
+      "key": "root.imports.requests",
+      "~k_parent": "2l"
     },
     "51": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "50"
+      "key": "root.imports.websockets",
+      "~k_parent": "2l"
     },
     "52": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "51"
+      "key": "root.imports.operators",
+      "~k_parent": "2l"
     },
     "53": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "51"
+      "key": "root.imports.operators.client",
+      "~k_parent": "52"
     },
     "54": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "53"
+    },
+    "55": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "53"
+    },
+    "56": {
       "key": "root.imports.operators.server",
-      "~k_parent": "50"
+      "~k_parent": "52"
     },
     "a": {
       "key": "root.pages[1:404:Result].style",
@@ -435,352 +443,352 @@
       "~k_parent": "1o"
     },
     "1r": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1o"
+    },
+    "1s": {
       "key": "root.types.blocks",
       "~k_parent": "1j"
     },
-    "1s": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1r"
-    },
     "1t": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1s"
     },
     "1u": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1s"
     },
     "1v": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1s"
     },
     "1w": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1s"
     },
     "1x": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1s"
     },
     "1y": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1s"
     },
     "1z": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1s"
     },
     "2a": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1r"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1s"
     },
     "2b": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1s"
+    },
+    "2c": {
       "key": "root.types.connections",
       "~k_parent": "1j"
     },
-    "2c": {
+    "2d": {
       "key": "root.types.requests",
       "~k_parent": "1j"
     },
-    "2d": {
+    "2e": {
       "key": "root.types.websockets",
       "~k_parent": "1j"
     },
-    "2e": {
+    "2f": {
       "key": "root.types.api",
       "~k_parent": "1j"
     },
-    "2f": {
+    "2g": {
       "key": "root.types.operators",
       "~k_parent": "1j"
     },
-    "2g": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2f"
-    },
     "2h": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2g"
     },
     "2i": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2g"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2h"
     },
     "2j": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2f"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2h"
     },
     "2k": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2g"
+    },
+    "2l": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2l": {
-      "key": "root.imports.actions",
-      "~k_parent": "2k"
-    },
     "2m": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2l"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.imports.agents",
-      "~k_parent": "2k"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2m"
     },
     "2p": {
-      "key": "root.imports.auth",
-      "~k_parent": "2k"
+      "key": "root.imports.agents",
+      "~k_parent": "2l"
     },
     "2q": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2p"
+      "key": "root.imports.auth",
+      "~k_parent": "2l"
     },
     "2r": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2p"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2k"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2q"
     },
     "2t": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2s"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2q"
     },
     "2u": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks",
+      "~k_parent": "2l"
     },
     "2v": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2u"
     },
     "2y": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2u"
     },
     "2z": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2u"
     },
     "3b": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2u"
     },
     "3c": {
-      "key": "root.imports.connections",
-      "~k_parent": "2k"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2u"
     },
     "3d": {
-      "key": "root.imports.icons",
-      "~k_parent": "2k"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "2u"
     },
     "3e": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3d"
+      "key": "root.imports.connections",
+      "~k_parent": "2l"
     },
     "3f": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3e"
+      "key": "root.imports.icons",
+      "~k_parent": "2l"
     },
     "3g": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3f"
     },
     "3n": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3f"
     },
     "3r": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3f"
     },
     "3t": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3f"
     },
     "3v": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3f"
     },
     "3x": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3f"
     },
     "3z": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3f"
     },
     "4b": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3f"
     },
     "4d": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3f"
     },
     "4f": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3f"
     },
     "4h": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3f"
     },
     "4j": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3f"
     },
     "4l": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3f"
     },
     "4n": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3f"
     },
     "4p": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3f"
     },
     "4r": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3f"
     },
     "4t": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3f"
     },
     "4v": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3d"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3f"
     },
     "4x": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.requests",
-      "~k_parent": "2k"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3f"
     },
     "4z": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2k"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4y"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -977,6 +985,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5471,6 +5480,9 @@
       "providers": {
         "~k": "1q"
       },
+      "strategies": {
+        "~k": "1r"
+      },
       "~k": "1o"
     },
     "blocks": {
@@ -5478,129 +5490,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1s"
+        "~k": "1t"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1t"
+        "~k": "1u"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1u"
+        "~k": "1v"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1v"
+        "~k": "1w"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1w"
+        "~k": "1x"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
-      "~k": "1r"
+      "~k": "1s"
     },
     "connections": {
-      "~k": "2b"
-    },
-    "requests": {
       "~k": "2c"
     },
-    "websockets": {
+    "requests": {
       "~k": "2d"
     },
-    "api": {
+    "websockets": {
       "~k": "2e"
+    },
+    "api": {
+      "~k": "2f"
     },
     "operators": {
       "client": {
@@ -5608,20 +5620,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2h"
+          "~k": "2i"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2i"
+          "~k": "2j"
         },
-        "~k": "2g"
+        "~k": "2h"
       },
       "server": {
-        "~k": "2j"
+        "~k": "2k"
       },
-      "~k": "2f"
+      "~k": "2g"
     },
     "~k": "1j"
   }

--- a/packages/build/src/tests/success/23-page-404-custom/snapshot.json
+++ b/packages/build/src/tests/success/23-page-404-custom/snapshot.json
@@ -129,124 +129,124 @@
       "~k_parent": "18"
     },
     "20": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "1z"
     },
     "21": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "1z"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "20"
     },
     "22": {
-      "key": "root.types.operators.server",
-      "~k_parent": "1y"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "20"
     },
     "23": {
+      "key": "root.types.operators.server",
+      "~k_parent": "1z"
+    },
+    "24": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "24": {
-      "key": "root.imports.actions",
-      "~k_parent": "23"
-    },
     "25": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "24"
     },
     "26": {
-      "key": "root.imports.agents",
-      "~k_parent": "23"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "25"
     },
     "27": {
-      "key": "root.imports.auth",
-      "~k_parent": "23"
+      "key": "root.imports.agents",
+      "~k_parent": "24"
     },
     "28": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "27"
+      "key": "root.imports.auth",
+      "~k_parent": "24"
     },
     "29": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "27"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "28"
     },
     "30": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "2z"
     },
     "31": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "2w"
     },
     "32": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "31"
     },
     "33": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "2w"
     },
     "34": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "33"
     },
     "35": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "2w"
     },
     "36": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "35"
     },
     "37": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "2w"
     },
     "38": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "37"
     },
     "39": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "2w"
     },
     "40": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "2w"
     },
     "42": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "2w"
     },
     "44": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "2w"
     },
     "46": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "2w"
     },
     "48": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "2w"
     },
     "a": {
       "key": "root.pages",
@@ -353,360 +353,368 @@
       "~k_parent": "18"
     },
     "1b": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "18"
+    },
+    "1c": {
       "key": "root.types.blocks",
       "~k_parent": "14"
     },
-    "1c": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1b"
-    },
     "1d": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1c"
     },
     "1e": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1c"
     },
     "1f": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1c"
     },
     "1g": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1c"
     },
     "1h": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1c"
     },
     "1i": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1c"
     },
     "1j": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1c"
     },
     "1k": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1c"
     },
     "1l": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1c"
     },
     "1m": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1c"
     },
     "1n": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1c"
     },
     "1o": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1c"
     },
     "1p": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1c"
     },
     "1q": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1c"
     },
     "1r": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1c"
     },
     "1s": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1c"
     },
     "1t": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1b"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1c"
     },
     "1u": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1c"
+    },
+    "1v": {
       "key": "root.types.connections",
       "~k_parent": "14"
     },
-    "1v": {
+    "1w": {
       "key": "root.types.requests",
       "~k_parent": "14"
     },
-    "1w": {
+    "1x": {
       "key": "root.types.websockets",
       "~k_parent": "14"
     },
-    "1x": {
+    "1y": {
       "key": "root.types.api",
       "~k_parent": "14"
     },
-    "1y": {
+    "1z": {
       "key": "root.types.operators",
       "~k_parent": "14"
     },
-    "1z": {
-      "key": "root.types.operators.client",
-      "~k_parent": "1y"
-    },
     "2a": {
-      "key": "root.imports.blocks",
-      "~k_parent": "23"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "28"
     },
     "2b": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2a"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "28"
     },
     "2c": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks",
+      "~k_parent": "24"
     },
     "2d": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "2c"
     },
     "2e": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "2c"
     },
     "2f": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "2c"
     },
     "2g": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "2c"
     },
     "2h": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "2c"
     },
     "2i": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "2c"
     },
     "2j": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "2c"
     },
     "2k": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "2c"
     },
     "2l": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "2c"
     },
     "2m": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "2c"
     },
     "2n": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "2c"
     },
     "2o": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "2c"
     },
     "2p": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "2c"
     },
     "2q": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "2c"
     },
     "2r": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "2c"
     },
     "2s": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2a"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "2c"
     },
     "2t": {
-      "key": "root.imports.connections",
-      "~k_parent": "23"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "2c"
     },
     "2u": {
-      "key": "root.imports.icons",
-      "~k_parent": "23"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "2c"
     },
     "2v": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "2u"
+      "key": "root.imports.connections",
+      "~k_parent": "24"
     },
     "2w": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "2v"
+      "key": "root.imports.icons",
+      "~k_parent": "24"
     },
     "2x": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "2w"
     },
     "3a": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "39"
     },
     "3b": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "2w"
     },
     "3c": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "2w"
     },
     "3e": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "3d"
     },
     "3f": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "2w"
     },
     "3g": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "2w"
     },
     "3i": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "2w"
     },
     "3k": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "3j"
     },
     "3l": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "2w"
     },
     "3m": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "3l"
     },
     "3n": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "2w"
     },
     "3o": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "2w"
     },
     "3q": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "2w"
     },
     "3s": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "2w"
     },
     "3u": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "2w"
     },
     "3w": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "2w"
     },
     "3y": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "2w"
     },
     "4a": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "2w"
     },
     "4c": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "2u"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "2w"
     },
     "4e": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.requests",
-      "~k_parent": "23"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "2w"
     },
     "4g": {
-      "key": "root.imports.websockets",
-      "~k_parent": "23"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.operators",
-      "~k_parent": "23"
+      "key": "root.imports.requests",
+      "~k_parent": "24"
     },
     "4i": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "4h"
+      "key": "root.imports.websockets",
+      "~k_parent": "24"
     },
     "4j": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "4i"
+      "key": "root.imports.operators",
+      "~k_parent": "24"
     },
     "4k": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "4i"
+      "key": "root.imports.operators.client",
+      "~k_parent": "4j"
     },
     "4l": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "4k"
+    },
+    "4m": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "4k"
+    },
+    "4n": {
       "key": "root.imports.operators.server",
-      "~k_parent": "4h"
+      "~k_parent": "4j"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -807,6 +815,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5295,6 +5304,9 @@
       "providers": {
         "~k": "1a"
       },
+      "strategies": {
+        "~k": "1b"
+      },
       "~k": "18"
     },
     "blocks": {
@@ -5302,123 +5314,123 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1c"
+        "~k": "1d"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1d"
+        "~k": "1e"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1e"
+        "~k": "1f"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1f"
+        "~k": "1g"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1g"
+        "~k": "1h"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1h"
+        "~k": "1i"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1i"
+        "~k": "1j"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1j"
+        "~k": "1k"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1k"
+        "~k": "1l"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1l"
+        "~k": "1m"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1m"
+        "~k": "1n"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1n"
+        "~k": "1o"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1o"
+        "~k": "1p"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1p"
+        "~k": "1q"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1q"
+        "~k": "1r"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1r"
+        "~k": "1s"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "1s"
+        "~k": "1t"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1t"
+        "~k": "1u"
       },
-      "~k": "1b"
+      "~k": "1c"
     },
     "connections": {
-      "~k": "1u"
-    },
-    "requests": {
       "~k": "1v"
     },
-    "websockets": {
+    "requests": {
       "~k": "1w"
     },
-    "api": {
+    "websockets": {
       "~k": "1x"
+    },
+    "api": {
+      "~k": "1y"
     },
     "operators": {
       "client": {
@@ -5426,20 +5438,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "20"
+          "~k": "21"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "21"
+          "~k": "22"
         },
-        "~k": "1z"
+        "~k": "20"
       },
       "server": {
-        "~k": "22"
+        "~k": "23"
       },
-      "~k": "1y"
+      "~k": "1z"
     },
     "~k": "14"
   }

--- a/packages/build/src/tests/success/24-page-with-skeleton/snapshot.json
+++ b/packages/build/src/tests/success/24-page-with-skeleton/snapshot.json
@@ -134,164 +134,164 @@
       "~k_parent": "14"
     },
     "20": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1z"
     },
     "21": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "1z"
     },
     "22": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1z"
     },
     "23": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1z"
     },
     "24": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1z"
     },
     "25": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1z"
     },
     "26": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1z"
     },
     "27": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1z"
     },
     "28": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1z"
     },
     "29": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1z"
     },
     "30": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2s"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2y"
     },
     "31": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "30"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2y"
     },
     "32": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks",
+      "~k_parent": "2t"
     },
     "33": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "32"
     },
     "35": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "32"
     },
     "36": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "32"
     },
     "37": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "32"
     },
     "38": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "32"
     },
     "39": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "32"
     },
     "40": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3o"
     },
     "42": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3o"
     },
     "44": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3o"
     },
     "46": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3o"
     },
     "48": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3o"
     },
     "50": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3o"
     },
     "52": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3o"
     },
     "54": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3o"
     },
     "56": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.requests",
-      "~k_parent": "2s"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3o"
     },
     "58": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2s"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.operators",
-      "~k_parent": "2s"
+      "key": "root.imports.requests",
+      "~k_parent": "2t"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[0:content:Paragraph]",
@@ -488,340 +488,348 @@
       "~k_parent": "1v"
     },
     "1y": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1v"
+    },
+    "1z": {
       "key": "root.types.blocks",
       "~k_parent": "1q"
     },
-    "1z": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1y"
-    },
     "2a": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1z"
     },
     "2b": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1z"
     },
     "2c": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1z"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1z"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1z"
     },
     "2f": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1z"
     },
     "2g": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1z"
     },
     "2h": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1z"
     },
     "2i": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1z"
     },
     "2j": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1z"
+    },
+    "2k": {
       "key": "root.types.connections",
       "~k_parent": "1q"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.requests",
       "~k_parent": "1q"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.websockets",
       "~k_parent": "1q"
     },
-    "2m": {
+    "2n": {
       "key": "root.types.api",
       "~k_parent": "1q"
     },
-    "2n": {
+    "2o": {
       "key": "root.types.operators",
       "~k_parent": "1q"
     },
-    "2o": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2n"
-    },
     "2p": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2o"
     },
     "2q": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2o"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2p"
     },
     "2r": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2n"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2p"
     },
     "2s": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2o"
+    },
+    "2t": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2t": {
-      "key": "root.imports.actions",
-      "~k_parent": "2s"
-    },
     "2u": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2t"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.imports.agents",
-      "~k_parent": "2s"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.imports.auth",
-      "~k_parent": "2s"
+      "key": "root.imports.agents",
+      "~k_parent": "2t"
     },
     "2y": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2x"
+      "key": "root.imports.auth",
+      "~k_parent": "2t"
     },
     "2z": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2x"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "32"
     },
     "3b": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "32"
     },
     "3c": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "32"
     },
     "3d": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "32"
     },
     "3e": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "32"
     },
     "3f": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "32"
     },
     "3g": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "32"
     },
     "3h": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "32"
     },
     "3i": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "32"
     },
     "3j": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "32"
     },
     "3k": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "32"
     },
     "3l": {
-      "key": "root.imports.connections",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "32"
     },
     "3m": {
-      "key": "root.imports.icons",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "32"
     },
     "3n": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3m"
+      "key": "root.imports.connections",
+      "~k_parent": "2t"
     },
     "3o": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3n"
+      "key": "root.imports.icons",
+      "~k_parent": "2t"
     },
     "3p": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3o"
     },
     "3s": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3o"
     },
     "3u": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3o"
     },
     "3w": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3o"
     },
     "3y": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3o"
     },
     "4a": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3o"
     },
     "4c": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3o"
     },
     "4e": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3o"
     },
     "4g": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3o"
     },
     "4i": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3o"
     },
     "4k": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3o"
     },
     "4m": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3o"
     },
     "4o": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3o"
     },
     "4q": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3o"
     },
     "4s": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3o"
     },
     "4u": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3o"
     },
     "4w": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3o"
     },
     "4y": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3o"
     },
     "5a": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "59"
+      "key": "root.imports.websockets",
+      "~k_parent": "2t"
     },
     "5b": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5a"
+      "key": "root.imports.operators",
+      "~k_parent": "2t"
     },
     "5c": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5a"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5b"
     },
     "5d": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5c"
+    },
+    "5e": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5c"
+    },
+    "5f": {
       "key": "root.imports.operators.server",
-      "~k_parent": "59"
+      "~k_parent": "5b"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1047,6 +1055,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5541,6 +5550,9 @@
       "providers": {
         "~k": "1x"
       },
+      "strategies": {
+        "~k": "1y"
+      },
       "~k": "1v"
     },
     "blocks": {
@@ -5548,135 +5560,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1z"
+        "~k": "20"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
-      "~k": "1y"
+      "~k": "1z"
     },
     "connections": {
-      "~k": "2j"
-    },
-    "requests": {
       "~k": "2k"
     },
-    "websockets": {
+    "requests": {
       "~k": "2l"
     },
-    "api": {
+    "websockets": {
       "~k": "2m"
+    },
+    "api": {
+      "~k": "2n"
     },
     "operators": {
       "client": {
@@ -5684,20 +5696,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2p"
+          "~k": "2q"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2q"
+          "~k": "2r"
         },
-        "~k": "2o"
+        "~k": "2p"
       },
       "server": {
-        "~k": "2r"
+        "~k": "2s"
       },
-      "~k": "2n"
+      "~k": "2o"
     },
     "~k": "1q"
   }

--- a/packages/build/src/tests/success/25-page-with-loading/snapshot.json
+++ b/packages/build/src/tests/success/25-page-with-loading/snapshot.json
@@ -134,164 +134,164 @@
       "~k_parent": "13"
     },
     "20": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1y"
     },
     "21": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "1y"
     },
     "22": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1y"
     },
     "23": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1y"
     },
     "24": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1y"
     },
     "25": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1y"
     },
     "26": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1y"
     },
     "27": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1y"
     },
     "28": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1y"
     },
     "29": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1y"
     },
     "30": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2z"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2x"
     },
     "31": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks",
+      "~k_parent": "2s"
     },
     "32": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "31"
     },
     "33": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "31"
     },
     "34": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "31"
     },
     "35": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "31"
     },
     "36": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "31"
     },
     "37": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "31"
     },
     "38": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "31"
     },
     "39": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "31"
     },
     "40": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3n"
     },
     "41": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3n"
     },
     "43": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3n"
     },
     "45": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3n"
     },
     "47": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3n"
     },
     "49": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3n"
     },
     "51": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3n"
     },
     "53": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3n"
     },
     "55": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.requests",
-      "~k_parent": "2r"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3n"
     },
     "57": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2r"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.operators",
-      "~k_parent": "2r"
+      "key": "root.imports.requests",
+      "~k_parent": "2s"
     },
     "59": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "58"
+      "key": "root.imports.websockets",
+      "~k_parent": "2s"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[1:content:Paragraph].properties",
@@ -483,340 +483,348 @@
       "~k_parent": "1u"
     },
     "1x": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1u"
+    },
+    "1y": {
       "key": "root.types.blocks",
       "~k_parent": "1p"
     },
-    "1y": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1x"
-    },
     "1z": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1y"
     },
     "2a": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1y"
     },
     "2b": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1y"
     },
     "2c": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1y"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1y"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1y"
     },
     "2f": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1y"
     },
     "2g": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1y"
     },
     "2h": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1x"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1y"
     },
     "2i": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1y"
+    },
+    "2j": {
       "key": "root.types.connections",
       "~k_parent": "1p"
     },
-    "2j": {
+    "2k": {
       "key": "root.types.requests",
       "~k_parent": "1p"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.websockets",
       "~k_parent": "1p"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.api",
       "~k_parent": "1p"
     },
-    "2m": {
+    "2n": {
       "key": "root.types.operators",
       "~k_parent": "1p"
     },
-    "2n": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2m"
-    },
     "2o": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2n"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2o"
     },
     "2q": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2m"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2o"
     },
     "2r": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2n"
+    },
+    "2s": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2s": {
-      "key": "root.imports.actions",
-      "~k_parent": "2r"
-    },
     "2t": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.imports.agents",
-      "~k_parent": "2r"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2t"
     },
     "2w": {
-      "key": "root.imports.auth",
-      "~k_parent": "2r"
+      "key": "root.imports.agents",
+      "~k_parent": "2s"
     },
     "2x": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2w"
+      "key": "root.imports.auth",
+      "~k_parent": "2s"
     },
     "2y": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2w"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2r"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2x"
     },
     "3a": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "31"
     },
     "3b": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "31"
     },
     "3c": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "31"
     },
     "3d": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "31"
     },
     "3e": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "31"
     },
     "3f": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "31"
     },
     "3g": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "31"
     },
     "3h": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "31"
     },
     "3i": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "31"
     },
     "3j": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "31"
     },
     "3k": {
-      "key": "root.imports.connections",
-      "~k_parent": "2r"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "31"
     },
     "3l": {
-      "key": "root.imports.icons",
-      "~k_parent": "2r"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "31"
     },
     "3m": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3l"
+      "key": "root.imports.connections",
+      "~k_parent": "2s"
     },
     "3n": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3m"
+      "key": "root.imports.icons",
+      "~k_parent": "2s"
     },
     "3o": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3n"
     },
     "3r": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3n"
     },
     "3t": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3n"
     },
     "3v": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3n"
     },
     "3x": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3n"
     },
     "3z": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3n"
     },
     "4b": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3n"
     },
     "4d": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3n"
     },
     "4f": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3n"
     },
     "4h": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3n"
     },
     "4j": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3n"
     },
     "4l": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3n"
     },
     "4n": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3n"
     },
     "4p": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3n"
     },
     "4r": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3n"
     },
     "4t": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3n"
     },
     "4v": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3n"
     },
     "4x": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3n"
     },
     "4z": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "59"
+      "key": "root.imports.operators",
+      "~k_parent": "2s"
     },
     "5b": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "59"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5a"
     },
     "5c": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5b"
+    },
+    "5d": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5b"
+    },
+    "5e": {
       "key": "root.imports.operators.server",
-      "~k_parent": "58"
+      "~k_parent": "5a"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1043,6 +1051,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5537,6 +5546,9 @@
       "providers": {
         "~k": "1w"
       },
+      "strategies": {
+        "~k": "1x"
+      },
       "~k": "1u"
     },
     "blocks": {
@@ -5544,135 +5556,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 2,
-        "~k": "1z"
+        "~k": "20"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
-      "~k": "1x"
+      "~k": "1y"
     },
     "connections": {
-      "~k": "2i"
-    },
-    "requests": {
       "~k": "2j"
     },
-    "websockets": {
+    "requests": {
       "~k": "2k"
     },
-    "api": {
+    "websockets": {
       "~k": "2l"
+    },
+    "api": {
+      "~k": "2m"
     },
     "operators": {
       "client": {
@@ -5680,20 +5692,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2o"
+          "~k": "2p"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2p"
+          "~k": "2q"
         },
-        "~k": "2n"
+        "~k": "2o"
       },
       "server": {
-        "~k": "2q"
+        "~k": "2r"
       },
-      "~k": "2m"
+      "~k": "2n"
     },
     "~k": "1p"
   }

--- a/packages/build/src/tests/success/30-multifile-pages-ref/snapshot.json
+++ b/packages/build/src/tests/success/30-multifile-pages-ref/snapshot.json
@@ -178,163 +178,163 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2y"
     },
     "31": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "2y"
     },
     "32": {
-      "key": "root.types.blocks.TextArea",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "2y"
     },
     "33": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.TextArea",
+      "~k_parent": "2y"
     },
     "34": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2y"
     },
     "35": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2y"
     },
     "36": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2y"
     },
     "37": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2y"
     },
     "38": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2y"
     },
     "39": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2y"
     },
     "40": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3z"
+      "key": "root.imports.auth",
+      "~k_parent": "3v"
     },
     "41": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3z"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3u"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "40"
     },
     "43": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "42"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "40"
     },
     "44": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks",
+      "~k_parent": "3v"
     },
     "45": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "44"
     },
     "47": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "44"
     },
     "48": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "44"
     },
     "49": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "44"
     },
     "50": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4t"
     },
     "51": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4t"
     },
     "53": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4t"
     },
     "55": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4t"
     },
     "57": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4t"
     },
     "59": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4t"
     },
     "61": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4t"
     },
     "63": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4t"
     },
     "65": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4t"
     },
     "67": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4t"
     },
     "69": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "68"
     },
     "a": {
@@ -672,364 +672,372 @@
       "~k_parent": "2u"
     },
     "2x": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2u"
+    },
+    "2y": {
       "key": "root.types.blocks",
       "~k_parent": "2p"
     },
-    "2y": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2x"
-    },
     "2z": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2y"
     },
     "3b": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2y"
     },
     "3c": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2y"
     },
     "3d": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2y"
     },
     "3e": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2y"
     },
     "3f": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2y"
     },
     "3g": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2y"
     },
     "3h": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2y"
     },
     "3i": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2y"
     },
     "3j": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2y"
     },
     "3k": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2x"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2y"
     },
     "3l": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2y"
+    },
+    "3m": {
       "key": "root.types.connections",
       "~k_parent": "2p"
     },
-    "3m": {
+    "3n": {
       "key": "root.types.requests",
       "~k_parent": "2p"
     },
-    "3n": {
+    "3o": {
       "key": "root.types.websockets",
       "~k_parent": "2p"
     },
-    "3o": {
+    "3p": {
       "key": "root.types.api",
       "~k_parent": "2p"
     },
-    "3p": {
+    "3q": {
       "key": "root.types.operators",
       "~k_parent": "2p"
     },
-    "3q": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3p"
-    },
     "3r": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3q"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3p"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3r"
     },
     "3u": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3q"
+    },
+    "3v": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "3v": {
-      "key": "root.imports.actions",
-      "~k_parent": "3u"
-    },
     "3w": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3v"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.agents",
-      "~k_parent": "3u"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3w"
     },
     "3z": {
-      "key": "root.imports.auth",
-      "~k_parent": "3u"
+      "key": "root.imports.agents",
+      "~k_parent": "3v"
     },
     "4a": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "44"
     },
     "4b": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "44"
     },
     "4c": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "44"
     },
     "4d": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "44"
     },
     "4e": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "44"
     },
     "4f": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "44"
     },
     "4g": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "44"
     },
     "4h": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "44"
     },
     "4i": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "44"
     },
     "4j": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "44"
     },
     "4k": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "44"
     },
     "4l": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "44"
     },
     "4m": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "44"
     },
     "4n": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "44"
     },
     "4o": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "44"
     },
     "4p": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "44"
     },
     "4q": {
-      "key": "root.imports.connections",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "44"
     },
     "4r": {
-      "key": "root.imports.icons",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "44"
     },
     "4s": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4r"
+      "key": "root.imports.connections",
+      "~k_parent": "3v"
     },
     "4t": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4s"
+      "key": "root.imports.icons",
+      "~k_parent": "3v"
     },
     "4u": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4t"
     },
     "4x": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4t"
     },
     "4z": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4t"
     },
     "5b": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4t"
     },
     "5d": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4t"
     },
     "5f": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4t"
     },
     "5h": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4t"
     },
     "5j": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4t"
     },
     "5l": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4t"
     },
     "5n": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4t"
     },
     "5p": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4t"
     },
     "5r": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4t"
     },
     "5t": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4t"
     },
     "5v": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4t"
     },
     "5x": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4t"
     },
     "5z": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4r"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4t"
     },
     "6b": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.requests",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4t"
     },
     "6d": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3u"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.operators",
-      "~k_parent": "3u"
+      "key": "root.imports.requests",
+      "~k_parent": "3v"
     },
     "6f": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6e"
+      "key": "root.imports.websockets",
+      "~k_parent": "3v"
     },
     "6g": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6f"
+      "key": "root.imports.operators",
+      "~k_parent": "3v"
     },
     "6h": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6f"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6g"
     },
     "6i": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6h"
+    },
+    "6j": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6h"
+    },
+    "6k": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6e"
+      "~k_parent": "6g"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1411,6 +1419,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -7395,6 +7404,9 @@
       "providers": {
         "~k": "2w"
       },
+      "strategies": {
+        "~k": "2x"
+      },
       "~k": "2u"
     },
     "blocks": {
@@ -7402,153 +7414,153 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2z"
+        "~k": "30"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "30"
+        "~k": "31"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "TextArea": {
         "originalTypeName": "TextArea",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "33"
+        "~k": "34"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3f"
+        "~k": "3g"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3h"
+        "~k": "3i"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3i"
+        "~k": "3j"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3j"
+        "~k": "3k"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3k"
+        "~k": "3l"
       },
-      "~k": "2x"
+      "~k": "2y"
     },
     "connections": {
-      "~k": "3l"
-    },
-    "requests": {
       "~k": "3m"
     },
-    "websockets": {
+    "requests": {
       "~k": "3n"
     },
-    "api": {
+    "websockets": {
       "~k": "3o"
+    },
+    "api": {
+      "~k": "3p"
     },
     "operators": {
       "client": {
@@ -7556,20 +7568,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3r"
+          "~k": "3s"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3s"
+          "~k": "3t"
         },
-        "~k": "3q"
+        "~k": "3r"
       },
       "server": {
-        "~k": "3t"
+        "~k": "3u"
       },
-      "~k": "3p"
+      "~k": "3q"
     },
     "~k": "2p"
   }

--- a/packages/build/src/tests/success/31-multifile-blocks-ref/snapshot.json
+++ b/packages/build/src/tests/success/31-multifile-blocks-ref/snapshot.json
@@ -212,124 +212,124 @@
       "~k_parent": "37"
     },
     "40": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3f"
+    },
+    "41": {
       "key": "root.types.connections",
       "~k_parent": "36"
     },
-    "41": {
+    "42": {
       "key": "root.types.requests",
       "~k_parent": "36"
     },
-    "42": {
+    "43": {
       "key": "root.types.websockets",
       "~k_parent": "36"
     },
-    "43": {
+    "44": {
       "key": "root.types.api",
       "~k_parent": "36"
     },
-    "44": {
+    "45": {
       "key": "root.types.operators",
       "~k_parent": "36"
     },
-    "45": {
-      "key": "root.types.operators.client",
-      "~k_parent": "44"
-    },
     "46": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "45"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "46"
     },
     "48": {
-      "key": "root.types.operators.server",
-      "~k_parent": "44"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "46"
     },
     "49": {
-      "key": "root.imports",
-      "~k_parent": "4"
+      "key": "root.types.operators.server",
+      "~k_parent": "45"
     },
     "50": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "4j"
     },
     "51": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "4j"
     },
     "52": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "4j"
     },
     "53": {
-      "key": "root.imports.connections",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "4j"
     },
     "54": {
-      "key": "root.imports.icons",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "4j"
     },
     "55": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "54"
+      "key": "root.imports.connections",
+      "~k_parent": "4a"
     },
     "56": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "55"
+      "key": "root.imports.icons",
+      "~k_parent": "4a"
     },
     "57": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "56"
     },
     "60": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "56"
     },
     "62": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "56"
     },
     "64": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "56"
     },
     "66": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "56"
     },
     "68": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "56"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[0:header:Box].blocks",
@@ -702,388 +702,396 @@
       "~k_parent": "3b"
     },
     "3e": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "3b"
+    },
+    "3f": {
       "key": "root.types.blocks",
       "~k_parent": "36"
     },
-    "3f": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "3e"
-    },
     "3g": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "3f"
     },
     "3i": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3f"
     },
     "3k": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3f"
     },
     "3m": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3f"
     },
     "3n": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3f"
     },
     "3o": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3f"
     },
     "3q": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3f"
     },
     "3r": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3f"
     },
     "3s": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3f"
     },
     "3t": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3f"
     },
     "3u": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3f"
     },
     "3v": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3f"
     },
     "3w": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3f"
     },
     "3x": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3f"
     },
     "3y": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3f"
     },
     "3z": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "3e"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3f"
     },
     "4a": {
-      "key": "root.imports.actions",
-      "~k_parent": "49"
+      "key": "root.imports",
+      "~k_parent": "4"
     },
     "4b": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "4a"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.agents",
-      "~k_parent": "49"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "4b"
     },
     "4e": {
-      "key": "root.imports.auth",
-      "~k_parent": "49"
+      "key": "root.imports.agents",
+      "~k_parent": "4a"
     },
     "4f": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "4e"
+      "key": "root.imports.auth",
+      "~k_parent": "4a"
     },
     "4g": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "4e"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.blocks",
-      "~k_parent": "49"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "4f"
     },
     "4i": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "4h"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "4f"
     },
     "4j": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks",
+      "~k_parent": "4a"
     },
     "4k": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "4j"
     },
     "4m": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "4j"
     },
     "4n": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "4j"
     },
     "4o": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "4j"
     },
     "4p": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "4j"
     },
     "4q": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "4j"
     },
     "4r": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "4j"
     },
     "4s": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "4j"
     },
     "4t": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "4j"
     },
     "4u": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "4j"
     },
     "4v": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "4j"
     },
     "4w": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "4j"
     },
     "4x": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "4j"
     },
     "4y": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "4j"
     },
     "4z": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "4h"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "4j"
     },
     "5a": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "56"
     },
     "5c": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "56"
     },
     "5e": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "56"
     },
     "5g": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "56"
     },
     "5i": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "56"
     },
     "5k": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "56"
     },
     "5m": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "56"
     },
     "5o": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "56"
     },
     "5q": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "56"
     },
     "5s": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "56"
     },
     "5u": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "56"
     },
     "5w": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "56"
     },
     "5y": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "56"
     },
     "6a": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "56"
     },
     "6c": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "56"
     },
     "6e": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "56"
     },
     "6g": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "6f"
     },
     "6h": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "56"
     },
     "6i": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "56"
     },
     "6k": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "6j"
     },
     "6l": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "56"
     },
     "6m": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "6l"
     },
     "6n": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "56"
     },
     "6o": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6n"
     },
     "6p": {
-      "key": "root.imports.requests",
-      "~k_parent": "49"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "56"
     },
     "6q": {
-      "key": "root.imports.websockets",
-      "~k_parent": "49"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.operators",
-      "~k_parent": "49"
+      "key": "root.imports.requests",
+      "~k_parent": "4a"
     },
     "6s": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6r"
+      "key": "root.imports.websockets",
+      "~k_parent": "4a"
     },
     "6t": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6s"
+      "key": "root.imports.operators",
+      "~k_parent": "4a"
     },
     "6u": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6s"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6t"
     },
     "6v": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6u"
+    },
+    "6w": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6u"
+    },
+    "6x": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6r"
+      "~k_parent": "6t"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1510,6 +1518,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -6024,6 +6033,9 @@
       "providers": {
         "~k": "3d"
       },
+      "strategies": {
+        "~k": "3e"
+      },
       "~k": "3b"
     },
     "blocks": {
@@ -6031,141 +6043,141 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "3f"
+        "~k": "3g"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "3g"
+        "~k": "3h"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "3h"
+        "~k": "3i"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3i"
+        "~k": "3j"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3j"
+        "~k": "3k"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3k"
+        "~k": "3l"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3l"
+        "~k": "3m"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3m"
+        "~k": "3n"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3n"
+        "~k": "3o"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3o"
+        "~k": "3p"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3p"
+        "~k": "3q"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3q"
+        "~k": "3r"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3r"
+        "~k": "3s"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3s"
+        "~k": "3t"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3t"
+        "~k": "3u"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3u"
+        "~k": "3v"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3v"
+        "~k": "3w"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3w"
+        "~k": "3x"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3x"
+        "~k": "3y"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3y"
+        "~k": "3z"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3z"
+        "~k": "40"
       },
-      "~k": "3e"
+      "~k": "3f"
     },
     "connections": {
-      "~k": "40"
-    },
-    "requests": {
       "~k": "41"
     },
-    "websockets": {
+    "requests": {
       "~k": "42"
     },
-    "api": {
+    "websockets": {
       "~k": "43"
+    },
+    "api": {
+      "~k": "44"
     },
     "operators": {
       "client": {
@@ -6173,20 +6185,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "46"
+          "~k": "47"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "47"
+          "~k": "48"
         },
-        "~k": "45"
+        "~k": "46"
       },
       "server": {
-        "~k": "48"
+        "~k": "49"
       },
-      "~k": "44"
+      "~k": "45"
     },
     "~k": "36"
   }

--- a/packages/build/src/tests/success/32-multifile-connections-ref/snapshot.json
+++ b/packages/build/src/tests/success/32-multifile-connections-ref/snapshot.json
@@ -188,136 +188,136 @@
       "~k_parent": "24"
     },
     "27": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "24"
+    },
+    "28": {
       "key": "root.types.blocks",
       "~k_parent": "1z"
     },
-    "28": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "27"
-    },
     "29": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2z"
+      "key": "root.types.operators",
+      "~k_parent": "1z"
     },
     "31": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "30"
     },
     "32": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "30"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "31"
     },
     "33": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2z"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "31"
     },
     "34": {
+      "key": "root.types.operators.server",
+      "~k_parent": "30"
+    },
+    "35": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "35": {
-      "key": "root.imports.actions",
-      "~k_parent": "34"
-    },
     "36": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "35"
     },
     "37": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "35"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "36"
     },
     "38": {
-      "key": "root.imports.agents",
-      "~k_parent": "34"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "36"
     },
     "39": {
-      "key": "root.imports.auth",
-      "~k_parent": "34"
+      "key": "root.imports.agents",
+      "~k_parent": "35"
     },
     "40": {
-      "key": "root.imports.icons",
-      "~k_parent": "34"
+      "key": "root.imports.connections[0]",
+      "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "40"
+      "key": "root.imports.connections[1]",
+      "~k_parent": "3z"
     },
     "42": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "41"
+      "key": "root.imports.icons",
+      "~k_parent": "35"
     },
     "43": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "42"
     },
     "46": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "42"
     },
     "48": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "42"
     },
     "50": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "42"
     },
     "52": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "42"
     },
     "54": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "42"
     },
     "56": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "42"
     },
     "58": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "42"
     },
     "a": {
       "key": "root.connections[1:db:MongoDBCollection].properties",
@@ -534,392 +534,400 @@
       "~k_parent": "4"
     },
     "2a": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "28"
     },
     "2b": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "28"
     },
     "2c": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "28"
     },
     "2d": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "28"
     },
     "2e": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "27"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "28"
     },
     "2f": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "28"
     },
     "2g": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "28"
     },
     "2h": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "28"
     },
     "2i": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "27"
+      "key": "root.types.blocks.List",
+      "~k_parent": "28"
     },
     "2j": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "28"
     },
     "2k": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "28"
     },
     "2l": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "27"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "28"
     },
     "2m": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "28"
     },
     "2n": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "28"
     },
     "2o": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "28"
     },
     "2p": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "28"
     },
     "2q": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "28"
     },
     "2r": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "28"
     },
     "2s": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "28"
+    },
+    "2t": {
       "key": "root.types.connections",
       "~k_parent": "1z"
     },
-    "2t": {
-      "key": "root.types.connections.AxiosHttp",
-      "~k_parent": "2s"
-    },
     "2u": {
-      "key": "root.types.connections.MongoDBCollection",
-      "~k_parent": "2s"
+      "key": "root.types.connections.AxiosHttp",
+      "~k_parent": "2t"
     },
     "2v": {
+      "key": "root.types.connections.MongoDBCollection",
+      "~k_parent": "2t"
+    },
+    "2w": {
       "key": "root.types.requests",
       "~k_parent": "1z"
     },
-    "2w": {
-      "key": "root.types.requests.AxiosHttp",
-      "~k_parent": "2v"
-    },
     "2x": {
+      "key": "root.types.requests.AxiosHttp",
+      "~k_parent": "2w"
+    },
+    "2y": {
       "key": "root.types.websockets",
       "~k_parent": "1z"
     },
-    "2y": {
+    "2z": {
       "key": "root.types.api",
       "~k_parent": "1z"
     },
-    "2z": {
-      "key": "root.types.operators",
-      "~k_parent": "1z"
-    },
     "3a": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "39"
+      "key": "root.imports.auth",
+      "~k_parent": "35"
     },
     "3b": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "39"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3a"
     },
     "3c": {
-      "key": "root.imports.blocks",
-      "~k_parent": "34"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3a"
     },
     "3d": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3c"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3a"
     },
     "3e": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks",
+      "~k_parent": "35"
     },
     "3f": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3e"
     },
     "3h": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3e"
     },
     "3i": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3e"
     },
     "3j": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3e"
     },
     "3k": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3e"
     },
     "3l": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3e"
     },
     "3m": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3e"
     },
     "3n": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3e"
     },
     "3o": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3e"
     },
     "3p": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3e"
     },
     "3q": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3e"
     },
     "3r": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3e"
     },
     "3s": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3e"
     },
     "3t": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3e"
     },
     "3u": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3e"
     },
     "3v": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3e"
     },
     "3w": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3e"
     },
     "3x": {
-      "key": "root.imports.connections",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3e"
     },
     "3y": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3e"
     },
     "3z": {
-      "key": "root.imports.connections[1]",
-      "~k_parent": "3x"
+      "key": "root.imports.connections",
+      "~k_parent": "35"
     },
     "4a": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "42"
     },
     "4c": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "42"
     },
     "4e": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "42"
     },
     "4g": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "42"
     },
     "4i": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "42"
     },
     "4k": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "42"
     },
     "4m": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "42"
     },
     "4o": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "42"
     },
     "4q": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "42"
     },
     "4s": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "42"
     },
     "4u": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "42"
     },
     "4w": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "42"
     },
     "4y": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "42"
     },
     "5a": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "42"
     },
     "5c": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "42"
     },
     "5e": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "42"
     },
     "5g": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "42"
     },
     "5i": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "42"
     },
     "5k": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.requests",
-      "~k_parent": "34"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "42"
     },
     "5m": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.websockets",
-      "~k_parent": "34"
+      "key": "root.imports.requests",
+      "~k_parent": "35"
     },
     "5o": {
-      "key": "root.imports.operators",
-      "~k_parent": "34"
+      "key": "root.imports.requests[0]",
+      "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5o"
+      "key": "root.imports.websockets",
+      "~k_parent": "35"
     },
     "5q": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5p"
+      "key": "root.imports.operators",
+      "~k_parent": "35"
     },
     "5r": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5p"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5q"
     },
     "5s": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5r"
+    },
+    "5t": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5r"
+    },
+    "5u": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5o"
+      "~k_parent": "5q"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1166,6 +1174,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5665,6 +5674,9 @@
       "providers": {
         "~k": "26"
       },
+      "strategies": {
+        "~k": "27"
+      },
       "~k": "24"
     },
     "blocks": {
@@ -5672,153 +5684,153 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "28"
+        "~k": "29"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
-      "~k": "27"
+      "~k": "28"
     },
     "connections": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "MongoDBCollection": {
         "originalTypeName": "MongoDBCollection",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
-      "~k": "2s"
+      "~k": "2t"
     },
     "requests": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
-      "~k": "2v"
+      "~k": "2w"
     },
     "websockets": {
-      "~k": "2x"
+      "~k": "2y"
     },
     "api": {
-      "~k": "2y"
+      "~k": "2z"
     },
     "operators": {
       "client": {
@@ -5826,20 +5838,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "31"
+          "~k": "32"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "32"
+          "~k": "33"
         },
-        "~k": "30"
+        "~k": "31"
       },
       "server": {
-        "~k": "33"
+        "~k": "34"
       },
-      "~k": "2z"
+      "~k": "30"
     },
     "~k": "1z"
   }

--- a/packages/build/src/tests/success/33-multifile-nested-refs/snapshot.json
+++ b/packages/build/src/tests/success/33-multifile-nested-refs/snapshot.json
@@ -252,147 +252,147 @@
       "~k_parent": "41"
     },
     "44": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "41"
+    },
+    "45": {
       "key": "root.types.blocks",
       "~k_parent": "3w"
     },
-    "45": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "44"
-    },
     "46": {
-      "key": "root.types.blocks.Breadcrumb",
-      "~k_parent": "44"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "45"
     },
     "47": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "44"
+      "key": "root.types.blocks.Breadcrumb",
+      "~k_parent": "45"
     },
     "48": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "44"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "45"
     },
     "49": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "44"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "45"
     },
     "50": {
-      "key": "root.types.operators.client._global",
+      "key": "root.types.operators.client",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "4z"
+      "key": "root.types.operators.client._global",
+      "~k_parent": "50"
     },
     "52": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "4z"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "50"
     },
     "53": {
-      "key": "root.types.operators.server",
-      "~k_parent": "4y"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "50"
     },
     "54": {
+      "key": "root.types.operators.server",
+      "~k_parent": "4z"
+    },
+    "55": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "55": {
-      "key": "root.imports.actions",
-      "~k_parent": "54"
-    },
     "56": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "55"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.agents",
-      "~k_parent": "54"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "56"
     },
     "59": {
-      "key": "root.imports.auth",
-      "~k_parent": "54"
+      "key": "root.imports.agents",
+      "~k_parent": "55"
     },
     "60": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "5e"
     },
     "61": {
-      "key": "root.imports.blocks[24]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "5e"
     },
     "62": {
-      "key": "root.imports.connections",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "5e"
     },
     "63": {
-      "key": "root.imports.icons",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[24]",
+      "~k_parent": "5e"
     },
     "64": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "63"
+      "key": "root.imports.connections",
+      "~k_parent": "55"
     },
     "65": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "64"
+      "key": "root.imports.icons",
+      "~k_parent": "55"
     },
     "66": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "65"
     },
     "69": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "68"
     },
     "70": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "65"
     },
     "71": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "70"
     },
     "72": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "65"
     },
     "73": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "72"
     },
     "74": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "65"
     },
     "75": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "74"
     },
     "76": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "65"
     },
     "77": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "76"
     },
     "78": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "65"
     },
     "79": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "78"
     },
     "a": {
@@ -886,404 +886,412 @@
       "~k_parent": "3x"
     },
     "4a": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "44"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "45"
     },
     "4b": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "44"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "45"
     },
     "4c": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "44"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "45"
     },
     "4d": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "44"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "45"
     },
     "4e": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "44"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "45"
     },
     "4f": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "44"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "45"
     },
     "4g": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "44"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "45"
     },
     "4h": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "44"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "45"
     },
     "4i": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "44"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "45"
     },
     "4j": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "44"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "45"
     },
     "4k": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "44"
+      "key": "root.types.blocks.List",
+      "~k_parent": "45"
     },
     "4l": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "44"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "45"
     },
     "4m": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "44"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "45"
     },
     "4n": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "44"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "45"
     },
     "4o": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "44"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "45"
     },
     "4p": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "44"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "45"
     },
     "4q": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "44"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "45"
     },
     "4r": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "44"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "45"
     },
     "4s": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "44"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "45"
     },
     "4t": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "44"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "45"
     },
     "4u": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "45"
+    },
+    "4v": {
       "key": "root.types.connections",
       "~k_parent": "3w"
     },
-    "4v": {
+    "4w": {
       "key": "root.types.requests",
       "~k_parent": "3w"
     },
-    "4w": {
+    "4x": {
       "key": "root.types.websockets",
       "~k_parent": "3w"
     },
-    "4x": {
+    "4y": {
       "key": "root.types.api",
       "~k_parent": "3w"
     },
-    "4y": {
+    "4z": {
       "key": "root.types.operators",
       "~k_parent": "3w"
     },
-    "4z": {
-      "key": "root.types.operators.client",
-      "~k_parent": "4y"
-    },
     "5a": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "59"
+      "key": "root.imports.auth",
+      "~k_parent": "55"
     },
     "5b": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "59"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.blocks",
-      "~k_parent": "54"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "5a"
     },
     "5d": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "5c"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "5a"
     },
     "5e": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks",
+      "~k_parent": "55"
     },
     "5f": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "5e"
     },
     "5h": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "5e"
     },
     "5i": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "5e"
     },
     "5j": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "5e"
     },
     "5k": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "5e"
     },
     "5l": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "5e"
     },
     "5m": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "5e"
     },
     "5n": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "5e"
     },
     "5o": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "5e"
     },
     "5p": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "5e"
     },
     "5q": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "5e"
     },
     "5r": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "5e"
     },
     "5s": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "5e"
     },
     "5t": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "5e"
     },
     "5u": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "5e"
     },
     "5v": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "5e"
     },
     "5w": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "5e"
     },
     "5x": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "5e"
     },
     "5y": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "5e"
     },
     "5z": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "5c"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "5e"
     },
     "6a": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "65"
     },
     "6b": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "65"
     },
     "6d": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "65"
     },
     "6f": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "6e"
     },
     "6g": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "65"
     },
     "6h": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "6g"
     },
     "6i": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "65"
     },
     "6j": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "6i"
     },
     "6k": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "65"
     },
     "6l": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "6k"
     },
     "6m": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "65"
     },
     "6n": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "6m"
     },
     "6o": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "65"
     },
     "6p": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "6o"
     },
     "6q": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "65"
     },
     "6r": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "6q"
     },
     "6s": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "65"
     },
     "6t": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "6s"
     },
     "6u": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "65"
     },
     "6v": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "6u"
     },
     "6w": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "65"
     },
     "6x": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "6w"
     },
     "6y": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "65"
     },
     "6z": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "6y"
     },
     "7a": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "65"
     },
     "7b": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "7a"
     },
     "7c": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "65"
     },
     "7d": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "7c"
     },
     "7e": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "65"
     },
     "7f": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "7e"
     },
     "7g": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "65"
     },
     "7h": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "7g"
     },
     "7i": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "65"
     },
     "7j": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "7i"
     },
     "7k": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "65"
     },
     "7l": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "7k"
     },
     "7m": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "63"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "65"
     },
     "7n": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "7m"
     },
     "7o": {
-      "key": "root.imports.requests",
-      "~k_parent": "54"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "65"
     },
     "7p": {
-      "key": "root.imports.websockets",
-      "~k_parent": "54"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "7o"
     },
     "7q": {
-      "key": "root.imports.operators",
-      "~k_parent": "54"
+      "key": "root.imports.requests",
+      "~k_parent": "55"
     },
     "7r": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "7q"
+      "key": "root.imports.websockets",
+      "~k_parent": "55"
     },
     "7s": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "7r"
+      "key": "root.imports.operators",
+      "~k_parent": "55"
     },
     "7t": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "7r"
+      "key": "root.imports.operators.client",
+      "~k_parent": "7s"
     },
     "7u": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "7r"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "7t"
     },
     "7v": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "7t"
+    },
+    "7w": {
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "7t"
+    },
+    "7x": {
       "key": "root.imports.operators.server",
-      "~k_parent": "7q"
+      "~k_parent": "7s"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1828,6 +1836,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -8425,6 +8434,9 @@
       "providers": {
         "~k": "43"
       },
+      "strategies": {
+        "~k": "44"
+      },
       "~k": "41"
     },
     "blocks": {
@@ -8432,165 +8444,165 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 8,
-        "~k": "45"
+        "~k": "46"
       },
       "Breadcrumb": {
         "originalTypeName": "Breadcrumb",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "46"
+        "~k": "47"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "47"
+        "~k": "48"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "48"
+        "~k": "49"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "49"
+        "~k": "4a"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "4a"
+        "~k": "4b"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "4b"
+        "~k": "4c"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4c"
+        "~k": "4d"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4d"
+        "~k": "4e"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4e"
+        "~k": "4f"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4f"
+        "~k": "4g"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4g"
+        "~k": "4h"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4h"
+        "~k": "4i"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4i"
+        "~k": "4j"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4j"
+        "~k": "4k"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4k"
+        "~k": "4l"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4l"
+        "~k": "4m"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4m"
+        "~k": "4n"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4n"
+        "~k": "4o"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4o"
+        "~k": "4p"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4p"
+        "~k": "4q"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4q"
+        "~k": "4r"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4r"
+        "~k": "4s"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4s"
+        "~k": "4t"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4t"
+        "~k": "4u"
       },
-      "~k": "44"
+      "~k": "45"
     },
     "connections": {
-      "~k": "4u"
-    },
-    "requests": {
       "~k": "4v"
     },
-    "websockets": {
+    "requests": {
       "~k": "4w"
     },
-    "api": {
+    "websockets": {
       "~k": "4x"
+    },
+    "api": {
+      "~k": "4y"
     },
     "operators": {
       "client": {
@@ -8598,26 +8610,26 @@
           "originalTypeName": "_global",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "50"
+          "~k": "51"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "51"
+          "~k": "52"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "52"
+          "~k": "53"
         },
-        "~k": "4z"
+        "~k": "50"
       },
       "server": {
-        "~k": "53"
+        "~k": "54"
       },
-      "~k": "4y"
+      "~k": "4z"
     },
     "~k": "3w"
   }

--- a/packages/build/src/tests/success/34-crud-app-complete/snapshot.json
+++ b/packages/build/src/tests/success/34-crud-app-complete/snapshot.json
@@ -452,92 +452,92 @@
       "~k_parent": "75"
     },
     "78": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "75"
+    },
+    "79": {
       "key": "root.types.blocks",
       "~k_parent": "6x"
     },
-    "79": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "78"
-    },
     "80": {
-      "key": "root.types.requests.MongoDBDeleteOne",
-      "~k_parent": "7y"
+      "key": "root.types.requests.MongoDBFind",
+      "~k_parent": "7z"
     },
     "81": {
-      "key": "root.types.requests.MongoDBInsertOne",
-      "~k_parent": "7y"
+      "key": "root.types.requests.MongoDBDeleteOne",
+      "~k_parent": "7z"
     },
     "82": {
-      "key": "root.types.requests.MongoDBFindOne",
-      "~k_parent": "7y"
+      "key": "root.types.requests.MongoDBInsertOne",
+      "~k_parent": "7z"
     },
     "83": {
-      "key": "root.types.requests.MongoDBUpdateOne",
-      "~k_parent": "7y"
+      "key": "root.types.requests.MongoDBFindOne",
+      "~k_parent": "7z"
     },
     "84": {
+      "key": "root.types.requests.MongoDBUpdateOne",
+      "~k_parent": "7z"
+    },
+    "85": {
       "key": "root.types.websockets",
       "~k_parent": "6x"
     },
-    "85": {
+    "86": {
       "key": "root.types.api",
       "~k_parent": "6x"
     },
-    "86": {
+    "87": {
       "key": "root.types.operators",
       "~k_parent": "6x"
     },
-    "87": {
-      "key": "root.types.operators.client",
-      "~k_parent": "86"
-    },
     "88": {
-      "key": "root.types.operators.client._state",
+      "key": "root.types.operators.client",
       "~k_parent": "87"
     },
     "89": {
-      "key": "root.types.operators.client._request",
-      "~k_parent": "87"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "88"
     },
     "90": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "8t"
     },
     "91": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "8t"
     },
     "92": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "8t"
     },
     "93": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "8t"
     },
     "94": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "8t"
     },
     "95": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "8t"
     },
     "96": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "8t"
     },
     "97": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "8t"
     },
     "98": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "8t"
     },
     "99": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "8t"
     },
     "a": {
       "key": "root.menus[0:default].links",
@@ -1466,536 +1466,544 @@
       "~k_parent": "6y"
     },
     "7a": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "78"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "79"
     },
     "7b": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "78"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "79"
     },
     "7c": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "78"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "79"
     },
     "7d": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "78"
+      "key": "root.types.blocks.List",
+      "~k_parent": "79"
     },
     "7e": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "78"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "79"
     },
     "7f": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "78"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "79"
     },
     "7g": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "78"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "79"
     },
     "7h": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "78"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "79"
     },
     "7i": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "78"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "79"
     },
     "7j": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "78"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "79"
     },
     "7k": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "78"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "79"
     },
     "7l": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "78"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "79"
     },
     "7m": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "78"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "79"
     },
     "7n": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "78"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "79"
     },
     "7o": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "78"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "79"
     },
     "7p": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "78"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "79"
     },
     "7q": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "78"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "79"
     },
     "7r": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "78"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "79"
     },
     "7s": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "78"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "79"
     },
     "7t": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "78"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "79"
     },
     "7u": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "78"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "79"
     },
     "7v": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "78"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "79"
     },
     "7w": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "79"
+    },
+    "7x": {
       "key": "root.types.connections",
       "~k_parent": "6x"
     },
-    "7x": {
-      "key": "root.types.connections.MongoDBCollection",
-      "~k_parent": "7w"
-    },
     "7y": {
+      "key": "root.types.connections.MongoDBCollection",
+      "~k_parent": "7x"
+    },
+    "7z": {
       "key": "root.types.requests",
       "~k_parent": "6x"
     },
-    "7z": {
-      "key": "root.types.requests.MongoDBFind",
-      "~k_parent": "7y"
-    },
     "8a": {
-      "key": "root.types.operators.client._url_query",
-      "~k_parent": "87"
+      "key": "root.types.operators.client._request",
+      "~k_parent": "88"
     },
     "8b": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "87"
+      "key": "root.types.operators.client._url_query",
+      "~k_parent": "88"
     },
     "8c": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "87"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "88"
     },
     "8d": {
-      "key": "root.types.operators.server",
-      "~k_parent": "86"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "88"
     },
     "8e": {
-      "key": "root.types.operators.server._payload",
-      "~k_parent": "8d"
+      "key": "root.types.operators.server",
+      "~k_parent": "87"
     },
     "8f": {
-      "key": "root.types.operators.server._date",
-      "~k_parent": "8d"
+      "key": "root.types.operators.server._payload",
+      "~k_parent": "8e"
     },
     "8g": {
+      "key": "root.types.operators.server._date",
+      "~k_parent": "8e"
+    },
+    "8h": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "8h": {
-      "key": "root.imports.actions",
-      "~k_parent": "8g"
-    },
     "8i": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "8h"
     },
     "8j": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "8h"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "8i"
     },
     "8k": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "8h"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "8i"
     },
     "8l": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "8h"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "8i"
     },
     "8m": {
-      "key": "root.imports.actions[4]",
-      "~k_parent": "8h"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "8i"
     },
     "8n": {
-      "key": "root.imports.agents",
-      "~k_parent": "8g"
+      "key": "root.imports.actions[4]",
+      "~k_parent": "8i"
     },
     "8o": {
-      "key": "root.imports.auth",
-      "~k_parent": "8g"
+      "key": "root.imports.agents",
+      "~k_parent": "8h"
     },
     "8p": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "8o"
+      "key": "root.imports.auth",
+      "~k_parent": "8h"
     },
     "8q": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "8o"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "8p"
     },
     "8r": {
-      "key": "root.imports.blocks",
-      "~k_parent": "8g"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "8p"
     },
     "8s": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "8r"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "8p"
     },
     "8t": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks",
+      "~k_parent": "8h"
     },
     "8u": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "8t"
     },
     "8v": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "8t"
     },
     "8w": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "8t"
     },
     "8x": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "8t"
     },
     "8y": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "8t"
     },
     "8z": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "8t"
     },
     "9a": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "8t"
     },
     "9b": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "8t"
     },
     "9c": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "8t"
     },
     "9d": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "8t"
     },
     "9e": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "8r"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "8t"
     },
     "9f": {
-      "key": "root.imports.connections",
-      "~k_parent": "8g"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "8t"
     },
     "9g": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "9f"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "8t"
     },
     "9h": {
-      "key": "root.imports.icons",
-      "~k_parent": "8g"
+      "key": "root.imports.connections",
+      "~k_parent": "8h"
     },
     "9i": {
-      "key": "root.imports.icons[0]",
+      "key": "root.imports.connections[0]",
       "~k_parent": "9h"
     },
     "9j": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "9i"
+      "key": "root.imports.icons",
+      "~k_parent": "8h"
     },
     "9k": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "9j"
     },
     "9l": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "9k"
     },
     "9m": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "9j"
     },
     "9n": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "9m"
     },
     "9o": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "9j"
     },
     "9p": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "9o"
     },
     "9q": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "9j"
     },
     "9r": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "9q"
     },
     "9s": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "9j"
     },
     "9t": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "9s"
     },
     "9u": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "9j"
     },
     "9v": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "9u"
     },
     "9w": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "9j"
     },
     "9x": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "9w"
     },
     "9y": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "9j"
     },
     "9z": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "9y"
     },
     "a0": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "9j"
     },
     "a1": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "a0"
     },
     "a2": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "9j"
     },
     "a3": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "a2"
     },
     "a4": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "9j"
     },
     "a5": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "a4"
     },
     "a6": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "9j"
     },
     "a7": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "a6"
     },
     "a8": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "9j"
     },
     "a9": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "a8"
     },
     "aa": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "9j"
     },
     "ab": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "aa"
     },
     "ac": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "9j"
     },
     "ad": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "ac"
     },
     "ae": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "9j"
     },
     "af": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "ae"
     },
     "ag": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "9j"
     },
     "ah": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "ag"
     },
     "ai": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "9j"
     },
     "aj": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "ai"
     },
     "ak": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "9j"
     },
     "al": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "ak"
     },
     "am": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "9j"
     },
     "an": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "am"
     },
     "ao": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "9j"
     },
     "ap": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "ao"
     },
     "aq": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "9j"
     },
     "ar": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "aq"
     },
     "as": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "9j"
     },
     "at": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "as"
     },
     "au": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "9j"
     },
     "av": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "au"
     },
     "aw": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "9j"
     },
     "ax": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "aw"
     },
     "ay": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "9j"
     },
     "az": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "ay"
     },
     "b0": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "9h"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "9j"
     },
     "b1": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "b0"
     },
     "b2": {
-      "key": "root.imports.requests",
-      "~k_parent": "8g"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "9j"
     },
     "b3": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "b2"
     },
     "b4": {
-      "key": "root.imports.requests[1]",
-      "~k_parent": "b2"
+      "key": "root.imports.requests",
+      "~k_parent": "8h"
     },
     "b5": {
-      "key": "root.imports.requests[2]",
-      "~k_parent": "b2"
+      "key": "root.imports.requests[0]",
+      "~k_parent": "b4"
     },
     "b6": {
-      "key": "root.imports.requests[3]",
-      "~k_parent": "b2"
+      "key": "root.imports.requests[1]",
+      "~k_parent": "b4"
     },
     "b7": {
-      "key": "root.imports.requests[4]",
-      "~k_parent": "b2"
+      "key": "root.imports.requests[2]",
+      "~k_parent": "b4"
     },
     "b8": {
-      "key": "root.imports.websockets",
-      "~k_parent": "8g"
+      "key": "root.imports.requests[3]",
+      "~k_parent": "b4"
     },
     "b9": {
-      "key": "root.imports.operators",
-      "~k_parent": "8g"
+      "key": "root.imports.requests[4]",
+      "~k_parent": "b4"
     },
     "ba": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "b9"
+      "key": "root.imports.websockets",
+      "~k_parent": "8h"
     },
     "bb": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "ba"
+      "key": "root.imports.operators",
+      "~k_parent": "8h"
     },
     "bc": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "ba"
+      "key": "root.imports.operators.client",
+      "~k_parent": "bb"
     },
     "bd": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "ba"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "bc"
     },
     "be": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "ba"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "bc"
     },
     "bf": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "ba"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "bc"
     },
     "bg": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "b9"
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "bc"
     },
     "bh": {
-      "key": "root.imports.operators.server[0]",
-      "~k_parent": "bg"
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "bc"
     },
     "bi": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "bb"
+    },
+    "bj": {
+      "key": "root.imports.operators.server[0]",
+      "~k_parent": "bi"
+    },
+    "bk": {
       "key": "root.imports.operators.server[1]",
-      "~k_parent": "bg"
+      "~k_parent": "bi"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -3163,6 +3171,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -9118,6 +9127,9 @@
       "providers": {
         "~k": "77"
       },
+      "strategies": {
+        "~k": "78"
+      },
       "~k": "75"
     },
     "blocks": {
@@ -9125,189 +9137,189 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "79"
+        "~k": "7a"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "7a"
+        "~k": "7b"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "7b"
+        "~k": "7c"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "7c"
+        "~k": "7d"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "7d"
+        "~k": "7e"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7e"
+        "~k": "7f"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 4,
-        "~k": "7f"
+        "~k": "7g"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "7g"
+        "~k": "7h"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7h"
+        "~k": "7i"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7i"
+        "~k": "7j"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7j"
+        "~k": "7k"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7k"
+        "~k": "7l"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7l"
+        "~k": "7m"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7m"
+        "~k": "7n"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7n"
+        "~k": "7o"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7o"
+        "~k": "7p"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7p"
+        "~k": "7q"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7q"
+        "~k": "7r"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7r"
+        "~k": "7s"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7s"
+        "~k": "7t"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7t"
+        "~k": "7u"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7u"
+        "~k": "7v"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "7v"
+        "~k": "7w"
       },
-      "~k": "78"
+      "~k": "79"
     },
     "connections": {
       "MongoDBCollection": {
         "originalTypeName": "MongoDBCollection",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "7x"
+        "~k": "7y"
       },
-      "~k": "7w"
+      "~k": "7x"
     },
     "requests": {
       "MongoDBFind": {
         "originalTypeName": "MongoDBFind",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "7z"
+        "~k": "80"
       },
       "MongoDBDeleteOne": {
         "originalTypeName": "MongoDBDeleteOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "80"
+        "~k": "81"
       },
       "MongoDBInsertOne": {
         "originalTypeName": "MongoDBInsertOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "81"
+        "~k": "82"
       },
       "MongoDBFindOne": {
         "originalTypeName": "MongoDBFindOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "82"
+        "~k": "83"
       },
       "MongoDBUpdateOne": {
         "originalTypeName": "MongoDBUpdateOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "83"
+        "~k": "84"
       },
-      "~k": "7y"
+      "~k": "7z"
     },
     "websockets": {
-      "~k": "84"
+      "~k": "85"
     },
     "api": {
-      "~k": "85"
+      "~k": "86"
     },
     "operators": {
       "client": {
@@ -9315,50 +9327,50 @@
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 8,
-          "~k": "88"
+          "~k": "89"
         },
         "_request": {
           "originalTypeName": "_request",
           "package": "@lowdefy/operators-js",
           "count": 3,
-          "~k": "89"
+          "~k": "8a"
         },
         "_url_query": {
           "originalTypeName": "_url_query",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "8a"
+          "~k": "8b"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "8b"
+          "~k": "8c"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "8c"
+          "~k": "8d"
         },
-        "~k": "87"
+        "~k": "88"
       },
       "server": {
         "_payload": {
           "originalTypeName": "_payload",
           "package": "@lowdefy/operators-js",
           "count": 7,
-          "~k": "8e"
+          "~k": "8f"
         },
         "_date": {
           "originalTypeName": "_date",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "8f"
+          "~k": "8g"
         },
-        "~k": "8d"
+        "~k": "8e"
       },
-      "~k": "86"
+      "~k": "87"
     },
     "~k": "6x"
   }

--- a/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
+++ b/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
@@ -97,11 +97,15 @@
       "~arr": [],
       "~k": "37"
     },
+    "strategies": {
+      "~arr": [],
+      "~k": "38"
+    },
     "organizations": {
       "policy": "pinned",
       "org": "default",
       "signup": "invite-only",
-      "~k": "38"
+      "~k": "39"
     },
     "authPages": {
       "signIn": "/login",
@@ -110,28 +114,28 @@
       "forgotPassword": "/forgot-password",
       "resetPassword": "/reset-password",
       "verifyEmail": "/verify-email",
-      "~k": "39"
+      "~k": "3a"
     },
     "account": {
       "accountLinking": {
         "enabled": true,
         "trustedProviders": {
           "~arr": [],
-          "~k": "3c"
+          "~k": "3d"
         },
-        "~k": "3b"
+        "~k": "3c"
       },
-      "~k": "3a"
+      "~k": "3b"
     },
     "rateLimit": {
       "enabled": true,
       "window": 60,
       "max": 100,
-      "~k": "3d"
+      "~k": "3e"
     },
     "roles": {
       "~arr": [],
-      "~k": "3e"
+      "~k": "3f"
     },
     "~k": "5"
   },
@@ -333,212 +337,216 @@
       "~k_parent": "5"
     },
     "38": {
-      "key": "root.auth.organizations",
+      "key": "root.auth.strategies",
       "~k_parent": "5"
     },
     "39": {
-      "key": "root.auth.authPages",
+      "key": "root.auth.organizations",
       "~k_parent": "5"
     },
     "40": {
+      "key": "root.pages[2:dashboard:Box].slots.content",
+      "~k_parent": "3z"
+    },
+    "41": {
       "key": "root.pages[2:dashboard:Box].blocks[1:stats:Box].slots",
       "~k_parent": "1f"
     },
-    "41": {
-      "key": "root.pages[2:dashboard:Box].blocks[1:stats:Box].slots.content",
-      "~k_parent": "40"
-    },
     "42": {
-      "key": "root.pages[2:dashboard:Box].subscriptions",
-      "~k_parent": "3w"
+      "key": "root.pages[2:dashboard:Box].blocks[1:stats:Box].slots.content",
+      "~k_parent": "41"
     },
     "43": {
-      "key": "root.pages[2:dashboard:Box].requests",
-      "~k_parent": "3w"
+      "key": "root.pages[2:dashboard:Box].subscriptions",
+      "~k_parent": "3x"
     },
     "44": {
-      "key": "root.pages[3:profile:Box]",
-      "~k_parent": "3j"
+      "key": "root.pages[2:dashboard:Box].requests",
+      "~k_parent": "3x"
     },
     "45": {
-      "key": "root.pages[3:profile:Box].auth",
-      "~k_parent": "44"
+      "key": "root.pages[3:profile:Box]",
+      "~k_parent": "3k"
     },
     "46": {
-      "key": "root.pages[3:profile:Box].slots",
-      "~k_parent": "44"
+      "key": "root.pages[3:profile:Box].auth",
+      "~k_parent": "45"
     },
     "47": {
-      "key": "root.pages[3:profile:Box].slots.content",
-      "~k_parent": "46"
+      "key": "root.pages[3:profile:Box].slots",
+      "~k_parent": "45"
     },
     "48": {
-      "key": "root.pages[3:profile:Box].subscriptions",
-      "~k_parent": "44"
+      "key": "root.pages[3:profile:Box].slots.content",
+      "~k_parent": "47"
     },
     "49": {
-      "key": "root.pages[3:profile:Box].requests",
-      "~k_parent": "44"
+      "key": "root.pages[3:profile:Box].subscriptions",
+      "~k_parent": "45"
     },
     "50": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "4x"
+      "key": "root.types.auth.adapters.MongoDBAuthAdapter",
+      "~k_parent": "4z"
     },
     "51": {
-      "key": "root.types.auth.providers.Google",
-      "~k_parent": "50"
+      "key": "root.types.auth.providers",
+      "~k_parent": "4y"
     },
     "52": {
-      "key": "root.types.blocks",
-      "~k_parent": "4q"
+      "key": "root.types.auth.providers.Google",
+      "~k_parent": "51"
     },
     "53": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "52"
+      "key": "root.types.auth.strategies",
+      "~k_parent": "4y"
     },
     "54": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "52"
+      "key": "root.types.blocks",
+      "~k_parent": "4r"
     },
     "55": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "52"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "54"
     },
     "56": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "52"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "54"
     },
     "57": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "52"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "54"
     },
     "58": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "52"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "54"
     },
     "59": {
-      "key": "root.types.blocks.Avatar",
-      "~k_parent": "52"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "54"
     },
     "60": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "5x"
+      "key": "root.types.operators.client._user",
+      "~k_parent": "5z"
     },
     "61": {
-      "key": "root.types.operators.server",
-      "~k_parent": "5w"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "5z"
     },
     "62": {
+      "key": "root.types.operators.client._type",
+      "~k_parent": "5z"
+    },
+    "63": {
+      "key": "root.types.operators.server",
+      "~k_parent": "5y"
+    },
+    "64": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "63": {
-      "key": "root.imports.actions",
-      "~k_parent": "62"
-    },
-    "64": {
-      "key": "root.imports.actions[0]",
-      "~k_parent": "63"
-    },
     "65": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "63"
+      "key": "root.imports.actions",
+      "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "63"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "63"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "65"
     },
     "68": {
-      "key": "root.imports.agents",
-      "~k_parent": "62"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "65"
     },
     "69": {
-      "key": "root.imports.auth",
-      "~k_parent": "62"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "65"
     },
     "70": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "6h"
     },
     "71": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "6h"
     },
     "72": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "6h"
     },
     "73": {
-      "key": "root.imports.blocks[24]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "6h"
     },
     "74": {
-      "key": "root.imports.connections",
-      "~k_parent": "62"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "6h"
     },
     "75": {
-      "key": "root.imports.icons",
-      "~k_parent": "62"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "6h"
     },
     "76": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "75"
+      "key": "root.imports.blocks[24]",
+      "~k_parent": "6h"
     },
     "77": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "76"
+      "key": "root.imports.connections",
+      "~k_parent": "64"
     },
     "78": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "75"
+      "key": "root.imports.icons",
+      "~k_parent": "64"
     },
     "79": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0]",
       "~k_parent": "78"
     },
     "80": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[13].icons",
+      "~k_parent": "7z"
     },
     "81": {
-      "key": "root.imports.icons[15].icons",
-      "~k_parent": "80"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "78"
     },
     "82": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[14].icons",
+      "~k_parent": "81"
     },
     "83": {
-      "key": "root.imports.icons[16].icons",
-      "~k_parent": "82"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "78"
     },
     "84": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[15].icons",
+      "~k_parent": "83"
     },
     "85": {
-      "key": "root.imports.icons[17].icons",
-      "~k_parent": "84"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "78"
     },
     "86": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[16].icons",
+      "~k_parent": "85"
     },
     "87": {
-      "key": "root.imports.icons[18].icons",
-      "~k_parent": "86"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "78"
     },
     "88": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[17].icons",
+      "~k_parent": "87"
     },
     "89": {
-      "key": "root.imports.icons[19].icons",
-      "~k_parent": "88"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "78"
+    },
+    "90": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "8v"
     },
     "a": {
       "key": "root.auth.providers[0:google:Google]",
@@ -942,620 +950,628 @@
       "~k_parent": "4"
     },
     "3a": {
-      "key": "root.auth.account",
+      "key": "root.auth.authPages",
       "~k_parent": "5"
     },
     "3b": {
-      "key": "root.auth.account.accountLinking",
-      "~k_parent": "3a"
+      "key": "root.auth.account",
+      "~k_parent": "5"
     },
     "3c": {
-      "key": "root.auth.account.accountLinking.trustedProviders",
+      "key": "root.auth.account.accountLinking",
       "~k_parent": "3b"
     },
     "3d": {
+      "key": "root.auth.account.accountLinking.trustedProviders",
+      "~k_parent": "3c"
+    },
+    "3e": {
       "key": "root.auth.rateLimit",
       "~k_parent": "5"
     },
-    "3e": {
+    "3f": {
       "key": "root.auth.roles",
       "~k_parent": "5"
     },
-    "3f": {
+    "3g": {
       "key": "root.menus[0:default].links",
       "~k_parent": "i"
     },
-    "3g": {
+    "3h": {
       "key": "root.menus[0:default].links[0:dashboard:MenuLink].auth",
       "~k_parent": "k"
     },
-    "3h": {
+    "3i": {
       "key": "root.menus[0:default].links[1:profile:MenuLink].auth",
       "~k_parent": "m"
     },
-    "3i": {
+    "3j": {
       "key": "root.menus[0:default].links[2:settings:MenuLink].auth",
       "~k_parent": "o"
     },
-    "3j": {
+    "3k": {
       "key": "root.pages",
       "~k_parent": "4"
     },
-    "3k": {
-      "key": "root.pages[0:login:Result]",
-      "~k_parent": "3j"
-    },
     "3l": {
-      "key": "root.pages[0:login:Result].auth",
+      "key": "root.pages[0:login:Result]",
       "~k_parent": "3k"
     },
     "3m": {
+      "key": "root.pages[0:login:Result].auth",
+      "~k_parent": "3l"
+    },
+    "3n": {
       "key": "root.pages[0:login:Result].areas.extra.blocks[0:loginBtn:Button].events.onClick",
       "~k_parent": "y"
     },
-    "3n": {
-      "key": "root.pages[0:login:Result].areas.extra.blocks[0:loginBtn:Button].events.onClick.catch",
-      "~k_parent": "3m"
-    },
     "3o": {
-      "key": "root.pages[0:login:Result].subscriptions",
-      "~k_parent": "3k"
+      "key": "root.pages[0:login:Result].areas.extra.blocks[0:loginBtn:Button].events.onClick.catch",
+      "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.pages[0:login:Result].requests",
-      "~k_parent": "3k"
+      "key": "root.pages[0:login:Result].subscriptions",
+      "~k_parent": "3l"
     },
     "3q": {
-      "key": "root.pages[1:public-page:Box]",
-      "~k_parent": "3j"
+      "key": "root.pages[0:login:Result].requests",
+      "~k_parent": "3l"
     },
     "3r": {
-      "key": "root.pages[1:public-page:Box].auth",
-      "~k_parent": "3q"
+      "key": "root.pages[1:public-page:Box]",
+      "~k_parent": "3k"
     },
     "3s": {
-      "key": "root.pages[1:public-page:Box].slots",
-      "~k_parent": "3q"
+      "key": "root.pages[1:public-page:Box].auth",
+      "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.pages[1:public-page:Box].slots.content",
-      "~k_parent": "3s"
+      "key": "root.pages[1:public-page:Box].slots",
+      "~k_parent": "3r"
     },
     "3u": {
-      "key": "root.pages[1:public-page:Box].subscriptions",
-      "~k_parent": "3q"
+      "key": "root.pages[1:public-page:Box].slots.content",
+      "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.pages[1:public-page:Box].requests",
-      "~k_parent": "3q"
+      "key": "root.pages[1:public-page:Box].subscriptions",
+      "~k_parent": "3r"
     },
     "3w": {
-      "key": "root.pages[2:dashboard:Box]",
-      "~k_parent": "3j"
+      "key": "root.pages[1:public-page:Box].requests",
+      "~k_parent": "3r"
     },
     "3x": {
-      "key": "root.pages[2:dashboard:Box].auth",
-      "~k_parent": "3w"
+      "key": "root.pages[2:dashboard:Box]",
+      "~k_parent": "3k"
     },
     "3y": {
-      "key": "root.pages[2:dashboard:Box].slots",
-      "~k_parent": "3w"
+      "key": "root.pages[2:dashboard:Box].auth",
+      "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.pages[2:dashboard:Box].slots.content",
-      "~k_parent": "3y"
+      "key": "root.pages[2:dashboard:Box].slots",
+      "~k_parent": "3x"
     },
     "4a": {
-      "key": "root.pages[4:settings:Box]",
-      "~k_parent": "3j"
+      "key": "root.pages[3:profile:Box].requests",
+      "~k_parent": "45"
     },
     "4b": {
-      "key": "root.pages[4:settings:Box].auth",
-      "~k_parent": "4a"
+      "key": "root.pages[4:settings:Box]",
+      "~k_parent": "3k"
     },
     "4c": {
-      "key": "root.pages[4:settings:Box].slots",
-      "~k_parent": "4a"
+      "key": "root.pages[4:settings:Box].auth",
+      "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.pages[4:settings:Box].slots.content",
-      "~k_parent": "4c"
+      "key": "root.pages[4:settings:Box].slots",
+      "~k_parent": "4b"
     },
     "4e": {
+      "key": "root.pages[4:settings:Box].slots.content",
+      "~k_parent": "4d"
+    },
+    "4f": {
       "key": "root.pages[4:settings:Box].blocks[3:logoutBtn:Button].events.onClick",
       "~k_parent": "2c"
     },
-    "4f": {
-      "key": "root.pages[4:settings:Box].blocks[3:logoutBtn:Button].events.onClick.catch",
-      "~k_parent": "4e"
-    },
     "4g": {
-      "key": "root.pages[4:settings:Box].subscriptions",
-      "~k_parent": "4a"
+      "key": "root.pages[4:settings:Box].blocks[3:logoutBtn:Button].events.onClick.catch",
+      "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.pages[4:settings:Box].requests",
-      "~k_parent": "4a"
+      "key": "root.pages[4:settings:Box].subscriptions",
+      "~k_parent": "4b"
     },
     "4i": {
-      "key": "root.pages[5:404:Result]",
-      "~k_parent": "3j"
+      "key": "root.pages[4:settings:Box].requests",
+      "~k_parent": "4b"
     },
     "4j": {
-      "key": "root.pages[5:404:Result].style",
-      "~k_parent": "4i"
+      "key": "root.pages[5:404:Result]",
+      "~k_parent": "3k"
     },
     "4k": {
-      "key": "root.pages[5:404:Result].style.block",
+      "key": "root.pages[5:404:Result].style",
       "~k_parent": "4j"
     },
     "4l": {
+      "key": "root.pages[5:404:Result].style.block",
+      "~k_parent": "4k"
+    },
+    "4m": {
       "key": "root.pages[5:404:Result].slots.extra.blocks[0:home:Button].events.onClick",
       "~k_parent": "2q"
     },
-    "4m": {
-      "key": "root.pages[5:404:Result].slots.extra.blocks[0:home:Button].events.onClick.catch",
-      "~k_parent": "4l"
-    },
     "4n": {
-      "key": "root.pages[5:404:Result].auth",
-      "~k_parent": "4i"
+      "key": "root.pages[5:404:Result].slots.extra.blocks[0:home:Button].events.onClick.catch",
+      "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.pages[5:404:Result].subscriptions",
-      "~k_parent": "4i"
+      "key": "root.pages[5:404:Result].auth",
+      "~k_parent": "4j"
     },
     "4p": {
-      "key": "root.pages[5:404:Result].requests",
-      "~k_parent": "4i"
+      "key": "root.pages[5:404:Result].subscriptions",
+      "~k_parent": "4j"
     },
     "4q": {
+      "key": "root.pages[5:404:Result].requests",
+      "~k_parent": "4j"
+    },
+    "4r": {
       "key": "root.types",
       "~k_parent": "4"
     },
-    "4r": {
-      "key": "root.types.actions",
-      "~k_parent": "4q"
-    },
     "4s": {
-      "key": "root.types.actions.Login",
+      "key": "root.types.actions",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.types.actions.Logout",
-      "~k_parent": "4r"
+      "key": "root.types.actions.Login",
+      "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.types.actions.Link",
-      "~k_parent": "4r"
+      "key": "root.types.actions.Logout",
+      "~k_parent": "4s"
     },
     "4v": {
-      "key": "root.types.actions.SetDarkMode",
-      "~k_parent": "4r"
+      "key": "root.types.actions.Link",
+      "~k_parent": "4s"
     },
     "4w": {
-      "key": "root.types.agents",
-      "~k_parent": "4q"
+      "key": "root.types.actions.SetDarkMode",
+      "~k_parent": "4s"
     },
     "4x": {
-      "key": "root.types.auth",
-      "~k_parent": "4q"
+      "key": "root.types.agents",
+      "~k_parent": "4r"
     },
     "4y": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "4x"
+      "key": "root.types.auth",
+      "~k_parent": "4r"
     },
     "4z": {
-      "key": "root.types.auth.adapters.MongoDBAuthAdapter",
+      "key": "root.types.auth.adapters",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "52"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "54"
     },
     "5b": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "52"
+      "key": "root.types.blocks.Avatar",
+      "~k_parent": "54"
     },
     "5c": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "52"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "54"
     },
     "5d": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "52"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "54"
     },
     "5e": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "52"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "54"
     },
     "5f": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "52"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "54"
     },
     "5g": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "52"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "54"
     },
     "5h": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "52"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "54"
     },
     "5i": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "52"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "54"
     },
     "5j": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "52"
+      "key": "root.types.blocks.List",
+      "~k_parent": "54"
     },
     "5k": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "52"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "54"
     },
     "5l": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "52"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "54"
     },
     "5m": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "52"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "54"
     },
     "5n": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "52"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "54"
     },
     "5o": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "52"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "54"
     },
     "5p": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "52"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "54"
     },
     "5q": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "52"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "54"
     },
     "5r": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "52"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "54"
     },
     "5s": {
-      "key": "root.types.connections",
-      "~k_parent": "4q"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "54"
     },
     "5t": {
-      "key": "root.types.requests",
-      "~k_parent": "4q"
+      "key": "root.types.blocks.Message",
+      "~k_parent": "54"
     },
     "5u": {
-      "key": "root.types.websockets",
-      "~k_parent": "4q"
+      "key": "root.types.connections",
+      "~k_parent": "4r"
     },
     "5v": {
-      "key": "root.types.api",
-      "~k_parent": "4q"
+      "key": "root.types.requests",
+      "~k_parent": "4r"
     },
     "5w": {
-      "key": "root.types.operators",
-      "~k_parent": "4q"
+      "key": "root.types.websockets",
+      "~k_parent": "4r"
     },
     "5x": {
-      "key": "root.types.operators.client",
-      "~k_parent": "5w"
+      "key": "root.types.api",
+      "~k_parent": "4r"
     },
     "5y": {
-      "key": "root.types.operators.client._user",
-      "~k_parent": "5x"
+      "key": "root.types.operators",
+      "~k_parent": "4r"
     },
     "5z": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "5x"
+      "key": "root.types.operators.client",
+      "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "69"
+      "key": "root.imports.agents",
+      "~k_parent": "64"
     },
     "6b": {
-      "key": "root.imports.auth.adapters[0]",
-      "~k_parent": "6a"
+      "key": "root.imports.auth",
+      "~k_parent": "64"
     },
     "6c": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "69"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.auth.providers[0]",
+      "key": "root.imports.auth.adapters[0]",
       "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.blocks",
-      "~k_parent": "62"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "6b"
     },
     "6f": {
-      "key": "root.imports.blocks[0]",
+      "key": "root.imports.auth.providers[0]",
       "~k_parent": "6e"
     },
     "6g": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "6e"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "6b"
     },
     "6h": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks",
+      "~k_parent": "64"
     },
     "6i": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "6h"
     },
     "6k": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "6h"
     },
     "6l": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "6h"
     },
     "6m": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "6h"
     },
     "6n": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "6h"
     },
     "6o": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "6h"
     },
     "6p": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "6h"
     },
     "6q": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "6h"
     },
     "6r": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "6h"
     },
     "6s": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "6h"
     },
     "6t": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "6h"
     },
     "6u": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "6h"
     },
     "6v": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "6h"
     },
     "6w": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "6h"
     },
     "6x": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "6h"
     },
     "6y": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "6h"
     },
     "6z": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "6e"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "6h"
     },
     "7a": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[0].icons",
+      "~k_parent": "79"
     },
     "7b": {
-      "key": "root.imports.icons[2].icons",
-      "~k_parent": "7a"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "78"
     },
     "7c": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[1].icons",
+      "~k_parent": "7b"
     },
     "7d": {
-      "key": "root.imports.icons[3].icons",
-      "~k_parent": "7c"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "78"
     },
     "7e": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[2].icons",
+      "~k_parent": "7d"
     },
     "7f": {
-      "key": "root.imports.icons[4].icons",
-      "~k_parent": "7e"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "78"
     },
     "7g": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[3].icons",
+      "~k_parent": "7f"
     },
     "7h": {
-      "key": "root.imports.icons[5].icons",
-      "~k_parent": "7g"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "78"
     },
     "7i": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[4].icons",
+      "~k_parent": "7h"
     },
     "7j": {
-      "key": "root.imports.icons[6].icons",
-      "~k_parent": "7i"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "78"
     },
     "7k": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[5].icons",
+      "~k_parent": "7j"
     },
     "7l": {
-      "key": "root.imports.icons[7].icons",
-      "~k_parent": "7k"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "78"
     },
     "7m": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[6].icons",
+      "~k_parent": "7l"
     },
     "7n": {
-      "key": "root.imports.icons[8].icons",
-      "~k_parent": "7m"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "78"
     },
     "7o": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[7].icons",
+      "~k_parent": "7n"
     },
     "7p": {
-      "key": "root.imports.icons[9].icons",
-      "~k_parent": "7o"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "78"
     },
     "7q": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[8].icons",
+      "~k_parent": "7p"
     },
     "7r": {
-      "key": "root.imports.icons[10].icons",
-      "~k_parent": "7q"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "78"
     },
     "7s": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[9].icons",
+      "~k_parent": "7r"
     },
     "7t": {
-      "key": "root.imports.icons[11].icons",
-      "~k_parent": "7s"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "78"
     },
     "7u": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[10].icons",
+      "~k_parent": "7t"
     },
     "7v": {
-      "key": "root.imports.icons[12].icons",
-      "~k_parent": "7u"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "78"
     },
     "7w": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[11].icons",
+      "~k_parent": "7v"
     },
     "7x": {
-      "key": "root.imports.icons[13].icons",
-      "~k_parent": "7w"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "78"
     },
     "7y": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[12].icons",
+      "~k_parent": "7x"
     },
     "7z": {
-      "key": "root.imports.icons[14].icons",
-      "~k_parent": "7y"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "78"
     },
     "8a": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[18].icons",
+      "~k_parent": "89"
     },
     "8b": {
-      "key": "root.imports.icons[20].icons",
-      "~k_parent": "8a"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "78"
     },
     "8c": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[19].icons",
+      "~k_parent": "8b"
     },
     "8d": {
-      "key": "root.imports.icons[21].icons",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "78"
     },
     "8e": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[20].icons",
+      "~k_parent": "8d"
     },
     "8f": {
-      "key": "root.imports.icons[22].icons",
-      "~k_parent": "8e"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "78"
     },
     "8g": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[21].icons",
+      "~k_parent": "8f"
     },
     "8h": {
-      "key": "root.imports.icons[23].icons",
-      "~k_parent": "8g"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "78"
     },
     "8i": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[22].icons",
+      "~k_parent": "8h"
     },
     "8j": {
-      "key": "root.imports.icons[24].icons",
-      "~k_parent": "8i"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "78"
     },
     "8k": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[23].icons",
+      "~k_parent": "8j"
     },
     "8l": {
-      "key": "root.imports.icons[25].icons",
-      "~k_parent": "8k"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "78"
     },
     "8m": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[24].icons",
+      "~k_parent": "8l"
     },
     "8n": {
-      "key": "root.imports.icons[26].icons",
-      "~k_parent": "8m"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "78"
     },
     "8o": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "75"
+      "key": "root.imports.icons[25].icons",
+      "~k_parent": "8n"
     },
     "8p": {
-      "key": "root.imports.icons[27].icons",
-      "~k_parent": "8o"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "78"
     },
     "8q": {
-      "key": "root.imports.requests",
-      "~k_parent": "62"
+      "key": "root.imports.icons[26].icons",
+      "~k_parent": "8p"
     },
     "8r": {
-      "key": "root.imports.websockets",
-      "~k_parent": "62"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "78"
     },
     "8s": {
-      "key": "root.imports.operators",
-      "~k_parent": "62"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "8r"
     },
     "8t": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "8s"
+      "key": "root.imports.requests",
+      "~k_parent": "64"
     },
     "8u": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "8t"
+      "key": "root.imports.websockets",
+      "~k_parent": "64"
     },
     "8v": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "8t"
+      "key": "root.imports.operators",
+      "~k_parent": "64"
     },
     "8w": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "8t"
+      "key": "root.imports.operators.client",
+      "~k_parent": "8v"
     },
     "8x": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "8s"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "8w"
+    },
+    "8y": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "8w"
+    },
+    "8z": {
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "8w"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1579,7 +1595,7 @@
               },
               "auth": {
                 "public": false,
-                "~k": "3g"
+                "~k": "3h"
               },
               "menuItemId": "dashboard",
               "~k": "k"
@@ -1595,7 +1611,7 @@
               },
               "auth": {
                 "public": false,
-                "~k": "3h"
+                "~k": "3i"
               },
               "menuItemId": "profile",
               "~k": "m"
@@ -1611,13 +1627,13 @@
               },
               "auth": {
                 "public": false,
-                "~k": "3i"
+                "~k": "3j"
               },
               "menuItemId": "settings",
               "~k": "o"
             }
           ],
-          "~k": "3f"
+          "~k": "3g"
         },
         "menuId": "default",
         "~k": "i"
@@ -1632,9 +1648,9 @@
       "block": {
         "minHeight": "100vh",
         "background": "var(--ant-color-bg-layout)",
-        "~k": "4k"
+        "~k": "4l"
       },
-      "~k": "4j"
+      "~k": "4k"
     },
     "properties": {
       "status": "info",
@@ -1677,9 +1693,9 @@
                   },
                   "catch": {
                     "~arr": [],
-                    "~k": "4m"
+                    "~k": "4n"
                   },
-                  "~k": "4l"
+                  "~k": "4m"
                 },
                 "~k": "2q"
               },
@@ -1695,19 +1711,19 @@
     },
     "auth": {
       "public": true,
-      "~k": "4n"
+      "~k": "4o"
     },
     "pageId": "404",
     "blockId": "404",
     "subscriptions": {
       "~arr": [],
-      "~k": "4o"
+      "~k": "4p"
     },
     "requests": {
       "~arr": [],
-      "~k": "4p"
+      "~k": "4q"
     },
-    "~k": "4i"
+    "~k": "4j"
   },
   "pages/dashboard.json": {
     "id": "page:dashboard",
@@ -1718,7 +1734,7 @@
     },
     "auth": {
       "public": false,
-      "~k": "3x"
+      "~k": "3y"
     },
     "pageId": "dashboard",
     "blockId": "dashboard",
@@ -1776,28 +1792,28 @@
                     ],
                     "~k": "1g"
                   },
-                  "~k": "41"
+                  "~k": "42"
                 },
-                "~k": "40"
+                "~k": "41"
               },
               "~k": "1f"
             }
           ],
           "~k": "1a"
         },
-        "~k": "3z"
+        "~k": "40"
       },
-      "~k": "3y"
+      "~k": "3z"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "42"
+      "~k": "43"
     },
     "requests": {
       "~arr": [],
-      "~k": "43"
+      "~k": "44"
     },
-    "~k": "3w"
+    "~k": "3x"
   },
   "pages/login.json": {
     "id": "page:login",
@@ -1810,7 +1826,7 @@
     },
     "auth": {
       "public": true,
-      "~k": "3l"
+      "~k": "3m"
     },
     "pageId": "login",
     "blockId": "login",
@@ -1841,9 +1857,9 @@
                   },
                   "catch": {
                     "~arr": [],
-                    "~k": "3n"
+                    "~k": "3o"
                   },
-                  "~k": "3m"
+                  "~k": "3n"
                 },
                 "~k": "y"
               },
@@ -1859,13 +1875,13 @@
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "3o"
+      "~k": "3p"
     },
     "requests": {
       "~arr": [],
-      "~k": "3p"
+      "~k": "3q"
     },
-    "~k": "3k"
+    "~k": "3l"
   },
   "pages/profile.json": {
     "id": "page:profile",
@@ -1876,7 +1892,7 @@
     },
     "auth": {
       "public": false,
-      "~k": "45"
+      "~k": "46"
     },
     "pageId": "profile",
     "blockId": "profile",
@@ -1928,19 +1944,19 @@
           ],
           "~k": "1n"
         },
-        "~k": "47"
+        "~k": "48"
       },
-      "~k": "46"
+      "~k": "47"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "48"
+      "~k": "49"
     },
     "requests": {
       "~arr": [],
-      "~k": "49"
+      "~k": "4a"
     },
-    "~k": "44"
+    "~k": "45"
   },
   "pages/public-page.json": {
     "id": "page:public-page",
@@ -1951,7 +1967,7 @@
     },
     "auth": {
       "public": true,
-      "~k": "3r"
+      "~k": "3s"
     },
     "pageId": "public-page",
     "blockId": "public-page",
@@ -1982,19 +1998,19 @@
           ],
           "~k": "13"
         },
-        "~k": "3t"
+        "~k": "3u"
       },
-      "~k": "3s"
+      "~k": "3t"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "3u"
+      "~k": "3v"
     },
     "requests": {
       "~arr": [],
-      "~k": "3v"
+      "~k": "3w"
     },
-    "~k": "3q"
+    "~k": "3r"
   },
   "pages/settings.json": {
     "id": "page:settings",
@@ -2005,7 +2021,7 @@
     },
     "auth": {
       "public": false,
-      "~k": "4b"
+      "~k": "4c"
     },
     "pageId": "settings",
     "blockId": "settings",
@@ -2085,9 +2101,9 @@
                   },
                   "catch": {
                     "~arr": [],
-                    "~k": "4f"
+                    "~k": "4g"
                   },
-                  "~k": "4e"
+                  "~k": "4f"
                 },
                 "~k": "2c"
               },
@@ -2097,19 +2113,19 @@
           ],
           "~k": "1z"
         },
-        "~k": "4d"
+        "~k": "4e"
       },
-      "~k": "4c"
+      "~k": "4d"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "4g"
+      "~k": "4h"
     },
     "requests": {
       "~arr": [],
-      "~k": "4h"
+      "~k": "4i"
     },
-    "~k": "4a"
+    "~k": "4b"
   },
   "plugins/actionSchemas.json": {
     "Login": {
@@ -2195,6 +2211,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "import { MongoDBAuthAdapter as MongoDBAuthAdapter } from '@lowdefy/connection-mongodb/auth/adapters';\nexport default {\n  MongoDBAuthAdapter,\n  };",
   "plugins/auth/providers.js": "import { Google as Google } from '@lowdefy/plugin-better-auth/auth/providers';\nexport default {\n  Google,\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Result": {
       "category": "container"
@@ -9212,30 +9229,30 @@
         "originalTypeName": "Login",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "4s"
+        "~k": "4t"
       },
       "Logout": {
         "originalTypeName": "Logout",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "4t"
+        "~k": "4u"
       },
       "Link": {
         "originalTypeName": "Link",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "4u"
+        "~k": "4v"
       },
       "SetDarkMode": {
         "originalTypeName": "SetDarkMode",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "4v"
+        "~k": "4w"
       },
-      "~k": "4r"
+      "~k": "4s"
     },
     "agents": {
-      "~k": "4w"
+      "~k": "4x"
     },
     "auth": {
       "adapters": {
@@ -9243,185 +9260,188 @@
           "originalTypeName": "MongoDBAuthAdapter",
           "package": "@lowdefy/connection-mongodb",
           "count": 1,
-          "~k": "4z"
+          "~k": "50"
         },
-        "~k": "4y"
+        "~k": "4z"
       },
       "providers": {
         "Google": {
           "originalTypeName": "Google",
           "package": "@lowdefy/plugin-better-auth",
           "count": 1,
-          "~k": "51"
+          "~k": "52"
         },
-        "~k": "50"
+        "~k": "51"
       },
-      "~k": "4x"
+      "strategies": {
+        "~k": "53"
+      },
+      "~k": "4y"
     },
     "blocks": {
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "53"
+        "~k": "55"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "54"
+        "~k": "56"
       },
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 6,
-        "~k": "55"
+        "~k": "57"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "56"
+        "~k": "58"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "57"
+        "~k": "59"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "58"
+        "~k": "5a"
       },
       "Avatar": {
         "originalTypeName": "Avatar",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "59"
+        "~k": "5b"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "5a"
+        "~k": "5c"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "5b"
+        "~k": "5d"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5c"
+        "~k": "5e"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5d"
+        "~k": "5f"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5e"
+        "~k": "5g"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5f"
+        "~k": "5h"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5g"
+        "~k": "5i"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5h"
+        "~k": "5j"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5i"
+        "~k": "5k"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5j"
+        "~k": "5l"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5k"
+        "~k": "5m"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5l"
+        "~k": "5n"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5m"
+        "~k": "5o"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5n"
+        "~k": "5p"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5o"
+        "~k": "5q"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5p"
+        "~k": "5r"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5q"
+        "~k": "5s"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "5r"
+        "~k": "5t"
       },
-      "~k": "52"
+      "~k": "54"
     },
     "connections": {
-      "~k": "5s"
-    },
-    "requests": {
-      "~k": "5t"
-    },
-    "websockets": {
       "~k": "5u"
     },
-    "api": {
+    "requests": {
       "~k": "5v"
+    },
+    "websockets": {
+      "~k": "5w"
+    },
+    "api": {
+      "~k": "5x"
     },
     "operators": {
       "client": {
@@ -9429,27 +9449,27 @@
           "originalTypeName": "_user",
           "package": "@lowdefy/operators-js",
           "count": 4,
-          "~k": "5y"
+          "~k": "60"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5z"
+          "~k": "61"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "60"
+          "~k": "62"
         },
-        "~k": "5x"
+        "~k": "5z"
       },
       "server": {
-        "~k": "61"
+        "~k": "63"
       },
-      "~k": "5w"
+      "~k": "5y"
     },
-    "~k": "4q"
+    "~k": "4r"
   }
 }

--- a/packages/build/src/tests/success/36-auth-roles-app/snapshot.json
+++ b/packages/build/src/tests/success/36-auth-roles-app/snapshot.json
@@ -93,11 +93,15 @@
       "~arr": [],
       "~k": "2b"
     },
+    "strategies": {
+      "~arr": [],
+      "~k": "2c"
+    },
     "organizations": {
       "policy": "pinned",
       "org": "default",
       "signup": "invite-only",
-      "~k": "2c"
+      "~k": "2d"
     },
     "authPages": {
       "signIn": "/login",
@@ -106,7 +110,7 @@
       "forgotPassword": "/forgot-password",
       "resetPassword": "/reset-password",
       "verifyEmail": "/verify-email",
-      "~k": "2d"
+      "~k": "2e"
     },
     "session": {
       "expiresIn": 604800,
@@ -114,30 +118,30 @@
       "cookieCache": {
         "enabled": false,
         "maxAge": 300,
-        "~k": "2f"
+        "~k": "2g"
       },
       "crossSubDomainCookies": {
         "enabled": false,
-        "~k": "2g"
+        "~k": "2h"
       },
-      "~k": "2e"
+      "~k": "2f"
     },
     "account": {
       "accountLinking": {
         "enabled": true,
         "trustedProviders": {
           "~arr": [],
-          "~k": "2j"
+          "~k": "2k"
         },
-        "~k": "2i"
+        "~k": "2j"
       },
-      "~k": "2h"
+      "~k": "2i"
     },
     "rateLimit": {
       "enabled": true,
       "window": 60,
       "max": 100,
-      "~k": "2k"
+      "~k": "2l"
     },
     "roles": {
       "~arr": [
@@ -145,7 +149,7 @@
         "manager",
         "user"
       ],
-      "~k": "2l"
+      "~k": "2m"
     },
     "~k": "5"
   },
@@ -281,244 +285,244 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.pages[2:profile:Box]",
-      "~k_parent": "2m"
+      "key": "root.pages[1:dashboard:Box].requests",
+      "~k_parent": "2u"
     },
     "31": {
-      "key": "root.pages[2:profile:Box].auth",
-      "~k_parent": "30"
+      "key": "root.pages[2:profile:Box]",
+      "~k_parent": "2n"
     },
     "32": {
-      "key": "root.pages[2:profile:Box].auth.roles",
+      "key": "root.pages[2:profile:Box].auth",
       "~k_parent": "31"
     },
     "33": {
-      "key": "root.pages[2:profile:Box].slots",
-      "~k_parent": "30"
+      "key": "root.pages[2:profile:Box].auth.roles",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.pages[2:profile:Box].slots.content",
-      "~k_parent": "33"
+      "key": "root.pages[2:profile:Box].slots",
+      "~k_parent": "31"
     },
     "35": {
-      "key": "root.pages[2:profile:Box].subscriptions",
-      "~k_parent": "30"
+      "key": "root.pages[2:profile:Box].slots.content",
+      "~k_parent": "34"
     },
     "36": {
-      "key": "root.pages[2:profile:Box].requests",
-      "~k_parent": "30"
+      "key": "root.pages[2:profile:Box].subscriptions",
+      "~k_parent": "31"
     },
     "37": {
-      "key": "root.pages[3:reports:Box]",
-      "~k_parent": "2m"
+      "key": "root.pages[2:profile:Box].requests",
+      "~k_parent": "31"
     },
     "38": {
-      "key": "root.pages[3:reports:Box].auth",
-      "~k_parent": "37"
+      "key": "root.pages[3:reports:Box]",
+      "~k_parent": "2n"
     },
     "39": {
-      "key": "root.pages[3:reports:Box].auth.roles",
+      "key": "root.pages[3:reports:Box].auth",
       "~k_parent": "38"
     },
     "40": {
-      "key": "root.pages[7:404:Result].style",
-      "~k_parent": "3z"
+      "key": "root.pages[7:404:Result]",
+      "~k_parent": "2n"
     },
     "41": {
-      "key": "root.pages[7:404:Result].style.block",
+      "key": "root.pages[7:404:Result].style",
       "~k_parent": "40"
     },
     "42": {
+      "key": "root.pages[7:404:Result].style.block",
+      "~k_parent": "41"
+    },
+    "43": {
       "key": "root.pages[7:404:Result].slots.extra.blocks[0:home:Button].events.onClick",
       "~k_parent": "1w"
     },
-    "43": {
-      "key": "root.pages[7:404:Result].slots.extra.blocks[0:home:Button].events.onClick.catch",
-      "~k_parent": "42"
-    },
     "44": {
-      "key": "root.pages[7:404:Result].auth",
-      "~k_parent": "3z"
+      "key": "root.pages[7:404:Result].slots.extra.blocks[0:home:Button].events.onClick.catch",
+      "~k_parent": "43"
     },
     "45": {
-      "key": "root.pages[7:404:Result].subscriptions",
-      "~k_parent": "3z"
+      "key": "root.pages[7:404:Result].auth",
+      "~k_parent": "40"
     },
     "46": {
-      "key": "root.pages[7:404:Result].requests",
-      "~k_parent": "3z"
+      "key": "root.pages[7:404:Result].subscriptions",
+      "~k_parent": "40"
     },
     "47": {
+      "key": "root.pages[7:404:Result].requests",
+      "~k_parent": "40"
+    },
+    "48": {
       "key": "root.menus",
       "~k_parent": "4"
     },
-    "48": {
-      "key": "root.menus[0:default]",
-      "~k_parent": "47"
-    },
     "49": {
-      "key": "root.menus[0:default].links",
+      "key": "root.menus[0:default]",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.types.auth",
-      "~k_parent": "4u"
+      "key": "root.types.agents",
+      "~k_parent": "4v"
     },
     "51": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "50"
+      "key": "root.types.auth",
+      "~k_parent": "4v"
     },
     "52": {
-      "key": "root.types.auth.adapters.MongoDBAuthAdapter",
+      "key": "root.types.auth.adapters",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "50"
+      "key": "root.types.auth.adapters.MongoDBAuthAdapter",
+      "~k_parent": "52"
     },
     "54": {
-      "key": "root.types.blocks",
-      "~k_parent": "4u"
+      "key": "root.types.auth.providers",
+      "~k_parent": "51"
     },
     "55": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "54"
+      "key": "root.types.auth.strategies",
+      "~k_parent": "51"
     },
     "56": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "54"
+      "key": "root.types.blocks",
+      "~k_parent": "4v"
     },
     "57": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "54"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "56"
     },
     "58": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "54"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "56"
     },
     "59": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "54"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "56"
     },
     "60": {
-      "key": "root.imports.actions[0]",
-      "~k_parent": "5z"
+      "key": "root.imports",
+      "~k_parent": "4"
     },
     "61": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "5z"
+      "key": "root.imports.actions",
+      "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "5z"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.agents",
-      "~k_parent": "5y"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "61"
     },
     "64": {
-      "key": "root.imports.auth",
-      "~k_parent": "5y"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "61"
     },
     "65": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "64"
+      "key": "root.imports.agents",
+      "~k_parent": "60"
     },
     "66": {
-      "key": "root.imports.auth.adapters[0]",
-      "~k_parent": "65"
+      "key": "root.imports.auth",
+      "~k_parent": "60"
     },
     "67": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "64"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.blocks",
-      "~k_parent": "5y"
+      "key": "root.imports.auth.adapters[0]",
+      "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "68"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "66"
     },
     "70": {
-      "key": "root.imports.icons[2].icons",
-      "~k_parent": "6z"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "6x"
     },
     "71": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[1].icons",
+      "~k_parent": "70"
     },
     "72": {
-      "key": "root.imports.icons[3].icons",
-      "~k_parent": "71"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "6x"
     },
     "73": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[2].icons",
+      "~k_parent": "72"
     },
     "74": {
-      "key": "root.imports.icons[4].icons",
-      "~k_parent": "73"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "6x"
     },
     "75": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[3].icons",
+      "~k_parent": "74"
     },
     "76": {
-      "key": "root.imports.icons[5].icons",
-      "~k_parent": "75"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "6x"
     },
     "77": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[4].icons",
+      "~k_parent": "76"
     },
     "78": {
-      "key": "root.imports.icons[6].icons",
-      "~k_parent": "77"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "6x"
     },
     "79": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[5].icons",
+      "~k_parent": "78"
     },
     "80": {
-      "key": "root.imports.icons[20].icons",
-      "~k_parent": "7z"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "6x"
     },
     "81": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[19].icons",
+      "~k_parent": "80"
     },
     "82": {
-      "key": "root.imports.icons[21].icons",
-      "~k_parent": "81"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "6x"
     },
     "83": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[20].icons",
+      "~k_parent": "82"
     },
     "84": {
-      "key": "root.imports.icons[22].icons",
-      "~k_parent": "83"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "6x"
     },
     "85": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[21].icons",
+      "~k_parent": "84"
     },
     "86": {
-      "key": "root.imports.icons[23].icons",
-      "~k_parent": "85"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "6x"
     },
     "87": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[22].icons",
+      "~k_parent": "86"
     },
     "88": {
-      "key": "root.imports.icons[24].icons",
-      "~k_parent": "87"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "6x"
     },
     "89": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[23].icons",
+      "~k_parent": "88"
     },
     "a": {
       "key": "root.auth.pages",
@@ -770,668 +774,680 @@
       "~k_parent": "5"
     },
     "2c": {
-      "key": "root.auth.organizations",
+      "key": "root.auth.strategies",
       "~k_parent": "5"
     },
     "2d": {
-      "key": "root.auth.authPages",
+      "key": "root.auth.organizations",
       "~k_parent": "5"
     },
     "2e": {
-      "key": "root.auth.session",
+      "key": "root.auth.authPages",
       "~k_parent": "5"
     },
     "2f": {
-      "key": "root.auth.session.cookieCache",
-      "~k_parent": "2e"
+      "key": "root.auth.session",
+      "~k_parent": "5"
     },
     "2g": {
-      "key": "root.auth.session.crossSubDomainCookies",
-      "~k_parent": "2e"
+      "key": "root.auth.session.cookieCache",
+      "~k_parent": "2f"
     },
     "2h": {
+      "key": "root.auth.session.crossSubDomainCookies",
+      "~k_parent": "2f"
+    },
+    "2i": {
       "key": "root.auth.account",
       "~k_parent": "5"
     },
-    "2i": {
-      "key": "root.auth.account.accountLinking",
-      "~k_parent": "2h"
-    },
     "2j": {
-      "key": "root.auth.account.accountLinking.trustedProviders",
+      "key": "root.auth.account.accountLinking",
       "~k_parent": "2i"
     },
     "2k": {
+      "key": "root.auth.account.accountLinking.trustedProviders",
+      "~k_parent": "2j"
+    },
+    "2l": {
       "key": "root.auth.rateLimit",
       "~k_parent": "5"
     },
-    "2l": {
+    "2m": {
       "key": "root.auth.roles",
       "~k_parent": "5"
     },
-    "2m": {
+    "2n": {
       "key": "root.pages",
       "~k_parent": "4"
     },
-    "2n": {
-      "key": "root.pages[0:login:Result]",
-      "~k_parent": "2m"
-    },
     "2o": {
-      "key": "root.pages[0:login:Result].auth",
+      "key": "root.pages[0:login:Result]",
       "~k_parent": "2n"
     },
     "2p": {
+      "key": "root.pages[0:login:Result].auth",
+      "~k_parent": "2o"
+    },
+    "2q": {
       "key": "root.pages[0:login:Result].areas.extra.blocks[0:loginBtn:Button].events.onClick",
       "~k_parent": "o"
     },
-    "2q": {
-      "key": "root.pages[0:login:Result].areas.extra.blocks[0:loginBtn:Button].events.onClick.catch",
-      "~k_parent": "2p"
-    },
     "2r": {
-      "key": "root.pages[0:login:Result].subscriptions",
-      "~k_parent": "2n"
+      "key": "root.pages[0:login:Result].areas.extra.blocks[0:loginBtn:Button].events.onClick.catch",
+      "~k_parent": "2q"
     },
     "2s": {
-      "key": "root.pages[0:login:Result].requests",
-      "~k_parent": "2n"
+      "key": "root.pages[0:login:Result].subscriptions",
+      "~k_parent": "2o"
     },
     "2t": {
-      "key": "root.pages[1:dashboard:Box]",
-      "~k_parent": "2m"
+      "key": "root.pages[0:login:Result].requests",
+      "~k_parent": "2o"
     },
     "2u": {
-      "key": "root.pages[1:dashboard:Box].auth",
-      "~k_parent": "2t"
+      "key": "root.pages[1:dashboard:Box]",
+      "~k_parent": "2n"
     },
     "2v": {
-      "key": "root.pages[1:dashboard:Box].auth.roles",
+      "key": "root.pages[1:dashboard:Box].auth",
       "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.pages[1:dashboard:Box].slots",
-      "~k_parent": "2t"
+      "key": "root.pages[1:dashboard:Box].auth.roles",
+      "~k_parent": "2v"
     },
     "2x": {
-      "key": "root.pages[1:dashboard:Box].slots.content",
-      "~k_parent": "2w"
+      "key": "root.pages[1:dashboard:Box].slots",
+      "~k_parent": "2u"
     },
     "2y": {
-      "key": "root.pages[1:dashboard:Box].subscriptions",
-      "~k_parent": "2t"
+      "key": "root.pages[1:dashboard:Box].slots.content",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.pages[1:dashboard:Box].requests",
-      "~k_parent": "2t"
+      "key": "root.pages[1:dashboard:Box].subscriptions",
+      "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.pages[3:reports:Box].slots",
-      "~k_parent": "37"
+      "key": "root.pages[3:reports:Box].auth.roles",
+      "~k_parent": "39"
     },
     "3b": {
-      "key": "root.pages[3:reports:Box].slots.content",
-      "~k_parent": "3a"
+      "key": "root.pages[3:reports:Box].slots",
+      "~k_parent": "38"
     },
     "3c": {
-      "key": "root.pages[3:reports:Box].subscriptions",
-      "~k_parent": "37"
+      "key": "root.pages[3:reports:Box].slots.content",
+      "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.pages[3:reports:Box].requests",
-      "~k_parent": "37"
+      "key": "root.pages[3:reports:Box].subscriptions",
+      "~k_parent": "38"
     },
     "3e": {
-      "key": "root.pages[4:team:Box]",
-      "~k_parent": "2m"
+      "key": "root.pages[3:reports:Box].requests",
+      "~k_parent": "38"
     },
     "3f": {
-      "key": "root.pages[4:team:Box].auth",
-      "~k_parent": "3e"
+      "key": "root.pages[4:team:Box]",
+      "~k_parent": "2n"
     },
     "3g": {
-      "key": "root.pages[4:team:Box].auth.roles",
+      "key": "root.pages[4:team:Box].auth",
       "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.pages[4:team:Box].slots",
-      "~k_parent": "3e"
+      "key": "root.pages[4:team:Box].auth.roles",
+      "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.pages[4:team:Box].slots.content",
-      "~k_parent": "3h"
+      "key": "root.pages[4:team:Box].slots",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.pages[4:team:Box].subscriptions",
-      "~k_parent": "3e"
+      "key": "root.pages[4:team:Box].slots.content",
+      "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.pages[4:team:Box].requests",
-      "~k_parent": "3e"
+      "key": "root.pages[4:team:Box].subscriptions",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.pages[5:admin-panel:Box]",
-      "~k_parent": "2m"
+      "key": "root.pages[4:team:Box].requests",
+      "~k_parent": "3f"
     },
     "3m": {
-      "key": "root.pages[5:admin-panel:Box].auth",
-      "~k_parent": "3l"
+      "key": "root.pages[5:admin-panel:Box]",
+      "~k_parent": "2n"
     },
     "3n": {
-      "key": "root.pages[5:admin-panel:Box].auth.roles",
+      "key": "root.pages[5:admin-panel:Box].auth",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.pages[5:admin-panel:Box].slots",
-      "~k_parent": "3l"
+      "key": "root.pages[5:admin-panel:Box].auth.roles",
+      "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.pages[5:admin-panel:Box].slots.content",
-      "~k_parent": "3o"
+      "key": "root.pages[5:admin-panel:Box].slots",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.pages[5:admin-panel:Box].subscriptions",
-      "~k_parent": "3l"
+      "key": "root.pages[5:admin-panel:Box].slots.content",
+      "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.pages[5:admin-panel:Box].requests",
-      "~k_parent": "3l"
+      "key": "root.pages[5:admin-panel:Box].subscriptions",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.pages[6:user-management:Box]",
-      "~k_parent": "2m"
+      "key": "root.pages[5:admin-panel:Box].requests",
+      "~k_parent": "3m"
     },
     "3t": {
-      "key": "root.pages[6:user-management:Box].auth",
-      "~k_parent": "3s"
+      "key": "root.pages[6:user-management:Box]",
+      "~k_parent": "2n"
     },
     "3u": {
-      "key": "root.pages[6:user-management:Box].auth.roles",
+      "key": "root.pages[6:user-management:Box].auth",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.pages[6:user-management:Box].slots",
-      "~k_parent": "3s"
+      "key": "root.pages[6:user-management:Box].auth.roles",
+      "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.pages[6:user-management:Box].slots.content",
-      "~k_parent": "3v"
+      "key": "root.pages[6:user-management:Box].slots",
+      "~k_parent": "3t"
     },
     "3x": {
-      "key": "root.pages[6:user-management:Box].subscriptions",
-      "~k_parent": "3s"
+      "key": "root.pages[6:user-management:Box].slots.content",
+      "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.pages[6:user-management:Box].requests",
-      "~k_parent": "3s"
+      "key": "root.pages[6:user-management:Box].subscriptions",
+      "~k_parent": "3t"
     },
     "3z": {
-      "key": "root.pages[7:404:Result]",
-      "~k_parent": "2m"
+      "key": "root.pages[6:user-management:Box].requests",
+      "~k_parent": "3t"
     },
     "4a": {
-      "key": "root.menus[0:default].links[0:0:MenuLink]",
+      "key": "root.menus[0:default].links",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.menus[0:default].links[0:0:MenuLink].auth",
+      "key": "root.menus[0:default].links[0:0:MenuLink]",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.menus[0:default].links[1:1:MenuLink]",
-      "~k_parent": "49"
+      "key": "root.menus[0:default].links[0:0:MenuLink].auth",
+      "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.menus[0:default].links[1:1:MenuLink].auth",
-      "~k_parent": "4c"
+      "key": "root.menus[0:default].links[1:1:MenuLink]",
+      "~k_parent": "4a"
     },
     "4e": {
-      "key": "root.menus[0:default].links[1:1:MenuLink].auth.roles",
+      "key": "root.menus[0:default].links[1:1:MenuLink].auth",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.menus[0:default].links[2:2:MenuLink]",
-      "~k_parent": "49"
+      "key": "root.menus[0:default].links[1:1:MenuLink].auth.roles",
+      "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.menus[0:default].links[2:2:MenuLink].auth",
-      "~k_parent": "4f"
+      "key": "root.menus[0:default].links[2:2:MenuLink]",
+      "~k_parent": "4a"
     },
     "4h": {
-      "key": "root.menus[0:default].links[2:2:MenuLink].auth.roles",
+      "key": "root.menus[0:default].links[2:2:MenuLink].auth",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.menus[0:default].links[3:3:MenuLink]",
-      "~k_parent": "49"
+      "key": "root.menus[0:default].links[2:2:MenuLink].auth.roles",
+      "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.menus[0:default].links[3:3:MenuLink].auth",
-      "~k_parent": "4i"
+      "key": "root.menus[0:default].links[3:3:MenuLink]",
+      "~k_parent": "4a"
     },
     "4k": {
-      "key": "root.menus[0:default].links[3:3:MenuLink].auth.roles",
+      "key": "root.menus[0:default].links[3:3:MenuLink].auth",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.menus[0:default].links[4:4:MenuLink]",
-      "~k_parent": "49"
+      "key": "root.menus[0:default].links[3:3:MenuLink].auth.roles",
+      "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.menus[0:default].links[4:4:MenuLink].auth",
-      "~k_parent": "4l"
+      "key": "root.menus[0:default].links[4:4:MenuLink]",
+      "~k_parent": "4a"
     },
     "4n": {
-      "key": "root.menus[0:default].links[4:4:MenuLink].auth.roles",
+      "key": "root.menus[0:default].links[4:4:MenuLink].auth",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.menus[0:default].links[5:5:MenuLink]",
-      "~k_parent": "49"
+      "key": "root.menus[0:default].links[4:4:MenuLink].auth.roles",
+      "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.menus[0:default].links[5:5:MenuLink].auth",
-      "~k_parent": "4o"
+      "key": "root.menus[0:default].links[5:5:MenuLink]",
+      "~k_parent": "4a"
     },
     "4q": {
-      "key": "root.menus[0:default].links[5:5:MenuLink].auth.roles",
+      "key": "root.menus[0:default].links[5:5:MenuLink].auth",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.menus[0:default].links[6:6:MenuLink]",
-      "~k_parent": "49"
+      "key": "root.menus[0:default].links[5:5:MenuLink].auth.roles",
+      "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.menus[0:default].links[6:6:MenuLink].auth",
-      "~k_parent": "4r"
+      "key": "root.menus[0:default].links[6:6:MenuLink]",
+      "~k_parent": "4a"
     },
     "4t": {
-      "key": "root.menus[0:default].links[6:6:MenuLink].auth.roles",
+      "key": "root.menus[0:default].links[6:6:MenuLink].auth",
       "~k_parent": "4s"
     },
     "4u": {
+      "key": "root.menus[0:default].links[6:6:MenuLink].auth.roles",
+      "~k_parent": "4t"
+    },
+    "4v": {
       "key": "root.types",
       "~k_parent": "4"
     },
-    "4v": {
-      "key": "root.types.actions",
-      "~k_parent": "4u"
-    },
     "4w": {
-      "key": "root.types.actions.Login",
+      "key": "root.types.actions",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.types.actions.Link",
-      "~k_parent": "4v"
+      "key": "root.types.actions.Login",
+      "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.types.actions.SetDarkMode",
-      "~k_parent": "4v"
+      "key": "root.types.actions.Link",
+      "~k_parent": "4w"
     },
     "4z": {
-      "key": "root.types.agents",
-      "~k_parent": "4u"
+      "key": "root.types.actions.SetDarkMode",
+      "~k_parent": "4w"
     },
     "5a": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "54"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "56"
     },
     "5b": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "54"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "56"
     },
     "5c": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "54"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "56"
     },
     "5d": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "54"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "56"
     },
     "5e": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "54"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "56"
     },
     "5f": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "54"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "56"
     },
     "5g": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "54"
+      "key": "root.types.blocks.List",
+      "~k_parent": "56"
     },
     "5h": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "54"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "56"
     },
     "5i": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "54"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "56"
     },
     "5j": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "54"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "56"
     },
     "5k": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "54"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "56"
     },
     "5l": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "54"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "56"
     },
     "5m": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "54"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "56"
     },
     "5n": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "54"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "56"
     },
     "5o": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "54"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "56"
     },
     "5p": {
-      "key": "root.types.connections",
-      "~k_parent": "4u"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "56"
     },
     "5q": {
-      "key": "root.types.requests",
-      "~k_parent": "4u"
+      "key": "root.types.blocks.Message",
+      "~k_parent": "56"
     },
     "5r": {
-      "key": "root.types.websockets",
-      "~k_parent": "4u"
+      "key": "root.types.connections",
+      "~k_parent": "4v"
     },
     "5s": {
-      "key": "root.types.api",
-      "~k_parent": "4u"
+      "key": "root.types.requests",
+      "~k_parent": "4v"
     },
     "5t": {
-      "key": "root.types.operators",
-      "~k_parent": "4u"
+      "key": "root.types.websockets",
+      "~k_parent": "4v"
     },
     "5u": {
-      "key": "root.types.operators.client",
-      "~k_parent": "5t"
+      "key": "root.types.api",
+      "~k_parent": "4v"
     },
     "5v": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "5u"
+      "key": "root.types.operators",
+      "~k_parent": "4v"
     },
     "5w": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "5u"
+      "key": "root.types.operators.client",
+      "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.types.operators.server",
-      "~k_parent": "5t"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports",
-      "~k_parent": "4"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "5w"
     },
     "5z": {
-      "key": "root.imports.actions",
-      "~k_parent": "5y"
+      "key": "root.types.operators.server",
+      "~k_parent": "5v"
     },
     "6a": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "68"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "66"
     },
     "6b": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks",
+      "~k_parent": "60"
     },
     "6c": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "6b"
     },
     "6e": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "6b"
     },
     "6f": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "6b"
     },
     "6g": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "6b"
     },
     "6h": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "6b"
     },
     "6i": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "6b"
     },
     "6j": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "6b"
     },
     "6k": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "6b"
     },
     "6l": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "6b"
     },
     "6m": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "6b"
     },
     "6n": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "6b"
     },
     "6o": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "6b"
     },
     "6p": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "6b"
     },
     "6q": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "6b"
     },
     "6r": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "6b"
     },
     "6s": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "6b"
     },
     "6t": {
-      "key": "root.imports.connections",
-      "~k_parent": "5y"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "6b"
     },
     "6u": {
-      "key": "root.imports.icons",
-      "~k_parent": "5y"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "6b"
     },
     "6v": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "6u"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "6b"
     },
     "6w": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "6v"
+      "key": "root.imports.connections",
+      "~k_parent": "60"
     },
     "6x": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons",
+      "~k_parent": "60"
     },
     "6y": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0]",
       "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[0].icons",
+      "~k_parent": "6y"
     },
     "7a": {
-      "key": "root.imports.icons[7].icons",
-      "~k_parent": "79"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "6x"
     },
     "7b": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[6].icons",
+      "~k_parent": "7a"
     },
     "7c": {
-      "key": "root.imports.icons[8].icons",
-      "~k_parent": "7b"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "6x"
     },
     "7d": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[7].icons",
+      "~k_parent": "7c"
     },
     "7e": {
-      "key": "root.imports.icons[9].icons",
-      "~k_parent": "7d"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "6x"
     },
     "7f": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[8].icons",
+      "~k_parent": "7e"
     },
     "7g": {
-      "key": "root.imports.icons[10].icons",
-      "~k_parent": "7f"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "6x"
     },
     "7h": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[9].icons",
+      "~k_parent": "7g"
     },
     "7i": {
-      "key": "root.imports.icons[11].icons",
-      "~k_parent": "7h"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "6x"
     },
     "7j": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[10].icons",
+      "~k_parent": "7i"
     },
     "7k": {
-      "key": "root.imports.icons[12].icons",
-      "~k_parent": "7j"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "6x"
     },
     "7l": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[11].icons",
+      "~k_parent": "7k"
     },
     "7m": {
-      "key": "root.imports.icons[13].icons",
-      "~k_parent": "7l"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "6x"
     },
     "7n": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[12].icons",
+      "~k_parent": "7m"
     },
     "7o": {
-      "key": "root.imports.icons[14].icons",
-      "~k_parent": "7n"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "6x"
     },
     "7p": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[13].icons",
+      "~k_parent": "7o"
     },
     "7q": {
-      "key": "root.imports.icons[15].icons",
-      "~k_parent": "7p"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "6x"
     },
     "7r": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[14].icons",
+      "~k_parent": "7q"
     },
     "7s": {
-      "key": "root.imports.icons[16].icons",
-      "~k_parent": "7r"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "6x"
     },
     "7t": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[15].icons",
+      "~k_parent": "7s"
     },
     "7u": {
-      "key": "root.imports.icons[17].icons",
-      "~k_parent": "7t"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "6x"
     },
     "7v": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[16].icons",
+      "~k_parent": "7u"
     },
     "7w": {
-      "key": "root.imports.icons[18].icons",
-      "~k_parent": "7v"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "6x"
     },
     "7x": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[17].icons",
+      "~k_parent": "7w"
     },
     "7y": {
-      "key": "root.imports.icons[19].icons",
-      "~k_parent": "7x"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "6x"
     },
     "7z": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[18].icons",
+      "~k_parent": "7y"
     },
     "8a": {
-      "key": "root.imports.icons[25].icons",
-      "~k_parent": "89"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "6x"
     },
     "8b": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[24].icons",
+      "~k_parent": "8a"
     },
     "8c": {
-      "key": "root.imports.icons[26].icons",
-      "~k_parent": "8b"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "6x"
     },
     "8d": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "6u"
+      "key": "root.imports.icons[25].icons",
+      "~k_parent": "8c"
     },
     "8e": {
-      "key": "root.imports.icons[27].icons",
-      "~k_parent": "8d"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "6x"
     },
     "8f": {
-      "key": "root.imports.requests",
-      "~k_parent": "5y"
+      "key": "root.imports.icons[26].icons",
+      "~k_parent": "8e"
     },
     "8g": {
-      "key": "root.imports.websockets",
-      "~k_parent": "5y"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "6x"
     },
     "8h": {
-      "key": "root.imports.operators",
-      "~k_parent": "5y"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "8g"
     },
     "8i": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "8h"
+      "key": "root.imports.requests",
+      "~k_parent": "60"
     },
     "8j": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "8i"
+      "key": "root.imports.websockets",
+      "~k_parent": "60"
     },
     "8k": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "8i"
+      "key": "root.imports.operators",
+      "~k_parent": "60"
     },
     "8l": {
+      "key": "root.imports.operators.client",
+      "~k_parent": "8k"
+    },
+    "8m": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "8l"
+    },
+    "8n": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "8l"
+    },
+    "8o": {
       "key": "root.imports.operators.server",
-      "~k_parent": "8h"
+      "~k_parent": "8k"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1450,10 +1466,10 @@
               "pageId": "login",
               "auth": {
                 "public": true,
-                "~k": "4b"
+                "~k": "4c"
               },
               "menuItemId": "0",
-              "~k": "4a"
+              "~k": "4b"
             },
             {
               "id": "menuitem:default:1",
@@ -1465,12 +1481,12 @@
                   "~arr": [
                     "user"
                   ],
-                  "~k": "4e"
+                  "~k": "4f"
                 },
-                "~k": "4d"
+                "~k": "4e"
               },
               "menuItemId": "1",
-              "~k": "4c"
+              "~k": "4d"
             },
             {
               "id": "menuitem:default:2",
@@ -1482,12 +1498,12 @@
                   "~arr": [
                     "user"
                   ],
-                  "~k": "4h"
+                  "~k": "4i"
                 },
-                "~k": "4g"
+                "~k": "4h"
               },
               "menuItemId": "2",
-              "~k": "4f"
+              "~k": "4g"
             },
             {
               "id": "menuitem:default:3",
@@ -1499,12 +1515,12 @@
                   "~arr": [
                     "manager"
                   ],
-                  "~k": "4k"
+                  "~k": "4l"
                 },
-                "~k": "4j"
+                "~k": "4k"
               },
               "menuItemId": "3",
-              "~k": "4i"
+              "~k": "4j"
             },
             {
               "id": "menuitem:default:4",
@@ -1516,12 +1532,12 @@
                   "~arr": [
                     "manager"
                   ],
-                  "~k": "4n"
+                  "~k": "4o"
                 },
-                "~k": "4m"
+                "~k": "4n"
               },
               "menuItemId": "4",
-              "~k": "4l"
+              "~k": "4m"
             },
             {
               "id": "menuitem:default:5",
@@ -1533,12 +1549,12 @@
                   "~arr": [
                     "admin"
                   ],
-                  "~k": "4q"
+                  "~k": "4r"
                 },
-                "~k": "4p"
+                "~k": "4q"
               },
               "menuItemId": "5",
-              "~k": "4o"
+              "~k": "4p"
             },
             {
               "id": "menuitem:default:6",
@@ -1550,21 +1566,21 @@
                   "~arr": [
                     "admin"
                   ],
-                  "~k": "4t"
+                  "~k": "4u"
                 },
-                "~k": "4s"
+                "~k": "4t"
               },
               "menuItemId": "6",
-              "~k": "4r"
+              "~k": "4s"
             }
           ],
-          "~k": "49"
+          "~k": "4a"
         },
         "menuId": "default",
-        "~k": "48"
+        "~k": "49"
       }
     ],
-    "~k": "47"
+    "~k": "48"
   },
   "pages/404.json": {
     "id": "page:404",
@@ -1573,9 +1589,9 @@
       "block": {
         "minHeight": "100vh",
         "background": "var(--ant-color-bg-layout)",
-        "~k": "41"
+        "~k": "42"
       },
-      "~k": "40"
+      "~k": "41"
     },
     "properties": {
       "status": "info",
@@ -1618,9 +1634,9 @@
                   },
                   "catch": {
                     "~arr": [],
-                    "~k": "43"
+                    "~k": "44"
                   },
-                  "~k": "42"
+                  "~k": "43"
                 },
                 "~k": "1w"
               },
@@ -1636,19 +1652,19 @@
     },
     "auth": {
       "public": true,
-      "~k": "44"
+      "~k": "45"
     },
     "pageId": "404",
     "blockId": "404",
     "subscriptions": {
       "~arr": [],
-      "~k": "45"
+      "~k": "46"
     },
     "requests": {
       "~arr": [],
-      "~k": "46"
+      "~k": "47"
     },
-    "~k": "3z"
+    "~k": "40"
   },
   "pages/admin-panel.json": {
     "id": "page:admin-panel",
@@ -1663,9 +1679,9 @@
         "~arr": [
           "admin"
         ],
-        "~k": "3n"
+        "~k": "3o"
       },
-      "~k": "3m"
+      "~k": "3n"
     },
     "pageId": "admin-panel",
     "blockId": "admin-panel",
@@ -1686,19 +1702,19 @@
           ],
           "~k": "1d"
         },
-        "~k": "3p"
+        "~k": "3q"
       },
-      "~k": "3o"
+      "~k": "3p"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "3q"
+      "~k": "3r"
     },
     "requests": {
       "~arr": [],
-      "~k": "3r"
+      "~k": "3s"
     },
-    "~k": "3l"
+    "~k": "3m"
   },
   "pages/dashboard.json": {
     "id": "page:dashboard",
@@ -1713,9 +1729,9 @@
         "~arr": [
           "user"
         ],
-        "~k": "2v"
+        "~k": "2w"
       },
-      "~k": "2u"
+      "~k": "2v"
     },
     "pageId": "dashboard",
     "blockId": "dashboard",
@@ -1736,19 +1752,19 @@
           ],
           "~k": "t"
         },
-        "~k": "2x"
+        "~k": "2y"
       },
-      "~k": "2w"
+      "~k": "2x"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "2y"
+      "~k": "2z"
     },
     "requests": {
       "~arr": [],
-      "~k": "2z"
+      "~k": "30"
     },
-    "~k": "2t"
+    "~k": "2u"
   },
   "pages/login.json": {
     "id": "page:login",
@@ -1760,7 +1776,7 @@
     },
     "auth": {
       "public": true,
-      "~k": "2o"
+      "~k": "2p"
     },
     "pageId": "login",
     "blockId": "login",
@@ -1789,9 +1805,9 @@
                   },
                   "catch": {
                     "~arr": [],
-                    "~k": "2q"
+                    "~k": "2r"
                   },
-                  "~k": "2p"
+                  "~k": "2q"
                 },
                 "~k": "o"
               },
@@ -1807,13 +1823,13 @@
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "2r"
+      "~k": "2s"
     },
     "requests": {
       "~arr": [],
-      "~k": "2s"
+      "~k": "2t"
     },
-    "~k": "2n"
+    "~k": "2o"
   },
   "pages/profile.json": {
     "id": "page:profile",
@@ -1828,9 +1844,9 @@
         "~arr": [
           "user"
         ],
-        "~k": "32"
+        "~k": "33"
       },
-      "~k": "31"
+      "~k": "32"
     },
     "pageId": "profile",
     "blockId": "profile",
@@ -1851,19 +1867,19 @@
           ],
           "~k": "y"
         },
-        "~k": "34"
+        "~k": "35"
       },
-      "~k": "33"
+      "~k": "34"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "35"
+      "~k": "36"
     },
     "requests": {
       "~arr": [],
-      "~k": "36"
+      "~k": "37"
     },
-    "~k": "30"
+    "~k": "31"
   },
   "pages/reports.json": {
     "id": "page:reports",
@@ -1878,9 +1894,9 @@
         "~arr": [
           "manager"
         ],
-        "~k": "39"
+        "~k": "3a"
       },
-      "~k": "38"
+      "~k": "39"
     },
     "pageId": "reports",
     "blockId": "reports",
@@ -1901,19 +1917,19 @@
           ],
           "~k": "13"
         },
-        "~k": "3b"
+        "~k": "3c"
       },
-      "~k": "3a"
+      "~k": "3b"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "3c"
+      "~k": "3d"
     },
     "requests": {
       "~arr": [],
-      "~k": "3d"
+      "~k": "3e"
     },
-    "~k": "37"
+    "~k": "38"
   },
   "pages/team.json": {
     "id": "page:team",
@@ -1928,9 +1944,9 @@
         "~arr": [
           "manager"
         ],
-        "~k": "3g"
+        "~k": "3h"
       },
-      "~k": "3f"
+      "~k": "3g"
     },
     "pageId": "team",
     "blockId": "team",
@@ -1951,19 +1967,19 @@
           ],
           "~k": "18"
         },
-        "~k": "3i"
+        "~k": "3j"
       },
-      "~k": "3h"
+      "~k": "3i"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "3j"
+      "~k": "3k"
     },
     "requests": {
       "~arr": [],
-      "~k": "3k"
+      "~k": "3l"
     },
-    "~k": "3e"
+    "~k": "3f"
   },
   "pages/user-management.json": {
     "id": "page:user-management",
@@ -1978,9 +1994,9 @@
         "~arr": [
           "admin"
         ],
-        "~k": "3u"
+        "~k": "3v"
       },
-      "~k": "3t"
+      "~k": "3u"
     },
     "pageId": "user-management",
     "blockId": "user-management",
@@ -2001,19 +2017,19 @@
           ],
           "~k": "1i"
         },
-        "~k": "3w"
+        "~k": "3x"
       },
-      "~k": "3v"
+      "~k": "3w"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "3x"
+      "~k": "3y"
     },
     "requests": {
       "~arr": [],
-      "~k": "3y"
+      "~k": "3z"
     },
-    "~k": "3s"
+    "~k": "3t"
   },
   "plugins/actionSchemas.json": {
     "Login": {
@@ -2093,6 +2109,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "import { MongoDBAuthAdapter as MongoDBAuthAdapter } from '@lowdefy/connection-mongodb/auth/adapters';\nexport default {\n  MongoDBAuthAdapter,\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Result": {
       "category": "container"
@@ -6567,24 +6584,24 @@
         "originalTypeName": "Login",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "4w"
+        "~k": "4x"
       },
       "Link": {
         "originalTypeName": "Link",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "4x"
+        "~k": "4y"
       },
       "SetDarkMode": {
         "originalTypeName": "SetDarkMode",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "4y"
+        "~k": "4z"
       },
-      "~k": "4v"
+      "~k": "4w"
     },
     "agents": {
-      "~k": "4z"
+      "~k": "50"
     },
     "auth": {
       "adapters": {
@@ -6592,149 +6609,152 @@
           "originalTypeName": "MongoDBAuthAdapter",
           "package": "@lowdefy/connection-mongodb",
           "count": 1,
-          "~k": "52"
+          "~k": "53"
         },
-        "~k": "51"
+        "~k": "52"
       },
       "providers": {
-        "~k": "53"
+        "~k": "54"
       },
-      "~k": "50"
+      "strategies": {
+        "~k": "55"
+      },
+      "~k": "51"
     },
     "blocks": {
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "55"
+        "~k": "57"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "56"
+        "~k": "58"
       },
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "57"
+        "~k": "59"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 6,
-        "~k": "58"
+        "~k": "5a"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "59"
+        "~k": "5b"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5a"
+        "~k": "5c"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5b"
+        "~k": "5d"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5c"
+        "~k": "5e"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5d"
+        "~k": "5f"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5e"
+        "~k": "5g"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5f"
+        "~k": "5h"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5g"
+        "~k": "5i"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5h"
+        "~k": "5j"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5i"
+        "~k": "5k"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5j"
+        "~k": "5l"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5k"
+        "~k": "5m"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5l"
+        "~k": "5n"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5m"
+        "~k": "5o"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5n"
+        "~k": "5p"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "5o"
+        "~k": "5q"
       },
-      "~k": "54"
+      "~k": "56"
     },
     "connections": {
-      "~k": "5p"
-    },
-    "requests": {
-      "~k": "5q"
-    },
-    "websockets": {
       "~k": "5r"
     },
-    "api": {
+    "requests": {
       "~k": "5s"
+    },
+    "websockets": {
+      "~k": "5t"
+    },
+    "api": {
+      "~k": "5u"
     },
     "operators": {
       "client": {
@@ -6742,21 +6762,21 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5v"
+          "~k": "5x"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5w"
+          "~k": "5y"
         },
-        "~k": "5u"
+        "~k": "5w"
       },
       "server": {
-        "~k": "5x"
+        "~k": "5z"
       },
-      "~k": "5t"
+      "~k": "5v"
     },
-    "~k": "4u"
+    "~k": "4v"
   }
 }

--- a/packages/build/src/tests/success/37-api-endpoints-app/snapshot.json
+++ b/packages/build/src/tests/success/37-api-endpoints-app/snapshot.json
@@ -174,124 +174,124 @@
       "~k_parent": "27"
     },
     "30": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2f"
+    },
+    "31": {
       "key": "root.types.connections",
       "~k_parent": "26"
     },
-    "31": {
+    "32": {
       "key": "root.types.requests",
       "~k_parent": "26"
     },
-    "32": {
+    "33": {
       "key": "root.types.websockets",
       "~k_parent": "26"
     },
-    "33": {
+    "34": {
       "key": "root.types.api",
       "~k_parent": "26"
     },
-    "34": {
+    "35": {
       "key": "root.types.operators",
       "~k_parent": "26"
     },
-    "35": {
-      "key": "root.types.operators.client",
-      "~k_parent": "34"
-    },
     "36": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "35"
     },
     "37": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "35"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "36"
     },
     "38": {
-      "key": "root.types.operators.server",
-      "~k_parent": "34"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "36"
     },
     "39": {
-      "key": "root.imports",
-      "~k_parent": "4"
+      "key": "root.types.operators.server",
+      "~k_parent": "35"
     },
     "40": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3j"
     },
     "41": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3j"
     },
     "42": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3j"
     },
     "43": {
-      "key": "root.imports.connections",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3j"
     },
     "44": {
-      "key": "root.imports.icons",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "3j"
     },
     "45": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "44"
+      "key": "root.imports.connections",
+      "~k_parent": "3a"
     },
     "46": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "45"
+      "key": "root.imports.icons",
+      "~k_parent": "3a"
     },
     "47": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "46"
     },
     "50": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "46"
     },
     "52": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "46"
     },
     "54": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "46"
     },
     "56": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "46"
     },
     "58": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "46"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[0:title:Title].properties",
@@ -534,388 +534,396 @@
       "~k_parent": "2b"
     },
     "2e": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2b"
+    },
+    "2f": {
       "key": "root.types.blocks",
       "~k_parent": "26"
     },
-    "2f": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2e"
-    },
     "2g": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2f"
     },
     "2h": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2f"
     },
     "2i": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "2f"
     },
     "2j": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2f"
     },
     "2k": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2f"
     },
     "2l": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2f"
     },
     "2m": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2f"
     },
     "2n": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2f"
     },
     "2o": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2f"
     },
     "2p": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2f"
     },
     "2q": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2f"
     },
     "2r": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2f"
     },
     "2s": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2f"
     },
     "2t": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2f"
     },
     "2u": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2f"
     },
     "2v": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2f"
     },
     "2w": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2f"
     },
     "2x": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2f"
     },
     "2y": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2f"
     },
     "2z": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2e"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2f"
     },
     "3a": {
-      "key": "root.imports.actions",
-      "~k_parent": "39"
+      "key": "root.imports",
+      "~k_parent": "4"
     },
     "3b": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3a"
     },
     "3c": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3a"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.imports.agents",
-      "~k_parent": "39"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3b"
     },
     "3e": {
-      "key": "root.imports.auth",
-      "~k_parent": "39"
+      "key": "root.imports.agents",
+      "~k_parent": "3a"
     },
     "3f": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3e"
+      "key": "root.imports.auth",
+      "~k_parent": "3a"
     },
     "3g": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3e"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.blocks",
-      "~k_parent": "39"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3f"
     },
     "3i": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3h"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks",
+      "~k_parent": "3a"
     },
     "3k": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3j"
     },
     "3l": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3j"
     },
     "3m": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3j"
     },
     "3n": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3j"
     },
     "3o": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3j"
     },
     "3p": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3j"
     },
     "3q": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3j"
     },
     "3r": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3j"
     },
     "3s": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3j"
     },
     "3t": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3j"
     },
     "3u": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3j"
     },
     "3v": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3j"
     },
     "3w": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3j"
     },
     "3x": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3j"
     },
     "3y": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3j"
     },
     "3z": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3j"
     },
     "4a": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "46"
     },
     "4c": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "46"
     },
     "4e": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "46"
     },
     "4g": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "46"
     },
     "4i": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "46"
     },
     "4k": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "46"
     },
     "4m": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "46"
     },
     "4o": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "46"
     },
     "4q": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "46"
     },
     "4s": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "46"
     },
     "4u": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "46"
     },
     "4w": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "46"
     },
     "4y": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "46"
     },
     "5a": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "46"
     },
     "5c": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "46"
     },
     "5e": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "46"
     },
     "5g": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "46"
     },
     "5i": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "46"
     },
     "5k": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "46"
     },
     "5m": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "44"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "46"
     },
     "5o": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.requests",
-      "~k_parent": "39"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "46"
     },
     "5q": {
-      "key": "root.imports.websockets",
-      "~k_parent": "39"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.operators",
-      "~k_parent": "39"
+      "key": "root.imports.requests",
+      "~k_parent": "3a"
     },
     "5s": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5r"
+      "key": "root.imports.websockets",
+      "~k_parent": "3a"
     },
     "5t": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5s"
+      "key": "root.imports.operators",
+      "~k_parent": "3a"
     },
     "5u": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5s"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5t"
     },
     "5v": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5u"
+    },
+    "5w": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5u"
+    },
+    "5x": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5r"
+      "~k_parent": "5t"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1212,6 +1220,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5716,6 +5725,9 @@
       "providers": {
         "~k": "2d"
       },
+      "strategies": {
+        "~k": "2e"
+      },
       "~k": "2b"
     },
     "blocks": {
@@ -5723,141 +5735,141 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
-      "~k": "2e"
+      "~k": "2f"
     },
     "connections": {
-      "~k": "30"
-    },
-    "requests": {
       "~k": "31"
     },
-    "websockets": {
+    "requests": {
       "~k": "32"
     },
-    "api": {
+    "websockets": {
       "~k": "33"
+    },
+    "api": {
+      "~k": "34"
     },
     "operators": {
       "client": {
@@ -5865,20 +5877,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "36"
+          "~k": "37"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "37"
+          "~k": "38"
         },
-        "~k": "35"
+        "~k": "36"
       },
       "server": {
-        "~k": "38"
+        "~k": "39"
       },
-      "~k": "34"
+      "~k": "35"
     },
     "~k": "26"
   }

--- a/packages/build/src/tests/success/38-menu-navigation-app/snapshot.json
+++ b/packages/build/src/tests/success/38-menu-navigation-app/snapshot.json
@@ -350,123 +350,123 @@
       "~k_parent": "65"
     },
     "70": {
-      "key": "root.types.websockets",
+      "key": "root.types.requests",
       "~k_parent": "65"
     },
     "71": {
-      "key": "root.types.api",
+      "key": "root.types.websockets",
       "~k_parent": "65"
     },
     "72": {
-      "key": "root.types.operators",
+      "key": "root.types.api",
       "~k_parent": "65"
     },
     "73": {
-      "key": "root.types.operators.client",
-      "~k_parent": "72"
+      "key": "root.types.operators",
+      "~k_parent": "65"
     },
     "74": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "73"
     },
     "75": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "73"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "74"
     },
     "76": {
-      "key": "root.types.operators.server",
-      "~k_parent": "72"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "74"
     },
     "77": {
+      "key": "root.types.operators.server",
+      "~k_parent": "73"
+    },
+    "78": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "78": {
-      "key": "root.imports.actions",
-      "~k_parent": "77"
-    },
     "79": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "78"
     },
     "80": {
-      "key": "root.imports.connections",
-      "~k_parent": "77"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "7h"
     },
     "81": {
-      "key": "root.imports.icons",
-      "~k_parent": "77"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "7h"
     },
     "82": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "81"
+      "key": "root.imports.connections",
+      "~k_parent": "78"
     },
     "83": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "82"
+      "key": "root.imports.icons",
+      "~k_parent": "78"
     },
     "84": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "83"
     },
     "85": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "84"
     },
     "86": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "83"
     },
     "87": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "86"
     },
     "88": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "83"
     },
     "89": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "88"
     },
     "90": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "83"
     },
     "91": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "90"
     },
     "92": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "83"
     },
     "93": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "92"
     },
     "94": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "83"
     },
     "95": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "94"
     },
     "96": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "83"
     },
     "97": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "96"
     },
     "98": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "83"
     },
     "99": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "98"
     },
     "a": {
@@ -1169,380 +1169,388 @@
       "~k_parent": "6a"
     },
     "6d": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "6a"
+    },
+    "6e": {
       "key": "root.types.blocks",
       "~k_parent": "65"
     },
-    "6e": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "6d"
-    },
     "6f": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "6e"
     },
     "6g": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "6e"
     },
     "6h": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "6e"
     },
     "6i": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "6e"
     },
     "6j": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "6e"
     },
     "6k": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "6e"
     },
     "6l": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "6e"
     },
     "6m": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "6e"
     },
     "6n": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "6e"
     },
     "6o": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.List",
+      "~k_parent": "6e"
     },
     "6p": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "6e"
     },
     "6q": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "6e"
     },
     "6r": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "6e"
     },
     "6s": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "6e"
     },
     "6t": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "6e"
     },
     "6u": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "6e"
     },
     "6v": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "6e"
     },
     "6w": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "6e"
     },
     "6x": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "6d"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "6e"
     },
     "6y": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "6e"
+    },
+    "6z": {
       "key": "root.types.connections",
       "~k_parent": "65"
     },
-    "6z": {
-      "key": "root.types.requests",
-      "~k_parent": "65"
-    },
     "7a": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "78"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "79"
     },
     "7b": {
-      "key": "root.imports.agents",
-      "~k_parent": "77"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "79"
     },
     "7c": {
-      "key": "root.imports.auth",
-      "~k_parent": "77"
+      "key": "root.imports.agents",
+      "~k_parent": "78"
     },
     "7d": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "7c"
+      "key": "root.imports.auth",
+      "~k_parent": "78"
     },
     "7e": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "7c"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "7d"
     },
     "7f": {
-      "key": "root.imports.blocks",
-      "~k_parent": "77"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "7d"
     },
     "7g": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "7f"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "7d"
     },
     "7h": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks",
+      "~k_parent": "78"
     },
     "7i": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "7h"
     },
     "7j": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "7h"
     },
     "7k": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "7h"
     },
     "7l": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "7h"
     },
     "7m": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "7h"
     },
     "7n": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "7h"
     },
     "7o": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "7h"
     },
     "7p": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "7h"
     },
     "7q": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "7h"
     },
     "7r": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "7h"
     },
     "7s": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "7h"
     },
     "7t": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "7h"
     },
     "7u": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "7h"
     },
     "7v": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "7h"
     },
     "7w": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "7h"
     },
     "7x": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "7h"
     },
     "7y": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "7h"
     },
     "7z": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "7f"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "7h"
     },
     "8a": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "83"
     },
     "8b": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "8a"
     },
     "8c": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "83"
     },
     "8d": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "8c"
     },
     "8e": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "83"
     },
     "8f": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "8e"
     },
     "8g": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "83"
     },
     "8h": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "8g"
     },
     "8i": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "83"
     },
     "8j": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "8i"
     },
     "8k": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "83"
     },
     "8l": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "8k"
     },
     "8m": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "83"
     },
     "8n": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "8m"
     },
     "8o": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "83"
     },
     "8p": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "8o"
     },
     "8q": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "83"
     },
     "8r": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "8q"
     },
     "8s": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "83"
     },
     "8t": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "8s"
     },
     "8u": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "83"
     },
     "8v": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "8u"
     },
     "8w": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "83"
     },
     "8x": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "8w"
     },
     "8y": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "83"
     },
     "8z": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "8y"
     },
     "9a": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "83"
     },
     "9b": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "9a"
     },
     "9c": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "83"
     },
     "9d": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "9c"
     },
     "9e": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "83"
     },
     "9f": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "9e"
     },
     "9g": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "83"
     },
     "9h": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "9g"
     },
     "9i": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "83"
     },
     "9j": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "9i"
     },
     "9k": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "81"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "83"
     },
     "9l": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "9k"
     },
     "9m": {
-      "key": "root.imports.requests",
-      "~k_parent": "77"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "83"
     },
     "9n": {
-      "key": "root.imports.websockets",
-      "~k_parent": "77"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "9m"
     },
     "9o": {
-      "key": "root.imports.operators",
-      "~k_parent": "77"
+      "key": "root.imports.requests",
+      "~k_parent": "78"
     },
     "9p": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "9o"
+      "key": "root.imports.websockets",
+      "~k_parent": "78"
     },
     "9q": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "9p"
+      "key": "root.imports.operators",
+      "~k_parent": "78"
     },
     "9r": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "9p"
+      "key": "root.imports.operators.client",
+      "~k_parent": "9q"
     },
     "9s": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "9r"
+    },
+    "9t": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "9r"
+    },
+    "9u": {
       "key": "root.imports.operators.server",
-      "~k_parent": "9o"
+      "~k_parent": "9q"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -2430,6 +2438,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -6924,6 +6933,9 @@
       "providers": {
         "~k": "6c"
       },
+      "strategies": {
+        "~k": "6d"
+      },
       "~k": "6a"
     },
     "blocks": {
@@ -6931,135 +6943,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 12,
-        "~k": "6e"
+        "~k": "6f"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 11,
-        "~k": "6f"
+        "~k": "6g"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "6g"
+        "~k": "6h"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6h"
+        "~k": "6i"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6i"
+        "~k": "6j"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6j"
+        "~k": "6k"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6k"
+        "~k": "6l"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6l"
+        "~k": "6m"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6m"
+        "~k": "6n"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6n"
+        "~k": "6o"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6o"
+        "~k": "6p"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6p"
+        "~k": "6q"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6q"
+        "~k": "6r"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6r"
+        "~k": "6s"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6s"
+        "~k": "6t"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6t"
+        "~k": "6u"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6u"
+        "~k": "6v"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6v"
+        "~k": "6w"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6w"
+        "~k": "6x"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "6x"
+        "~k": "6y"
       },
-      "~k": "6d"
+      "~k": "6e"
     },
     "connections": {
-      "~k": "6y"
-    },
-    "requests": {
       "~k": "6z"
     },
-    "websockets": {
+    "requests": {
       "~k": "70"
     },
-    "api": {
+    "websockets": {
       "~k": "71"
+    },
+    "api": {
+      "~k": "72"
     },
     "operators": {
       "client": {
@@ -7067,20 +7079,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "74"
+          "~k": "75"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "75"
+          "~k": "76"
         },
-        "~k": "73"
+        "~k": "74"
       },
       "server": {
-        "~k": "76"
+        "~k": "77"
       },
-      "~k": "72"
+      "~k": "73"
     },
     "~k": "65"
   }

--- a/packages/build/src/tests/success/39-global-state-app/snapshot.json
+++ b/packages/build/src/tests/success/39-global-state-app/snapshot.json
@@ -294,164 +294,164 @@
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.List",
+      "~k_parent": "4m"
     },
     "51": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "4m"
     },
     "52": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "4m"
     },
     "53": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "4m"
     },
     "54": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "4m"
     },
     "55": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "4m"
     },
     "56": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "4m"
     },
     "57": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "4m"
     },
     "58": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "4m"
     },
     "59": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "4m"
     },
     "60": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "5y"
     },
     "61": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "5y"
     },
     "62": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "5y"
     },
     "63": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "5y"
     },
     "64": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "5y"
     },
     "65": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "5y"
     },
     "66": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "5y"
     },
     "67": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "5y"
     },
     "68": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "5y"
     },
     "69": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "5y"
     },
     "70": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "6z"
     },
     "71": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "6o"
     },
     "72": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "71"
     },
     "73": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "6o"
     },
     "74": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "73"
     },
     "75": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "6o"
     },
     "76": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "75"
     },
     "77": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "6o"
     },
     "78": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "77"
     },
     "79": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "6o"
     },
     "80": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "7z"
     },
     "81": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "6o"
     },
     "82": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "81"
     },
     "83": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "6o"
     },
     "84": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "83"
     },
     "85": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "6o"
     },
     "86": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "85"
     },
     "87": {
-      "key": "root.imports.requests",
-      "~k_parent": "5n"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "6o"
     },
     "88": {
-      "key": "root.imports.websockets",
-      "~k_parent": "5n"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "87"
     },
     "89": {
-      "key": "root.imports.operators",
-      "~k_parent": "5n"
+      "key": "root.imports.requests",
+      "~k_parent": "5o"
     },
     "a": {
       "key": "root.global.settings",
@@ -962,408 +962,416 @@
       "~k_parent": "4i"
     },
     "4l": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "4i"
+    },
+    "4m": {
       "key": "root.types.blocks",
       "~k_parent": "4c"
     },
-    "4m": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "4l"
-    },
     "4n": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "4m"
     },
     "4p": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "4m"
     },
     "4q": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "4m"
     },
     "4r": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "4m"
     },
     "4s": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "4m"
     },
     "4t": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "4m"
     },
     "4u": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "4m"
     },
     "4v": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "4m"
     },
     "4w": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "4m"
     },
     "4x": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "4m"
     },
     "4y": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "4m"
     },
     "4z": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "4l"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "4m"
     },
     "5a": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "4m"
+    },
+    "5b": {
       "key": "root.types.connections",
       "~k_parent": "4c"
     },
-    "5b": {
+    "5c": {
       "key": "root.types.requests",
       "~k_parent": "4c"
     },
-    "5c": {
+    "5d": {
       "key": "root.types.websockets",
       "~k_parent": "4c"
     },
-    "5d": {
+    "5e": {
       "key": "root.types.api",
       "~k_parent": "4c"
     },
-    "5e": {
+    "5f": {
       "key": "root.types.operators",
       "~k_parent": "4c"
     },
-    "5f": {
-      "key": "root.types.operators.client",
-      "~k_parent": "5e"
-    },
     "5g": {
-      "key": "root.types.operators.client._date",
+      "key": "root.types.operators.client",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.types.operators.client._global",
-      "~k_parent": "5f"
+      "key": "root.types.operators.client._date",
+      "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.types.operators.client._state",
-      "~k_parent": "5f"
+      "key": "root.types.operators.client._global",
+      "~k_parent": "5g"
     },
     "5j": {
-      "key": "root.types.operators.client._array",
-      "~k_parent": "5f"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "5g"
     },
     "5k": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "5f"
+      "key": "root.types.operators.client._array",
+      "~k_parent": "5g"
     },
     "5l": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "5f"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "5g"
     },
     "5m": {
-      "key": "root.types.operators.server",
-      "~k_parent": "5e"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "5g"
     },
     "5n": {
+      "key": "root.types.operators.server",
+      "~k_parent": "5f"
+    },
+    "5o": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "5o": {
-      "key": "root.imports.actions",
-      "~k_parent": "5n"
-    },
     "5p": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "5o"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "5o"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "5p"
     },
     "5s": {
-      "key": "root.imports.agents",
-      "~k_parent": "5n"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "5p"
     },
     "5t": {
-      "key": "root.imports.auth",
-      "~k_parent": "5n"
+      "key": "root.imports.agents",
+      "~k_parent": "5o"
     },
     "5u": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "5t"
+      "key": "root.imports.auth",
+      "~k_parent": "5o"
     },
     "5v": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "5t"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.blocks",
-      "~k_parent": "5n"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "5u"
     },
     "5x": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "5w"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "5u"
     },
     "5y": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks",
+      "~k_parent": "5o"
     },
     "5z": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "5y"
     },
     "6b": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "5y"
     },
     "6c": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "5y"
     },
     "6d": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "5y"
     },
     "6e": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "5y"
     },
     "6f": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "5y"
     },
     "6g": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "5y"
     },
     "6h": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "5y"
     },
     "6i": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "5y"
     },
     "6j": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "5y"
     },
     "6k": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "5w"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "5y"
     },
     "6l": {
-      "key": "root.imports.connections",
-      "~k_parent": "5n"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "5y"
     },
     "6m": {
-      "key": "root.imports.icons",
-      "~k_parent": "5n"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "5y"
     },
     "6n": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "6m"
+      "key": "root.imports.connections",
+      "~k_parent": "5o"
     },
     "6o": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "6n"
+      "key": "root.imports.icons",
+      "~k_parent": "5o"
     },
     "6p": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "6o"
     },
     "6q": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "6o"
     },
     "6s": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "6r"
     },
     "6t": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "6o"
     },
     "6u": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "6o"
     },
     "6w": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "6v"
     },
     "6x": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "6o"
     },
     "6y": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "6o"
     },
     "7a": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "79"
     },
     "7b": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "6o"
     },
     "7c": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "7b"
     },
     "7d": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "6o"
     },
     "7e": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "7d"
     },
     "7f": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "6o"
     },
     "7g": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "7f"
     },
     "7h": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "6o"
     },
     "7i": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "7h"
     },
     "7j": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "6o"
     },
     "7k": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "7j"
     },
     "7l": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "6o"
     },
     "7m": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "7l"
     },
     "7n": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "6o"
     },
     "7o": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "7n"
     },
     "7p": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "6o"
     },
     "7q": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "7p"
     },
     "7r": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "6o"
     },
     "7s": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "7r"
     },
     "7t": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "6o"
     },
     "7u": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "7t"
     },
     "7v": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "6o"
     },
     "7w": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "7v"
     },
     "7x": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "6o"
     },
     "7y": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "7x"
     },
     "7z": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "6m"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "6o"
     },
     "8a": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "89"
+      "key": "root.imports.websockets",
+      "~k_parent": "5o"
     },
     "8b": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "8a"
+      "key": "root.imports.operators",
+      "~k_parent": "5o"
     },
     "8c": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "8a"
+      "key": "root.imports.operators.client",
+      "~k_parent": "8b"
     },
     "8d": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "8a"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "8c"
     },
     "8e": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "8a"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "8c"
     },
     "8f": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "8a"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "8c"
     },
     "8g": {
-      "key": "root.imports.operators.client[5]",
-      "~k_parent": "8a"
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "8c"
     },
     "8h": {
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "8c"
+    },
+    "8i": {
+      "key": "root.imports.operators.client[5]",
+      "~k_parent": "8c"
+    },
+    "8j": {
       "key": "root.imports.operators.server",
-      "~k_parent": "89"
+      "~k_parent": "8b"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1966,6 +1974,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -8520,6 +8529,9 @@
       "providers": {
         "~k": "4k"
       },
+      "strategies": {
+        "~k": "4l"
+      },
       "~k": "4i"
     },
     "blocks": {
@@ -8527,159 +8539,159 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "4m"
+        "~k": "4n"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "4n"
+        "~k": "4o"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "4o"
+        "~k": "4p"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4p"
+        "~k": "4q"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4q"
+        "~k": "4r"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "4r"
+        "~k": "4s"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "4s"
+        "~k": "4t"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4t"
+        "~k": "4u"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4u"
+        "~k": "4v"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4v"
+        "~k": "4w"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4w"
+        "~k": "4x"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4x"
+        "~k": "4y"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4y"
+        "~k": "4z"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4z"
+        "~k": "50"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "50"
+        "~k": "51"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "51"
+        "~k": "52"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "52"
+        "~k": "53"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "53"
+        "~k": "54"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "54"
+        "~k": "55"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "55"
+        "~k": "56"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "56"
+        "~k": "57"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "57"
+        "~k": "58"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "58"
+        "~k": "59"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "59"
+        "~k": "5a"
       },
-      "~k": "4l"
+      "~k": "4m"
     },
     "connections": {
-      "~k": "5a"
-    },
-    "requests": {
       "~k": "5b"
     },
-    "websockets": {
+    "requests": {
       "~k": "5c"
     },
-    "api": {
+    "websockets": {
       "~k": "5d"
+    },
+    "api": {
+      "~k": "5e"
     },
     "operators": {
       "client": {
@@ -8687,44 +8699,44 @@
           "originalTypeName": "_date",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5g"
+          "~k": "5h"
         },
         "_global": {
           "originalTypeName": "_global",
           "package": "@lowdefy/operators-js",
           "count": 4,
-          "~k": "5h"
+          "~k": "5i"
         },
         "_state": {
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 3,
-          "~k": "5i"
+          "~k": "5j"
         },
         "_array": {
           "originalTypeName": "_array",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5j"
+          "~k": "5k"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5k"
+          "~k": "5l"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5l"
+          "~k": "5m"
         },
-        "~k": "5f"
+        "~k": "5g"
       },
       "server": {
-        "~k": "5m"
+        "~k": "5n"
       },
-      "~k": "5e"
+      "~k": "5f"
     },
     "~k": "4c"
   }

--- a/packages/build/src/tests/success/40-form-validation-app/snapshot.json
+++ b/packages/build/src/tests/success/40-form-validation-app/snapshot.json
@@ -224,164 +224,172 @@
       "~k_parent": "38"
     },
     "40": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "3x"
     },
     "41": {
-      "key": "root.types.blocks.PasswordInput",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "3x"
     },
     "42": {
-      "key": "root.types.blocks.NumberInput",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.PasswordInput",
+      "~k_parent": "3x"
     },
     "43": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.NumberInput",
+      "~k_parent": "3x"
     },
     "44": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "3x"
     },
     "45": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3x"
     },
     "46": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3x"
     },
     "47": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3x"
     },
     "48": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3x"
     },
     "49": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3x"
     },
     "50": {
-      "key": "root.types.operators.server",
-      "~k_parent": "4q"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "4s"
     },
     "51": {
+      "key": "root.types.operators.server",
+      "~k_parent": "4r"
+    },
+    "52": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "52": {
-      "key": "root.imports.actions",
-      "~k_parent": "51"
-    },
     "53": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "52"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "52"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "53"
     },
     "56": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "52"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "53"
     },
     "57": {
-      "key": "root.imports.agents",
-      "~k_parent": "51"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "53"
     },
     "58": {
-      "key": "root.imports.auth",
-      "~k_parent": "51"
+      "key": "root.imports.agents",
+      "~k_parent": "52"
     },
     "59": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "58"
+      "key": "root.imports.auth",
+      "~k_parent": "52"
     },
     "60": {
-      "key": "root.imports.blocks[24]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "5d"
     },
     "61": {
-      "key": "root.imports.connections",
-      "~k_parent": "51"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "5d"
     },
     "62": {
-      "key": "root.imports.icons",
-      "~k_parent": "51"
+      "key": "root.imports.blocks[24]",
+      "~k_parent": "5d"
     },
     "63": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "62"
+      "key": "root.imports.connections",
+      "~k_parent": "52"
     },
     "64": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "63"
+      "key": "root.imports.icons",
+      "~k_parent": "52"
     },
     "65": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "64"
     },
     "68": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "64"
     },
     "70": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "6z"
     },
     "71": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "64"
     },
     "72": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "71"
     },
     "73": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "64"
     },
     "74": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "73"
     },
     "75": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "64"
     },
     "76": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "75"
     },
     "77": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "64"
     },
     "78": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "77"
     },
     "79": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "64"
+    },
+    "80": {
+      "key": "root.imports.operators.client[7]",
+      "~k_parent": "7s"
+    },
+    "81": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "7r"
     },
     "a": {
       "key": "root.pages[0:registration:Box].blocks[0:title:Title].properties",
@@ -832,436 +840,436 @@
       "~k_parent": "3t"
     },
     "3w": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "3t"
+    },
+    "3x": {
       "key": "root.types.blocks",
       "~k_parent": "3m"
     },
-    "3x": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "3w"
-    },
     "3y": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "3x"
     },
     "4a": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3x"
     },
     "4b": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3x"
     },
     "4c": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3x"
     },
     "4d": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3x"
     },
     "4e": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3x"
     },
     "4f": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3x"
     },
     "4g": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3x"
     },
     "4h": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3x"
     },
     "4i": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3x"
     },
     "4j": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3x"
     },
     "4k": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3x"
     },
     "4l": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3x"
     },
     "4m": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3x"
+    },
+    "4n": {
       "key": "root.types.connections",
       "~k_parent": "3m"
     },
-    "4n": {
+    "4o": {
       "key": "root.types.requests",
       "~k_parent": "3m"
     },
-    "4o": {
+    "4p": {
       "key": "root.types.websockets",
       "~k_parent": "3m"
     },
-    "4p": {
+    "4q": {
       "key": "root.types.api",
       "~k_parent": "3m"
     },
-    "4q": {
+    "4r": {
       "key": "root.types.operators",
       "~k_parent": "3m"
     },
-    "4r": {
-      "key": "root.types.operators.client",
-      "~k_parent": "4q"
-    },
     "4s": {
-      "key": "root.types.operators.client._gte",
+      "key": "root.types.operators.client",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.types.operators.client._state",
-      "~k_parent": "4r"
+      "key": "root.types.operators.client._gte",
+      "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.types.operators.client._regex",
-      "~k_parent": "4r"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "4s"
     },
     "4v": {
-      "key": "root.types.operators.client._string",
-      "~k_parent": "4r"
+      "key": "root.types.operators.client._regex",
+      "~k_parent": "4s"
     },
     "4w": {
-      "key": "root.types.operators.client._eq",
-      "~k_parent": "4r"
+      "key": "root.types.operators.client._string",
+      "~k_parent": "4s"
     },
     "4x": {
-      "key": "root.types.operators.client._lte",
-      "~k_parent": "4r"
+      "key": "root.types.operators.client._eq",
+      "~k_parent": "4s"
     },
     "4y": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "4r"
+      "key": "root.types.operators.client._lte",
+      "~k_parent": "4s"
     },
     "4z": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "4r"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "4s"
     },
     "5a": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "58"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.blocks",
-      "~k_parent": "51"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "59"
     },
     "5c": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "5b"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "59"
     },
     "5d": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks",
+      "~k_parent": "52"
     },
     "5e": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "5d"
     },
     "5g": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "5d"
     },
     "5h": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "5d"
     },
     "5i": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "5d"
     },
     "5j": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "5d"
     },
     "5k": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "5d"
     },
     "5l": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "5d"
     },
     "5m": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "5d"
     },
     "5n": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "5d"
     },
     "5o": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "5d"
     },
     "5p": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "5d"
     },
     "5q": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "5d"
     },
     "5r": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "5d"
     },
     "5s": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "5d"
     },
     "5t": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "5d"
     },
     "5u": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "5d"
     },
     "5v": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "5d"
     },
     "5w": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "5d"
     },
     "5x": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "5d"
     },
     "5y": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "5d"
     },
     "5z": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "5d"
     },
     "6a": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "64"
     },
     "6c": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "64"
     },
     "6e": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "64"
     },
     "6g": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "6f"
     },
     "6h": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "64"
     },
     "6i": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "64"
     },
     "6k": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "6j"
     },
     "6l": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "64"
     },
     "6m": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "6l"
     },
     "6n": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "64"
     },
     "6o": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "6n"
     },
     "6p": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "64"
     },
     "6q": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "64"
     },
     "6s": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "6r"
     },
     "6t": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "64"
     },
     "6u": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "64"
     },
     "6w": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "6v"
     },
     "6x": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "64"
     },
     "6y": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "64"
     },
     "7a": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "79"
     },
     "7b": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "64"
     },
     "7c": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "7b"
     },
     "7d": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "64"
     },
     "7e": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "7d"
     },
     "7f": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "64"
     },
     "7g": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "7f"
     },
     "7h": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "64"
     },
     "7i": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "7h"
     },
     "7j": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "64"
     },
     "7k": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "7j"
     },
     "7l": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "62"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "64"
     },
     "7m": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "7l"
     },
     "7n": {
-      "key": "root.imports.requests",
-      "~k_parent": "51"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "64"
     },
     "7o": {
-      "key": "root.imports.websockets",
-      "~k_parent": "51"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "7n"
     },
     "7p": {
-      "key": "root.imports.operators",
-      "~k_parent": "51"
+      "key": "root.imports.requests",
+      "~k_parent": "52"
     },
     "7q": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "7p"
+      "key": "root.imports.websockets",
+      "~k_parent": "52"
     },
     "7r": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "7q"
+      "key": "root.imports.operators",
+      "~k_parent": "52"
     },
     "7s": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "7q"
+      "key": "root.imports.operators.client",
+      "~k_parent": "7r"
     },
     "7t": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "7q"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "7s"
     },
     "7u": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "7q"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "7s"
     },
     "7v": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "7q"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "7s"
     },
     "7w": {
-      "key": "root.imports.operators.client[5]",
-      "~k_parent": "7q"
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "7s"
     },
     "7x": {
-      "key": "root.imports.operators.client[6]",
-      "~k_parent": "7q"
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "7s"
     },
     "7y": {
-      "key": "root.imports.operators.client[7]",
-      "~k_parent": "7q"
+      "key": "root.imports.operators.client[5]",
+      "~k_parent": "7s"
     },
     "7z": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "7p"
+      "key": "root.imports.operators.client[6]",
+      "~k_parent": "7s"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1850,6 +1858,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -9662,6 +9671,9 @@
       "providers": {
         "~k": "3v"
       },
+      "strategies": {
+        "~k": "3w"
+      },
       "~k": "3t"
     },
     "blocks": {
@@ -9669,165 +9681,165 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "3x"
+        "~k": "3y"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3y"
+        "~k": "3z"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3z"
+        "~k": "40"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "40"
+        "~k": "41"
       },
       "PasswordInput": {
         "originalTypeName": "PasswordInput",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "41"
+        "~k": "42"
       },
       "NumberInput": {
         "originalTypeName": "NumberInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "42"
+        "~k": "43"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "43"
+        "~k": "44"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "44"
+        "~k": "45"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "45"
+        "~k": "46"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "46"
+        "~k": "47"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "47"
+        "~k": "48"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "48"
+        "~k": "49"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "49"
+        "~k": "4a"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4a"
+        "~k": "4b"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4b"
+        "~k": "4c"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4c"
+        "~k": "4d"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4d"
+        "~k": "4e"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4e"
+        "~k": "4f"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4f"
+        "~k": "4g"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4g"
+        "~k": "4h"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4h"
+        "~k": "4i"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4i"
+        "~k": "4j"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4j"
+        "~k": "4k"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4k"
+        "~k": "4l"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4l"
+        "~k": "4m"
       },
-      "~k": "3w"
+      "~k": "3x"
     },
     "connections": {
-      "~k": "4m"
-    },
-    "requests": {
       "~k": "4n"
     },
-    "websockets": {
+    "requests": {
       "~k": "4o"
     },
-    "api": {
+    "websockets": {
       "~k": "4p"
+    },
+    "api": {
+      "~k": "4q"
     },
     "operators": {
       "client": {
@@ -9835,56 +9847,56 @@
           "originalTypeName": "_gte",
           "package": "@lowdefy/operators-js",
           "count": 3,
-          "~k": "4s"
+          "~k": "4t"
         },
         "_state": {
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 10,
-          "~k": "4t"
+          "~k": "4u"
         },
         "_regex": {
           "originalTypeName": "_regex",
           "package": "@lowdefy/operators-js",
           "count": 3,
-          "~k": "4u"
+          "~k": "4v"
         },
         "_string": {
           "originalTypeName": "_string",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4v"
+          "~k": "4w"
         },
         "_eq": {
           "originalTypeName": "_eq",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "4w"
+          "~k": "4x"
         },
         "_lte": {
           "originalTypeName": "_lte",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4x"
+          "~k": "4y"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4y"
+          "~k": "4z"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4z"
+          "~k": "50"
         },
-        "~k": "4r"
+        "~k": "4s"
       },
       "server": {
-        "~k": "50"
+        "~k": "51"
       },
-      "~k": "4q"
+      "~k": "4r"
     },
     "~k": "3m"
   }

--- a/packages/build/src/tests/success/41-list-crud-app/snapshot.json
+++ b/packages/build/src/tests/success/41-list-crud-app/snapshot.json
@@ -224,140 +224,148 @@
       "~k_parent": "38"
     },
     "40": {
-      "key": "root.types.websockets",
+      "key": "root.types.requests",
       "~k_parent": "32"
     },
     "41": {
-      "key": "root.types.api",
+      "key": "root.types.websockets",
       "~k_parent": "32"
     },
     "42": {
-      "key": "root.types.operators",
+      "key": "root.types.api",
       "~k_parent": "32"
     },
     "43": {
-      "key": "root.types.operators.client",
-      "~k_parent": "42"
+      "key": "root.types.operators",
+      "~k_parent": "32"
     },
     "44": {
-      "key": "root.types.operators.client._array",
+      "key": "root.types.operators.client",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.types.operators.client._state",
-      "~k_parent": "43"
+      "key": "root.types.operators.client._array",
+      "~k_parent": "44"
     },
     "46": {
-      "key": "root.types.operators.client._random",
-      "~k_parent": "43"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "44"
     },
     "47": {
-      "key": "root.types.operators.client._if",
-      "~k_parent": "43"
+      "key": "root.types.operators.client._random",
+      "~k_parent": "44"
     },
     "48": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "43"
+      "key": "root.types.operators.client._if",
+      "~k_parent": "44"
     },
     "49": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "43"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "44"
     },
     "50": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "4m"
     },
     "51": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "4m"
     },
     "52": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "4m"
     },
     "53": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "4m"
     },
     "54": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "4m"
     },
     "55": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "4m"
     },
     "56": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "4m"
     },
     "57": {
-      "key": "root.imports.connections",
-      "~k_parent": "4b"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "4m"
     },
     "58": {
-      "key": "root.imports.icons",
-      "~k_parent": "4b"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "4m"
     },
     "59": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "58"
+      "key": "root.imports.connections",
+      "~k_parent": "4c"
     },
     "60": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "5a"
     },
     "62": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "5a"
     },
     "64": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "5a"
     },
     "66": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "5a"
     },
     "68": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "5a"
     },
     "70": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "6w"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6y"
     },
     "71": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "6w"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "6y"
     },
     "72": {
-      "key": "root.imports.operators.client[5]",
-      "~k_parent": "6w"
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "6y"
     },
     "73": {
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "6y"
+    },
+    "74": {
+      "key": "root.imports.operators.client[5]",
+      "~k_parent": "6y"
+    },
+    "75": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6v"
+      "~k_parent": "6x"
     },
     "a": {
       "key": "root.pages[0:todos:Box].events.onInit[0:initTodos:SetState]",
@@ -698,416 +706,416 @@
       "~k_parent": "38"
     },
     "3b": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "38"
+    },
+    "3c": {
       "key": "root.types.blocks",
       "~k_parent": "32"
     },
-    "3c": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "3b"
-    },
     "3d": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3c"
     },
     "3e": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "3c"
     },
     "3f": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3c"
     },
     "3g": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3c"
     },
     "3h": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "3c"
     },
     "3i": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "3c"
     },
     "3j": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3c"
     },
     "3k": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3c"
     },
     "3l": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3c"
     },
     "3m": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3c"
     },
     "3n": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3c"
     },
     "3o": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3c"
     },
     "3p": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3c"
     },
     "3q": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3c"
     },
     "3r": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3c"
     },
     "3s": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3c"
     },
     "3t": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3c"
     },
     "3u": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3c"
     },
     "3v": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3c"
     },
     "3w": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3c"
     },
     "3x": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "3b"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3c"
     },
     "3y": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3c"
+    },
+    "3z": {
       "key": "root.types.connections",
       "~k_parent": "32"
     },
-    "3z": {
-      "key": "root.types.requests",
-      "~k_parent": "32"
-    },
     "4a": {
-      "key": "root.types.operators.server",
-      "~k_parent": "42"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "44"
     },
     "4b": {
+      "key": "root.types.operators.server",
+      "~k_parent": "43"
+    },
+    "4c": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "4c": {
-      "key": "root.imports.actions",
-      "~k_parent": "4b"
-    },
     "4d": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "4c"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "4c"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "4d"
     },
     "4g": {
-      "key": "root.imports.agents",
-      "~k_parent": "4b"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "4d"
     },
     "4h": {
-      "key": "root.imports.auth",
-      "~k_parent": "4b"
+      "key": "root.imports.agents",
+      "~k_parent": "4c"
     },
     "4i": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "4h"
+      "key": "root.imports.auth",
+      "~k_parent": "4c"
     },
     "4j": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "4h"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.blocks",
-      "~k_parent": "4b"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "4i"
     },
     "4l": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "4k"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "4i"
     },
     "4m": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks",
+      "~k_parent": "4c"
     },
     "4n": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "4m"
     },
     "4p": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "4m"
     },
     "4q": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "4m"
     },
     "4r": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "4m"
     },
     "4s": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "4m"
     },
     "4t": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "4m"
     },
     "4u": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "4m"
     },
     "4v": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "4m"
     },
     "4w": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "4m"
     },
     "4x": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "4m"
     },
     "4y": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "4m"
     },
     "4z": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "4m"
     },
     "5a": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "59"
+      "key": "root.imports.icons",
+      "~k_parent": "4c"
     },
     "5b": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "5a"
     },
     "5e": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "5a"
     },
     "5g": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "5a"
     },
     "5i": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "5a"
     },
     "5k": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "5a"
     },
     "5m": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "5a"
     },
     "5o": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "5a"
     },
     "5q": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "5a"
     },
     "5s": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "5a"
     },
     "5u": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "5a"
     },
     "5w": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "5a"
     },
     "5y": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "5a"
     },
     "6a": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "5a"
     },
     "6c": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "5a"
     },
     "6e": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "5a"
     },
     "6g": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "6f"
     },
     "6h": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "5a"
     },
     "6i": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "5a"
     },
     "6k": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "6j"
     },
     "6l": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "5a"
     },
     "6m": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "6l"
     },
     "6n": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "5a"
     },
     "6o": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "6n"
     },
     "6p": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "5a"
     },
     "6q": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "58"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "5a"
     },
     "6s": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6r"
     },
     "6t": {
-      "key": "root.imports.requests",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "5a"
     },
     "6u": {
-      "key": "root.imports.websockets",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.imports.operators",
-      "~k_parent": "4b"
+      "key": "root.imports.requests",
+      "~k_parent": "4c"
     },
     "6w": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6v"
+      "key": "root.imports.websockets",
+      "~k_parent": "4c"
     },
     "6x": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6w"
+      "key": "root.imports.operators",
+      "~k_parent": "4c"
     },
     "6y": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6w"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "6w"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6y"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1535,6 +1543,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -7545,6 +7554,9 @@
       "providers": {
         "~k": "3a"
       },
+      "strategies": {
+        "~k": "3b"
+      },
       "~k": "38"
     },
     "blocks": {
@@ -7552,147 +7564,147 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "3c"
+        "~k": "3d"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "3e"
+        "~k": "3f"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "3f"
+        "~k": "3g"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3h"
+        "~k": "3i"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3i"
+        "~k": "3j"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3j"
+        "~k": "3k"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3k"
+        "~k": "3l"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3l"
+        "~k": "3m"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3m"
+        "~k": "3n"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3n"
+        "~k": "3o"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3o"
+        "~k": "3p"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3p"
+        "~k": "3q"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3q"
+        "~k": "3r"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3r"
+        "~k": "3s"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3s"
+        "~k": "3t"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3t"
+        "~k": "3u"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3u"
+        "~k": "3v"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3v"
+        "~k": "3w"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3w"
+        "~k": "3x"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3x"
+        "~k": "3y"
       },
-      "~k": "3b"
+      "~k": "3c"
     },
     "connections": {
-      "~k": "3y"
-    },
-    "requests": {
       "~k": "3z"
     },
-    "websockets": {
+    "requests": {
       "~k": "40"
     },
-    "api": {
+    "websockets": {
       "~k": "41"
+    },
+    "api": {
+      "~k": "42"
     },
     "operators": {
       "client": {
@@ -7700,44 +7712,44 @@
           "originalTypeName": "_array",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "44"
+          "~k": "45"
         },
         "_state": {
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 6,
-          "~k": "45"
+          "~k": "46"
         },
         "_random": {
           "originalTypeName": "_random",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "46"
+          "~k": "47"
         },
         "_if": {
           "originalTypeName": "_if",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "47"
+          "~k": "48"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "48"
+          "~k": "49"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "49"
+          "~k": "4a"
         },
-        "~k": "43"
+        "~k": "44"
       },
       "server": {
-        "~k": "4a"
+        "~k": "4b"
       },
-      "~k": "42"
+      "~k": "43"
     },
     "~k": "32"
   }

--- a/packages/build/src/tests/success/42-dashboard-app/snapshot.json
+++ b/packages/build/src/tests/success/42-dashboard-app/snapshot.json
@@ -224,128 +224,136 @@
       "~k_parent": "38"
     },
     "40": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3g"
     },
     "41": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3g"
     },
     "42": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3g"
     },
     "43": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3g"
+    },
+    "44": {
       "key": "root.types.connections",
       "~k_parent": "37"
     },
-    "44": {
+    "45": {
       "key": "root.types.requests",
       "~k_parent": "37"
     },
-    "45": {
+    "46": {
       "key": "root.types.websockets",
       "~k_parent": "37"
     },
-    "46": {
+    "47": {
       "key": "root.types.api",
       "~k_parent": "37"
     },
-    "47": {
+    "48": {
       "key": "root.types.operators",
       "~k_parent": "37"
     },
-    "48": {
-      "key": "root.types.operators.client",
-      "~k_parent": "47"
-    },
     "49": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "4m"
     },
     "51": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "4m"
     },
     "52": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "4m"
     },
     "53": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "4m"
     },
     "54": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "4m"
     },
     "55": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "4m"
     },
     "56": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "4m"
     },
     "57": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "4m"
     },
     "58": {
-      "key": "root.imports.connections",
-      "~k_parent": "4c"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "4m"
     },
     "59": {
-      "key": "root.imports.icons",
-      "~k_parent": "4c"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "4m"
     },
     "60": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "5b"
     },
     "61": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "5b"
     },
     "63": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "5b"
     },
     "65": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "5b"
     },
     "67": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "5b"
     },
     "69": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "68"
     },
     "70": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6z"
+    },
+    "71": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6z"
+    },
+    "72": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6w"
+      "~k_parent": "6y"
     },
     "a": {
       "key": "root.pages[0:dashboard:PageSiderMenu].areas.content.blocks",
@@ -703,400 +711,400 @@
       "~k_parent": "3c"
     },
     "3f": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "3c"
+    },
+    "3g": {
       "key": "root.types.blocks",
       "~k_parent": "37"
     },
-    "3g": {
-      "key": "root.types.blocks.PageSiderMenu",
-      "~k_parent": "3f"
-    },
     "3h": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.PageSiderMenu",
+      "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3g"
     },
     "3j": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "3g"
     },
     "3k": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "3g"
     },
     "3l": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "3g"
     },
     "3m": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3g"
     },
     "3n": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3g"
     },
     "3o": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3g"
     },
     "3p": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3g"
     },
     "3q": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3g"
     },
     "3r": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3g"
     },
     "3s": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3g"
     },
     "3t": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3g"
     },
     "3u": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3g"
     },
     "3v": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3g"
     },
     "3w": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3g"
     },
     "3x": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3g"
     },
     "3y": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3g"
     },
     "3z": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "3f"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3g"
     },
     "4a": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "48"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "49"
     },
     "4b": {
-      "key": "root.types.operators.server",
-      "~k_parent": "47"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "49"
     },
     "4c": {
+      "key": "root.types.operators.server",
+      "~k_parent": "48"
+    },
+    "4d": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "4d": {
-      "key": "root.imports.actions",
-      "~k_parent": "4c"
-    },
     "4e": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "4d"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.agents",
-      "~k_parent": "4c"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "4e"
     },
     "4h": {
-      "key": "root.imports.auth",
-      "~k_parent": "4c"
+      "key": "root.imports.agents",
+      "~k_parent": "4d"
     },
     "4i": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "4h"
+      "key": "root.imports.auth",
+      "~k_parent": "4d"
     },
     "4j": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "4h"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.blocks",
-      "~k_parent": "4c"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "4i"
     },
     "4l": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "4k"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "4i"
     },
     "4m": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks",
+      "~k_parent": "4d"
     },
     "4n": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "4m"
     },
     "4p": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "4m"
     },
     "4q": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "4m"
     },
     "4r": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "4m"
     },
     "4s": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "4m"
     },
     "4t": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "4m"
     },
     "4u": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "4m"
     },
     "4v": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "4m"
     },
     "4w": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "4m"
     },
     "4x": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "4m"
     },
     "4y": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "4m"
     },
     "4z": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "4m"
     },
     "5a": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "59"
+      "key": "root.imports.connections",
+      "~k_parent": "4d"
     },
     "5b": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "5a"
+      "key": "root.imports.icons",
+      "~k_parent": "4d"
     },
     "5c": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "5b"
     },
     "5f": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "5b"
     },
     "5h": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "5b"
     },
     "5j": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "5b"
     },
     "5l": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "5b"
     },
     "5n": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "5b"
     },
     "5p": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "5b"
     },
     "5r": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "5b"
     },
     "5t": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "5b"
     },
     "5v": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "5b"
     },
     "5x": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "5b"
     },
     "5z": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "5b"
     },
     "6b": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "5b"
     },
     "6d": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "5b"
     },
     "6f": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "6e"
     },
     "6g": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "5b"
     },
     "6h": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "6g"
     },
     "6i": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "5b"
     },
     "6j": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "6i"
     },
     "6k": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "5b"
     },
     "6l": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "6k"
     },
     "6m": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "5b"
     },
     "6n": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "6m"
     },
     "6o": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "5b"
     },
     "6p": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "6o"
     },
     "6q": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "5b"
     },
     "6r": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "6q"
     },
     "6s": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "59"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "5b"
     },
     "6t": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6s"
     },
     "6u": {
-      "key": "root.imports.requests",
-      "~k_parent": "4c"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "5b"
     },
     "6v": {
-      "key": "root.imports.websockets",
-      "~k_parent": "4c"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6u"
     },
     "6w": {
-      "key": "root.imports.operators",
-      "~k_parent": "4c"
+      "key": "root.imports.requests",
+      "~k_parent": "4d"
     },
     "6x": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6w"
+      "key": "root.imports.websockets",
+      "~k_parent": "4d"
     },
     "6y": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6x"
+      "key": "root.imports.operators",
+      "~k_parent": "4d"
     },
     "6z": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6x"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6y"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1555,6 +1563,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "PageSiderMenu": {
       "category": "container"
@@ -8360,6 +8369,9 @@
       "providers": {
         "~k": "3e"
       },
+      "strategies": {
+        "~k": "3f"
+      },
       "~k": "3c"
     },
     "blocks": {
@@ -8367,153 +8379,153 @@
         "originalTypeName": "PageSiderMenu",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "3h"
+        "~k": "3i"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 6,
-        "~k": "3i"
+        "~k": "3j"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 4,
-        "~k": "3j"
+        "~k": "3k"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "3k"
+        "~k": "3l"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3l"
+        "~k": "3m"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3m"
+        "~k": "3n"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3n"
+        "~k": "3o"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3o"
+        "~k": "3p"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3p"
+        "~k": "3q"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3q"
+        "~k": "3r"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3r"
+        "~k": "3s"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3s"
+        "~k": "3t"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3t"
+        "~k": "3u"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3u"
+        "~k": "3v"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3v"
+        "~k": "3w"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3w"
+        "~k": "3x"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3x"
+        "~k": "3y"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3y"
+        "~k": "3z"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3z"
+        "~k": "40"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "40"
+        "~k": "41"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "41"
+        "~k": "42"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "42"
+        "~k": "43"
       },
-      "~k": "3f"
+      "~k": "3g"
     },
     "connections": {
-      "~k": "43"
-    },
-    "requests": {
       "~k": "44"
     },
-    "websockets": {
+    "requests": {
       "~k": "45"
     },
-    "api": {
+    "websockets": {
       "~k": "46"
+    },
+    "api": {
+      "~k": "47"
     },
     "operators": {
       "client": {
@@ -8521,20 +8533,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "49"
+          "~k": "4a"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4a"
+          "~k": "4b"
         },
-        "~k": "48"
+        "~k": "49"
       },
       "server": {
-        "~k": "4b"
+        "~k": "4c"
       },
-      "~k": "47"
+      "~k": "48"
     },
     "~k": "37"
   }

--- a/packages/build/src/tests/success/43-wizard-flow-app/snapshot.json
+++ b/packages/build/src/tests/success/43-wizard-flow-app/snapshot.json
@@ -270,164 +270,164 @@
       "~k_parent": "44"
     },
     "50": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "4t"
     },
     "51": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "4t"
     },
     "52": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "4t"
     },
     "53": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "4t"
     },
     "54": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "4t"
     },
     "55": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "4t"
     },
     "56": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.List",
+      "~k_parent": "4t"
     },
     "57": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "4t"
     },
     "58": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "4t"
     },
     "59": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "4t"
     },
     "60": {
-      "key": "root.imports.auth",
-      "~k_parent": "5t"
+      "key": "root.imports.agents",
+      "~k_parent": "5u"
     },
     "61": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "60"
+      "key": "root.imports.auth",
+      "~k_parent": "5u"
     },
     "62": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "60"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.blocks",
-      "~k_parent": "5t"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "61"
     },
     "64": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "63"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "61"
     },
     "65": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks",
+      "~k_parent": "5u"
     },
     "66": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "65"
     },
     "68": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "65"
     },
     "69": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "65"
     },
     "70": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "6z"
     },
     "71": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "6u"
     },
     "72": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "71"
     },
     "73": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "6u"
     },
     "74": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "73"
     },
     "75": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "6u"
     },
     "76": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "75"
     },
     "77": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "6u"
     },
     "78": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "77"
     },
     "79": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "6u"
     },
     "80": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "7z"
     },
     "81": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "6u"
     },
     "82": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "81"
     },
     "83": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "6u"
     },
     "84": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "83"
     },
     "85": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "6u"
     },
     "86": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "85"
     },
     "87": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "6u"
     },
     "88": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "87"
     },
     "89": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "6u"
     },
     "a": {
       "key": "root.pages[0:wizard:Box].events.onInit[0:initStep:SetState]",
@@ -978,404 +978,412 @@
       "~k_parent": "4p"
     },
     "4s": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "4p"
+    },
+    "4t": {
       "key": "root.types.blocks",
       "~k_parent": "4i"
     },
-    "4t": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "4s"
-    },
     "4u": {
-      "key": "root.types.blocks.Progress",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Progress",
+      "~k_parent": "4t"
     },
     "4w": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "4t"
     },
     "4x": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "4t"
     },
     "4y": {
-      "key": "root.types.blocks.Descriptions",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "4t"
     },
     "4z": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Descriptions",
+      "~k_parent": "4t"
     },
     "5a": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "4t"
     },
     "5b": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "4t"
     },
     "5c": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "4t"
     },
     "5d": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "4t"
     },
     "5e": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "4t"
     },
     "5f": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "4s"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "4t"
     },
     "5g": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "4t"
+    },
+    "5h": {
       "key": "root.types.connections",
       "~k_parent": "4i"
     },
-    "5h": {
+    "5i": {
       "key": "root.types.requests",
       "~k_parent": "4i"
     },
-    "5i": {
+    "5j": {
       "key": "root.types.websockets",
       "~k_parent": "4i"
     },
-    "5j": {
+    "5k": {
       "key": "root.types.api",
       "~k_parent": "4i"
     },
-    "5k": {
+    "5l": {
       "key": "root.types.operators",
       "~k_parent": "4i"
     },
-    "5l": {
-      "key": "root.types.operators.client",
-      "~k_parent": "5k"
-    },
     "5m": {
-      "key": "root.types.operators.client._product",
+      "key": "root.types.operators.client",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.types.operators.client._divide",
-      "~k_parent": "5l"
+      "key": "root.types.operators.client._product",
+      "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.types.operators.client._state",
-      "~k_parent": "5l"
+      "key": "root.types.operators.client._divide",
+      "~k_parent": "5m"
     },
     "5p": {
-      "key": "root.types.operators.client._eq",
-      "~k_parent": "5l"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "5m"
     },
     "5q": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "5l"
+      "key": "root.types.operators.client._eq",
+      "~k_parent": "5m"
     },
     "5r": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "5l"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "5m"
     },
     "5s": {
-      "key": "root.types.operators.server",
-      "~k_parent": "5k"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "5m"
     },
     "5t": {
+      "key": "root.types.operators.server",
+      "~k_parent": "5l"
+    },
+    "5u": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "5u": {
-      "key": "root.imports.actions",
-      "~k_parent": "5t"
-    },
     "5v": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "5u"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "5u"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "5v"
     },
     "5y": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "5u"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "5v"
     },
     "5z": {
-      "key": "root.imports.agents",
-      "~k_parent": "5t"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "5v"
     },
     "6a": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "65"
     },
     "6b": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "65"
     },
     "6c": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "65"
     },
     "6d": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "65"
     },
     "6e": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "65"
     },
     "6f": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "65"
     },
     "6g": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "65"
     },
     "6h": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "65"
     },
     "6i": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "65"
     },
     "6j": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "65"
     },
     "6k": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "65"
     },
     "6l": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "65"
     },
     "6m": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "65"
     },
     "6n": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "65"
     },
     "6o": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "65"
     },
     "6p": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "65"
     },
     "6q": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "63"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "65"
     },
     "6r": {
-      "key": "root.imports.connections",
-      "~k_parent": "5t"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "65"
     },
     "6s": {
-      "key": "root.imports.icons",
-      "~k_parent": "5t"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "65"
     },
     "6t": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "6s"
+      "key": "root.imports.connections",
+      "~k_parent": "5u"
     },
     "6u": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "6t"
+      "key": "root.imports.icons",
+      "~k_parent": "5u"
     },
     "6v": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "6u"
     },
     "6w": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "6v"
     },
     "6x": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "6u"
     },
     "6y": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "6u"
     },
     "7a": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "79"
     },
     "7b": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "6u"
     },
     "7c": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "7b"
     },
     "7d": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "6u"
     },
     "7e": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "7d"
     },
     "7f": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "6u"
     },
     "7g": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "7f"
     },
     "7h": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "6u"
     },
     "7i": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "7h"
     },
     "7j": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "6u"
     },
     "7k": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "7j"
     },
     "7l": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "6u"
     },
     "7m": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "7l"
     },
     "7n": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "6u"
     },
     "7o": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "7n"
     },
     "7p": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "6u"
     },
     "7q": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "7p"
     },
     "7r": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "6u"
     },
     "7s": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "7r"
     },
     "7t": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "6u"
     },
     "7u": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "7t"
     },
     "7v": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "6u"
     },
     "7w": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "7v"
     },
     "7x": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "6u"
     },
     "7y": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "7x"
     },
     "7z": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "6u"
     },
     "8a": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "89"
     },
     "8b": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "6u"
     },
     "8c": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "8b"
     },
     "8d": {
-      "key": "root.imports.requests",
-      "~k_parent": "5t"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "6u"
     },
     "8e": {
-      "key": "root.imports.websockets",
-      "~k_parent": "5t"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "8d"
     },
     "8f": {
-      "key": "root.imports.operators",
-      "~k_parent": "5t"
+      "key": "root.imports.requests",
+      "~k_parent": "5u"
     },
     "8g": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "8f"
+      "key": "root.imports.websockets",
+      "~k_parent": "5u"
     },
     "8h": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "8g"
+      "key": "root.imports.operators",
+      "~k_parent": "5u"
     },
     "8i": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "8g"
+      "key": "root.imports.operators.client",
+      "~k_parent": "8h"
     },
     "8j": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "8g"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "8i"
     },
     "8k": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "8g"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "8i"
     },
     "8l": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "8g"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "8i"
     },
     "8m": {
-      "key": "root.imports.operators.client[5]",
-      "~k_parent": "8g"
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "8i"
     },
     "8n": {
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "8i"
+    },
+    "8o": {
+      "key": "root.imports.operators.client[5]",
+      "~k_parent": "8i"
+    },
+    "8p": {
       "key": "root.imports.operators.server",
-      "~k_parent": "8f"
+      "~k_parent": "8h"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -2066,6 +2074,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -8775,6 +8784,9 @@
       "providers": {
         "~k": "4r"
       },
+      "strategies": {
+        "~k": "4s"
+      },
       "~k": "4p"
     },
     "blocks": {
@@ -8782,153 +8794,153 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "4t"
+        "~k": "4u"
       },
       "Progress": {
         "originalTypeName": "Progress",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4u"
+        "~k": "4v"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "4v"
+        "~k": "4w"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 4,
-        "~k": "4w"
+        "~k": "4x"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 6,
-        "~k": "4x"
+        "~k": "4y"
       },
       "Descriptions": {
         "originalTypeName": "Descriptions",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4y"
+        "~k": "4z"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "4z"
+        "~k": "50"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "50"
+        "~k": "51"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "51"
+        "~k": "52"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "52"
+        "~k": "53"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "53"
+        "~k": "54"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "54"
+        "~k": "55"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "55"
+        "~k": "56"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "56"
+        "~k": "57"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "57"
+        "~k": "58"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "58"
+        "~k": "59"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "59"
+        "~k": "5a"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5a"
+        "~k": "5b"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5b"
+        "~k": "5c"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5c"
+        "~k": "5d"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5d"
+        "~k": "5e"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5e"
+        "~k": "5f"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "5f"
+        "~k": "5g"
       },
-      "~k": "4s"
+      "~k": "4t"
     },
     "connections": {
-      "~k": "5g"
-    },
-    "requests": {
       "~k": "5h"
     },
-    "websockets": {
+    "requests": {
       "~k": "5i"
     },
-    "api": {
+    "websockets": {
       "~k": "5j"
+    },
+    "api": {
+      "~k": "5k"
     },
     "operators": {
       "client": {
@@ -8936,44 +8948,44 @@
           "originalTypeName": "_product",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5m"
+          "~k": "5n"
         },
         "_divide": {
           "originalTypeName": "_divide",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5n"
+          "~k": "5o"
         },
         "_state": {
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 9,
-          "~k": "5o"
+          "~k": "5p"
         },
         "_eq": {
           "originalTypeName": "_eq",
           "package": "@lowdefy/operators-js",
           "count": 4,
-          "~k": "5p"
+          "~k": "5q"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5q"
+          "~k": "5r"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5r"
+          "~k": "5s"
         },
-        "~k": "5l"
+        "~k": "5m"
       },
       "server": {
-        "~k": "5s"
+        "~k": "5t"
       },
-      "~k": "5k"
+      "~k": "5l"
     },
     "~k": "4i"
   }

--- a/packages/build/src/tests/success/44-modal-drawer-app/snapshot.json
+++ b/packages/build/src/tests/success/44-modal-drawer-app/snapshot.json
@@ -220,164 +220,164 @@
       "~k_parent": "38"
     },
     "40": {
-      "key": "root.types.blocks.Modal",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3x"
     },
     "41": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Modal",
+      "~k_parent": "3x"
     },
     "42": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "3x"
     },
     "43": {
-      "key": "root.types.blocks.Drawer",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "3x"
     },
     "44": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Drawer",
+      "~k_parent": "3x"
     },
     "45": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3x"
     },
     "46": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3x"
     },
     "47": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3x"
     },
     "48": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3x"
     },
     "49": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3x"
     },
     "50": {
-      "key": "root.imports.agents",
-      "~k_parent": "4u"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "4w"
     },
     "51": {
-      "key": "root.imports.auth",
-      "~k_parent": "4u"
+      "key": "root.imports.agents",
+      "~k_parent": "4v"
     },
     "52": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "51"
+      "key": "root.imports.auth",
+      "~k_parent": "4v"
     },
     "53": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "51"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.blocks",
-      "~k_parent": "4u"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "52"
     },
     "55": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "54"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "52"
     },
     "56": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks",
+      "~k_parent": "4v"
     },
     "57": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "56"
     },
     "59": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "56"
     },
     "60": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "5w"
     },
     "62": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "5w"
     },
     "64": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "5w"
     },
     "66": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "5w"
     },
     "68": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "5w"
     },
     "70": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "6z"
     },
     "71": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "5w"
     },
     "72": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "71"
     },
     "73": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "5w"
     },
     "74": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "73"
     },
     "75": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "5w"
     },
     "76": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "75"
     },
     "77": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "5w"
     },
     "78": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "77"
     },
     "79": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "5w"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[0:title:Title].properties",
@@ -816,380 +816,388 @@
       "~k_parent": "3t"
     },
     "3w": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "3t"
+    },
+    "3x": {
       "key": "root.types.blocks",
       "~k_parent": "3m"
     },
-    "3x": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "3w"
-    },
     "3y": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "3x"
     },
     "4a": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3x"
     },
     "4b": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3x"
     },
     "4c": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3x"
     },
     "4d": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3x"
     },
     "4e": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3x"
     },
     "4f": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3x"
     },
     "4g": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3x"
     },
     "4h": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3x"
     },
     "4i": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3x"
     },
     "4j": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3x"
     },
     "4k": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "3w"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3x"
     },
     "4l": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3x"
+    },
+    "4m": {
       "key": "root.types.connections",
       "~k_parent": "3m"
     },
-    "4m": {
+    "4n": {
       "key": "root.types.requests",
       "~k_parent": "3m"
     },
-    "4n": {
+    "4o": {
       "key": "root.types.websockets",
       "~k_parent": "3m"
     },
-    "4o": {
+    "4p": {
       "key": "root.types.api",
       "~k_parent": "3m"
     },
-    "4p": {
+    "4q": {
       "key": "root.types.operators",
       "~k_parent": "3m"
     },
-    "4q": {
-      "key": "root.types.operators.client",
-      "~k_parent": "4p"
-    },
     "4r": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "4q"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.types.operators.server",
-      "~k_parent": "4p"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "4r"
     },
     "4u": {
+      "key": "root.types.operators.server",
+      "~k_parent": "4q"
+    },
+    "4v": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "4v": {
-      "key": "root.imports.actions",
-      "~k_parent": "4u"
-    },
     "4w": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "4v"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "4v"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "4w"
     },
     "4z": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "4v"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "4w"
     },
     "5a": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "56"
     },
     "5b": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "56"
     },
     "5c": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "56"
     },
     "5d": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "56"
     },
     "5e": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "56"
     },
     "5f": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "56"
     },
     "5g": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "56"
     },
     "5h": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "56"
     },
     "5i": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "56"
     },
     "5j": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "56"
     },
     "5k": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "56"
     },
     "5l": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "56"
     },
     "5m": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "56"
     },
     "5n": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "56"
     },
     "5o": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "56"
     },
     "5p": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "56"
     },
     "5q": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "56"
     },
     "5r": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "56"
     },
     "5s": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "56"
     },
     "5t": {
-      "key": "root.imports.connections",
-      "~k_parent": "4u"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "56"
     },
     "5u": {
-      "key": "root.imports.icons",
-      "~k_parent": "4u"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "56"
     },
     "5v": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "5u"
+      "key": "root.imports.connections",
+      "~k_parent": "4v"
     },
     "5w": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "5v"
+      "key": "root.imports.icons",
+      "~k_parent": "4v"
     },
     "5x": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "5w"
     },
     "6a": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "5w"
     },
     "6c": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "5w"
     },
     "6e": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "5w"
     },
     "6g": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "6f"
     },
     "6h": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "5w"
     },
     "6i": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "5w"
     },
     "6k": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "6j"
     },
     "6l": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "5w"
     },
     "6m": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "6l"
     },
     "6n": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "5w"
     },
     "6o": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "6n"
     },
     "6p": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "5w"
     },
     "6q": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "5w"
     },
     "6s": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "6r"
     },
     "6t": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "5w"
     },
     "6u": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "5w"
     },
     "6w": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "6v"
     },
     "6x": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "5w"
     },
     "6y": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "5w"
     },
     "7a": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "79"
     },
     "7b": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "5w"
     },
     "7c": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "7b"
     },
     "7d": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "5u"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "5w"
     },
     "7e": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "7d"
     },
     "7f": {
-      "key": "root.imports.requests",
-      "~k_parent": "4u"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "5w"
     },
     "7g": {
-      "key": "root.imports.websockets",
-      "~k_parent": "4u"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "7f"
     },
     "7h": {
-      "key": "root.imports.operators",
-      "~k_parent": "4u"
+      "key": "root.imports.requests",
+      "~k_parent": "4v"
     },
     "7i": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "7h"
+      "key": "root.imports.websockets",
+      "~k_parent": "4v"
     },
     "7j": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "7i"
+      "key": "root.imports.operators",
+      "~k_parent": "4v"
     },
     "7k": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "7i"
+      "key": "root.imports.operators.client",
+      "~k_parent": "7j"
     },
     "7l": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "7k"
+    },
+    "7m": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "7k"
+    },
+    "7n": {
       "key": "root.imports.operators.server",
-      "~k_parent": "7h"
+      "~k_parent": "7j"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1772,6 +1780,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -8853,6 +8862,9 @@
       "providers": {
         "~k": "3v"
       },
+      "strategies": {
+        "~k": "3w"
+      },
       "~k": "3t"
     },
     "blocks": {
@@ -8860,159 +8872,159 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "3x"
+        "~k": "3y"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3y"
+        "~k": "3z"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "3z"
+        "~k": "40"
       },
       "Modal": {
         "originalTypeName": "Modal",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "40"
+        "~k": "41"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "41"
+        "~k": "42"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "42"
+        "~k": "43"
       },
       "Drawer": {
         "originalTypeName": "Drawer",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "43"
+        "~k": "44"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "44"
+        "~k": "45"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "45"
+        "~k": "46"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "46"
+        "~k": "47"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "47"
+        "~k": "48"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "48"
+        "~k": "49"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "49"
+        "~k": "4a"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4a"
+        "~k": "4b"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4b"
+        "~k": "4c"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4c"
+        "~k": "4d"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4d"
+        "~k": "4e"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4e"
+        "~k": "4f"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4f"
+        "~k": "4g"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4g"
+        "~k": "4h"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4h"
+        "~k": "4i"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4i"
+        "~k": "4j"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4j"
+        "~k": "4k"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4k"
+        "~k": "4l"
       },
-      "~k": "3w"
+      "~k": "3x"
     },
     "connections": {
-      "~k": "4l"
-    },
-    "requests": {
       "~k": "4m"
     },
-    "websockets": {
+    "requests": {
       "~k": "4n"
     },
-    "api": {
+    "websockets": {
       "~k": "4o"
+    },
+    "api": {
+      "~k": "4p"
     },
     "operators": {
       "client": {
@@ -9020,20 +9032,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4r"
+          "~k": "4s"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4s"
+          "~k": "4t"
         },
-        "~k": "4q"
+        "~k": "4r"
       },
       "server": {
-        "~k": "4t"
+        "~k": "4u"
       },
-      "~k": "4p"
+      "~k": "4q"
     },
     "~k": "3m"
   }

--- a/packages/build/src/tests/success/45-tabs-layout-app/snapshot.json
+++ b/packages/build/src/tests/success/45-tabs-layout-app/snapshot.json
@@ -224,163 +224,163 @@
       "~k_parent": "38"
     },
     "40": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "3u"
     },
     "41": {
-      "key": "root.types.blocks.TextArea",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "3u"
     },
     "42": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.TextArea",
+      "~k_parent": "3u"
     },
     "43": {
-      "key": "root.types.blocks.NumberInput",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "3u"
     },
     "44": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.NumberInput",
+      "~k_parent": "3u"
     },
     "45": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "3u"
     },
     "46": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3u"
     },
     "47": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3u"
     },
     "48": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3u"
     },
     "49": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3u"
     },
     "50": {
-      "key": "root.imports.agents",
-      "~k_parent": "4w"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "4y"
     },
     "51": {
-      "key": "root.imports.auth",
-      "~k_parent": "4w"
+      "key": "root.imports.agents",
+      "~k_parent": "4x"
     },
     "52": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "51"
+      "key": "root.imports.auth",
+      "~k_parent": "4x"
     },
     "53": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "51"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.blocks",
-      "~k_parent": "4w"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "52"
     },
     "55": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "54"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "52"
     },
     "56": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks",
+      "~k_parent": "4x"
     },
     "57": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "56"
     },
     "59": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "56"
     },
     "60": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "5z"
+      "key": "root.imports.connections",
+      "~k_parent": "4x"
     },
     "61": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "60"
+      "key": "root.imports.icons",
+      "~k_parent": "4x"
     },
     "62": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "61"
     },
     "65": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "61"
     },
     "67": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "61"
     },
     "69": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "68"
     },
     "70": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "61"
     },
     "71": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "70"
     },
     "72": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "61"
     },
     "73": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "72"
     },
     "74": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "61"
     },
     "75": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "74"
     },
     "76": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "61"
     },
     "77": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "76"
     },
     "78": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "61"
     },
     "79": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "78"
     },
     "a": {
@@ -815,412 +815,420 @@
       "~k_parent": "3q"
     },
     "3t": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "3q"
+    },
+    "3u": {
       "key": "root.types.blocks",
       "~k_parent": "3l"
     },
-    "3u": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "3t"
-    },
     "3v": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.types.blocks.Tabs",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "3u"
     },
     "3x": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Tabs",
+      "~k_parent": "3u"
     },
     "3y": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "3u"
     },
     "3z": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "3u"
     },
     "4a": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3u"
     },
     "4b": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3u"
     },
     "4c": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3u"
     },
     "4d": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3u"
     },
     "4e": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3u"
     },
     "4f": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3u"
     },
     "4g": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3u"
     },
     "4h": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3u"
     },
     "4i": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3u"
     },
     "4j": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3u"
     },
     "4k": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3u"
     },
     "4l": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3u"
     },
     "4m": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "3t"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3u"
     },
     "4n": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3u"
+    },
+    "4o": {
       "key": "root.types.connections",
       "~k_parent": "3l"
     },
-    "4o": {
+    "4p": {
       "key": "root.types.requests",
       "~k_parent": "3l"
     },
-    "4p": {
+    "4q": {
       "key": "root.types.websockets",
       "~k_parent": "3l"
     },
-    "4q": {
+    "4r": {
       "key": "root.types.api",
       "~k_parent": "3l"
     },
-    "4r": {
+    "4s": {
       "key": "root.types.operators",
       "~k_parent": "3l"
     },
-    "4s": {
-      "key": "root.types.operators.client",
-      "~k_parent": "4r"
-    },
     "4t": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "4s"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.types.operators.server",
-      "~k_parent": "4r"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "4t"
     },
     "4w": {
+      "key": "root.types.operators.server",
+      "~k_parent": "4s"
+    },
+    "4x": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "4x": {
-      "key": "root.imports.actions",
-      "~k_parent": "4w"
-    },
     "4y": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "4x"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "56"
     },
     "5b": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "56"
     },
     "5c": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "56"
     },
     "5d": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "56"
     },
     "5e": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "56"
     },
     "5f": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "56"
     },
     "5g": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "56"
     },
     "5h": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "56"
     },
     "5i": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "56"
     },
     "5j": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "56"
     },
     "5k": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "56"
     },
     "5l": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "56"
     },
     "5m": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "56"
     },
     "5n": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "56"
     },
     "5o": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "56"
     },
     "5p": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "56"
     },
     "5q": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "56"
     },
     "5r": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "56"
     },
     "5s": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "56"
     },
     "5t": {
-      "key": "root.imports.blocks[24]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "56"
     },
     "5u": {
-      "key": "root.imports.blocks[25]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "56"
     },
     "5v": {
-      "key": "root.imports.blocks[26]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[24]",
+      "~k_parent": "56"
     },
     "5w": {
-      "key": "root.imports.blocks[27]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[25]",
+      "~k_parent": "56"
     },
     "5x": {
-      "key": "root.imports.blocks[28]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[26]",
+      "~k_parent": "56"
     },
     "5y": {
-      "key": "root.imports.connections",
-      "~k_parent": "4w"
+      "key": "root.imports.blocks[27]",
+      "~k_parent": "56"
     },
     "5z": {
-      "key": "root.imports.icons",
-      "~k_parent": "4w"
+      "key": "root.imports.blocks[28]",
+      "~k_parent": "56"
     },
     "6a": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "61"
     },
     "6b": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "61"
     },
     "6d": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "61"
     },
     "6f": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "6e"
     },
     "6g": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "61"
     },
     "6h": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "6g"
     },
     "6i": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "61"
     },
     "6j": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "6i"
     },
     "6k": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "61"
     },
     "6l": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "6k"
     },
     "6m": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "61"
     },
     "6n": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "6m"
     },
     "6o": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "61"
     },
     "6p": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "6o"
     },
     "6q": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "61"
     },
     "6r": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "6q"
     },
     "6s": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "61"
     },
     "6t": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "6s"
     },
     "6u": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "61"
     },
     "6v": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "6u"
     },
     "6w": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "61"
     },
     "6x": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "6w"
     },
     "6y": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "61"
     },
     "6z": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "6y"
     },
     "7a": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "61"
     },
     "7b": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "7a"
     },
     "7c": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "61"
     },
     "7d": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "7c"
     },
     "7e": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "61"
     },
     "7f": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "7e"
     },
     "7g": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "61"
     },
     "7h": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "7g"
     },
     "7i": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "5z"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "61"
     },
     "7j": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "7i"
     },
     "7k": {
-      "key": "root.imports.requests",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "61"
     },
     "7l": {
-      "key": "root.imports.websockets",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "7k"
     },
     "7m": {
-      "key": "root.imports.operators",
-      "~k_parent": "4w"
+      "key": "root.imports.requests",
+      "~k_parent": "4x"
     },
     "7n": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "7m"
+      "key": "root.imports.websockets",
+      "~k_parent": "4x"
     },
     "7o": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "7n"
+      "key": "root.imports.operators",
+      "~k_parent": "4x"
     },
     "7p": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "7n"
+      "key": "root.imports.operators.client",
+      "~k_parent": "7o"
     },
     "7q": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "7p"
+    },
+    "7r": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "7p"
+    },
+    "7s": {
       "key": "root.imports.operators.server",
-      "~k_parent": "7m"
+      "~k_parent": "7o"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1759,6 +1767,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -11415,6 +11424,9 @@
       "providers": {
         "~k": "3s"
       },
+      "strategies": {
+        "~k": "3t"
+      },
       "~k": "3q"
     },
     "blocks": {
@@ -11422,189 +11434,189 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "3u"
+        "~k": "3v"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "3v"
+        "~k": "3w"
       },
       "Tabs": {
         "originalTypeName": "Tabs",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "3w"
+        "~k": "3x"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "3x"
+        "~k": "3y"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "3y"
+        "~k": "3z"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "3z"
+        "~k": "40"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "40"
+        "~k": "41"
       },
       "TextArea": {
         "originalTypeName": "TextArea",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "41"
+        "~k": "42"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "42"
+        "~k": "43"
       },
       "NumberInput": {
         "originalTypeName": "NumberInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "43"
+        "~k": "44"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "44"
+        "~k": "45"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "45"
+        "~k": "46"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "46"
+        "~k": "47"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "47"
+        "~k": "48"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "48"
+        "~k": "49"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "49"
+        "~k": "4a"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4a"
+        "~k": "4b"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4b"
+        "~k": "4c"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4c"
+        "~k": "4d"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4d"
+        "~k": "4e"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4e"
+        "~k": "4f"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4f"
+        "~k": "4g"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4g"
+        "~k": "4h"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4h"
+        "~k": "4i"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4i"
+        "~k": "4j"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4j"
+        "~k": "4k"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4k"
+        "~k": "4l"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4l"
+        "~k": "4m"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4m"
+        "~k": "4n"
       },
-      "~k": "3t"
+      "~k": "3u"
     },
     "connections": {
-      "~k": "4n"
-    },
-    "requests": {
       "~k": "4o"
     },
-    "websockets": {
+    "requests": {
       "~k": "4p"
     },
-    "api": {
+    "websockets": {
       "~k": "4q"
+    },
+    "api": {
+      "~k": "4r"
     },
     "operators": {
       "client": {
@@ -11612,20 +11624,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4t"
+          "~k": "4u"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4u"
+          "~k": "4v"
         },
-        "~k": "4s"
+        "~k": "4t"
       },
       "server": {
-        "~k": "4v"
+        "~k": "4w"
       },
-      "~k": "4r"
+      "~k": "4s"
     },
     "~k": "3l"
   }

--- a/packages/build/src/tests/success/46-responsive-layout-app/snapshot.json
+++ b/packages/build/src/tests/success/46-responsive-layout-app/snapshot.json
@@ -244,143 +244,143 @@
       "~k_parent": "42"
     },
     "45": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "42"
+    },
+    "46": {
       "key": "root.types.blocks",
       "~k_parent": "3x"
     },
-    "46": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "45"
-    },
     "47": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "46"
     },
     "48": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "46"
     },
     "49": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "46"
     },
     "50": {
-      "key": "root.types.operators.server",
-      "~k_parent": "4w"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "4y"
     },
     "51": {
+      "key": "root.types.operators.server",
+      "~k_parent": "4x"
+    },
+    "52": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "52": {
-      "key": "root.imports.actions",
-      "~k_parent": "51"
-    },
     "53": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "52"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.agents",
-      "~k_parent": "51"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "53"
     },
     "56": {
-      "key": "root.imports.auth",
-      "~k_parent": "51"
+      "key": "root.imports.agents",
+      "~k_parent": "52"
     },
     "57": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "56"
+      "key": "root.imports.auth",
+      "~k_parent": "52"
     },
     "58": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "56"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.blocks",
-      "~k_parent": "51"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "57"
     },
     "60": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "5z"
     },
     "63": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "5z"
     },
     "65": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "5z"
     },
     "67": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "5z"
     },
     "69": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "68"
     },
     "70": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "5z"
     },
     "71": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "70"
     },
     "72": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "5z"
     },
     "73": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "72"
     },
     "74": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "5z"
     },
     "75": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "74"
     },
     "76": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "5z"
     },
     "77": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "76"
     },
     "78": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "5z"
     },
     "79": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "78"
     },
     "a": {
@@ -841,376 +841,384 @@
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "46"
     },
     "4b": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "46"
     },
     "4c": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "46"
     },
     "4d": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "46"
     },
     "4e": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "45"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "46"
     },
     "4f": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "46"
     },
     "4g": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "46"
     },
     "4h": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "46"
     },
     "4i": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "45"
+      "key": "root.types.blocks.List",
+      "~k_parent": "46"
     },
     "4j": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "46"
     },
     "4k": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "46"
     },
     "4l": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "45"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "46"
     },
     "4m": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "46"
     },
     "4n": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "45"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "46"
     },
     "4o": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "45"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "46"
     },
     "4p": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "45"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "46"
     },
     "4q": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "45"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "46"
     },
     "4r": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "46"
     },
     "4s": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "46"
+    },
+    "4t": {
       "key": "root.types.connections",
       "~k_parent": "3x"
     },
-    "4t": {
+    "4u": {
       "key": "root.types.requests",
       "~k_parent": "3x"
     },
-    "4u": {
+    "4v": {
       "key": "root.types.websockets",
       "~k_parent": "3x"
     },
-    "4v": {
+    "4w": {
       "key": "root.types.api",
       "~k_parent": "3x"
     },
-    "4w": {
+    "4x": {
       "key": "root.types.operators",
       "~k_parent": "3x"
     },
-    "4x": {
-      "key": "root.types.operators.client",
-      "~k_parent": "4w"
-    },
     "4y": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "4x"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "59"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "57"
     },
     "5b": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks",
+      "~k_parent": "52"
     },
     "5c": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "5b"
     },
     "5e": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "5b"
     },
     "5f": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "5b"
     },
     "5g": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "5b"
     },
     "5h": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "5b"
     },
     "5i": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "5b"
     },
     "5j": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "5b"
     },
     "5k": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "5b"
     },
     "5l": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "5b"
     },
     "5m": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "5b"
     },
     "5n": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "5b"
     },
     "5o": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "5b"
     },
     "5p": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "5b"
     },
     "5q": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "5b"
     },
     "5r": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "5b"
     },
     "5s": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "5b"
     },
     "5t": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "5b"
     },
     "5u": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "5b"
     },
     "5v": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "5b"
     },
     "5w": {
-      "key": "root.imports.connections",
-      "~k_parent": "51"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "5b"
     },
     "5x": {
-      "key": "root.imports.icons",
-      "~k_parent": "51"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "5b"
     },
     "5y": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "5x"
+      "key": "root.imports.connections",
+      "~k_parent": "52"
     },
     "5z": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "5y"
+      "key": "root.imports.icons",
+      "~k_parent": "52"
     },
     "6a": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "5z"
     },
     "6b": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "5z"
     },
     "6d": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "5z"
     },
     "6f": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "6e"
     },
     "6g": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "5z"
     },
     "6h": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "6g"
     },
     "6i": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "5z"
     },
     "6j": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "6i"
     },
     "6k": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "5z"
     },
     "6l": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "6k"
     },
     "6m": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "5z"
     },
     "6n": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "6m"
     },
     "6o": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "5z"
     },
     "6p": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "6o"
     },
     "6q": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "5z"
     },
     "6r": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "6q"
     },
     "6s": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "5z"
     },
     "6t": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "6s"
     },
     "6u": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "5z"
     },
     "6v": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "6u"
     },
     "6w": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "5z"
     },
     "6x": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "6w"
     },
     "6y": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "5z"
     },
     "6z": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "6y"
     },
     "7a": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "5z"
     },
     "7b": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "7a"
     },
     "7c": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "5z"
     },
     "7d": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "7c"
     },
     "7e": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "5z"
     },
     "7f": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "7e"
     },
     "7g": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "5x"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "5z"
     },
     "7h": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "7g"
     },
     "7i": {
-      "key": "root.imports.requests",
-      "~k_parent": "51"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "5z"
     },
     "7j": {
-      "key": "root.imports.websockets",
-      "~k_parent": "51"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "7i"
     },
     "7k": {
-      "key": "root.imports.operators",
-      "~k_parent": "51"
+      "key": "root.imports.requests",
+      "~k_parent": "52"
     },
     "7l": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "7k"
+      "key": "root.imports.websockets",
+      "~k_parent": "52"
     },
     "7m": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "7l"
+      "key": "root.imports.operators",
+      "~k_parent": "52"
     },
     "7n": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "7l"
+      "key": "root.imports.operators.client",
+      "~k_parent": "7m"
     },
     "7o": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "7n"
+    },
+    "7p": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "7n"
+    },
+    "7q": {
       "key": "root.imports.operators.server",
-      "~k_parent": "7k"
+      "~k_parent": "7m"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1795,6 +1803,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -6779,6 +6788,9 @@
       "providers": {
         "~k": "44"
       },
+      "strategies": {
+        "~k": "45"
+      },
       "~k": "42"
     },
     "blocks": {
@@ -6786,147 +6798,147 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "46"
+        "~k": "47"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "47"
+        "~k": "48"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 7,
-        "~k": "48"
+        "~k": "49"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "49"
+        "~k": "4a"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "4a"
+        "~k": "4b"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4b"
+        "~k": "4c"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4c"
+        "~k": "4d"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4d"
+        "~k": "4e"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4e"
+        "~k": "4f"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4f"
+        "~k": "4g"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4g"
+        "~k": "4h"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4h"
+        "~k": "4i"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4i"
+        "~k": "4j"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4j"
+        "~k": "4k"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4k"
+        "~k": "4l"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4l"
+        "~k": "4m"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4m"
+        "~k": "4n"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4n"
+        "~k": "4o"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4o"
+        "~k": "4p"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4p"
+        "~k": "4q"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4q"
+        "~k": "4r"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4r"
+        "~k": "4s"
       },
-      "~k": "45"
+      "~k": "46"
     },
     "connections": {
-      "~k": "4s"
-    },
-    "requests": {
       "~k": "4t"
     },
-    "websockets": {
+    "requests": {
       "~k": "4u"
     },
-    "api": {
+    "websockets": {
       "~k": "4v"
+    },
+    "api": {
+      "~k": "4w"
     },
     "operators": {
       "client": {
@@ -6934,20 +6946,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4y"
+          "~k": "4z"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4z"
+          "~k": "50"
         },
-        "~k": "4x"
+        "~k": "4y"
       },
       "server": {
-        "~k": "50"
+        "~k": "51"
       },
-      "~k": "4w"
+      "~k": "4x"
     },
     "~k": "3x"
   }

--- a/packages/build/src/tests/success/47-operators-comprehensive/snapshot.json
+++ b/packages/build/src/tests/success/47-operators-comprehensive/snapshot.json
@@ -356,155 +356,155 @@
       "~k_parent": "5z"
     },
     "62": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "5z"
+    },
+    "63": {
       "key": "root.types.blocks",
       "~k_parent": "5u"
     },
-    "63": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "62"
-    },
     "64": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "63"
     },
     "65": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "63"
     },
     "66": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "63"
     },
     "67": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "63"
     },
     "68": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "63"
     },
     "69": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "62"
+      "key": "root.types.blocks.List",
+      "~k_parent": "63"
     },
     "70": {
-      "key": "root.types.operators.client",
-      "~k_parent": "6z"
+      "key": "root.types.operators",
+      "~k_parent": "5u"
     },
     "71": {
-      "key": "root.types.operators.client._if",
+      "key": "root.types.operators.client",
       "~k_parent": "70"
     },
     "72": {
-      "key": "root.types.operators.client._state",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._if",
+      "~k_parent": "71"
     },
     "73": {
-      "key": "root.types.operators.client._array",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "71"
     },
     "74": {
-      "key": "root.types.operators.client._global",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._array",
+      "~k_parent": "71"
     },
     "75": {
-      "key": "root.types.operators.client._function",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._global",
+      "~k_parent": "71"
     },
     "76": {
-      "key": "root.types.operators.client._eq",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._function",
+      "~k_parent": "71"
     },
     "77": {
-      "key": "root.types.operators.client._args",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._eq",
+      "~k_parent": "71"
     },
     "78": {
-      "key": "root.types.operators.client._string",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._args",
+      "~k_parent": "71"
     },
     "79": {
-      "key": "root.types.operators.client._json",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._string",
+      "~k_parent": "71"
     },
     "80": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "7t"
     },
     "81": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "7t"
     },
     "82": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "7t"
     },
     "83": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "7t"
     },
     "84": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "7t"
     },
     "85": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "7t"
     },
     "86": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "7t"
     },
     "87": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "7t"
     },
     "88": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "7t"
     },
     "89": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "7t"
     },
     "90": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "8n"
     },
     "91": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "90"
     },
     "92": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "8n"
     },
     "93": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "92"
     },
     "94": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "8n"
     },
     "95": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "94"
     },
     "96": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "8n"
     },
     "97": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "96"
     },
     "98": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "8n"
     },
     "99": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "98"
     },
     "a": {
@@ -1224,532 +1224,540 @@
       "~k_parent": "5u"
     },
     "6a": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "63"
     },
     "6b": {
-      "key": "root.types.blocks.Tag",
-      "~k_parent": "62"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "63"
     },
     "6c": {
-      "key": "root.types.blocks.NumberInput",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Tag",
+      "~k_parent": "63"
     },
     "6d": {
-      "key": "root.types.blocks.Alert",
-      "~k_parent": "62"
+      "key": "root.types.blocks.NumberInput",
+      "~k_parent": "63"
     },
     "6e": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Alert",
+      "~k_parent": "63"
     },
     "6f": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "63"
     },
     "6g": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "63"
     },
     "6h": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "63"
     },
     "6i": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "62"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "63"
     },
     "6j": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "63"
     },
     "6k": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "63"
     },
     "6l": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "63"
     },
     "6m": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "63"
     },
     "6n": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "63"
     },
     "6o": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "62"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "63"
     },
     "6p": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "63"
     },
     "6q": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "62"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "63"
     },
     "6r": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "62"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "63"
     },
     "6s": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "62"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "63"
     },
     "6t": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "62"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "63"
     },
     "6u": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "62"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "63"
     },
     "6v": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "63"
+    },
+    "6w": {
       "key": "root.types.connections",
       "~k_parent": "5u"
     },
-    "6w": {
+    "6x": {
       "key": "root.types.requests",
       "~k_parent": "5u"
     },
-    "6x": {
+    "6y": {
       "key": "root.types.websockets",
       "~k_parent": "5u"
     },
-    "6y": {
+    "6z": {
       "key": "root.types.api",
       "~k_parent": "5u"
     },
-    "6z": {
-      "key": "root.types.operators",
-      "~k_parent": "5u"
-    },
     "7a": {
-      "key": "root.types.operators.client._object",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._json",
+      "~k_parent": "71"
     },
     "7b": {
-      "key": "root.types.operators.client._gt",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._object",
+      "~k_parent": "71"
     },
     "7c": {
-      "key": "root.types.operators.client._and",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._gt",
+      "~k_parent": "71"
     },
     "7d": {
-      "key": "root.types.operators.client._or",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._and",
+      "~k_parent": "71"
     },
     "7e": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._or",
+      "~k_parent": "71"
     },
     "7f": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "71"
     },
     "7g": {
-      "key": "root.types.operators.client._date",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "71"
     },
     "7h": {
-      "key": "root.types.operators.client._dayjs",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._date",
+      "~k_parent": "71"
     },
     "7i": {
-      "key": "root.types.operators.server",
-      "~k_parent": "6z"
+      "key": "root.types.operators.client._dayjs",
+      "~k_parent": "71"
     },
     "7j": {
+      "key": "root.types.operators.server",
+      "~k_parent": "70"
+    },
+    "7k": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "7k": {
-      "key": "root.imports.actions",
-      "~k_parent": "7j"
-    },
     "7l": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "7k"
     },
     "7m": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "7k"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "7l"
     },
     "7n": {
-      "key": "root.imports.agents",
-      "~k_parent": "7j"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "7l"
     },
     "7o": {
-      "key": "root.imports.auth",
-      "~k_parent": "7j"
+      "key": "root.imports.agents",
+      "~k_parent": "7k"
     },
     "7p": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "7o"
+      "key": "root.imports.auth",
+      "~k_parent": "7k"
     },
     "7q": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "7o"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "7p"
     },
     "7r": {
-      "key": "root.imports.blocks",
-      "~k_parent": "7j"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "7p"
     },
     "7s": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "7r"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "7p"
     },
     "7t": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks",
+      "~k_parent": "7k"
     },
     "7u": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "7t"
     },
     "7v": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "7t"
     },
     "7w": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "7t"
     },
     "7x": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "7t"
     },
     "7y": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "7t"
     },
     "7z": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "7t"
     },
     "8a": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "7t"
     },
     "8b": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "7t"
     },
     "8c": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "7t"
     },
     "8d": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "7t"
     },
     "8e": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "7t"
     },
     "8f": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "7t"
     },
     "8g": {
-      "key": "root.imports.blocks[24]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "7t"
     },
     "8h": {
-      "key": "root.imports.blocks[25]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "7t"
     },
     "8i": {
-      "key": "root.imports.blocks[26]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[24]",
+      "~k_parent": "7t"
     },
     "8j": {
-      "key": "root.imports.blocks[27]",
-      "~k_parent": "7r"
+      "key": "root.imports.blocks[25]",
+      "~k_parent": "7t"
     },
     "8k": {
-      "key": "root.imports.connections",
-      "~k_parent": "7j"
+      "key": "root.imports.blocks[26]",
+      "~k_parent": "7t"
     },
     "8l": {
-      "key": "root.imports.icons",
-      "~k_parent": "7j"
+      "key": "root.imports.blocks[27]",
+      "~k_parent": "7t"
     },
     "8m": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "8l"
+      "key": "root.imports.connections",
+      "~k_parent": "7k"
     },
     "8n": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "8m"
+      "key": "root.imports.icons",
+      "~k_parent": "7k"
     },
     "8o": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "8n"
     },
     "8p": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "8o"
     },
     "8q": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "8n"
     },
     "8r": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "8q"
     },
     "8s": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "8n"
     },
     "8t": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "8s"
     },
     "8u": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "8n"
     },
     "8v": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "8u"
     },
     "8w": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "8n"
     },
     "8x": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "8w"
     },
     "8y": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "8n"
     },
     "8z": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "8y"
     },
     "9a": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "8n"
     },
     "9b": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "9a"
     },
     "9c": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "8n"
     },
     "9d": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "9c"
     },
     "9e": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "8n"
     },
     "9f": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "9e"
     },
     "9g": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "8n"
     },
     "9h": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "9g"
     },
     "9i": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "8n"
     },
     "9j": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "9i"
     },
     "9k": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "8n"
     },
     "9l": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "9k"
     },
     "9m": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "8n"
     },
     "9n": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "9m"
     },
     "9o": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "8n"
     },
     "9p": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "9o"
     },
     "9q": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "8n"
     },
     "9r": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "9q"
     },
     "9s": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "8n"
     },
     "9t": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "9s"
     },
     "9u": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "8n"
     },
     "9v": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "9u"
     },
     "9w": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "8n"
     },
     "9x": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "9w"
     },
     "9y": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "8n"
     },
     "9z": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "9y"
     },
     "a0": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "8n"
     },
     "a1": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "a0"
     },
     "a2": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "8n"
     },
     "a3": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "a2"
     },
     "a4": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "8l"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "8n"
     },
     "a5": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "a4"
     },
     "a6": {
-      "key": "root.imports.requests",
-      "~k_parent": "7j"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "8n"
     },
     "a7": {
-      "key": "root.imports.websockets",
-      "~k_parent": "7j"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "a6"
     },
     "a8": {
-      "key": "root.imports.operators",
-      "~k_parent": "7j"
+      "key": "root.imports.requests",
+      "~k_parent": "7k"
     },
     "a9": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "a8"
+      "key": "root.imports.websockets",
+      "~k_parent": "7k"
     },
     "aa": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "a9"
+      "key": "root.imports.operators",
+      "~k_parent": "7k"
     },
     "ab": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "a9"
+      "key": "root.imports.operators.client",
+      "~k_parent": "aa"
     },
     "ac": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "a9"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "ab"
     },
     "ad": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "a9"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "ab"
     },
     "ae": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "a9"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "ab"
     },
     "af": {
-      "key": "root.imports.operators.client[5]",
-      "~k_parent": "a9"
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "ab"
     },
     "ag": {
-      "key": "root.imports.operators.client[6]",
-      "~k_parent": "a9"
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "ab"
     },
     "ah": {
-      "key": "root.imports.operators.client[7]",
-      "~k_parent": "a9"
+      "key": "root.imports.operators.client[5]",
+      "~k_parent": "ab"
     },
     "ai": {
-      "key": "root.imports.operators.client[8]",
-      "~k_parent": "a9"
+      "key": "root.imports.operators.client[6]",
+      "~k_parent": "ab"
     },
     "aj": {
-      "key": "root.imports.operators.client[9]",
-      "~k_parent": "a9"
+      "key": "root.imports.operators.client[7]",
+      "~k_parent": "ab"
     },
     "ak": {
-      "key": "root.imports.operators.client[10]",
-      "~k_parent": "a9"
+      "key": "root.imports.operators.client[8]",
+      "~k_parent": "ab"
     },
     "al": {
-      "key": "root.imports.operators.client[11]",
-      "~k_parent": "a9"
+      "key": "root.imports.operators.client[9]",
+      "~k_parent": "ab"
     },
     "am": {
-      "key": "root.imports.operators.client[12]",
-      "~k_parent": "a9"
+      "key": "root.imports.operators.client[10]",
+      "~k_parent": "ab"
     },
     "an": {
-      "key": "root.imports.operators.client[13]",
-      "~k_parent": "a9"
+      "key": "root.imports.operators.client[11]",
+      "~k_parent": "ab"
     },
     "ao": {
-      "key": "root.imports.operators.client[14]",
-      "~k_parent": "a9"
+      "key": "root.imports.operators.client[12]",
+      "~k_parent": "ab"
     },
     "ap": {
-      "key": "root.imports.operators.client[15]",
-      "~k_parent": "a9"
+      "key": "root.imports.operators.client[13]",
+      "~k_parent": "ab"
     },
     "aq": {
-      "key": "root.imports.operators.client[16]",
-      "~k_parent": "a9"
+      "key": "root.imports.operators.client[14]",
+      "~k_parent": "ab"
     },
     "ar": {
+      "key": "root.imports.operators.client[15]",
+      "~k_parent": "ab"
+    },
+    "as": {
+      "key": "root.imports.operators.client[16]",
+      "~k_parent": "ab"
+    },
+    "at": {
       "key": "root.imports.operators.server",
-      "~k_parent": "a8"
+      "~k_parent": "aa"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -2595,6 +2603,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -11102,6 +11111,9 @@
       "providers": {
         "~k": "61"
       },
+      "strategies": {
+        "~k": "62"
+      },
       "~k": "5z"
     },
     "blocks": {
@@ -11109,183 +11121,183 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "63"
+        "~k": "64"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "64"
+        "~k": "65"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "65"
+        "~k": "66"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 8,
-        "~k": "66"
+        "~k": "67"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 5,
-        "~k": "67"
+        "~k": "68"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "68"
+        "~k": "69"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "69"
+        "~k": "6a"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 4,
-        "~k": "6a"
+        "~k": "6b"
       },
       "Tag": {
         "originalTypeName": "Tag",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "6b"
+        "~k": "6c"
       },
       "NumberInput": {
         "originalTypeName": "NumberInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "6c"
+        "~k": "6d"
       },
       "Alert": {
         "originalTypeName": "Alert",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "6d"
+        "~k": "6e"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "6e"
+        "~k": "6f"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6f"
+        "~k": "6g"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6g"
+        "~k": "6h"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6h"
+        "~k": "6i"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6i"
+        "~k": "6j"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6j"
+        "~k": "6k"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6k"
+        "~k": "6l"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6l"
+        "~k": "6m"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6m"
+        "~k": "6n"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6n"
+        "~k": "6o"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6o"
+        "~k": "6p"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6p"
+        "~k": "6q"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6q"
+        "~k": "6r"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6r"
+        "~k": "6s"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6s"
+        "~k": "6t"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6t"
+        "~k": "6u"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "6u"
+        "~k": "6v"
       },
-      "~k": "62"
+      "~k": "63"
     },
     "connections": {
-      "~k": "6v"
-    },
-    "requests": {
       "~k": "6w"
     },
-    "websockets": {
+    "requests": {
       "~k": "6x"
     },
-    "api": {
+    "websockets": {
       "~k": "6y"
+    },
+    "api": {
+      "~k": "6z"
     },
     "operators": {
       "client": {
@@ -11293,110 +11305,110 @@
           "originalTypeName": "_if",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "71"
+          "~k": "72"
         },
         "_state": {
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 13,
-          "~k": "72"
+          "~k": "73"
         },
         "_array": {
           "originalTypeName": "_array",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "73"
+          "~k": "74"
         },
         "_global": {
           "originalTypeName": "_global",
           "package": "@lowdefy/operators-js",
           "count": 3,
-          "~k": "74"
+          "~k": "75"
         },
         "_function": {
           "originalTypeName": "_function",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "75"
+          "~k": "76"
         },
         "_eq": {
           "originalTypeName": "_eq",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "76"
+          "~k": "77"
         },
         "_args": {
           "originalTypeName": "_args",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "77"
+          "~k": "78"
         },
         "_string": {
           "originalTypeName": "_string",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "78"
+          "~k": "79"
         },
         "_json": {
           "originalTypeName": "_json",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "79"
+          "~k": "7a"
         },
         "_object": {
           "originalTypeName": "_object",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "7a"
+          "~k": "7b"
         },
         "_gt": {
           "originalTypeName": "_gt",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "7b"
+          "~k": "7c"
         },
         "_and": {
           "originalTypeName": "_and",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "7c"
+          "~k": "7d"
         },
         "_or": {
           "originalTypeName": "_or",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "7d"
+          "~k": "7e"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "7e"
+          "~k": "7f"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "7f"
+          "~k": "7g"
         },
         "_date": {
           "originalTypeName": "_date",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "7g"
+          "~k": "7h"
         },
         "_dayjs": {
           "originalTypeName": "_dayjs",
           "package": "@lowdefy/operators-dayjs",
           "count": 1,
-          "~k": "7h"
+          "~k": "7i"
         },
-        "~k": "70"
+        "~k": "71"
       },
       "server": {
-        "~k": "7i"
+        "~k": "7j"
       },
-      "~k": "6z"
+      "~k": "70"
     },
     "~k": "5u"
   }

--- a/packages/build/src/tests/success/48-events-actions-comprehensive/snapshot.json
+++ b/packages/build/src/tests/success/48-events-actions-comprehensive/snapshot.json
@@ -372,112 +372,112 @@
       "~k_parent": "70"
     },
     "73": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "70"
+    },
+    "74": {
       "key": "root.types.blocks",
       "~k_parent": "6r"
     },
-    "74": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "73"
-    },
     "75": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "73"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "74"
     },
     "76": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "73"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "74"
     },
     "77": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "73"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "74"
     },
     "78": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "73"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "74"
     },
     "79": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "73"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "74"
     },
     "80": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "7w"
+      "key": "root.types.operators.client._lte",
+      "~k_parent": "7x"
     },
     "81": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "7w"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "7x"
     },
     "82": {
-      "key": "root.types.operators.server",
-      "~k_parent": "7v"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "7x"
     },
     "83": {
+      "key": "root.types.operators.server",
+      "~k_parent": "7w"
+    },
+    "84": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "84": {
-      "key": "root.imports.actions",
-      "~k_parent": "83"
-    },
     "85": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "84"
     },
     "86": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "84"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "85"
     },
     "87": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "84"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "85"
     },
     "88": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "84"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "85"
     },
     "89": {
-      "key": "root.imports.actions[4]",
-      "~k_parent": "84"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "85"
     },
     "90": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "8h"
     },
     "91": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "8h"
     },
     "92": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "8h"
     },
     "93": {
-      "key": "root.imports.connections",
-      "~k_parent": "83"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "8h"
     },
     "94": {
-      "key": "root.imports.icons",
-      "~k_parent": "83"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "8h"
     },
     "95": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "94"
+      "key": "root.imports.connections",
+      "~k_parent": "84"
     },
     "96": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "95"
+      "key": "root.imports.icons",
+      "~k_parent": "84"
     },
     "97": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "96"
     },
     "98": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "97"
     },
     "99": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "96"
     },
     "a": {
       "key": "root.pages[0:home:Box].events.onInit[0:initState:SetState]",
@@ -1308,456 +1308,464 @@
       "~k_parent": "6r"
     },
     "7a": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "73"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "74"
     },
     "7b": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "73"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "74"
     },
     "7c": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "73"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "74"
     },
     "7d": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "73"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "74"
     },
     "7e": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "73"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "74"
     },
     "7f": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "73"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "74"
     },
     "7g": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "73"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "74"
     },
     "7h": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "73"
+      "key": "root.types.blocks.List",
+      "~k_parent": "74"
     },
     "7i": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "73"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "74"
     },
     "7j": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "73"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "74"
     },
     "7k": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "73"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "74"
     },
     "7l": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "73"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "74"
     },
     "7m": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "73"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "74"
     },
     "7n": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "73"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "74"
     },
     "7o": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "73"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "74"
     },
     "7p": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "73"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "74"
     },
     "7q": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "73"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "74"
     },
     "7r": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "74"
+    },
+    "7s": {
       "key": "root.types.connections",
       "~k_parent": "6r"
     },
-    "7s": {
+    "7t": {
       "key": "root.types.requests",
       "~k_parent": "6r"
     },
-    "7t": {
+    "7u": {
       "key": "root.types.websockets",
       "~k_parent": "6r"
     },
-    "7u": {
+    "7v": {
       "key": "root.types.api",
       "~k_parent": "6r"
     },
-    "7v": {
+    "7w": {
       "key": "root.types.operators",
       "~k_parent": "6r"
     },
-    "7w": {
-      "key": "root.types.operators.client",
-      "~k_parent": "7v"
-    },
     "7x": {
-      "key": "root.types.operators.client._state",
+      "key": "root.types.operators.client",
       "~k_parent": "7w"
     },
     "7y": {
-      "key": "root.types.operators.client._sum",
-      "~k_parent": "7w"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "7x"
     },
     "7z": {
-      "key": "root.types.operators.client._lte",
-      "~k_parent": "7w"
+      "key": "root.types.operators.client._sum",
+      "~k_parent": "7x"
     },
     "8a": {
-      "key": "root.imports.actions[5]",
-      "~k_parent": "84"
+      "key": "root.imports.actions[4]",
+      "~k_parent": "85"
     },
     "8b": {
-      "key": "root.imports.agents",
-      "~k_parent": "83"
+      "key": "root.imports.actions[5]",
+      "~k_parent": "85"
     },
     "8c": {
-      "key": "root.imports.auth",
-      "~k_parent": "83"
+      "key": "root.imports.agents",
+      "~k_parent": "84"
     },
     "8d": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "8c"
+      "key": "root.imports.auth",
+      "~k_parent": "84"
     },
     "8e": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "8c"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "8d"
     },
     "8f": {
-      "key": "root.imports.blocks",
-      "~k_parent": "83"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "8d"
     },
     "8g": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "8f"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "8d"
     },
     "8h": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks",
+      "~k_parent": "84"
     },
     "8i": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "8h"
     },
     "8j": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "8h"
     },
     "8k": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "8h"
     },
     "8l": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "8h"
     },
     "8m": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "8h"
     },
     "8n": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "8h"
     },
     "8o": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "8h"
     },
     "8p": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "8h"
     },
     "8q": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "8h"
     },
     "8r": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "8h"
     },
     "8s": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "8h"
     },
     "8t": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "8h"
     },
     "8u": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "8h"
     },
     "8v": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "8h"
     },
     "8w": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "8h"
     },
     "8x": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "8h"
     },
     "8y": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "8h"
     },
     "8z": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "8f"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "8h"
     },
     "9a": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "99"
     },
     "9b": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "96"
     },
     "9c": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "9b"
     },
     "9d": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "96"
     },
     "9e": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "9d"
     },
     "9f": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "96"
     },
     "9g": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "9f"
     },
     "9h": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "96"
     },
     "9i": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "9h"
     },
     "9j": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "96"
     },
     "9k": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "9j"
     },
     "9l": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "96"
     },
     "9m": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "9l"
     },
     "9n": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "96"
     },
     "9o": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "9n"
     },
     "9p": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "96"
     },
     "9q": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "9p"
     },
     "9r": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "96"
     },
     "9s": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "9r"
     },
     "9t": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "96"
     },
     "9u": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "9t"
     },
     "9v": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "96"
     },
     "9w": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "9v"
     },
     "9x": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "96"
     },
     "9y": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "9x"
     },
     "9z": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "96"
     },
     "a0": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "9z"
     },
     "a1": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "96"
     },
     "a2": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "a1"
     },
     "a3": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "96"
     },
     "a4": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "a3"
     },
     "a5": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "96"
     },
     "a6": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "a5"
     },
     "a7": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "96"
     },
     "a8": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "a7"
     },
     "a9": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "96"
     },
     "aa": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "a9"
     },
     "ab": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "96"
     },
     "ac": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "ab"
     },
     "ad": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "96"
     },
     "ae": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "ad"
     },
     "af": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "96"
     },
     "ag": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "af"
     },
     "ah": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "96"
     },
     "ai": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "ah"
     },
     "aj": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "96"
     },
     "ak": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "aj"
     },
     "al": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "96"
     },
     "am": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "al"
     },
     "an": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "94"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "96"
     },
     "ao": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "an"
     },
     "ap": {
-      "key": "root.imports.requests",
-      "~k_parent": "83"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "96"
     },
     "aq": {
-      "key": "root.imports.websockets",
-      "~k_parent": "83"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "ap"
     },
     "ar": {
-      "key": "root.imports.operators",
-      "~k_parent": "83"
+      "key": "root.imports.requests",
+      "~k_parent": "84"
     },
     "as": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "ar"
+      "key": "root.imports.websockets",
+      "~k_parent": "84"
     },
     "at": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "as"
+      "key": "root.imports.operators",
+      "~k_parent": "84"
     },
     "au": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "as"
+      "key": "root.imports.operators.client",
+      "~k_parent": "at"
     },
     "av": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "as"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "au"
     },
     "aw": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "as"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "au"
     },
     "ax": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "as"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "au"
     },
     "ay": {
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "au"
+    },
+    "az": {
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "au"
+    },
+    "b0": {
       "key": "root.imports.operators.server",
-      "~k_parent": "ar"
+      "~k_parent": "at"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -2814,6 +2822,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -9053,6 +9062,9 @@
       "providers": {
         "~k": "72"
       },
+      "strategies": {
+        "~k": "73"
+      },
       "~k": "70"
     },
     "blocks": {
@@ -9060,153 +9072,153 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "74"
+        "~k": "75"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "75"
+        "~k": "76"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 5,
-        "~k": "76"
+        "~k": "77"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "77"
+        "~k": "78"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 14,
-        "~k": "78"
+        "~k": "79"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "79"
+        "~k": "7a"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "7a"
+        "~k": "7b"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7b"
+        "~k": "7c"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7c"
+        "~k": "7d"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7d"
+        "~k": "7e"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7e"
+        "~k": "7f"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7f"
+        "~k": "7g"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7g"
+        "~k": "7h"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7h"
+        "~k": "7i"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "7i"
+        "~k": "7j"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7j"
+        "~k": "7k"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7k"
+        "~k": "7l"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7l"
+        "~k": "7m"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7m"
+        "~k": "7n"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7n"
+        "~k": "7o"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7o"
+        "~k": "7p"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "7p"
+        "~k": "7q"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "7q"
+        "~k": "7r"
       },
-      "~k": "73"
+      "~k": "74"
     },
     "connections": {
-      "~k": "7r"
-    },
-    "requests": {
       "~k": "7s"
     },
-    "websockets": {
+    "requests": {
       "~k": "7t"
     },
-    "api": {
+    "websockets": {
       "~k": "7u"
+    },
+    "api": {
+      "~k": "7v"
     },
     "operators": {
       "client": {
@@ -9214,38 +9226,38 @@
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 5,
-          "~k": "7x"
+          "~k": "7y"
         },
         "_sum": {
           "originalTypeName": "_sum",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "7y"
+          "~k": "7z"
         },
         "_lte": {
           "originalTypeName": "_lte",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "7z"
+          "~k": "80"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "80"
+          "~k": "81"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "81"
+          "~k": "82"
         },
-        "~k": "7w"
+        "~k": "7x"
       },
       "server": {
-        "~k": "82"
+        "~k": "83"
       },
-      "~k": "7v"
+      "~k": "7w"
     },
     "~k": "6r"
   }

--- a/packages/build/src/tests/success/49-request-payload-app/snapshot.json
+++ b/packages/build/src/tests/success/49-request-payload-app/snapshot.json
@@ -342,164 +342,164 @@
       "~k_parent": "52"
     },
     "60": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "5z"
     },
     "61": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "5z"
     },
     "62": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "5z"
     },
     "63": {
-      "key": "root.types.blocks.NumberInput",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "5z"
     },
     "64": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.NumberInput",
+      "~k_parent": "5z"
     },
     "65": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "5z"
     },
     "66": {
-      "key": "root.types.blocks.TextArea",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "5z"
     },
     "67": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.TextArea",
+      "~k_parent": "5z"
     },
     "68": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.List",
+      "~k_parent": "5z"
     },
     "69": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "5z"
     },
     "70": {
-      "key": "root.types.operators",
+      "key": "root.types.api",
       "~k_parent": "5o"
     },
     "71": {
-      "key": "root.types.operators.client",
-      "~k_parent": "70"
+      "key": "root.types.operators",
+      "~k_parent": "5o"
     },
     "72": {
-      "key": "root.types.operators.client._state",
+      "key": "root.types.operators.client",
       "~k_parent": "71"
     },
     "73": {
-      "key": "root.types.operators.client._request",
-      "~k_parent": "71"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "72"
     },
     "74": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "71"
+      "key": "root.types.operators.client._request",
+      "~k_parent": "72"
     },
     "75": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "71"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "72"
     },
     "76": {
-      "key": "root.types.operators.server",
-      "~k_parent": "70"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "72"
     },
     "77": {
-      "key": "root.types.operators.server._payload",
-      "~k_parent": "76"
+      "key": "root.types.operators.server",
+      "~k_parent": "71"
     },
     "78": {
+      "key": "root.types.operators.server._payload",
+      "~k_parent": "77"
+    },
+    "79": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "79": {
-      "key": "root.imports.actions",
-      "~k_parent": "78"
-    },
     "80": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "7k"
     },
     "81": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "7k"
     },
     "82": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "7k"
     },
     "83": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "7k"
     },
     "84": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "7k"
     },
     "85": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "7k"
     },
     "86": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "7k"
     },
     "87": {
-      "key": "root.imports.blocks[24]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "7k"
     },
     "88": {
-      "key": "root.imports.blocks[25]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "7k"
     },
     "89": {
-      "key": "root.imports.connections",
-      "~k_parent": "78"
+      "key": "root.imports.blocks[24]",
+      "~k_parent": "7k"
     },
     "90": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "8z"
     },
     "91": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "8e"
     },
     "92": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "91"
     },
     "93": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "8e"
     },
     "94": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "93"
     },
     "95": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "8e"
     },
     "96": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "95"
     },
     "97": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "8e"
     },
     "98": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "97"
     },
     "99": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "8e"
     },
     "a": {
       "key": "root.pages",
@@ -1201,476 +1201,484 @@
       "~k_parent": "5v"
     },
     "5y": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "5v"
+    },
+    "5z": {
       "key": "root.types.blocks",
       "~k_parent": "5o"
     },
-    "5z": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "5y"
-    },
     "6a": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "5z"
     },
     "6b": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "5z"
     },
     "6c": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "5z"
     },
     "6d": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "5z"
     },
     "6e": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "5z"
     },
     "6f": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "5z"
     },
     "6g": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "5z"
     },
     "6h": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "5z"
     },
     "6i": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "5z"
     },
     "6j": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "5z"
     },
     "6k": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "5z"
     },
     "6l": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "5z"
     },
     "6m": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "5z"
     },
     "6n": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "5z"
     },
     "6o": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "5y"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "5z"
     },
     "6p": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "5z"
+    },
+    "6q": {
       "key": "root.types.connections",
       "~k_parent": "5o"
     },
-    "6q": {
-      "key": "root.types.connections.AxiosHttp",
-      "~k_parent": "6p"
-    },
     "6r": {
-      "key": "root.types.connections.MongoDBCollection",
-      "~k_parent": "6p"
+      "key": "root.types.connections.AxiosHttp",
+      "~k_parent": "6q"
     },
     "6s": {
+      "key": "root.types.connections.MongoDBCollection",
+      "~k_parent": "6q"
+    },
+    "6t": {
       "key": "root.types.requests",
       "~k_parent": "5o"
     },
-    "6t": {
-      "key": "root.types.requests.AxiosHttp",
-      "~k_parent": "6s"
-    },
     "6u": {
-      "key": "root.types.requests.MongoDBFind",
-      "~k_parent": "6s"
+      "key": "root.types.requests.AxiosHttp",
+      "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.types.requests.MongoDBInsertOne",
-      "~k_parent": "6s"
+      "key": "root.types.requests.MongoDBFind",
+      "~k_parent": "6t"
     },
     "6w": {
-      "key": "root.types.requests.MongoDBUpdateOne",
-      "~k_parent": "6s"
+      "key": "root.types.requests.MongoDBInsertOne",
+      "~k_parent": "6t"
     },
     "6x": {
-      "key": "root.types.requests.MongoDBAggregate",
-      "~k_parent": "6s"
+      "key": "root.types.requests.MongoDBUpdateOne",
+      "~k_parent": "6t"
     },
     "6y": {
+      "key": "root.types.requests.MongoDBAggregate",
+      "~k_parent": "6t"
+    },
+    "6z": {
       "key": "root.types.websockets",
       "~k_parent": "5o"
     },
-    "6z": {
-      "key": "root.types.api",
-      "~k_parent": "5o"
-    },
     "7a": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "79"
     },
     "7b": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "79"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "7a"
     },
     "7c": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "79"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "7a"
     },
     "7d": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "79"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "7a"
     },
     "7e": {
-      "key": "root.imports.agents",
-      "~k_parent": "78"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "7a"
     },
     "7f": {
-      "key": "root.imports.auth",
-      "~k_parent": "78"
+      "key": "root.imports.agents",
+      "~k_parent": "79"
     },
     "7g": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "7f"
+      "key": "root.imports.auth",
+      "~k_parent": "79"
     },
     "7h": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "7f"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "7g"
     },
     "7i": {
-      "key": "root.imports.blocks",
-      "~k_parent": "78"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "7g"
     },
     "7j": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "7i"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "7g"
     },
     "7k": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks",
+      "~k_parent": "79"
     },
     "7l": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "7k"
     },
     "7m": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "7k"
     },
     "7n": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "7k"
     },
     "7o": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "7k"
     },
     "7p": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "7k"
     },
     "7q": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "7k"
     },
     "7r": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "7k"
     },
     "7s": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "7k"
     },
     "7t": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "7k"
     },
     "7u": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "7k"
     },
     "7v": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "7k"
     },
     "7w": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "7k"
     },
     "7x": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "7k"
     },
     "7y": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "7k"
     },
     "7z": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "7i"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "7k"
     },
     "8a": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "89"
+      "key": "root.imports.blocks[25]",
+      "~k_parent": "7k"
     },
     "8b": {
-      "key": "root.imports.connections[1]",
-      "~k_parent": "89"
+      "key": "root.imports.connections",
+      "~k_parent": "79"
     },
     "8c": {
-      "key": "root.imports.icons",
-      "~k_parent": "78"
+      "key": "root.imports.connections[0]",
+      "~k_parent": "8b"
     },
     "8d": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "8c"
+      "key": "root.imports.connections[1]",
+      "~k_parent": "8b"
     },
     "8e": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "8d"
+      "key": "root.imports.icons",
+      "~k_parent": "79"
     },
     "8f": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "8e"
     },
     "8g": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "8f"
     },
     "8h": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "8e"
     },
     "8i": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "8h"
     },
     "8j": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "8e"
     },
     "8k": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "8j"
     },
     "8l": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "8e"
     },
     "8m": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "8l"
     },
     "8n": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "8e"
     },
     "8o": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "8n"
     },
     "8p": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "8e"
     },
     "8q": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "8p"
     },
     "8r": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "8e"
     },
     "8s": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "8r"
     },
     "8t": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "8e"
     },
     "8u": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "8t"
     },
     "8v": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "8e"
     },
     "8w": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "8v"
     },
     "8x": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "8e"
     },
     "8y": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "8x"
     },
     "8z": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "8e"
     },
     "9a": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "99"
     },
     "9b": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "8e"
     },
     "9c": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "9b"
     },
     "9d": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "8e"
     },
     "9e": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "9d"
     },
     "9f": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "8e"
     },
     "9g": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "9f"
     },
     "9h": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "8e"
     },
     "9i": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "9h"
     },
     "9j": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "8e"
     },
     "9k": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "9j"
     },
     "9l": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "8e"
     },
     "9m": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "9l"
     },
     "9n": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "8e"
     },
     "9o": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "9n"
     },
     "9p": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "8e"
     },
     "9q": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "9p"
     },
     "9r": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "8e"
     },
     "9s": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "9r"
     },
     "9t": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "8e"
     },
     "9u": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "9t"
     },
     "9v": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "8c"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "8e"
     },
     "9w": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "9v"
     },
     "9x": {
-      "key": "root.imports.requests",
-      "~k_parent": "78"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "8e"
     },
     "9y": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "9x"
     },
     "9z": {
-      "key": "root.imports.requests[1]",
-      "~k_parent": "9x"
+      "key": "root.imports.requests",
+      "~k_parent": "79"
     },
     "a0": {
-      "key": "root.imports.requests[2]",
-      "~k_parent": "9x"
+      "key": "root.imports.requests[0]",
+      "~k_parent": "9z"
     },
     "a1": {
-      "key": "root.imports.requests[3]",
-      "~k_parent": "9x"
+      "key": "root.imports.requests[1]",
+      "~k_parent": "9z"
     },
     "a2": {
-      "key": "root.imports.requests[4]",
-      "~k_parent": "9x"
+      "key": "root.imports.requests[2]",
+      "~k_parent": "9z"
     },
     "a3": {
-      "key": "root.imports.websockets",
-      "~k_parent": "78"
+      "key": "root.imports.requests[3]",
+      "~k_parent": "9z"
     },
     "a4": {
-      "key": "root.imports.operators",
-      "~k_parent": "78"
+      "key": "root.imports.requests[4]",
+      "~k_parent": "9z"
     },
     "a5": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "a4"
+      "key": "root.imports.websockets",
+      "~k_parent": "79"
     },
     "a6": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "a5"
+      "key": "root.imports.operators",
+      "~k_parent": "79"
     },
     "a7": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "a5"
+      "key": "root.imports.operators.client",
+      "~k_parent": "a6"
     },
     "a8": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "a5"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "a7"
     },
     "a9": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "a5"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "a7"
     },
     "aa": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "a4"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "a7"
     },
     "ab": {
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "a7"
+    },
+    "ac": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "a6"
+    },
+    "ad": {
       "key": "root.imports.operators.server[0]",
-      "~k_parent": "aa"
+      "~k_parent": "ac"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -2685,6 +2693,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -10897,6 +10906,9 @@
       "providers": {
         "~k": "5x"
       },
+      "strategies": {
+        "~k": "5y"
+      },
       "~k": "5v"
     },
     "blocks": {
@@ -10904,213 +10916,213 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "5z"
+        "~k": "60"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "60"
+        "~k": "61"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 5,
-        "~k": "61"
+        "~k": "62"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 5,
-        "~k": "62"
+        "~k": "63"
       },
       "NumberInput": {
         "originalTypeName": "NumberInput",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "63"
+        "~k": "64"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "64"
+        "~k": "65"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "65"
+        "~k": "66"
       },
       "TextArea": {
         "originalTypeName": "TextArea",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "66"
+        "~k": "67"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "67"
+        "~k": "68"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "68"
+        "~k": "69"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "69"
+        "~k": "6a"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6a"
+        "~k": "6b"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6b"
+        "~k": "6c"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6c"
+        "~k": "6d"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6d"
+        "~k": "6e"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6e"
+        "~k": "6f"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6f"
+        "~k": "6g"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "6g"
+        "~k": "6h"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6h"
+        "~k": "6i"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6i"
+        "~k": "6j"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6j"
+        "~k": "6k"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6k"
+        "~k": "6l"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6l"
+        "~k": "6m"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6m"
+        "~k": "6n"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "6n"
+        "~k": "6o"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "6o"
+        "~k": "6p"
       },
-      "~k": "5y"
+      "~k": "5z"
     },
     "connections": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 1,
-        "~k": "6q"
+        "~k": "6r"
       },
       "MongoDBCollection": {
         "originalTypeName": "MongoDBCollection",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "6r"
+        "~k": "6s"
       },
-      "~k": "6p"
+      "~k": "6q"
     },
     "requests": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 3,
-        "~k": "6t"
+        "~k": "6u"
       },
       "MongoDBFind": {
         "originalTypeName": "MongoDBFind",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "6u"
+        "~k": "6v"
       },
       "MongoDBInsertOne": {
         "originalTypeName": "MongoDBInsertOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "6v"
+        "~k": "6w"
       },
       "MongoDBUpdateOne": {
         "originalTypeName": "MongoDBUpdateOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "6w"
+        "~k": "6x"
       },
       "MongoDBAggregate": {
         "originalTypeName": "MongoDBAggregate",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "6x"
+        "~k": "6y"
       },
-      "~k": "6s"
+      "~k": "6t"
     },
     "websockets": {
-      "~k": "6y"
+      "~k": "6z"
     },
     "api": {
-      "~k": "6z"
+      "~k": "70"
     },
     "operators": {
       "client": {
@@ -11118,38 +11130,38 @@
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 11,
-          "~k": "72"
+          "~k": "73"
         },
         "_request": {
           "originalTypeName": "_request",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "73"
+          "~k": "74"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "74"
+          "~k": "75"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "75"
+          "~k": "76"
         },
-        "~k": "71"
+        "~k": "72"
       },
       "server": {
         "_payload": {
           "originalTypeName": "_payload",
           "package": "@lowdefy/operators-js",
           "count": 9,
-          "~k": "77"
+          "~k": "78"
         },
-        "~k": "76"
+        "~k": "77"
       },
-      "~k": "70"
+      "~k": "71"
     },
     "~k": "5o"
   }

--- a/packages/build/src/tests/success/50-logger-sentry-app/snapshot.json
+++ b/packages/build/src/tests/success/50-logger-sentry-app/snapshot.json
@@ -166,128 +166,128 @@
       "~k_parent": "26"
     },
     "29": {
-      "key": "root.types.blocks",
-      "~k_parent": "20"
+      "key": "root.types.auth.strategies",
+      "~k_parent": "26"
     },
     "30": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2z"
     },
     "31": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2z"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "30"
     },
     "32": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2y"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "30"
     },
     "33": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2z"
+    },
+    "34": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "34": {
-      "key": "root.imports.actions",
-      "~k_parent": "33"
-    },
     "35": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "34"
     },
     "36": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "34"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "35"
     },
     "37": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "34"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "35"
     },
     "38": {
-      "key": "root.imports.agents",
-      "~k_parent": "33"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "35"
     },
     "39": {
-      "key": "root.imports.auth",
-      "~k_parent": "33"
+      "key": "root.imports.agents",
+      "~k_parent": "34"
     },
     "40": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3z"
+      "key": "root.imports.icons",
+      "~k_parent": "34"
     },
     "41": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "40"
     },
     "44": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "40"
     },
     "46": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "40"
     },
     "48": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "40"
     },
     "50": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "40"
     },
     "52": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "40"
     },
     "54": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "40"
     },
     "56": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "40"
     },
     "58": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "40"
     },
     "a": {
       "key": "root.pages[0:home:Box].properties",
@@ -504,380 +504,388 @@
       "~k_parent": "1y"
     },
     "2a": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "29"
+      "key": "root.types.blocks",
+      "~k_parent": "20"
     },
     "2b": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2a"
     },
     "2c": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2a"
     },
     "2d": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2a"
     },
     "2e": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2a"
     },
     "2f": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2a"
     },
     "2g": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "29"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2a"
     },
     "2h": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2a"
     },
     "2i": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2a"
     },
     "2j": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2a"
     },
     "2k": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "29"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2a"
     },
     "2l": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2a"
     },
     "2m": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2a"
     },
     "2n": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "29"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2a"
     },
     "2o": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2a"
     },
     "2p": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "29"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2a"
     },
     "2q": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "29"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2a"
     },
     "2r": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "29"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2a"
     },
     "2s": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "29"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2a"
     },
     "2t": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2a"
     },
     "2u": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2a"
+    },
+    "2v": {
       "key": "root.types.connections",
       "~k_parent": "20"
     },
-    "2v": {
+    "2w": {
       "key": "root.types.requests",
       "~k_parent": "20"
     },
-    "2w": {
+    "2x": {
       "key": "root.types.websockets",
       "~k_parent": "20"
     },
-    "2x": {
+    "2y": {
       "key": "root.types.api",
       "~k_parent": "20"
     },
-    "2y": {
+    "2z": {
       "key": "root.types.operators",
       "~k_parent": "20"
     },
-    "2z": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2y"
-    },
     "3a": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "39"
+      "key": "root.imports.auth",
+      "~k_parent": "34"
     },
     "3b": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "39"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3a"
     },
     "3c": {
-      "key": "root.imports.blocks",
-      "~k_parent": "33"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3a"
     },
     "3d": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3c"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3a"
     },
     "3e": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks",
+      "~k_parent": "34"
     },
     "3f": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3e"
     },
     "3h": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3e"
     },
     "3i": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3e"
     },
     "3j": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3e"
     },
     "3k": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3e"
     },
     "3l": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3e"
     },
     "3m": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3e"
     },
     "3n": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3e"
     },
     "3o": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3e"
     },
     "3p": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3e"
     },
     "3q": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3e"
     },
     "3r": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3e"
     },
     "3s": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3e"
     },
     "3t": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3e"
     },
     "3u": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3e"
     },
     "3v": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3e"
     },
     "3w": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3e"
     },
     "3x": {
-      "key": "root.imports.connections",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3e"
     },
     "3y": {
-      "key": "root.imports.icons",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3e"
     },
     "3z": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3y"
+      "key": "root.imports.connections",
+      "~k_parent": "34"
     },
     "4a": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "40"
     },
     "4c": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "40"
     },
     "4e": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "40"
     },
     "4g": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "40"
     },
     "4i": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "40"
     },
     "4k": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "40"
     },
     "4m": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "40"
     },
     "4o": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "40"
     },
     "4q": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "40"
     },
     "4s": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "40"
     },
     "4u": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "40"
     },
     "4w": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "40"
     },
     "4y": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "40"
     },
     "5a": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "40"
     },
     "5c": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "40"
     },
     "5e": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "40"
     },
     "5g": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "40"
     },
     "5i": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.requests",
-      "~k_parent": "33"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "40"
     },
     "5k": {
-      "key": "root.imports.websockets",
-      "~k_parent": "33"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.operators",
-      "~k_parent": "33"
+      "key": "root.imports.requests",
+      "~k_parent": "34"
     },
     "5m": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5l"
+      "key": "root.imports.websockets",
+      "~k_parent": "34"
     },
     "5n": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5m"
+      "key": "root.imports.operators",
+      "~k_parent": "34"
     },
     "5o": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5m"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5n"
     },
     "5p": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5o"
+    },
+    "5q": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5o"
+    },
+    "5r": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5l"
+      "~k_parent": "5n"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1176,6 +1184,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5676,6 +5685,9 @@
       "providers": {
         "~k": "28"
       },
+      "strategies": {
+        "~k": "29"
+      },
       "~k": "26"
     },
     "blocks": {
@@ -5683,135 +5695,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
-      "~k": "29"
+      "~k": "2a"
     },
     "connections": {
-      "~k": "2u"
-    },
-    "requests": {
       "~k": "2v"
     },
-    "websockets": {
+    "requests": {
       "~k": "2w"
     },
-    "api": {
+    "websockets": {
       "~k": "2x"
+    },
+    "api": {
+      "~k": "2y"
     },
     "operators": {
       "client": {
@@ -5819,20 +5831,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "30"
+          "~k": "31"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "31"
+          "~k": "32"
         },
-        "~k": "2z"
+        "~k": "30"
       },
       "server": {
-        "~k": "32"
+        "~k": "33"
       },
-      "~k": "2y"
+      "~k": "2z"
     },
     "~k": "20"
   }

--- a/packages/build/src/tests/success/51-config-options-app/snapshot.json
+++ b/packages/build/src/tests/success/51-config-options-app/snapshot.json
@@ -172,124 +172,124 @@
       "~k_parent": "27"
     },
     "30": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2z"
+      "key": "root.types.operators",
+      "~k_parent": "22"
     },
     "31": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "30"
     },
     "32": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "30"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "31"
     },
     "33": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2z"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "31"
     },
     "34": {
+      "key": "root.types.operators.server",
+      "~k_parent": "30"
+    },
+    "35": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "35": {
-      "key": "root.imports.actions",
-      "~k_parent": "34"
-    },
     "36": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "35"
     },
     "37": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "35"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "36"
     },
     "38": {
-      "key": "root.imports.agents",
-      "~k_parent": "34"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "36"
     },
     "39": {
-      "key": "root.imports.auth",
-      "~k_parent": "34"
+      "key": "root.imports.agents",
+      "~k_parent": "35"
     },
     "40": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3z"
+      "key": "root.imports.icons",
+      "~k_parent": "35"
     },
     "41": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "40"
     },
     "44": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "40"
     },
     "46": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "40"
     },
     "48": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "40"
     },
     "50": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "40"
     },
     "52": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "40"
     },
     "54": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "40"
     },
     "56": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "40"
     },
     "58": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "40"
     },
     "a": {
       "key": "root.pages[0:landing:Box].blocks[0:title:Title]",
@@ -503,380 +503,388 @@
       "~k_parent": "1y"
     },
     "2a": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "27"
+    },
+    "2b": {
       "key": "root.types.blocks",
       "~k_parent": "22"
     },
-    "2b": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2a"
-    },
     "2c": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2b"
     },
     "2d": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2b"
     },
     "2e": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2b"
     },
     "2f": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2b"
     },
     "2g": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2b"
     },
     "2h": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2b"
     },
     "2i": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2b"
     },
     "2j": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2b"
     },
     "2k": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2b"
     },
     "2l": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2b"
     },
     "2m": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2b"
     },
     "2n": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2b"
     },
     "2o": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2b"
     },
     "2p": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2b"
     },
     "2q": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2b"
     },
     "2r": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2b"
     },
     "2s": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2b"
     },
     "2t": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2b"
     },
     "2u": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2a"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2b"
     },
     "2v": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2b"
+    },
+    "2w": {
       "key": "root.types.connections",
       "~k_parent": "22"
     },
-    "2w": {
+    "2x": {
       "key": "root.types.requests",
       "~k_parent": "22"
     },
-    "2x": {
+    "2y": {
       "key": "root.types.websockets",
       "~k_parent": "22"
     },
-    "2y": {
+    "2z": {
       "key": "root.types.api",
       "~k_parent": "22"
     },
-    "2z": {
-      "key": "root.types.operators",
-      "~k_parent": "22"
-    },
     "3a": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "39"
+      "key": "root.imports.auth",
+      "~k_parent": "35"
     },
     "3b": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "39"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3a"
     },
     "3c": {
-      "key": "root.imports.blocks",
-      "~k_parent": "34"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3a"
     },
     "3d": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3c"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3a"
     },
     "3e": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks",
+      "~k_parent": "35"
     },
     "3f": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3e"
     },
     "3h": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3e"
     },
     "3i": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3e"
     },
     "3j": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3e"
     },
     "3k": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3e"
     },
     "3l": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3e"
     },
     "3m": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3e"
     },
     "3n": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3e"
     },
     "3o": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3e"
     },
     "3p": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3e"
     },
     "3q": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3e"
     },
     "3r": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3e"
     },
     "3s": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3e"
     },
     "3t": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3e"
     },
     "3u": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3e"
     },
     "3v": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3e"
     },
     "3w": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3e"
     },
     "3x": {
-      "key": "root.imports.connections",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3e"
     },
     "3y": {
-      "key": "root.imports.icons",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3e"
     },
     "3z": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3y"
+      "key": "root.imports.connections",
+      "~k_parent": "35"
     },
     "4a": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "40"
     },
     "4c": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "40"
     },
     "4e": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "40"
     },
     "4g": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "40"
     },
     "4i": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "40"
     },
     "4k": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "40"
     },
     "4m": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "40"
     },
     "4o": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "40"
     },
     "4q": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "40"
     },
     "4s": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "40"
     },
     "4u": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "40"
     },
     "4w": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "40"
     },
     "4y": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "40"
     },
     "5a": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "40"
     },
     "5c": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "40"
     },
     "5e": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "40"
     },
     "5g": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "40"
     },
     "5i": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.requests",
-      "~k_parent": "34"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "40"
     },
     "5k": {
-      "key": "root.imports.websockets",
-      "~k_parent": "34"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.operators",
-      "~k_parent": "34"
+      "key": "root.imports.requests",
+      "~k_parent": "35"
     },
     "5m": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5l"
+      "key": "root.imports.websockets",
+      "~k_parent": "35"
     },
     "5n": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5m"
+      "key": "root.imports.operators",
+      "~k_parent": "35"
     },
     "5o": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5m"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5n"
     },
     "5p": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5o"
+    },
+    "5q": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5o"
+    },
+    "5r": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5l"
+      "~k_parent": "5n"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1153,6 +1161,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5647,6 +5656,9 @@
       "providers": {
         "~k": "29"
       },
+      "strategies": {
+        "~k": "2a"
+      },
       "~k": "27"
     },
     "blocks": {
@@ -5654,135 +5666,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
-      "~k": "2a"
+      "~k": "2b"
     },
     "connections": {
-      "~k": "2v"
-    },
-    "requests": {
       "~k": "2w"
     },
-    "websockets": {
+    "requests": {
       "~k": "2x"
     },
-    "api": {
+    "websockets": {
       "~k": "2y"
+    },
+    "api": {
+      "~k": "2z"
     },
     "operators": {
       "client": {
@@ -5790,20 +5802,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "31"
+          "~k": "32"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "32"
+          "~k": "33"
         },
-        "~k": "30"
+        "~k": "31"
       },
       "server": {
-        "~k": "33"
+        "~k": "34"
       },
-      "~k": "2z"
+      "~k": "30"
     },
     "~k": "22"
   }

--- a/packages/build/src/tests/success/52-skeleton-loading-app/snapshot.json
+++ b/packages/build/src/tests/success/52-skeleton-loading-app/snapshot.json
@@ -172,163 +172,163 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.Avatar",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2v"
     },
     "31": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Avatar",
+      "~k_parent": "2v"
     },
     "32": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2v"
     },
     "33": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2v"
     },
     "34": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2v"
     },
     "35": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2v"
     },
     "36": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2v"
     },
     "37": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2v"
     },
     "38": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2v"
     },
     "39": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2v"
     },
     "40": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3s"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3y"
     },
     "41": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "40"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3y"
     },
     "42": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks",
+      "~k_parent": "3t"
     },
     "43": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "42"
     },
     "45": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "42"
     },
     "46": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "42"
     },
     "47": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "42"
     },
     "48": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "42"
     },
     "49": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "42"
     },
     "50": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4r"
     },
     "51": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4r"
     },
     "53": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4r"
     },
     "55": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4r"
     },
     "57": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4r"
     },
     "59": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4r"
     },
     "61": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4r"
     },
     "63": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4r"
     },
     "65": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4r"
     },
     "67": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4r"
     },
     "69": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "68"
     },
     "a": {
@@ -642,372 +642,380 @@
       "~k_parent": "2r"
     },
     "2u": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2r"
+    },
+    "2v": {
       "key": "root.types.blocks",
       "~k_parent": "2m"
     },
-    "2v": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2u"
-    },
     "2w": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2v"
     },
     "2x": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "2v"
     },
     "2y": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "2v"
     },
     "2z": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "2v"
     },
     "3a": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2v"
     },
     "3b": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2v"
     },
     "3c": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2v"
     },
     "3d": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2v"
     },
     "3e": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2v"
     },
     "3f": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2v"
     },
     "3g": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2v"
     },
     "3h": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2v"
     },
     "3i": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2v"
+    },
+    "3j": {
       "key": "root.types.connections",
       "~k_parent": "2m"
     },
-    "3j": {
+    "3k": {
       "key": "root.types.requests",
       "~k_parent": "2m"
     },
-    "3k": {
+    "3l": {
       "key": "root.types.websockets",
       "~k_parent": "2m"
     },
-    "3l": {
+    "3m": {
       "key": "root.types.api",
       "~k_parent": "2m"
     },
-    "3m": {
+    "3n": {
       "key": "root.types.operators",
       "~k_parent": "2m"
     },
-    "3n": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3m"
-    },
     "3o": {
-      "key": "root.types.operators.client._state",
+      "key": "root.types.operators.client",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "3n"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3n"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3o"
     },
     "3r": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3m"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3o"
     },
     "3s": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3n"
+    },
+    "3t": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "3t": {
-      "key": "root.imports.actions",
-      "~k_parent": "3s"
-    },
     "3u": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3t"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.agents",
-      "~k_parent": "3s"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3u"
     },
     "3x": {
-      "key": "root.imports.auth",
-      "~k_parent": "3s"
+      "key": "root.imports.agents",
+      "~k_parent": "3t"
     },
     "3y": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3x"
+      "key": "root.imports.auth",
+      "~k_parent": "3t"
     },
     "3z": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3x"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "42"
     },
     "4b": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "42"
     },
     "4c": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "42"
     },
     "4d": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "42"
     },
     "4e": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "42"
     },
     "4f": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "42"
     },
     "4g": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "42"
     },
     "4h": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "42"
     },
     "4i": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "42"
     },
     "4j": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "42"
     },
     "4k": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "42"
     },
     "4l": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "42"
     },
     "4m": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "42"
     },
     "4n": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "40"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "42"
     },
     "4o": {
-      "key": "root.imports.connections",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "42"
     },
     "4p": {
-      "key": "root.imports.icons",
-      "~k_parent": "3s"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "42"
     },
     "4q": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4p"
+      "key": "root.imports.connections",
+      "~k_parent": "3t"
     },
     "4r": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4q"
+      "key": "root.imports.icons",
+      "~k_parent": "3t"
     },
     "4s": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4r"
     },
     "4v": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4r"
     },
     "4x": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4r"
     },
     "4z": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4r"
     },
     "5b": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4r"
     },
     "5d": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4r"
     },
     "5f": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4r"
     },
     "5h": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4r"
     },
     "5j": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4r"
     },
     "5l": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4r"
     },
     "5n": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4r"
     },
     "5p": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4r"
     },
     "5r": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4r"
     },
     "5t": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4r"
     },
     "5v": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4r"
     },
     "5x": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4p"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4r"
     },
     "5z": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.imports.requests",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4r"
     },
     "6b": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3s"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.operators",
-      "~k_parent": "3s"
+      "key": "root.imports.requests",
+      "~k_parent": "3t"
     },
     "6d": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6c"
+      "key": "root.imports.websockets",
+      "~k_parent": "3t"
     },
     "6e": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6d"
+      "key": "root.imports.operators",
+      "~k_parent": "3t"
     },
     "6f": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6d"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6e"
     },
     "6g": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "6d"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6f"
     },
     "6h": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6f"
+    },
+    "6i": {
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "6f"
+    },
+    "6j": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6c"
+      "~k_parent": "6e"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1376,6 +1384,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -7528,6 +7537,9 @@
       "providers": {
         "~k": "2t"
       },
+      "strategies": {
+        "~k": "2u"
+      },
       "~k": "2r"
     },
     "blocks": {
@@ -7535,153 +7547,153 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 2,
-        "~k": "2z"
+        "~k": "30"
       },
       "Avatar": {
         "originalTypeName": "Avatar",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 2,
-        "~k": "31"
+        "~k": "32"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "32"
+        "~k": "33"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3f"
+        "~k": "3g"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3h"
+        "~k": "3i"
       },
-      "~k": "2u"
+      "~k": "2v"
     },
     "connections": {
-      "~k": "3i"
-    },
-    "requests": {
       "~k": "3j"
     },
-    "websockets": {
+    "requests": {
       "~k": "3k"
     },
-    "api": {
+    "websockets": {
       "~k": "3l"
+    },
+    "api": {
+      "~k": "3m"
     },
     "operators": {
       "client": {
@@ -7689,26 +7701,26 @@
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 5,
-          "~k": "3o"
+          "~k": "3p"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 3,
-          "~k": "3p"
+          "~k": "3q"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3q"
+          "~k": "3r"
         },
-        "~k": "3n"
+        "~k": "3o"
       },
       "server": {
-        "~k": "3r"
+        "~k": "3s"
       },
-      "~k": "3m"
+      "~k": "3n"
     },
     "~k": "2m"
   }

--- a/packages/build/src/tests/success/53-deep-nesting-app/snapshot.json
+++ b/packages/build/src/tests/success/53-deep-nesting-app/snapshot.json
@@ -174,156 +174,164 @@
       "~k_parent": "24"
     },
     "30": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2r"
     },
     "31": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2r"
     },
     "32": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2r"
     },
     "33": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2r"
     },
     "34": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2r"
     },
     "35": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2r"
     },
     "36": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2r"
     },
     "37": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2r"
     },
     "38": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2r"
     },
     "39": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2r"
     },
     "40": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3v"
     },
     "41": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3v"
     },
     "42": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3v"
     },
     "43": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3v"
     },
     "44": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3v"
     },
     "45": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3v"
     },
     "46": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3v"
     },
     "47": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3v"
     },
     "48": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3v"
     },
     "49": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3v"
     },
     "50": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4i"
     },
     "52": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4i"
     },
     "54": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4i"
     },
     "56": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4i"
     },
     "58": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4i"
     },
     "60": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.requests",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4i"
     },
     "62": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.operators",
-      "~k_parent": "3l"
+      "key": "root.imports.requests",
+      "~k_parent": "3m"
     },
     "64": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "63"
+      "key": "root.imports.websockets",
+      "~k_parent": "3m"
     },
     "65": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "64"
+      "key": "root.imports.operators",
+      "~k_parent": "3m"
     },
     "66": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "64"
+      "key": "root.imports.operators.client",
+      "~k_parent": "65"
     },
     "67": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "66"
+    },
+    "68": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "66"
+    },
+    "69": {
       "key": "root.imports.operators.server",
-      "~k_parent": "63"
+      "~k_parent": "65"
     },
     "a": {
       "key": "root.pages[0:nested:Box].blocks[0:level1:Card].properties",
@@ -608,356 +616,356 @@
       "~k_parent": "2n"
     },
     "2q": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2n"
+    },
+    "2r": {
       "key": "root.types.blocks",
       "~k_parent": "2i"
     },
-    "2r": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "2r"
     },
     "2u": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "2r"
     },
     "2v": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2r"
     },
     "2w": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2r"
     },
     "2x": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2r"
     },
     "2y": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2r"
     },
     "2z": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2r"
     },
     "3a": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2r"
     },
     "3b": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2r"
     },
     "3c": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2r"
+    },
+    "3d": {
       "key": "root.types.connections",
       "~k_parent": "2i"
     },
-    "3d": {
+    "3e": {
       "key": "root.types.requests",
       "~k_parent": "2i"
     },
-    "3e": {
+    "3f": {
       "key": "root.types.websockets",
       "~k_parent": "2i"
     },
-    "3f": {
+    "3g": {
       "key": "root.types.api",
       "~k_parent": "2i"
     },
-    "3g": {
+    "3h": {
       "key": "root.types.operators",
       "~k_parent": "2i"
     },
-    "3h": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3g"
-    },
     "3i": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3h"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3g"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3i"
     },
     "3l": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3h"
+    },
+    "3m": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "3m": {
-      "key": "root.imports.actions",
-      "~k_parent": "3l"
-    },
     "3n": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3m"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.agents",
-      "~k_parent": "3l"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3n"
     },
     "3q": {
-      "key": "root.imports.auth",
-      "~k_parent": "3l"
+      "key": "root.imports.agents",
+      "~k_parent": "3m"
     },
     "3r": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3q"
+      "key": "root.imports.auth",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3q"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3l"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3r"
     },
     "3u": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3t"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3r"
     },
     "3v": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks",
+      "~k_parent": "3m"
     },
     "3w": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3v"
     },
     "3y": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3v"
     },
     "3z": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3v"
     },
     "4a": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3v"
     },
     "4b": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3v"
     },
     "4c": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3v"
     },
     "4d": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3v"
     },
     "4e": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3v"
     },
     "4f": {
-      "key": "root.imports.connections",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3v"
     },
     "4g": {
-      "key": "root.imports.icons",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "3v"
     },
     "4h": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4g"
+      "key": "root.imports.connections",
+      "~k_parent": "3m"
     },
     "4i": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4h"
+      "key": "root.imports.icons",
+      "~k_parent": "3m"
     },
     "4j": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4i"
     },
     "4m": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4i"
     },
     "4o": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4i"
     },
     "4q": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4i"
     },
     "4s": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4i"
     },
     "4u": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4i"
     },
     "4w": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4i"
     },
     "4y": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4i"
     },
     "5a": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4i"
     },
     "5c": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4i"
     },
     "5e": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4i"
     },
     "5g": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4i"
     },
     "5i": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4i"
     },
     "5k": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4i"
     },
     "5m": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4i"
     },
     "5o": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4i"
     },
     "5q": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4i"
     },
     "5s": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4i"
     },
     "5u": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4i"
     },
     "5w": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4i"
     },
     "5y": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4i"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1303,6 +1311,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -6287,6 +6296,9 @@
       "providers": {
         "~k": "2p"
       },
+      "strategies": {
+        "~k": "2q"
+      },
       "~k": "2n"
     },
     "blocks": {
@@ -6294,141 +6306,141 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
-      "~k": "2q"
+      "~k": "2r"
     },
     "connections": {
-      "~k": "3c"
-    },
-    "requests": {
       "~k": "3d"
     },
-    "websockets": {
+    "requests": {
       "~k": "3e"
     },
-    "api": {
+    "websockets": {
       "~k": "3f"
+    },
+    "api": {
+      "~k": "3g"
     },
     "operators": {
       "client": {
@@ -6436,20 +6448,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3i"
+          "~k": "3j"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3j"
+          "~k": "3k"
         },
-        "~k": "3h"
+        "~k": "3i"
       },
       "server": {
-        "~k": "3k"
+        "~k": "3l"
       },
-      "~k": "3g"
+      "~k": "3h"
     },
     "~k": "2i"
   }

--- a/packages/build/src/tests/success/54-many-pages-app/snapshot.json
+++ b/packages/build/src/tests/success/54-many-pages-app/snapshot.json
@@ -264,164 +264,164 @@
       "~k_parent": "44"
     },
     "50": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "4z"
+      "key": "root.types.blocks",
+      "~k_parent": "4r"
     },
     "51": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "50"
     },
     "52": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "50"
     },
     "53": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "50"
     },
     "54": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "50"
     },
     "55": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "50"
     },
     "56": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "50"
     },
     "57": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "50"
     },
     "58": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "50"
     },
     "59": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "50"
     },
     "60": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "5y"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.blocks",
-      "~k_parent": "5t"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "5z"
     },
     "62": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "61"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "5z"
     },
     "63": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks",
+      "~k_parent": "5u"
     },
     "64": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "63"
     },
     "66": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "63"
     },
     "67": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "63"
     },
     "68": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "63"
     },
     "69": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "63"
     },
     "70": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "6p"
     },
     "71": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "70"
     },
     "72": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "6p"
     },
     "73": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "72"
     },
     "74": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "6p"
     },
     "75": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "74"
     },
     "76": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "6p"
     },
     "77": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "76"
     },
     "78": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "6p"
     },
     "79": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "78"
     },
     "80": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "6p"
     },
     "81": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "80"
     },
     "82": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "6p"
     },
     "83": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "82"
     },
     "84": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "6p"
     },
     "85": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "84"
     },
     "86": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "6p"
     },
     "87": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "86"
     },
     "88": {
-      "key": "root.imports.requests",
-      "~k_parent": "5t"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "6p"
     },
     "89": {
-      "key": "root.imports.websockets",
-      "~k_parent": "5t"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "88"
     },
     "a": {
       "key": "root.menus[0:default].links[1:section1:MenuGroup]",
@@ -983,340 +983,348 @@
       "~k_parent": "4w"
     },
     "4z": {
-      "key": "root.types.blocks",
-      "~k_parent": "4r"
+      "key": "root.types.auth.strategies",
+      "~k_parent": "4w"
     },
     "5a": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.List",
+      "~k_parent": "50"
     },
     "5b": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "50"
     },
     "5c": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "50"
     },
     "5d": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "50"
     },
     "5e": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "50"
     },
     "5f": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "50"
     },
     "5g": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "50"
     },
     "5h": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "50"
     },
     "5i": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "50"
     },
     "5j": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "4z"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "50"
     },
     "5k": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "50"
+    },
+    "5l": {
       "key": "root.types.connections",
       "~k_parent": "4r"
     },
-    "5l": {
+    "5m": {
       "key": "root.types.requests",
       "~k_parent": "4r"
     },
-    "5m": {
+    "5n": {
       "key": "root.types.websockets",
       "~k_parent": "4r"
     },
-    "5n": {
+    "5o": {
       "key": "root.types.api",
       "~k_parent": "4r"
     },
-    "5o": {
+    "5p": {
       "key": "root.types.operators",
       "~k_parent": "4r"
     },
-    "5p": {
-      "key": "root.types.operators.client",
-      "~k_parent": "5o"
-    },
     "5q": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "5p"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.types.operators.server",
-      "~k_parent": "5o"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "5q"
     },
     "5t": {
+      "key": "root.types.operators.server",
+      "~k_parent": "5p"
+    },
+    "5u": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "5u": {
-      "key": "root.imports.actions",
-      "~k_parent": "5t"
-    },
     "5v": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "5u"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.agents",
-      "~k_parent": "5t"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "5v"
     },
     "5y": {
-      "key": "root.imports.auth",
-      "~k_parent": "5t"
+      "key": "root.imports.agents",
+      "~k_parent": "5u"
     },
     "5z": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "5y"
+      "key": "root.imports.auth",
+      "~k_parent": "5u"
     },
     "6a": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "63"
     },
     "6b": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "63"
     },
     "6c": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "63"
     },
     "6d": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "63"
     },
     "6e": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "63"
     },
     "6f": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "63"
     },
     "6g": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "63"
     },
     "6h": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "63"
     },
     "6i": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "63"
     },
     "6j": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "63"
     },
     "6k": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "63"
     },
     "6l": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "61"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "63"
     },
     "6m": {
-      "key": "root.imports.connections",
-      "~k_parent": "5t"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "63"
     },
     "6n": {
-      "key": "root.imports.icons",
-      "~k_parent": "5t"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "63"
     },
     "6o": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "6n"
+      "key": "root.imports.connections",
+      "~k_parent": "5u"
     },
     "6p": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "6o"
+      "key": "root.imports.icons",
+      "~k_parent": "5u"
     },
     "6q": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "6q"
     },
     "6s": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "6p"
     },
     "6t": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "6s"
     },
     "6u": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "6p"
     },
     "6v": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "6u"
     },
     "6w": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "6p"
     },
     "6x": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "6w"
     },
     "6y": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "6p"
     },
     "6z": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "6y"
     },
     "7a": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "6p"
     },
     "7b": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "7a"
     },
     "7c": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "6p"
     },
     "7d": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "7c"
     },
     "7e": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "6p"
     },
     "7f": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "7e"
     },
     "7g": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "6p"
     },
     "7h": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "7g"
     },
     "7i": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "6p"
     },
     "7j": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "7i"
     },
     "7k": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "6p"
     },
     "7l": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "7k"
     },
     "7m": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "6p"
     },
     "7n": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "7m"
     },
     "7o": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "6p"
     },
     "7p": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "7o"
     },
     "7q": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "6p"
     },
     "7r": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "7q"
     },
     "7s": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "6p"
     },
     "7t": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "7s"
     },
     "7u": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "6p"
     },
     "7v": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "7u"
     },
     "7w": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "6p"
     },
     "7x": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "7w"
     },
     "7y": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "6n"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "6p"
     },
     "7z": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "7y"
     },
     "8a": {
-      "key": "root.imports.operators",
-      "~k_parent": "5t"
+      "key": "root.imports.requests",
+      "~k_parent": "5u"
     },
     "8b": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "8a"
+      "key": "root.imports.websockets",
+      "~k_parent": "5u"
     },
     "8c": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "8b"
+      "key": "root.imports.operators",
+      "~k_parent": "5u"
     },
     "8d": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "8b"
+      "key": "root.imports.operators.client",
+      "~k_parent": "8c"
     },
     "8e": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "8d"
+    },
+    "8f": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "8d"
+    },
+    "8g": {
       "key": "root.imports.operators.server",
-      "~k_parent": "8a"
+      "~k_parent": "8c"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1993,6 +2001,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -6487,6 +6496,9 @@
       "providers": {
         "~k": "4y"
       },
+      "strategies": {
+        "~k": "4z"
+      },
       "~k": "4w"
     },
     "blocks": {
@@ -6494,135 +6506,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 9,
-        "~k": "50"
+        "~k": "51"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 8,
-        "~k": "51"
+        "~k": "52"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "52"
+        "~k": "53"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "53"
+        "~k": "54"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "54"
+        "~k": "55"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "55"
+        "~k": "56"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "56"
+        "~k": "57"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "57"
+        "~k": "58"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "58"
+        "~k": "59"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "59"
+        "~k": "5a"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5a"
+        "~k": "5b"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "5b"
+        "~k": "5c"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5c"
+        "~k": "5d"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5d"
+        "~k": "5e"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5e"
+        "~k": "5f"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5f"
+        "~k": "5g"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5g"
+        "~k": "5h"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5h"
+        "~k": "5i"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "5i"
+        "~k": "5j"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "5j"
+        "~k": "5k"
       },
-      "~k": "4z"
+      "~k": "50"
     },
     "connections": {
-      "~k": "5k"
-    },
-    "requests": {
       "~k": "5l"
     },
-    "websockets": {
+    "requests": {
       "~k": "5m"
     },
-    "api": {
+    "websockets": {
       "~k": "5n"
+    },
+    "api": {
+      "~k": "5o"
     },
     "operators": {
       "client": {
@@ -6630,20 +6642,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5q"
+          "~k": "5r"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5r"
+          "~k": "5s"
         },
-        "~k": "5p"
+        "~k": "5q"
       },
       "server": {
-        "~k": "5s"
+        "~k": "5t"
       },
-      "~k": "5o"
+      "~k": "5p"
     },
     "~k": "4r"
   }

--- a/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
+++ b/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
@@ -118,11 +118,15 @@
       "~arr": [],
       "~k": "aa"
     },
+    "strategies": {
+      "~arr": [],
+      "~k": "ab"
+    },
     "organizations": {
       "policy": "pinned",
       "org": "default",
       "signup": "invite-only",
-      "~k": "ab"
+      "~k": "ac"
     },
     "authPages": {
       "signIn": "/login",
@@ -131,31 +135,31 @@
       "forgotPassword": "/forgot-password",
       "resetPassword": "/reset-password",
       "verifyEmail": "/verify-email",
-      "~k": "ac"
+      "~k": "ad"
     },
     "account": {
       "accountLinking": {
         "enabled": true,
         "trustedProviders": {
           "~arr": [],
-          "~k": "af"
+          "~k": "ag"
         },
-        "~k": "ae"
+        "~k": "af"
       },
-      "~k": "ad"
+      "~k": "ae"
     },
     "rateLimit": {
       "enabled": true,
       "window": 60,
       "max": 100,
-      "~k": "ag"
+      "~k": "ah"
     },
     "roles": {
       "~arr": [
         "admin",
         "sales"
       ],
-      "~k": "ah"
+      "~k": "ai"
     },
     "~k": "e"
   },
@@ -2367,1300 +2371,1312 @@
       "~k_parent": "e"
     },
     "ab": {
-      "key": "root.auth.organizations",
+      "key": "root.auth.strategies",
       "~k_parent": "e"
     },
     "ac": {
-      "key": "root.auth.authPages",
+      "key": "root.auth.organizations",
       "~k_parent": "e"
     },
     "ad": {
-      "key": "root.auth.account",
+      "key": "root.auth.authPages",
       "~k_parent": "e"
     },
     "ae": {
-      "key": "root.auth.account.accountLinking",
-      "~k_parent": "ad"
+      "key": "root.auth.account",
+      "~k_parent": "e"
     },
     "af": {
-      "key": "root.auth.account.accountLinking.trustedProviders",
+      "key": "root.auth.account.accountLinking",
       "~k_parent": "ae"
     },
     "ag": {
+      "key": "root.auth.account.accountLinking.trustedProviders",
+      "~k_parent": "af"
+    },
+    "ah": {
       "key": "root.auth.rateLimit",
       "~k_parent": "e"
     },
-    "ah": {
+    "ai": {
       "key": "root.auth.roles",
       "~k_parent": "e"
     },
-    "ai": {
+    "aj": {
       "key": "root.menus[0:default].links",
       "~k_parent": "11"
     },
-    "aj": {
+    "ak": {
       "key": "root.menus[0:default].links[0:dashboard:MenuLink].auth",
       "~k_parent": "13"
     },
-    "ak": {
+    "al": {
       "key": "root.menus[0:default].links[1:customers:MenuGroup].links",
       "~k_parent": "15"
     },
-    "al": {
+    "am": {
       "key": "root.menus[0:default].links[1:customers:MenuGroup].links[0:all-customers:MenuLink].auth",
       "~k_parent": "18"
     },
-    "am": {
-      "key": "root.menus[0:default].links[1:customers:MenuGroup].links[0:all-customers:MenuLink].auth.roles",
-      "~k_parent": "al"
-    },
     "an": {
+      "key": "root.menus[0:default].links[1:customers:MenuGroup].links[0:all-customers:MenuLink].auth.roles",
+      "~k_parent": "am"
+    },
+    "ao": {
       "key": "root.menus[0:default].links[1:customers:MenuGroup].links[1:add-customer:MenuLink].auth",
       "~k_parent": "1a"
     },
-    "ao": {
-      "key": "root.menus[0:default].links[1:customers:MenuGroup].links[1:add-customer:MenuLink].auth.roles",
-      "~k_parent": "an"
-    },
     "ap": {
+      "key": "root.menus[0:default].links[1:customers:MenuGroup].links[1:add-customer:MenuLink].auth.roles",
+      "~k_parent": "ao"
+    },
+    "aq": {
       "key": "root.menus[0:default].links[1:customers:MenuGroup].auth",
       "~k_parent": "15"
     },
-    "aq": {
+    "ar": {
       "key": "root.menus[0:default].links[2:orders:MenuLink].auth",
       "~k_parent": "1c"
     },
-    "ar": {
-      "key": "root.menus[0:default].links[2:orders:MenuLink].auth.roles",
-      "~k_parent": "aq"
-    },
     "as": {
+      "key": "root.menus[0:default].links[2:orders:MenuLink].auth.roles",
+      "~k_parent": "ar"
+    },
+    "at": {
       "key": "root.menus[0:default].links[3:reports:MenuLink].auth",
       "~k_parent": "1e"
     },
-    "at": {
-      "key": "root.menus[0:default].links[3:reports:MenuLink].auth.roles",
-      "~k_parent": "as"
-    },
     "au": {
+      "key": "root.menus[0:default].links[3:reports:MenuLink].auth.roles",
+      "~k_parent": "at"
+    },
+    "av": {
       "key": "root.menus[0:default].links[4:settings:MenuLink].auth",
       "~k_parent": "1g"
     },
-    "av": {
-      "key": "root.menus[0:default].links[4:settings:MenuLink].auth.roles",
-      "~k_parent": "au"
-    },
     "aw": {
+      "key": "root.menus[0:default].links[4:settings:MenuLink].auth.roles",
+      "~k_parent": "av"
+    },
+    "ax": {
       "key": "root.pages",
       "~k_parent": "4"
     },
-    "ax": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu]",
-      "~k_parent": "aw"
-    },
     "ay": {
+      "key": "root.pages[0:dashboard:PageHeaderMenu]",
+      "~k_parent": "ax"
+    },
+    "az": {
       "key": "root.pages[0:dashboard:PageHeaderMenu].events.onInitAsync",
       "~k_parent": "1o"
     },
-    "az": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].events.onInitAsync.catch",
-      "~k_parent": "ay"
-    },
     "b0": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].auth",
-      "~k_parent": "ax"
+      "key": "root.pages[0:dashboard:PageHeaderMenu].events.onInitAsync.catch",
+      "~k_parent": "az"
     },
     "b1": {
+      "key": "root.pages[0:dashboard:PageHeaderMenu].auth",
+      "~k_parent": "ay"
+    },
+    "b2": {
       "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].slots",
       "~k_parent": "1y"
     },
-    "b2": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].slots.content",
-      "~k_parent": "b1"
-    },
     "b3": {
+      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].slots.content",
+      "~k_parent": "b2"
+    },
+    "b4": {
       "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[0:totalCustomers:Card].slots",
       "~k_parent": "20"
     },
-    "b4": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[0:totalCustomers:Card].slots.content",
-      "~k_parent": "b3"
-    },
     "b5": {
+      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[0:totalCustomers:Card].slots.content",
+      "~k_parent": "b4"
+    },
+    "b6": {
       "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[1:totalOrders:Card].slots",
       "~k_parent": "26"
     },
-    "b6": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[1:totalOrders:Card].slots.content",
-      "~k_parent": "b5"
-    },
     "b7": {
+      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[1:totalOrders:Card].slots.content",
+      "~k_parent": "b6"
+    },
+    "b8": {
       "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[2:revenue:Card].slots",
       "~k_parent": "2c"
     },
-    "b8": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[2:revenue:Card].slots.content",
-      "~k_parent": "b7"
-    },
     "b9": {
+      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[2:revenue:Card].slots.content",
+      "~k_parent": "b8"
+    },
+    "ba": {
       "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[3:growth:Card].slots",
       "~k_parent": "2i"
     },
-    "ba": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[3:growth:Card].slots.content",
-      "~k_parent": "b9"
-    },
     "bb": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].subscriptions",
-      "~k_parent": "ax"
+      "key": "root.pages[0:dashboard:PageHeaderMenu].areas.content.blocks[1:statsRow:Box].blocks[3:growth:Card].slots.content",
+      "~k_parent": "ba"
     },
     "bc": {
-      "key": "root.pages[0:dashboard:PageHeaderMenu].requests",
-      "~k_parent": "ax"
+      "key": "root.pages[0:dashboard:PageHeaderMenu].subscriptions",
+      "~k_parent": "ay"
     },
     "bd": {
+      "key": "root.pages[0:dashboard:PageHeaderMenu].requests",
+      "~k_parent": "ay"
+    },
+    "be": {
       "key": "root.pages[0:dashboard:PageHeaderMenu].requests[0:api:AxiosHttp].payload",
       "~k_parent": "1m"
     },
-    "be": {
+    "bf": {
       "key": "root.pages[0:dashboard:PageHeaderMenu].requests[0:api:AxiosHttp].auth",
       "~k_parent": "1m"
     },
-    "bf": {
-      "key": "root.pages[1:customers:PageHeaderMenu]",
-      "~k_parent": "aw"
-    },
     "bg": {
+      "key": "root.pages[1:customers:PageHeaderMenu]",
+      "~k_parent": "ax"
+    },
+    "bh": {
       "key": "root.pages[1:customers:PageHeaderMenu].events.onInit",
       "~k_parent": "3e"
     },
-    "bh": {
-      "key": "root.pages[1:customers:PageHeaderMenu].events.onInit.catch",
-      "~k_parent": "bg"
-    },
     "bi": {
-      "key": "root.pages[1:customers:PageHeaderMenu].auth",
-      "~k_parent": "bf"
+      "key": "root.pages[1:customers:PageHeaderMenu].events.onInit.catch",
+      "~k_parent": "bh"
     },
     "bj": {
-      "key": "root.pages[1:customers:PageHeaderMenu].auth.roles",
-      "~k_parent": "bi"
+      "key": "root.pages[1:customers:PageHeaderMenu].auth",
+      "~k_parent": "bg"
     },
     "bk": {
+      "key": "root.pages[1:customers:PageHeaderMenu].auth.roles",
+      "~k_parent": "bj"
+    },
+    "bl": {
       "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].slots",
       "~k_parent": "3k"
     },
-    "bl": {
-      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].slots.content",
-      "~k_parent": "bk"
-    },
     "bm": {
+      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].slots.content",
+      "~k_parent": "bl"
+    },
+    "bn": {
       "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].blocks[0:searchQuery:TextInput].events.onChange.catch",
       "~k_parent": "3q"
     },
-    "bn": {
+    "bo": {
       "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].blocks[1:statusFilter:Selector].events.onChange",
       "~k_parent": "41"
     },
-    "bo": {
-      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].blocks[1:statusFilter:Selector].events.onChange.catch",
-      "~k_parent": "bn"
-    },
     "bp": {
+      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].blocks[1:statusFilter:Selector].events.onChange.catch",
+      "~k_parent": "bo"
+    },
+    "bq": {
       "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].blocks[2:addBtn:Button].events.onClick",
       "~k_parent": "47"
     },
-    "bq": {
-      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].blocks[2:addBtn:Button].events.onClick.catch",
-      "~k_parent": "bp"
-    },
     "br": {
+      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[0:toolbar:Box].blocks[2:addBtn:Button].events.onClick.catch",
+      "~k_parent": "bq"
+    },
+    "bs": {
       "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].slots",
       "~k_parent": "4b"
     },
-    "bs": {
-      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].slots.content",
-      "~k_parent": "br"
-    },
     "bt": {
+      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].slots.content",
+      "~k_parent": "bs"
+    },
+    "bu": {
       "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].blocks[0:customerCard:Card].events.onClick",
       "~k_parent": "4i"
     },
-    "bu": {
-      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].blocks[0:customerCard:Card].events.onClick.catch",
-      "~k_parent": "bt"
-    },
     "bv": {
+      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].blocks[0:customerCard:Card].events.onClick.catch",
+      "~k_parent": "bu"
+    },
+    "bw": {
       "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].blocks[0:customerCard:Card].slots",
       "~k_parent": "4f"
     },
-    "bw": {
-      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].blocks[0:customerCard:Card].slots.content",
-      "~k_parent": "bv"
-    },
     "bx": {
-      "key": "root.pages[1:customers:PageHeaderMenu].subscriptions",
-      "~k_parent": "bf"
+      "key": "root.pages[1:customers:PageHeaderMenu].areas.content.blocks[1:customerList:List].blocks[0:customerCard:Card].slots.content",
+      "~k_parent": "bw"
     },
     "by": {
-      "key": "root.pages[1:customers:PageHeaderMenu].requests",
-      "~k_parent": "bf"
+      "key": "root.pages[1:customers:PageHeaderMenu].subscriptions",
+      "~k_parent": "bg"
     },
     "bz": {
+      "key": "root.pages[1:customers:PageHeaderMenu].requests",
+      "~k_parent": "bg"
+    },
+    "c0": {
       "key": "root.pages[1:customers:PageHeaderMenu].requests[0:db:MongoDBFind].auth",
       "~k_parent": "2r"
     },
-    "c0": {
-      "key": "root.pages[1:customers:PageHeaderMenu].requests[0:db:MongoDBFind].auth.roles",
-      "~k_parent": "bz"
-    },
     "c1": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu]",
-      "~k_parent": "aw"
+      "key": "root.pages[1:customers:PageHeaderMenu].requests[0:db:MongoDBFind].auth.roles",
+      "~k_parent": "c0"
     },
     "c2": {
+      "key": "root.pages[2:customer-detail:PageHeaderMenu]",
+      "~k_parent": "ax"
+    },
+    "c3": {
       "key": "root.pages[2:customer-detail:PageHeaderMenu].events.onInit",
       "~k_parent": "5y"
     },
-    "c3": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].events.onInit.catch",
-      "~k_parent": "c2"
-    },
     "c4": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].auth",
-      "~k_parent": "c1"
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].events.onInit.catch",
+      "~k_parent": "c3"
     },
     "c5": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].auth.roles",
-      "~k_parent": "c4"
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].auth",
+      "~k_parent": "c2"
     },
     "c6": {
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].auth.roles",
+      "~k_parent": "c5"
+    },
+    "c7": {
       "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].slots",
       "~k_parent": "6j"
     },
-    "c7": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].slots.content",
-      "~k_parent": "c6"
-    },
     "c8": {
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].slots.content",
+      "~k_parent": "c7"
+    },
+    "c9": {
       "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].slots",
       "~k_parent": "73"
     },
-    "c9": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].slots.content",
-      "~k_parent": "c8"
-    },
     "ca": {
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].slots.content",
+      "~k_parent": "c9"
+    },
+    "cb": {
       "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].blocks[0:saveBtn:Button].events.onClick",
       "~k_parent": "77"
     },
-    "cb": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].blocks[0:saveBtn:Button].events.onClick.catch",
-      "~k_parent": "ca"
-    },
     "cc": {
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].blocks[0:saveBtn:Button].events.onClick.catch",
+      "~k_parent": "cb"
+    },
+    "cd": {
       "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].blocks[1:cancelBtn:Button].events.onClick",
       "~k_parent": "7h"
     },
-    "cd": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].blocks[1:cancelBtn:Button].events.onClick.catch",
-      "~k_parent": "cc"
-    },
     "ce": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].subscriptions",
-      "~k_parent": "c1"
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].areas.content.blocks[0:form:Card].blocks[5:actions:Box].blocks[1:cancelBtn:Button].events.onClick.catch",
+      "~k_parent": "cd"
     },
     "cf": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].requests",
-      "~k_parent": "c1"
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].subscriptions",
+      "~k_parent": "c2"
     },
     "cg": {
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].requests",
+      "~k_parent": "c2"
+    },
+    "ch": {
       "key": "root.pages[2:customer-detail:PageHeaderMenu].requests[0:db:MongoDBFindOne].auth",
       "~k_parent": "58"
     },
-    "ch": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].requests[0:db:MongoDBFindOne].auth.roles",
-      "~k_parent": "cg"
-    },
     "ci": {
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].requests[0:db:MongoDBFindOne].auth.roles",
+      "~k_parent": "ch"
+    },
+    "cj": {
       "key": "root.pages[2:customer-detail:PageHeaderMenu].requests[1:db:MongoDBUpdateOne].auth",
       "~k_parent": "5e"
     },
-    "cj": {
-      "key": "root.pages[2:customer-detail:PageHeaderMenu].requests[1:db:MongoDBUpdateOne].auth.roles",
-      "~k_parent": "ci"
-    },
     "ck": {
-      "key": "root.pages[3:orders:PageHeaderMenu]",
-      "~k_parent": "aw"
+      "key": "root.pages[2:customer-detail:PageHeaderMenu].requests[1:db:MongoDBUpdateOne].auth.roles",
+      "~k_parent": "cj"
     },
     "cl": {
-      "key": "root.pages[3:orders:PageHeaderMenu].auth",
-      "~k_parent": "ck"
+      "key": "root.pages[3:orders:PageHeaderMenu]",
+      "~k_parent": "ax"
     },
     "cm": {
-      "key": "root.pages[3:orders:PageHeaderMenu].auth.roles",
+      "key": "root.pages[3:orders:PageHeaderMenu].auth",
       "~k_parent": "cl"
     },
     "cn": {
-      "key": "root.pages[3:orders:PageHeaderMenu].slots",
-      "~k_parent": "ck"
+      "key": "root.pages[3:orders:PageHeaderMenu].auth.roles",
+      "~k_parent": "cm"
     },
     "co": {
-      "key": "root.pages[3:orders:PageHeaderMenu].slots.content",
-      "~k_parent": "cn"
+      "key": "root.pages[3:orders:PageHeaderMenu].slots",
+      "~k_parent": "cl"
     },
     "cp": {
-      "key": "root.pages[3:orders:PageHeaderMenu].subscriptions",
-      "~k_parent": "ck"
+      "key": "root.pages[3:orders:PageHeaderMenu].slots.content",
+      "~k_parent": "co"
     },
     "cq": {
-      "key": "root.pages[3:orders:PageHeaderMenu].requests",
-      "~k_parent": "ck"
+      "key": "root.pages[3:orders:PageHeaderMenu].subscriptions",
+      "~k_parent": "cl"
     },
     "cr": {
-      "key": "root.pages[4:reports:PageHeaderMenu]",
-      "~k_parent": "aw"
+      "key": "root.pages[3:orders:PageHeaderMenu].requests",
+      "~k_parent": "cl"
     },
     "cs": {
-      "key": "root.pages[4:reports:PageHeaderMenu].auth",
-      "~k_parent": "cr"
+      "key": "root.pages[4:reports:PageHeaderMenu]",
+      "~k_parent": "ax"
     },
     "ct": {
-      "key": "root.pages[4:reports:PageHeaderMenu].auth.roles",
+      "key": "root.pages[4:reports:PageHeaderMenu].auth",
       "~k_parent": "cs"
     },
     "cu": {
-      "key": "root.pages[4:reports:PageHeaderMenu].slots",
-      "~k_parent": "cr"
+      "key": "root.pages[4:reports:PageHeaderMenu].auth.roles",
+      "~k_parent": "ct"
     },
     "cv": {
-      "key": "root.pages[4:reports:PageHeaderMenu].slots.content",
-      "~k_parent": "cu"
+      "key": "root.pages[4:reports:PageHeaderMenu].slots",
+      "~k_parent": "cs"
     },
     "cw": {
-      "key": "root.pages[4:reports:PageHeaderMenu].subscriptions",
-      "~k_parent": "cr"
+      "key": "root.pages[4:reports:PageHeaderMenu].slots.content",
+      "~k_parent": "cv"
     },
     "cx": {
-      "key": "root.pages[4:reports:PageHeaderMenu].requests",
-      "~k_parent": "cr"
+      "key": "root.pages[4:reports:PageHeaderMenu].subscriptions",
+      "~k_parent": "cs"
     },
     "cy": {
-      "key": "root.pages[5:settings:PageHeaderMenu]",
-      "~k_parent": "aw"
+      "key": "root.pages[4:reports:PageHeaderMenu].requests",
+      "~k_parent": "cs"
     },
     "cz": {
-      "key": "root.pages[5:settings:PageHeaderMenu].auth",
-      "~k_parent": "cy"
+      "key": "root.pages[5:settings:PageHeaderMenu]",
+      "~k_parent": "ax"
     },
     "d0": {
-      "key": "root.pages[5:settings:PageHeaderMenu].auth.roles",
+      "key": "root.pages[5:settings:PageHeaderMenu].auth",
       "~k_parent": "cz"
     },
     "d1": {
-      "key": "root.pages[5:settings:PageHeaderMenu].slots",
-      "~k_parent": "cy"
+      "key": "root.pages[5:settings:PageHeaderMenu].auth.roles",
+      "~k_parent": "d0"
     },
     "d2": {
-      "key": "root.pages[5:settings:PageHeaderMenu].slots.content",
-      "~k_parent": "d1"
+      "key": "root.pages[5:settings:PageHeaderMenu].slots",
+      "~k_parent": "cz"
     },
     "d3": {
+      "key": "root.pages[5:settings:PageHeaderMenu].slots.content",
+      "~k_parent": "d2"
+    },
+    "d4": {
       "key": "root.pages[5:settings:PageHeaderMenu].blocks[1:settingsForm:Card].slots",
       "~k_parent": "84"
     },
-    "d4": {
-      "key": "root.pages[5:settings:PageHeaderMenu].blocks[1:settingsForm:Card].slots.content",
-      "~k_parent": "d3"
-    },
     "d5": {
+      "key": "root.pages[5:settings:PageHeaderMenu].blocks[1:settingsForm:Card].slots.content",
+      "~k_parent": "d4"
+    },
+    "d6": {
       "key": "root.pages[5:settings:PageHeaderMenu].blocks[1:settingsForm:Card].blocks[4:saveSettingsBtn:Button].events.onClick",
       "~k_parent": "8m"
     },
-    "d6": {
-      "key": "root.pages[5:settings:PageHeaderMenu].blocks[1:settingsForm:Card].blocks[4:saveSettingsBtn:Button].events.onClick.catch",
-      "~k_parent": "d5"
-    },
     "d7": {
-      "key": "root.pages[5:settings:PageHeaderMenu].subscriptions",
-      "~k_parent": "cy"
+      "key": "root.pages[5:settings:PageHeaderMenu].blocks[1:settingsForm:Card].blocks[4:saveSettingsBtn:Button].events.onClick.catch",
+      "~k_parent": "d6"
     },
     "d8": {
-      "key": "root.pages[5:settings:PageHeaderMenu].requests",
-      "~k_parent": "cy"
+      "key": "root.pages[5:settings:PageHeaderMenu].subscriptions",
+      "~k_parent": "cz"
     },
     "d9": {
-      "key": "root.pages[6:login:Result]",
-      "~k_parent": "aw"
+      "key": "root.pages[5:settings:PageHeaderMenu].requests",
+      "~k_parent": "cz"
     },
     "da": {
-      "key": "root.pages[6:login:Result].auth",
-      "~k_parent": "d9"
+      "key": "root.pages[6:login:Result]",
+      "~k_parent": "ax"
     },
     "db": {
+      "key": "root.pages[6:login:Result].auth",
+      "~k_parent": "da"
+    },
+    "dc": {
       "key": "root.pages[6:login:Result].areas.extra.blocks[0:googleBtn:Button].events.onClick",
       "~k_parent": "92"
     },
-    "dc": {
-      "key": "root.pages[6:login:Result].areas.extra.blocks[0:googleBtn:Button].events.onClick.catch",
-      "~k_parent": "db"
-    },
     "dd": {
+      "key": "root.pages[6:login:Result].areas.extra.blocks[0:googleBtn:Button].events.onClick.catch",
+      "~k_parent": "dc"
+    },
+    "de": {
       "key": "root.pages[6:login:Result].areas.extra.blocks[4:credentialsBtn:Button].events.onClick",
       "~k_parent": "9e"
     },
-    "de": {
-      "key": "root.pages[6:login:Result].areas.extra.blocks[4:credentialsBtn:Button].events.onClick.catch",
-      "~k_parent": "dd"
-    },
     "df": {
-      "key": "root.pages[6:login:Result].subscriptions",
-      "~k_parent": "d9"
+      "key": "root.pages[6:login:Result].areas.extra.blocks[4:credentialsBtn:Button].events.onClick.catch",
+      "~k_parent": "de"
     },
     "dg": {
-      "key": "root.pages[6:login:Result].requests",
-      "~k_parent": "d9"
+      "key": "root.pages[6:login:Result].subscriptions",
+      "~k_parent": "da"
     },
     "dh": {
-      "key": "root.pages[7:404:Result]",
-      "~k_parent": "aw"
+      "key": "root.pages[6:login:Result].requests",
+      "~k_parent": "da"
     },
     "di": {
-      "key": "root.pages[7:404:Result].style",
-      "~k_parent": "dh"
+      "key": "root.pages[7:404:Result]",
+      "~k_parent": "ax"
     },
     "dj": {
-      "key": "root.pages[7:404:Result].style.block",
+      "key": "root.pages[7:404:Result].style",
       "~k_parent": "di"
     },
     "dk": {
+      "key": "root.pages[7:404:Result].style.block",
+      "~k_parent": "dj"
+    },
+    "dl": {
       "key": "root.pages[7:404:Result].slots.extra.blocks[0:home:Button].events.onClick",
       "~k_parent": "9w"
     },
-    "dl": {
-      "key": "root.pages[7:404:Result].slots.extra.blocks[0:home:Button].events.onClick.catch",
-      "~k_parent": "dk"
-    },
     "dm": {
-      "key": "root.pages[7:404:Result].auth",
-      "~k_parent": "dh"
+      "key": "root.pages[7:404:Result].slots.extra.blocks[0:home:Button].events.onClick.catch",
+      "~k_parent": "dl"
     },
     "dn": {
-      "key": "root.pages[7:404:Result].subscriptions",
-      "~k_parent": "dh"
+      "key": "root.pages[7:404:Result].auth",
+      "~k_parent": "di"
     },
     "do": {
-      "key": "root.pages[7:404:Result].requests",
-      "~k_parent": "dh"
+      "key": "root.pages[7:404:Result].subscriptions",
+      "~k_parent": "di"
     },
     "dp": {
+      "key": "root.pages[7:404:Result].requests",
+      "~k_parent": "di"
+    },
+    "dq": {
       "key": "root.types",
       "~k_parent": "4"
     },
-    "dq": {
-      "key": "root.types.actions",
-      "~k_parent": "dp"
-    },
     "dr": {
-      "key": "root.types.actions.Request",
+      "key": "root.types.actions",
       "~k_parent": "dq"
     },
     "ds": {
-      "key": "root.types.actions.Link",
-      "~k_parent": "dq"
+      "key": "root.types.actions.Request",
+      "~k_parent": "dr"
     },
     "dt": {
-      "key": "root.types.actions.SetState",
-      "~k_parent": "dq"
+      "key": "root.types.actions.Link",
+      "~k_parent": "dr"
     },
     "du": {
-      "key": "root.types.actions.Validate",
-      "~k_parent": "dq"
+      "key": "root.types.actions.SetState",
+      "~k_parent": "dr"
     },
     "dv": {
-      "key": "root.types.actions.DisplayMessage",
-      "~k_parent": "dq"
+      "key": "root.types.actions.Validate",
+      "~k_parent": "dr"
     },
     "dw": {
-      "key": "root.types.actions.SetGlobal",
-      "~k_parent": "dq"
+      "key": "root.types.actions.DisplayMessage",
+      "~k_parent": "dr"
     },
     "dx": {
-      "key": "root.types.actions.Login",
-      "~k_parent": "dq"
+      "key": "root.types.actions.SetGlobal",
+      "~k_parent": "dr"
     },
     "dy": {
-      "key": "root.types.actions.SetDarkMode",
-      "~k_parent": "dq"
+      "key": "root.types.actions.Login",
+      "~k_parent": "dr"
     },
     "dz": {
-      "key": "root.types.agents",
-      "~k_parent": "dp"
+      "key": "root.types.actions.SetDarkMode",
+      "~k_parent": "dr"
     },
     "e0": {
-      "key": "root.types.auth",
-      "~k_parent": "dp"
+      "key": "root.types.agents",
+      "~k_parent": "dq"
     },
     "e1": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "e0"
+      "key": "root.types.auth",
+      "~k_parent": "dq"
     },
     "e2": {
-      "key": "root.types.auth.adapters.MongoDBAuthAdapter",
+      "key": "root.types.auth.adapters",
       "~k_parent": "e1"
     },
     "e3": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "e0"
+      "key": "root.types.auth.adapters.MongoDBAuthAdapter",
+      "~k_parent": "e2"
     },
     "e4": {
-      "key": "root.types.auth.providers.Google",
-      "~k_parent": "e3"
+      "key": "root.types.auth.providers",
+      "~k_parent": "e1"
     },
     "e5": {
-      "key": "root.types.blocks",
-      "~k_parent": "dp"
+      "key": "root.types.auth.providers.Google",
+      "~k_parent": "e4"
     },
     "e6": {
-      "key": "root.types.blocks.PageHeaderMenu",
-      "~k_parent": "e5"
+      "key": "root.types.auth.strategies",
+      "~k_parent": "e1"
     },
     "e7": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "e5"
+      "key": "root.types.blocks",
+      "~k_parent": "dq"
     },
     "e8": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.PageHeaderMenu",
+      "~k_parent": "e7"
     },
     "e9": {
-      "key": "root.types.blocks.Card",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "e7"
     },
     "ea": {
-      "key": "root.types.blocks.Statistic",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "e7"
     },
     "eb": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Card",
+      "~k_parent": "e7"
     },
     "ec": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Statistic",
+      "~k_parent": "e7"
     },
     "ed": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "e7"
     },
     "ee": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "e7"
     },
     "ef": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "e7"
     },
     "eg": {
-      "key": "root.types.blocks.Tag",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.List",
+      "~k_parent": "e7"
     },
     "eh": {
-      "key": "root.types.blocks.TextArea",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "e7"
     },
     "ei": {
-      "key": "root.types.blocks.NumberInput",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Tag",
+      "~k_parent": "e7"
     },
     "ej": {
-      "key": "root.types.blocks.Switch",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.TextArea",
+      "~k_parent": "e7"
     },
     "ek": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.NumberInput",
+      "~k_parent": "e7"
     },
     "el": {
-      "key": "root.types.blocks.Divider",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Switch",
+      "~k_parent": "e7"
     },
     "em": {
-      "key": "root.types.blocks.PasswordInput",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "e7"
     },
     "en": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Divider",
+      "~k_parent": "e7"
     },
     "eo": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.PasswordInput",
+      "~k_parent": "e7"
     },
     "ep": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "e7"
     },
     "eq": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "e7"
     },
     "er": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "e7"
     },
     "es": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "e7"
     },
     "et": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "e7"
     },
     "eu": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "e7"
     },
     "ev": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "e7"
     },
     "ew": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "e7"
     },
     "ex": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "e7"
     },
     "ey": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "e7"
     },
     "ez": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "e7"
     },
     "f0": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "e7"
     },
     "f1": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "e5"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "e7"
     },
     "f2": {
-      "key": "root.types.connections",
-      "~k_parent": "dp"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "e7"
     },
     "f3": {
-      "key": "root.types.connections.AxiosHttp",
-      "~k_parent": "f2"
+      "key": "root.types.blocks.Message",
+      "~k_parent": "e7"
     },
     "f4": {
-      "key": "root.types.connections.MongoDBCollection",
-      "~k_parent": "f2"
+      "key": "root.types.connections",
+      "~k_parent": "dq"
     },
     "f5": {
-      "key": "root.types.requests",
-      "~k_parent": "dp"
+      "key": "root.types.connections.AxiosHttp",
+      "~k_parent": "f4"
     },
     "f6": {
-      "key": "root.types.requests.AxiosHttp",
-      "~k_parent": "f5"
+      "key": "root.types.connections.MongoDBCollection",
+      "~k_parent": "f4"
     },
     "f7": {
-      "key": "root.types.requests.MongoDBFind",
-      "~k_parent": "f5"
+      "key": "root.types.requests",
+      "~k_parent": "dq"
     },
     "f8": {
-      "key": "root.types.requests.MongoDBFindOne",
-      "~k_parent": "f5"
+      "key": "root.types.requests.AxiosHttp",
+      "~k_parent": "f7"
     },
     "f9": {
-      "key": "root.types.requests.MongoDBUpdateOne",
-      "~k_parent": "f5"
+      "key": "root.types.requests.MongoDBFind",
+      "~k_parent": "f7"
     },
     "fa": {
-      "key": "root.types.websockets",
-      "~k_parent": "dp"
+      "key": "root.types.requests.MongoDBFindOne",
+      "~k_parent": "f7"
     },
     "fb": {
-      "key": "root.types.api",
-      "~k_parent": "dp"
+      "key": "root.types.requests.MongoDBUpdateOne",
+      "~k_parent": "f7"
     },
     "fc": {
-      "key": "root.types.operators",
-      "~k_parent": "dp"
+      "key": "root.types.websockets",
+      "~k_parent": "dq"
     },
     "fd": {
-      "key": "root.types.operators.client",
-      "~k_parent": "fc"
+      "key": "root.types.api",
+      "~k_parent": "dq"
     },
     "fe": {
-      "key": "root.types.operators.client._user",
-      "~k_parent": "fd"
+      "key": "root.types.operators",
+      "~k_parent": "dq"
     },
     "ff": {
-      "key": "root.types.operators.client._request",
-      "~k_parent": "fd"
+      "key": "root.types.operators.client",
+      "~k_parent": "fe"
     },
     "fg": {
-      "key": "root.types.operators.client._state",
-      "~k_parent": "fd"
+      "key": "root.types.operators.client._user",
+      "~k_parent": "ff"
     },
     "fh": {
-      "key": "root.types.operators.client._if",
-      "~k_parent": "fd"
+      "key": "root.types.operators.client._request",
+      "~k_parent": "ff"
     },
     "fi": {
-      "key": "root.types.operators.client._eq",
-      "~k_parent": "fd"
+      "key": "root.types.operators.client._state",
+      "~k_parent": "ff"
     },
     "fj": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "fd"
+      "key": "root.types.operators.client._if",
+      "~k_parent": "ff"
     },
     "fk": {
-      "key": "root.types.operators.client._url_query",
-      "~k_parent": "fd"
+      "key": "root.types.operators.client._eq",
+      "~k_parent": "ff"
     },
     "fl": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "fd"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "ff"
     },
     "fm": {
-      "key": "root.types.operators.server",
-      "~k_parent": "fc"
+      "key": "root.types.operators.client._url_query",
+      "~k_parent": "ff"
     },
     "fn": {
-      "key": "root.types.operators.server._payload",
-      "~k_parent": "fm"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "ff"
     },
     "fo": {
-      "key": "root.types.operators.server._if",
-      "~k_parent": "fm"
+      "key": "root.types.operators.server",
+      "~k_parent": "fe"
     },
     "fp": {
-      "key": "root.types.operators.server._date",
-      "~k_parent": "fm"
+      "key": "root.types.operators.server._payload",
+      "~k_parent": "fo"
     },
     "fq": {
+      "key": "root.types.operators.server._if",
+      "~k_parent": "fo"
+    },
+    "fr": {
+      "key": "root.types.operators.server._date",
+      "~k_parent": "fo"
+    },
+    "fs": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "fr": {
-      "key": "root.imports.actions",
-      "~k_parent": "fq"
-    },
-    "fs": {
-      "key": "root.imports.actions[0]",
-      "~k_parent": "fr"
-    },
     "ft": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "fr"
+      "key": "root.imports.actions",
+      "~k_parent": "fs"
     },
     "fu": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "fr"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "ft"
     },
     "fv": {
-      "key": "root.imports.actions[3]",
-      "~k_parent": "fr"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "ft"
     },
     "fw": {
-      "key": "root.imports.actions[4]",
-      "~k_parent": "fr"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "ft"
     },
     "fx": {
-      "key": "root.imports.actions[5]",
-      "~k_parent": "fr"
+      "key": "root.imports.actions[3]",
+      "~k_parent": "ft"
     },
     "fy": {
-      "key": "root.imports.actions[6]",
-      "~k_parent": "fr"
+      "key": "root.imports.actions[4]",
+      "~k_parent": "ft"
     },
     "fz": {
-      "key": "root.imports.actions[7]",
-      "~k_parent": "fr"
+      "key": "root.imports.actions[5]",
+      "~k_parent": "ft"
     },
     "g0": {
-      "key": "root.imports.agents",
-      "~k_parent": "fq"
+      "key": "root.imports.actions[6]",
+      "~k_parent": "ft"
     },
     "g1": {
-      "key": "root.imports.auth",
-      "~k_parent": "fq"
+      "key": "root.imports.actions[7]",
+      "~k_parent": "ft"
     },
     "g2": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "g1"
+      "key": "root.imports.agents",
+      "~k_parent": "fs"
     },
     "g3": {
-      "key": "root.imports.auth.adapters[0]",
-      "~k_parent": "g2"
+      "key": "root.imports.auth",
+      "~k_parent": "fs"
     },
     "g4": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "g1"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "g3"
     },
     "g5": {
-      "key": "root.imports.auth.providers[0]",
+      "key": "root.imports.auth.adapters[0]",
       "~k_parent": "g4"
     },
     "g6": {
-      "key": "root.imports.blocks",
-      "~k_parent": "fq"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "g3"
     },
     "g7": {
-      "key": "root.imports.blocks[0]",
+      "key": "root.imports.auth.providers[0]",
       "~k_parent": "g6"
     },
     "g8": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "g6"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "g3"
     },
     "g9": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks",
+      "~k_parent": "fs"
     },
     "ga": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "g9"
     },
     "gb": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "g9"
     },
     "gc": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "g9"
     },
     "gd": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "g9"
     },
     "ge": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "g9"
     },
     "gf": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "g9"
     },
     "gg": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "g9"
     },
     "gh": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "g9"
     },
     "gi": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "g9"
     },
     "gj": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "g9"
     },
     "gk": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "g9"
     },
     "gl": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "g9"
     },
     "gm": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "g9"
     },
     "gn": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "g9"
     },
     "go": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "g9"
     },
     "gp": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "g9"
     },
     "gq": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "g9"
     },
     "gr": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "g9"
     },
     "gs": {
-      "key": "root.imports.blocks[21]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "g9"
     },
     "gt": {
-      "key": "root.imports.blocks[22]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "g9"
     },
     "gu": {
-      "key": "root.imports.blocks[23]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "g9"
     },
     "gv": {
-      "key": "root.imports.blocks[24]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[21]",
+      "~k_parent": "g9"
     },
     "gw": {
-      "key": "root.imports.blocks[25]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[22]",
+      "~k_parent": "g9"
     },
     "gx": {
-      "key": "root.imports.blocks[26]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[23]",
+      "~k_parent": "g9"
     },
     "gy": {
-      "key": "root.imports.blocks[27]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[24]",
+      "~k_parent": "g9"
     },
     "gz": {
-      "key": "root.imports.blocks[28]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[25]",
+      "~k_parent": "g9"
     },
     "h0": {
-      "key": "root.imports.blocks[29]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[26]",
+      "~k_parent": "g9"
     },
     "h1": {
-      "key": "root.imports.blocks[30]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[27]",
+      "~k_parent": "g9"
     },
     "h2": {
-      "key": "root.imports.blocks[31]",
-      "~k_parent": "g6"
+      "key": "root.imports.blocks[28]",
+      "~k_parent": "g9"
     },
     "h3": {
-      "key": "root.imports.connections",
-      "~k_parent": "fq"
+      "key": "root.imports.blocks[29]",
+      "~k_parent": "g9"
     },
     "h4": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "h3"
+      "key": "root.imports.blocks[30]",
+      "~k_parent": "g9"
     },
     "h5": {
-      "key": "root.imports.connections[1]",
-      "~k_parent": "h3"
+      "key": "root.imports.blocks[31]",
+      "~k_parent": "g9"
     },
     "h6": {
-      "key": "root.imports.icons",
-      "~k_parent": "fq"
+      "key": "root.imports.connections",
+      "~k_parent": "fs"
     },
     "h7": {
-      "key": "root.imports.icons[0]",
+      "key": "root.imports.connections[0]",
       "~k_parent": "h6"
     },
     "h8": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "h7"
-    },
-    "h9": {
-      "key": "root.imports.icons[1]",
+      "key": "root.imports.connections[1]",
       "~k_parent": "h6"
     },
+    "h9": {
+      "key": "root.imports.icons",
+      "~k_parent": "fs"
+    },
     "ha": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0]",
       "~k_parent": "h9"
     },
     "hb": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[0].icons",
+      "~k_parent": "ha"
     },
     "hc": {
-      "key": "root.imports.icons[2].icons",
-      "~k_parent": "hb"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "h9"
     },
     "hd": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[1].icons",
+      "~k_parent": "hc"
     },
     "he": {
-      "key": "root.imports.icons[3].icons",
-      "~k_parent": "hd"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "h9"
     },
     "hf": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[2].icons",
+      "~k_parent": "he"
     },
     "hg": {
-      "key": "root.imports.icons[4].icons",
-      "~k_parent": "hf"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "h9"
     },
     "hh": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[3].icons",
+      "~k_parent": "hg"
     },
     "hi": {
-      "key": "root.imports.icons[5].icons",
-      "~k_parent": "hh"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "h9"
     },
     "hj": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[4].icons",
+      "~k_parent": "hi"
     },
     "hk": {
-      "key": "root.imports.icons[6].icons",
-      "~k_parent": "hj"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "h9"
     },
     "hl": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[5].icons",
+      "~k_parent": "hk"
     },
     "hm": {
-      "key": "root.imports.icons[7].icons",
-      "~k_parent": "hl"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "h9"
     },
     "hn": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[6].icons",
+      "~k_parent": "hm"
     },
     "ho": {
-      "key": "root.imports.icons[8].icons",
-      "~k_parent": "hn"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "h9"
     },
     "hp": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[7].icons",
+      "~k_parent": "ho"
     },
     "hq": {
-      "key": "root.imports.icons[9].icons",
-      "~k_parent": "hp"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "h9"
     },
     "hr": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[8].icons",
+      "~k_parent": "hq"
     },
     "hs": {
-      "key": "root.imports.icons[10].icons",
-      "~k_parent": "hr"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "h9"
     },
     "ht": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[9].icons",
+      "~k_parent": "hs"
     },
     "hu": {
-      "key": "root.imports.icons[11].icons",
-      "~k_parent": "ht"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "h9"
     },
     "hv": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[10].icons",
+      "~k_parent": "hu"
     },
     "hw": {
-      "key": "root.imports.icons[12].icons",
-      "~k_parent": "hv"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "h9"
     },
     "hx": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[11].icons",
+      "~k_parent": "hw"
     },
     "hy": {
-      "key": "root.imports.icons[13].icons",
-      "~k_parent": "hx"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "h9"
     },
     "hz": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[12].icons",
+      "~k_parent": "hy"
     },
     "i0": {
-      "key": "root.imports.icons[14].icons",
-      "~k_parent": "hz"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "h9"
     },
     "i1": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[13].icons",
+      "~k_parent": "i0"
     },
     "i2": {
-      "key": "root.imports.icons[15].icons",
-      "~k_parent": "i1"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "h9"
     },
     "i3": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[14].icons",
+      "~k_parent": "i2"
     },
     "i4": {
-      "key": "root.imports.icons[16].icons",
-      "~k_parent": "i3"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "h9"
     },
     "i5": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[15].icons",
+      "~k_parent": "i4"
     },
     "i6": {
-      "key": "root.imports.icons[17].icons",
-      "~k_parent": "i5"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "h9"
     },
     "i7": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[16].icons",
+      "~k_parent": "i6"
     },
     "i8": {
-      "key": "root.imports.icons[18].icons",
-      "~k_parent": "i7"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "h9"
     },
     "i9": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[17].icons",
+      "~k_parent": "i8"
     },
     "ia": {
-      "key": "root.imports.icons[19].icons",
-      "~k_parent": "i9"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "h9"
     },
     "ib": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[18].icons",
+      "~k_parent": "ia"
     },
     "ic": {
-      "key": "root.imports.icons[20].icons",
-      "~k_parent": "ib"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "h9"
     },
     "id": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[19].icons",
+      "~k_parent": "ic"
     },
     "ie": {
-      "key": "root.imports.icons[21].icons",
-      "~k_parent": "id"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "h9"
     },
     "if": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[20].icons",
+      "~k_parent": "ie"
     },
     "ig": {
-      "key": "root.imports.icons[22].icons",
-      "~k_parent": "if"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "h9"
     },
     "ih": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[21].icons",
+      "~k_parent": "ig"
     },
     "ii": {
-      "key": "root.imports.icons[23].icons",
-      "~k_parent": "ih"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "h9"
     },
     "ij": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[22].icons",
+      "~k_parent": "ii"
     },
     "ik": {
-      "key": "root.imports.icons[24].icons",
-      "~k_parent": "ij"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "h9"
     },
     "il": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[23].icons",
+      "~k_parent": "ik"
     },
     "im": {
-      "key": "root.imports.icons[25].icons",
-      "~k_parent": "il"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "h9"
     },
     "in": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[24].icons",
+      "~k_parent": "im"
     },
     "io": {
-      "key": "root.imports.icons[26].icons",
-      "~k_parent": "in"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "h9"
     },
     "ip": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "h6"
+      "key": "root.imports.icons[25].icons",
+      "~k_parent": "io"
     },
     "iq": {
-      "key": "root.imports.icons[27].icons",
-      "~k_parent": "ip"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "h9"
     },
     "ir": {
-      "key": "root.imports.requests",
-      "~k_parent": "fq"
+      "key": "root.imports.icons[26].icons",
+      "~k_parent": "iq"
     },
     "is": {
-      "key": "root.imports.requests[0]",
-      "~k_parent": "ir"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "h9"
     },
     "it": {
-      "key": "root.imports.requests[1]",
-      "~k_parent": "ir"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "is"
     },
     "iu": {
-      "key": "root.imports.requests[2]",
-      "~k_parent": "ir"
+      "key": "root.imports.requests",
+      "~k_parent": "fs"
     },
     "iv": {
-      "key": "root.imports.requests[3]",
-      "~k_parent": "ir"
+      "key": "root.imports.requests[0]",
+      "~k_parent": "iu"
     },
     "iw": {
-      "key": "root.imports.websockets",
-      "~k_parent": "fq"
+      "key": "root.imports.requests[1]",
+      "~k_parent": "iu"
     },
     "ix": {
-      "key": "root.imports.operators",
-      "~k_parent": "fq"
+      "key": "root.imports.requests[2]",
+      "~k_parent": "iu"
     },
     "iy": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "ix"
+      "key": "root.imports.requests[3]",
+      "~k_parent": "iu"
     },
     "iz": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "iy"
+      "key": "root.imports.websockets",
+      "~k_parent": "fs"
     },
     "j0": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "iy"
+      "key": "root.imports.operators",
+      "~k_parent": "fs"
     },
     "j1": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "iy"
+      "key": "root.imports.operators.client",
+      "~k_parent": "j0"
     },
     "j2": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "iy"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "j1"
     },
     "j3": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "iy"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "j1"
     },
     "j4": {
-      "key": "root.imports.operators.client[5]",
-      "~k_parent": "iy"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "j1"
     },
     "j5": {
-      "key": "root.imports.operators.client[6]",
-      "~k_parent": "iy"
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "j1"
     },
     "j6": {
-      "key": "root.imports.operators.client[7]",
-      "~k_parent": "iy"
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "j1"
     },
     "j7": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "ix"
+      "key": "root.imports.operators.client[5]",
+      "~k_parent": "j1"
     },
     "j8": {
-      "key": "root.imports.operators.server[0]",
-      "~k_parent": "j7"
+      "key": "root.imports.operators.client[6]",
+      "~k_parent": "j1"
     },
     "j9": {
-      "key": "root.imports.operators.server[1]",
-      "~k_parent": "j7"
+      "key": "root.imports.operators.client[7]",
+      "~k_parent": "j1"
     },
     "ja": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "j0"
+    },
+    "jb": {
+      "key": "root.imports.operators.server[0]",
+      "~k_parent": "ja"
+    },
+    "jc": {
+      "key": "root.imports.operators.server[1]",
+      "~k_parent": "ja"
+    },
+    "jd": {
       "key": "root.imports.operators.server[2]",
-      "~k_parent": "j7"
+      "~k_parent": "ja"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -3701,7 +3717,7 @@
               },
               "auth": {
                 "public": false,
-                "~k": "aj"
+                "~k": "ak"
               },
               "menuItemId": "dashboard",
               "~k": "13"
@@ -3730,9 +3746,9 @@
                         "~arr": [
                           "sales"
                         ],
-                        "~k": "am"
+                        "~k": "an"
                       },
-                      "~k": "al"
+                      "~k": "am"
                     },
                     "menuItemId": "all-customers",
                     "~k": "18"
@@ -3751,19 +3767,19 @@
                         "~arr": [
                           "sales"
                         ],
-                        "~k": "ao"
+                        "~k": "ap"
                       },
-                      "~k": "an"
+                      "~k": "ao"
                     },
                     "menuItemId": "add-customer",
                     "~k": "1a"
                   }
                 ],
-                "~k": "ak"
+                "~k": "al"
               },
               "auth": {
                 "public": true,
-                "~k": "ap"
+                "~k": "aq"
               },
               "menuItemId": "customers",
               "~k": "15"
@@ -3783,9 +3799,9 @@
                   "~arr": [
                     "sales"
                   ],
-                  "~k": "ar"
+                  "~k": "as"
                 },
-                "~k": "aq"
+                "~k": "ar"
               },
               "menuItemId": "orders",
               "~k": "1c"
@@ -3805,9 +3821,9 @@
                   "~arr": [
                     "admin"
                   ],
-                  "~k": "at"
+                  "~k": "au"
                 },
-                "~k": "as"
+                "~k": "at"
               },
               "menuItemId": "reports",
               "~k": "1e"
@@ -3827,15 +3843,15 @@
                   "~arr": [
                     "admin"
                   ],
-                  "~k": "av"
+                  "~k": "aw"
                 },
-                "~k": "au"
+                "~k": "av"
               },
               "menuItemId": "settings",
               "~k": "1g"
             }
           ],
-          "~k": "ai"
+          "~k": "aj"
         },
         "menuId": "default",
         "~k": "11"
@@ -3850,9 +3866,9 @@
       "block": {
         "minHeight": "100vh",
         "background": "var(--ant-color-bg-layout)",
-        "~k": "dj"
+        "~k": "dk"
       },
-      "~k": "di"
+      "~k": "dj"
     },
     "properties": {
       "status": "info",
@@ -3895,9 +3911,9 @@
                   },
                   "catch": {
                     "~arr": [],
-                    "~k": "dl"
+                    "~k": "dm"
                   },
-                  "~k": "dk"
+                  "~k": "dl"
                 },
                 "~k": "9w"
               },
@@ -3913,19 +3929,19 @@
     },
     "auth": {
       "public": true,
-      "~k": "dm"
+      "~k": "dn"
     },
     "pageId": "404",
     "blockId": "404",
     "subscriptions": {
       "~arr": [],
-      "~k": "dn"
+      "~k": "do"
     },
     "requests": {
       "~arr": [],
-      "~k": "do"
+      "~k": "dp"
     },
-    "~k": "dh"
+    "~k": "di"
   },
   "pages/customer-detail.json": {
     "id": "page:customer-detail",
@@ -4007,9 +4023,9 @@
         },
         "catch": {
           "~arr": [],
-          "~k": "c3"
+          "~k": "c4"
         },
-        "~k": "c2"
+        "~k": "c3"
       },
       "~k": "5y"
     },
@@ -4019,9 +4035,9 @@
         "~arr": [
           "sales"
         ],
-        "~k": "c5"
+        "~k": "c6"
       },
-      "~k": "c4"
+      "~k": "c5"
     },
     "pageId": "customer-detail",
     "blockId": "customer-detail",
@@ -4180,9 +4196,9 @@
                                       },
                                       "catch": {
                                         "~arr": [],
-                                        "~k": "cb"
+                                        "~k": "cc"
                                       },
-                                      "~k": "ca"
+                                      "~k": "cb"
                                     },
                                     "~k": "77"
                                   },
@@ -4214,9 +4230,9 @@
                                       },
                                       "catch": {
                                         "~arr": [],
-                                        "~k": "cd"
+                                        "~k": "ce"
                                       },
-                                      "~k": "cc"
+                                      "~k": "cd"
                                     },
                                     "~k": "7h"
                                   },
@@ -4226,18 +4242,18 @@
                               ],
                               "~k": "74"
                             },
-                            "~k": "c9"
+                            "~k": "ca"
                           },
-                          "~k": "c8"
+                          "~k": "c9"
                         },
                         "~k": "73"
                       }
                     ],
                     "~k": "6o"
                   },
-                  "~k": "c7"
+                  "~k": "c8"
                 },
-                "~k": "c6"
+                "~k": "c7"
               },
               "~k": "6j"
             }
@@ -4250,7 +4266,7 @@
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "ce"
+      "~k": "cf"
     },
     "requests": {
       "~arr": [
@@ -4301,9 +4317,9 @@
           "~k": "5e"
         }
       ],
-      "~k": "cf"
+      "~k": "cg"
     },
-    "~k": "c1"
+    "~k": "c2"
   },
   "pages/customer-detail/requests/getCustomer.json": {
     "id": "request:customer-detail:getCustomer",
@@ -4332,9 +4348,9 @@
         "~arr": [
           "sales"
         ],
-        "~k": "ch"
+        "~k": "ci"
       },
-      "~k": "cg"
+      "~k": "ch"
     },
     "requestId": "getCustomer",
     "pageId": "customer-detail",
@@ -4421,9 +4437,9 @@
         "~arr": [
           "sales"
         ],
-        "~k": "cj"
+        "~k": "ck"
       },
-      "~k": "ci"
+      "~k": "cj"
     },
     "requestId": "saveCustomer",
     "pageId": "customer-detail",
@@ -4451,9 +4467,9 @@
         },
         "catch": {
           "~arr": [],
-          "~k": "bh"
+          "~k": "bi"
         },
-        "~k": "bg"
+        "~k": "bh"
       },
       "~k": "3e"
     },
@@ -4463,9 +4479,9 @@
         "~arr": [
           "sales"
         ],
-        "~k": "bj"
+        "~k": "bk"
       },
-      "~k": "bi"
+      "~k": "bj"
     },
     "pageId": "customers",
     "blockId": "customers",
@@ -4512,7 +4528,7 @@
                             },
                             "catch": {
                               "~arr": [],
-                              "~k": "bm"
+                              "~k": "bn"
                             },
                             "~k": "3q"
                           },
@@ -4568,9 +4584,9 @@
                             },
                             "catch": {
                               "~arr": [],
-                              "~k": "bo"
+                              "~k": "bp"
                             },
-                            "~k": "bn"
+                            "~k": "bo"
                           },
                           "~k": "41"
                         },
@@ -4608,9 +4624,9 @@
                             },
                             "catch": {
                               "~arr": [],
-                              "~k": "bq"
+                              "~k": "br"
                             },
-                            "~k": "bp"
+                            "~k": "bq"
                           },
                           "~k": "47"
                         },
@@ -4620,9 +4636,9 @@
                     ],
                     "~k": "3l"
                   },
-                  "~k": "bl"
+                  "~k": "bm"
                 },
-                "~k": "bk"
+                "~k": "bl"
               },
               "~k": "3k"
             },
@@ -4677,9 +4693,9 @@
                             },
                             "catch": {
                               "~arr": [],
-                              "~k": "bu"
+                              "~k": "bv"
                             },
-                            "~k": "bt"
+                            "~k": "bu"
                           },
                           "~k": "4i"
                         },
@@ -4758,18 +4774,18 @@
                               ],
                               "~k": "4o"
                             },
-                            "~k": "bw"
+                            "~k": "bx"
                           },
-                          "~k": "bv"
+                          "~k": "bw"
                         },
                         "~k": "4f"
                       }
                     ],
                     "~k": "4e"
                   },
-                  "~k": "bs"
+                  "~k": "bt"
                 },
-                "~k": "br"
+                "~k": "bs"
               },
               "~k": "4b"
             }
@@ -4782,7 +4798,7 @@
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "bx"
+      "~k": "by"
     },
     "requests": {
       "~arr": [
@@ -4804,9 +4820,9 @@
           "~k": "2r"
         }
       ],
-      "~k": "by"
+      "~k": "bz"
     },
-    "~k": "bf"
+    "~k": "bg"
   },
   "pages/customers/requests/getCustomers.json": {
     "id": "request:customers:getCustomers",
@@ -4899,9 +4915,9 @@
         "~arr": [
           "sales"
         ],
-        "~k": "c0"
+        "~k": "c1"
       },
-      "~k": "bz"
+      "~k": "c0"
     },
     "requestId": "getCustomers",
     "pageId": "customers",
@@ -4929,15 +4945,15 @@
         },
         "catch": {
           "~arr": [],
-          "~k": "az"
+          "~k": "b0"
         },
-        "~k": "ay"
+        "~k": "az"
       },
       "~k": "1o"
     },
     "auth": {
       "public": false,
-      "~k": "b0"
+      "~k": "b1"
     },
     "pageId": "dashboard",
     "blockId": "dashboard",
@@ -4999,9 +5015,9 @@
                               ],
                               "~k": "22"
                             },
-                            "~k": "b4"
+                            "~k": "b5"
                           },
-                          "~k": "b3"
+                          "~k": "b4"
                         },
                         "~k": "20"
                       },
@@ -5034,9 +5050,9 @@
                               ],
                               "~k": "28"
                             },
-                            "~k": "b6"
+                            "~k": "b7"
                           },
-                          "~k": "b5"
+                          "~k": "b6"
                         },
                         "~k": "26"
                       },
@@ -5070,9 +5086,9 @@
                               ],
                               "~k": "2e"
                             },
-                            "~k": "b8"
+                            "~k": "b9"
                           },
-                          "~k": "b7"
+                          "~k": "b8"
                         },
                         "~k": "2c"
                       },
@@ -5106,18 +5122,18 @@
                               ],
                               "~k": "2k"
                             },
-                            "~k": "ba"
+                            "~k": "bb"
                           },
-                          "~k": "b9"
+                          "~k": "ba"
                         },
                         "~k": "2i"
                       }
                     ],
                     "~k": "1z"
                   },
-                  "~k": "b2"
+                  "~k": "b3"
                 },
-                "~k": "b1"
+                "~k": "b2"
               },
               "~k": "1y"
             }
@@ -5130,23 +5146,23 @@
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "bb"
+      "~k": "bc"
     },
     "requests": {
       "~arr": [
         {
           "id": "request:dashboard:getStats",
           "payload": {
-            "~k": "bd"
+            "~k": "be"
           },
           "requestId": "getStats",
           "pageId": "dashboard",
           "~k": "1m"
         }
       ],
-      "~k": "bc"
+      "~k": "bd"
     },
-    "~k": "ax"
+    "~k": "ay"
   },
   "pages/dashboard/requests/getStats.json": {
     "id": "request:dashboard:getStats",
@@ -5157,11 +5173,11 @@
       "~k": "1n"
     },
     "payload": {
-      "~k": "bd"
+      "~k": "be"
     },
     "auth": {
       "public": false,
-      "~k": "be"
+      "~k": "bf"
     },
     "requestId": "getStats",
     "pageId": "dashboard",
@@ -5178,7 +5194,7 @@
     },
     "auth": {
       "public": true,
-      "~k": "da"
+      "~k": "db"
     },
     "pageId": "login",
     "blockId": "login",
@@ -5213,9 +5229,9 @@
                   },
                   "catch": {
                     "~arr": [],
-                    "~k": "dc"
+                    "~k": "dd"
                   },
-                  "~k": "db"
+                  "~k": "dc"
                 },
                 "~k": "92"
               },
@@ -5289,9 +5305,9 @@
                   },
                   "catch": {
                     "~arr": [],
-                    "~k": "de"
+                    "~k": "df"
                   },
-                  "~k": "dd"
+                  "~k": "de"
                 },
                 "~k": "9e"
               },
@@ -5307,13 +5323,13 @@
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "df"
+      "~k": "dg"
     },
     "requests": {
       "~arr": [],
-      "~k": "dg"
+      "~k": "dh"
     },
-    "~k": "d9"
+    "~k": "da"
   },
   "pages/orders.json": {
     "id": "page:orders",
@@ -5328,9 +5344,9 @@
         "~arr": [
           "sales"
         ],
-        "~k": "cm"
+        "~k": "cn"
       },
-      "~k": "cl"
+      "~k": "cm"
     },
     "pageId": "orders",
     "blockId": "orders",
@@ -5361,19 +5377,19 @@
           ],
           "~k": "7n"
         },
-        "~k": "co"
+        "~k": "cp"
       },
-      "~k": "cn"
+      "~k": "co"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "cp"
+      "~k": "cq"
     },
     "requests": {
       "~arr": [],
-      "~k": "cq"
+      "~k": "cr"
     },
-    "~k": "ck"
+    "~k": "cl"
   },
   "pages/reports.json": {
     "id": "page:reports",
@@ -5388,9 +5404,9 @@
         "~arr": [
           "admin"
         ],
-        "~k": "ct"
+        "~k": "cu"
       },
-      "~k": "cs"
+      "~k": "ct"
     },
     "pageId": "reports",
     "blockId": "reports",
@@ -5421,19 +5437,19 @@
           ],
           "~k": "7u"
         },
-        "~k": "cv"
+        "~k": "cw"
       },
-      "~k": "cu"
+      "~k": "cv"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "cw"
+      "~k": "cx"
     },
     "requests": {
       "~arr": [],
-      "~k": "cx"
+      "~k": "cy"
     },
-    "~k": "cr"
+    "~k": "cs"
   },
   "pages/settings.json": {
     "id": "page:settings",
@@ -5448,9 +5464,9 @@
         "~arr": [
           "admin"
         ],
-        "~k": "d0"
+        "~k": "d1"
       },
-      "~k": "cz"
+      "~k": "d0"
     },
     "pageId": "settings",
     "blockId": "settings",
@@ -5593,9 +5609,9 @@
                             },
                             "catch": {
                               "~arr": [],
-                              "~k": "d6"
+                              "~k": "d7"
                             },
-                            "~k": "d5"
+                            "~k": "d6"
                           },
                           "~k": "8m"
                         },
@@ -5605,28 +5621,28 @@
                     ],
                     "~k": "86"
                   },
-                  "~k": "d4"
+                  "~k": "d5"
                 },
-                "~k": "d3"
+                "~k": "d4"
               },
               "~k": "84"
             }
           ],
           "~k": "81"
         },
-        "~k": "d2"
+        "~k": "d3"
       },
-      "~k": "d1"
+      "~k": "d2"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "d7"
+      "~k": "d8"
     },
     "requests": {
       "~arr": [],
-      "~k": "d8"
+      "~k": "d9"
     },
-    "~k": "cy"
+    "~k": "cz"
   },
   "plugins/actionSchemas.json": {
     "Request": {
@@ -5838,6 +5854,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "import { MongoDBAuthAdapter as MongoDBAuthAdapter } from '@lowdefy/connection-mongodb/auth/adapters';\nexport default {\n  MongoDBAuthAdapter,\n  };",
   "plugins/auth/providers.js": "import { Google as Google } from '@lowdefy/plugin-better-auth/auth/providers';\nexport default {\n  Google,\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "PageHeaderMenu": {
       "category": "container"
@@ -17710,54 +17727,54 @@
         "originalTypeName": "Request",
         "package": "@lowdefy/actions-core",
         "count": 6,
-        "~k": "dr"
+        "~k": "ds"
       },
       "Link": {
         "originalTypeName": "Link",
         "package": "@lowdefy/actions-core",
         "count": 5,
-        "~k": "ds"
+        "~k": "dt"
       },
       "SetState": {
         "originalTypeName": "SetState",
         "package": "@lowdefy/actions-core",
         "count": 2,
-        "~k": "dt"
+        "~k": "du"
       },
       "Validate": {
         "originalTypeName": "Validate",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "du"
+        "~k": "dv"
       },
       "DisplayMessage": {
         "originalTypeName": "DisplayMessage",
         "package": "@lowdefy/actions-core",
         "count": 2,
-        "~k": "dv"
+        "~k": "dw"
       },
       "SetGlobal": {
         "originalTypeName": "SetGlobal",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "dw"
+        "~k": "dx"
       },
       "Login": {
         "originalTypeName": "Login",
         "package": "@lowdefy/actions-core",
         "count": 2,
-        "~k": "dx"
+        "~k": "dy"
       },
       "SetDarkMode": {
         "originalTypeName": "SetDarkMode",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "dy"
+        "~k": "dz"
       },
-      "~k": "dq"
+      "~k": "dr"
     },
     "agents": {
-      "~k": "dz"
+      "~k": "e0"
     },
     "auth": {
       "adapters": {
@@ -17765,263 +17782,266 @@
           "originalTypeName": "MongoDBAuthAdapter",
           "package": "@lowdefy/connection-mongodb",
           "count": 1,
-          "~k": "e2"
+          "~k": "e3"
         },
-        "~k": "e1"
+        "~k": "e2"
       },
       "providers": {
         "Google": {
           "originalTypeName": "Google",
           "package": "@lowdefy/plugin-better-auth",
           "count": 1,
-          "~k": "e4"
+          "~k": "e5"
         },
-        "~k": "e3"
+        "~k": "e4"
       },
-      "~k": "e0"
+      "strategies": {
+        "~k": "e6"
+      },
+      "~k": "e1"
     },
     "blocks": {
       "PageHeaderMenu": {
         "originalTypeName": "PageHeaderMenu",
         "package": "@lowdefy/blocks-antd",
         "count": 6,
-        "~k": "e6"
+        "~k": "e8"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "e7"
+        "~k": "e9"
       },
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "e8"
+        "~k": "ea"
       },
       "Card": {
         "originalTypeName": "Card",
         "package": "@lowdefy/blocks-antd",
         "count": 7,
-        "~k": "e9"
+        "~k": "eb"
       },
       "Statistic": {
         "originalTypeName": "Statistic",
         "package": "@lowdefy/blocks-antd",
         "count": 4,
-        "~k": "ea"
+        "~k": "ec"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 5,
-        "~k": "eb"
+        "~k": "ed"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 3,
-        "~k": "ec"
+        "~k": "ee"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "ed"
+        "~k": "ef"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "ee"
+        "~k": "eg"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "ef"
+        "~k": "eh"
       },
       "Tag": {
         "originalTypeName": "Tag",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "eg"
+        "~k": "ei"
       },
       "TextArea": {
         "originalTypeName": "TextArea",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "eh"
+        "~k": "ej"
       },
       "NumberInput": {
         "originalTypeName": "NumberInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "ei"
+        "~k": "ek"
       },
       "Switch": {
         "originalTypeName": "Switch",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "ej"
+        "~k": "el"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "ek"
+        "~k": "em"
       },
       "Divider": {
         "originalTypeName": "Divider",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "el"
+        "~k": "en"
       },
       "PasswordInput": {
         "originalTypeName": "PasswordInput",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "em"
+        "~k": "eo"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "en"
+        "~k": "ep"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "eo"
+        "~k": "eq"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "ep"
+        "~k": "er"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "eq"
+        "~k": "es"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "er"
+        "~k": "et"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "es"
+        "~k": "eu"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "et"
+        "~k": "ev"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "eu"
+        "~k": "ew"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "ev"
+        "~k": "ex"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "ew"
+        "~k": "ey"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "ex"
+        "~k": "ez"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "ey"
+        "~k": "f0"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "ez"
+        "~k": "f1"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "f0"
+        "~k": "f2"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "f1"
+        "~k": "f3"
       },
-      "~k": "e5"
+      "~k": "e7"
     },
     "connections": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 1,
-        "~k": "f3"
+        "~k": "f5"
       },
       "MongoDBCollection": {
         "originalTypeName": "MongoDBCollection",
         "package": "@lowdefy/connection-mongodb",
         "count": 2,
-        "~k": "f4"
+        "~k": "f6"
       },
-      "~k": "f2"
+      "~k": "f4"
     },
     "requests": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 1,
-        "~k": "f6"
+        "~k": "f8"
       },
       "MongoDBFind": {
         "originalTypeName": "MongoDBFind",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "f7"
+        "~k": "f9"
       },
       "MongoDBFindOne": {
         "originalTypeName": "MongoDBFindOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "f8"
+        "~k": "fa"
       },
       "MongoDBUpdateOne": {
         "originalTypeName": "MongoDBUpdateOne",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "f9"
+        "~k": "fb"
       },
-      "~k": "f5"
+      "~k": "f7"
     },
     "websockets": {
-      "~k": "fa"
+      "~k": "fc"
     },
     "api": {
-      "~k": "fb"
+      "~k": "fd"
     },
     "operators": {
       "client": {
@@ -18029,75 +18049,75 @@
           "originalTypeName": "_user",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "fe"
+          "~k": "fg"
         },
         "_request": {
           "originalTypeName": "_request",
           "package": "@lowdefy/operators-js",
           "count": 10,
-          "~k": "ff"
+          "~k": "fh"
         },
         "_state": {
           "originalTypeName": "_state",
           "package": "@lowdefy/operators-js",
           "count": 18,
-          "~k": "fg"
+          "~k": "fi"
         },
         "_if": {
           "originalTypeName": "_if",
           "package": "@lowdefy/operators-js",
           "count": 3,
-          "~k": "fh"
+          "~k": "fj"
         },
         "_eq": {
           "originalTypeName": "_eq",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "fi"
+          "~k": "fk"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 4,
-          "~k": "fj"
+          "~k": "fl"
         },
         "_url_query": {
           "originalTypeName": "_url_query",
           "package": "@lowdefy/operators-js",
           "count": 5,
-          "~k": "fk"
+          "~k": "fm"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "fl"
+          "~k": "fn"
         },
-        "~k": "fd"
+        "~k": "ff"
       },
       "server": {
         "_payload": {
           "originalTypeName": "_payload",
           "package": "@lowdefy/operators-js",
           "count": 11,
-          "~k": "fn"
+          "~k": "fp"
         },
         "_if": {
           "originalTypeName": "_if",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "fo"
+          "~k": "fq"
         },
         "_date": {
           "originalTypeName": "_date",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "fp"
+          "~k": "fr"
         },
-        "~k": "fm"
+        "~k": "fo"
       },
-      "~k": "fc"
+      "~k": "fe"
     },
-    "~k": "dp"
+    "~k": "dq"
   }
 }

--- a/packages/build/src/tests/success/56-build-operator-in-ref-vars/snapshot.json
+++ b/packages/build/src/tests/success/56-build-operator-in-ref-vars/snapshot.json
@@ -154,147 +154,147 @@
       "~k_parent": "21"
     },
     "24": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "21"
+    },
+    "25": {
       "key": "root.types.blocks",
       "~k_parent": "1v"
     },
-    "25": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "24"
-    },
     "26": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "25"
     },
     "27": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "25"
     },
     "28": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "25"
     },
     "29": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "25"
     },
     "30": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2y"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2z"
     },
     "31": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "2y"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2z"
     },
     "32": {
-      "key": "root.imports.agents",
-      "~k_parent": "2x"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "2z"
     },
     "33": {
-      "key": "root.imports.auth",
-      "~k_parent": "2x"
+      "key": "root.imports.agents",
+      "~k_parent": "2y"
     },
     "34": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "33"
+      "key": "root.imports.auth",
+      "~k_parent": "2y"
     },
     "35": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "33"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "34"
     },
     "36": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2x"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "34"
     },
     "37": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "36"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "34"
     },
     "38": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks",
+      "~k_parent": "2y"
     },
     "39": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "38"
     },
     "40": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3t"
     },
     "41": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3t"
     },
     "43": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3t"
     },
     "45": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3t"
     },
     "47": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3t"
     },
     "49": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3t"
     },
     "51": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3t"
     },
     "53": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3t"
     },
     "55": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3t"
     },
     "57": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3t"
     },
     "59": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "58"
     },
     "a": {
@@ -508,352 +508,360 @@
       "~k_parent": "1w"
     },
     "2a": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "24"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "25"
     },
     "2b": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "25"
     },
     "2c": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "25"
     },
     "2d": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "25"
     },
     "2e": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "24"
+      "key": "root.types.blocks.List",
+      "~k_parent": "25"
     },
     "2f": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "25"
     },
     "2g": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "25"
     },
     "2h": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "24"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "25"
     },
     "2i": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "25"
     },
     "2j": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "24"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "25"
     },
     "2k": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "24"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "25"
     },
     "2l": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "24"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "25"
     },
     "2m": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "24"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "25"
     },
     "2n": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "24"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "25"
     },
     "2o": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "25"
+    },
+    "2p": {
       "key": "root.types.connections",
       "~k_parent": "1v"
     },
-    "2p": {
+    "2q": {
       "key": "root.types.requests",
       "~k_parent": "1v"
     },
-    "2q": {
+    "2r": {
       "key": "root.types.websockets",
       "~k_parent": "1v"
     },
-    "2r": {
+    "2s": {
       "key": "root.types.api",
       "~k_parent": "1v"
     },
-    "2s": {
+    "2t": {
       "key": "root.types.operators",
       "~k_parent": "1v"
     },
-    "2t": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2s"
-    },
     "2u": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2t"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2s"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2u"
     },
     "2x": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2t"
+    },
+    "2y": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2y": {
-      "key": "root.imports.actions",
-      "~k_parent": "2x"
-    },
     "2z": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "38"
     },
     "3b": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "38"
     },
     "3c": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "38"
     },
     "3d": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "38"
     },
     "3e": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "38"
     },
     "3f": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "38"
     },
     "3g": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "38"
     },
     "3h": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "38"
     },
     "3i": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "38"
     },
     "3j": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "38"
     },
     "3k": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "38"
     },
     "3l": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "38"
     },
     "3m": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "38"
     },
     "3n": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "38"
     },
     "3o": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "38"
     },
     "3p": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "38"
     },
     "3q": {
-      "key": "root.imports.connections",
-      "~k_parent": "2x"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "38"
     },
     "3r": {
-      "key": "root.imports.icons",
-      "~k_parent": "2x"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "38"
     },
     "3s": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3r"
+      "key": "root.imports.connections",
+      "~k_parent": "2y"
     },
     "3t": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3s"
+      "key": "root.imports.icons",
+      "~k_parent": "2y"
     },
     "3u": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3t"
     },
     "3x": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3t"
     },
     "3z": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3t"
     },
     "4b": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3t"
     },
     "4d": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3t"
     },
     "4f": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3t"
     },
     "4h": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3t"
     },
     "4j": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3t"
     },
     "4l": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3t"
     },
     "4n": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3t"
     },
     "4p": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3t"
     },
     "4r": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3t"
     },
     "4t": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3t"
     },
     "4v": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3t"
     },
     "4x": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3t"
     },
     "4z": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3r"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3t"
     },
     "5b": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.requests",
-      "~k_parent": "2x"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3t"
     },
     "5d": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2x"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.operators",
-      "~k_parent": "2x"
+      "key": "root.imports.requests",
+      "~k_parent": "2y"
     },
     "5f": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5e"
+      "key": "root.imports.websockets",
+      "~k_parent": "2y"
     },
     "5g": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5f"
+      "key": "root.imports.operators",
+      "~k_parent": "2y"
     },
     "5h": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5f"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5g"
     },
     "5i": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5h"
+    },
+    "5j": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5h"
+    },
+    "5k": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5e"
+      "~k_parent": "5g"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1107,6 +1115,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5617,6 +5626,9 @@
       "providers": {
         "~k": "23"
       },
+      "strategies": {
+        "~k": "24"
+      },
       "~k": "21"
     },
     "blocks": {
@@ -5624,129 +5636,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "25"
+        "~k": "26"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "26"
+        "~k": "27"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
-      "~k": "24"
+      "~k": "25"
     },
     "connections": {
-      "~k": "2o"
-    },
-    "requests": {
       "~k": "2p"
     },
-    "websockets": {
+    "requests": {
       "~k": "2q"
     },
-    "api": {
+    "websockets": {
       "~k": "2r"
+    },
+    "api": {
+      "~k": "2s"
     },
     "operators": {
       "client": {
@@ -5754,20 +5766,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2u"
+          "~k": "2v"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2v"
+          "~k": "2w"
         },
-        "~k": "2t"
+        "~k": "2u"
       },
       "server": {
-        "~k": "2w"
+        "~k": "2x"
       },
-      "~k": "2s"
+      "~k": "2t"
     },
     "~k": "1v"
   }

--- a/packages/build/src/tests/success/57-static-op-with-dynamic-child-in-vars/snapshot.json
+++ b/packages/build/src/tests/success/57-static-op-with-dynamic-child-in-vars/snapshot.json
@@ -162,136 +162,136 @@
       "~k_parent": "24"
     },
     "27": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "24"
+    },
+    "28": {
       "key": "root.types.blocks",
       "~k_parent": "1z"
     },
-    "28": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "27"
-    },
     "29": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.operators.client._url_query",
-      "~k_parent": "2x"
+      "key": "root.types.operators.client._eq",
+      "~k_parent": "2y"
     },
     "31": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "2x"
+      "key": "root.types.operators.client._url_query",
+      "~k_parent": "2y"
     },
     "32": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2x"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2y"
     },
     "33": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2w"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2y"
     },
     "34": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2x"
+    },
+    "35": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "35": {
-      "key": "root.imports.actions",
-      "~k_parent": "34"
-    },
     "36": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "35"
     },
     "37": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "35"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "36"
     },
     "38": {
-      "key": "root.imports.agents",
-      "~k_parent": "34"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "36"
     },
     "39": {
-      "key": "root.imports.auth",
-      "~k_parent": "34"
+      "key": "root.imports.agents",
+      "~k_parent": "35"
     },
     "40": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3z"
+      "key": "root.imports.icons",
+      "~k_parent": "35"
     },
     "41": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "40"
     },
     "44": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "40"
     },
     "46": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "40"
     },
     "48": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "40"
     },
     "50": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "40"
     },
     "52": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "40"
     },
     "54": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "40"
     },
     "56": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "40"
     },
     "58": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "40"
     },
     "a": {
       "key": "root.pages[0:login:Box].blocks[0:error_message:Paragraph].properties.content",
@@ -520,392 +520,400 @@
       "~k_parent": "4"
     },
     "2a": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "28"
     },
     "2b": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "28"
     },
     "2c": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "28"
     },
     "2d": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "28"
     },
     "2e": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "27"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "28"
     },
     "2f": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "28"
     },
     "2g": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "28"
     },
     "2h": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "28"
     },
     "2i": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "27"
+      "key": "root.types.blocks.List",
+      "~k_parent": "28"
     },
     "2j": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "28"
     },
     "2k": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "28"
     },
     "2l": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "27"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "28"
     },
     "2m": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "28"
     },
     "2n": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "28"
     },
     "2o": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "28"
     },
     "2p": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "28"
     },
     "2q": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "28"
     },
     "2r": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "28"
     },
     "2s": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "28"
+    },
+    "2t": {
       "key": "root.types.connections",
       "~k_parent": "1z"
     },
-    "2t": {
+    "2u": {
       "key": "root.types.requests",
       "~k_parent": "1z"
     },
-    "2u": {
+    "2v": {
       "key": "root.types.websockets",
       "~k_parent": "1z"
     },
-    "2v": {
+    "2w": {
       "key": "root.types.api",
       "~k_parent": "1z"
     },
-    "2w": {
+    "2x": {
       "key": "root.types.operators",
       "~k_parent": "1z"
     },
-    "2x": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2w"
-    },
     "2y": {
-      "key": "root.types.operators.client._switch",
+      "key": "root.types.operators.client",
       "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.types.operators.client._eq",
-      "~k_parent": "2x"
+      "key": "root.types.operators.client._switch",
+      "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "39"
+      "key": "root.imports.auth",
+      "~k_parent": "35"
     },
     "3b": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "39"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3a"
     },
     "3c": {
-      "key": "root.imports.blocks",
-      "~k_parent": "34"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3a"
     },
     "3d": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3c"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3a"
     },
     "3e": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks",
+      "~k_parent": "35"
     },
     "3f": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3e"
     },
     "3h": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3e"
     },
     "3i": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3e"
     },
     "3j": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3e"
     },
     "3k": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3e"
     },
     "3l": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3e"
     },
     "3m": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3e"
     },
     "3n": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3e"
     },
     "3o": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3e"
     },
     "3p": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3e"
     },
     "3q": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3e"
     },
     "3r": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3e"
     },
     "3s": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3e"
     },
     "3t": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3e"
     },
     "3u": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3e"
     },
     "3v": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3e"
     },
     "3w": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3e"
     },
     "3x": {
-      "key": "root.imports.connections",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3e"
     },
     "3y": {
-      "key": "root.imports.icons",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3e"
     },
     "3z": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3y"
+      "key": "root.imports.connections",
+      "~k_parent": "35"
     },
     "4a": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "40"
     },
     "4c": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "40"
     },
     "4e": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "40"
     },
     "4g": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "40"
     },
     "4i": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "40"
     },
     "4k": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "40"
     },
     "4m": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "40"
     },
     "4o": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "40"
     },
     "4q": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "40"
     },
     "4s": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "40"
     },
     "4u": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "40"
     },
     "4w": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "40"
     },
     "4y": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "40"
     },
     "5a": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "40"
     },
     "5c": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "40"
     },
     "5e": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "40"
     },
     "5g": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "40"
     },
     "5i": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.requests",
-      "~k_parent": "34"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "40"
     },
     "5k": {
-      "key": "root.imports.websockets",
-      "~k_parent": "34"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.operators",
-      "~k_parent": "34"
+      "key": "root.imports.requests",
+      "~k_parent": "35"
     },
     "5m": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5l"
+      "key": "root.imports.websockets",
+      "~k_parent": "35"
     },
     "5n": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5m"
+      "key": "root.imports.operators",
+      "~k_parent": "35"
     },
     "5o": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5m"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "5m"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.operators.client[3]",
-      "~k_parent": "5m"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5o"
     },
     "5r": {
-      "key": "root.imports.operators.client[4]",
-      "~k_parent": "5m"
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "5o"
     },
     "5s": {
+      "key": "root.imports.operators.client[3]",
+      "~k_parent": "5o"
+    },
+    "5t": {
+      "key": "root.imports.operators.client[4]",
+      "~k_parent": "5o"
+    },
+    "5u": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5l"
+      "~k_parent": "5n"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1168,6 +1176,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5758,6 +5767,9 @@
       "providers": {
         "~k": "26"
       },
+      "strategies": {
+        "~k": "27"
+      },
       "~k": "24"
     },
     "blocks": {
@@ -5765,135 +5777,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "28"
+        "~k": "29"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
-      "~k": "27"
+      "~k": "28"
     },
     "connections": {
-      "~k": "2s"
-    },
-    "requests": {
       "~k": "2t"
     },
-    "websockets": {
+    "requests": {
       "~k": "2u"
     },
-    "api": {
+    "websockets": {
       "~k": "2v"
+    },
+    "api": {
+      "~k": "2w"
     },
     "operators": {
       "client": {
@@ -5901,38 +5913,38 @@
           "originalTypeName": "_switch",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2y"
+          "~k": "2z"
         },
         "_eq": {
           "originalTypeName": "_eq",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "2z"
+          "~k": "30"
         },
         "_url_query": {
           "originalTypeName": "_url_query",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "30"
+          "~k": "31"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "31"
+          "~k": "32"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "32"
+          "~k": "33"
         },
-        "~k": "2x"
+        "~k": "2y"
       },
       "server": {
-        "~k": "33"
+        "~k": "34"
       },
-      "~k": "2w"
+      "~k": "2x"
     },
     "~k": "1z"
   }

--- a/packages/build/src/tests/success/58-build-array-map-with-var/snapshot.json
+++ b/packages/build/src/tests/success/58-build-array-map-with-var/snapshot.json
@@ -138,164 +138,164 @@
       "~k_parent": "12"
     },
     "20": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1x"
     },
     "21": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1x"
     },
     "22": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1x"
     },
     "23": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1x"
     },
     "24": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1x"
     },
     "25": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1x"
     },
     "26": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1x"
     },
     "27": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1x"
     },
     "28": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1x"
     },
     "29": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1x"
     },
     "30": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks",
+      "~k_parent": "2r"
     },
     "31": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "30"
     },
     "32": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "30"
     },
     "33": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "30"
     },
     "34": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "30"
     },
     "35": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "30"
     },
     "36": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "30"
     },
     "37": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "30"
     },
     "38": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "30"
     },
     "39": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "30"
     },
     "40": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3m"
     },
     "42": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3m"
     },
     "44": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3m"
     },
     "46": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3m"
     },
     "48": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3m"
     },
     "50": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3m"
     },
     "52": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3m"
     },
     "54": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.requests",
-      "~k_parent": "2q"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3m"
     },
     "56": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2q"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.operators",
-      "~k_parent": "2q"
+      "key": "root.imports.requests",
+      "~k_parent": "2r"
     },
     "58": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "57"
+      "key": "root.imports.websockets",
+      "~k_parent": "2r"
     },
     "59": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "58"
+      "key": "root.imports.operators",
+      "~k_parent": "2r"
     },
     "b": {
       "key": "root.pages",
@@ -482,340 +482,348 @@
       "~k_parent": "1t"
     },
     "1w": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1t"
+    },
+    "1x": {
       "key": "root.types.blocks",
       "~k_parent": "1o"
     },
-    "1x": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1w"
-    },
     "1y": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1x"
     },
     "1z": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "1x"
     },
     "2a": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1x"
     },
     "2b": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1x"
     },
     "2c": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1x"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1x"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1x"
     },
     "2f": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1x"
     },
     "2g": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1w"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1x"
     },
     "2h": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1x"
+    },
+    "2i": {
       "key": "root.types.connections",
       "~k_parent": "1o"
     },
-    "2i": {
+    "2j": {
       "key": "root.types.requests",
       "~k_parent": "1o"
     },
-    "2j": {
+    "2k": {
       "key": "root.types.websockets",
       "~k_parent": "1o"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.api",
       "~k_parent": "1o"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.operators",
       "~k_parent": "1o"
     },
-    "2m": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2l"
-    },
     "2n": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2m"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2l"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2n"
     },
     "2q": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2m"
+    },
+    "2r": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2r": {
-      "key": "root.imports.actions",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2r"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.imports.agents",
-      "~k_parent": "2q"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2s"
     },
     "2v": {
-      "key": "root.imports.auth",
-      "~k_parent": "2q"
+      "key": "root.imports.agents",
+      "~k_parent": "2r"
     },
     "2w": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2v"
+      "key": "root.imports.auth",
+      "~k_parent": "2r"
     },
     "2x": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2v"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2q"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2w"
     },
     "2z": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2y"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2w"
     },
     "3a": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "30"
     },
     "3b": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "30"
     },
     "3c": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "30"
     },
     "3d": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "30"
     },
     "3e": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "30"
     },
     "3f": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "30"
     },
     "3g": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "30"
     },
     "3h": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "30"
     },
     "3i": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "2y"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "30"
     },
     "3j": {
-      "key": "root.imports.connections",
-      "~k_parent": "2q"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "30"
     },
     "3k": {
-      "key": "root.imports.icons",
-      "~k_parent": "2q"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "30"
     },
     "3l": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3k"
+      "key": "root.imports.connections",
+      "~k_parent": "2r"
     },
     "3m": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3l"
+      "key": "root.imports.icons",
+      "~k_parent": "2r"
     },
     "3n": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3m"
     },
     "3u": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3m"
     },
     "3w": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3m"
     },
     "3y": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3m"
     },
     "4a": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3m"
     },
     "4c": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3m"
     },
     "4e": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3m"
     },
     "4g": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3m"
     },
     "4i": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3m"
     },
     "4k": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3m"
     },
     "4m": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3m"
     },
     "4o": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3m"
     },
     "4q": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3m"
     },
     "4s": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3m"
     },
     "4u": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3m"
     },
     "4w": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3m"
     },
     "4y": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3m"
     },
     "5a": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "58"
+      "key": "root.imports.operators.client",
+      "~k_parent": "59"
     },
     "5b": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5a"
+    },
+    "5c": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5a"
+    },
+    "5d": {
       "key": "root.imports.operators.server",
-      "~k_parent": "57"
+      "~k_parent": "59"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1033,6 +1041,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5537,6 +5546,9 @@
       "providers": {
         "~k": "1v"
       },
+      "strategies": {
+        "~k": "1w"
+      },
       "~k": "1t"
     },
     "blocks": {
@@ -5544,135 +5556,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1x"
+        "~k": "1y"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "1y"
+        "~k": "1z"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "1z"
+        "~k": "20"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
-      "~k": "1w"
+      "~k": "1x"
     },
     "connections": {
-      "~k": "2h"
-    },
-    "requests": {
       "~k": "2i"
     },
-    "websockets": {
+    "requests": {
       "~k": "2j"
     },
-    "api": {
+    "websockets": {
       "~k": "2k"
+    },
+    "api": {
+      "~k": "2l"
     },
     "operators": {
       "client": {
@@ -5680,20 +5692,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2n"
+          "~k": "2o"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2o"
+          "~k": "2p"
         },
-        "~k": "2m"
+        "~k": "2n"
       },
       "server": {
-        "~k": "2p"
+        "~k": "2q"
       },
-      "~k": "2l"
+      "~k": "2m"
     },
     "~k": "1o"
   }

--- a/packages/build/src/tests/success/60-module-single-basic/snapshot.json
+++ b/packages/build/src/tests/success/60-module-single-basic/snapshot.json
@@ -165,127 +165,127 @@
       "~k_parent": "26"
     },
     "29": {
-      "key": "root.types.blocks",
-      "~k_parent": "21"
+      "key": "root.types.auth.strategies",
+      "~k_parent": "26"
     },
     "30": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2z"
     },
     "31": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2z"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "30"
     },
     "32": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2y"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "30"
     },
     "33": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2z"
+    },
+    "34": {
       "key": "root.imports",
       "~k_parent": "5"
     },
-    "34": {
-      "key": "root.imports.actions",
-      "~k_parent": "33"
-    },
     "35": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "34"
     },
     "36": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "34"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "35"
     },
     "37": {
-      "key": "root.imports.agents",
-      "~k_parent": "33"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "35"
     },
     "38": {
-      "key": "root.imports.auth",
-      "~k_parent": "33"
+      "key": "root.imports.agents",
+      "~k_parent": "34"
     },
     "39": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "38"
+      "key": "root.imports.auth",
+      "~k_parent": "34"
     },
     "40": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3z"
     },
     "43": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3z"
     },
     "45": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3z"
     },
     "47": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3z"
     },
     "49": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3z"
     },
     "51": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3z"
     },
     "53": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3z"
     },
     "55": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3z"
     },
     "57": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3z"
     },
     "59": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "58"
     },
     "a": {
@@ -498,376 +498,384 @@
       "~k_parent": "1w"
     },
     "2a": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "29"
+      "key": "root.types.blocks",
+      "~k_parent": "21"
     },
     "2b": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2a"
     },
     "2c": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2a"
     },
     "2d": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2a"
     },
     "2e": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2a"
     },
     "2f": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2a"
     },
     "2g": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "29"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2a"
     },
     "2h": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2a"
     },
     "2i": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2a"
     },
     "2j": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2a"
     },
     "2k": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "29"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2a"
     },
     "2l": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2a"
     },
     "2m": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2a"
     },
     "2n": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "29"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2a"
     },
     "2o": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2a"
     },
     "2p": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "29"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2a"
     },
     "2q": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "29"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2a"
     },
     "2r": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "29"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2a"
     },
     "2s": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "29"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2a"
     },
     "2t": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "29"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2a"
     },
     "2u": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2a"
+    },
+    "2v": {
       "key": "root.types.connections",
       "~k_parent": "21"
     },
-    "2v": {
+    "2w": {
       "key": "root.types.requests",
       "~k_parent": "21"
     },
-    "2w": {
+    "2x": {
       "key": "root.types.websockets",
       "~k_parent": "21"
     },
-    "2x": {
+    "2y": {
       "key": "root.types.api",
       "~k_parent": "21"
     },
-    "2y": {
+    "2z": {
       "key": "root.types.operators",
       "~k_parent": "21"
     },
-    "2z": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2y"
-    },
     "3a": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "38"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "39"
     },
     "3b": {
-      "key": "root.imports.blocks",
-      "~k_parent": "33"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "39"
     },
     "3c": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3b"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "39"
     },
     "3d": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks",
+      "~k_parent": "34"
     },
     "3e": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3d"
     },
     "3f": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3d"
     },
     "3g": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3d"
     },
     "3h": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3d"
     },
     "3i": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3d"
     },
     "3j": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3d"
     },
     "3k": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3d"
     },
     "3l": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3d"
     },
     "3m": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3d"
     },
     "3n": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3d"
     },
     "3o": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3d"
     },
     "3p": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3d"
     },
     "3q": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3d"
     },
     "3r": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3d"
     },
     "3s": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3d"
     },
     "3t": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3d"
     },
     "3u": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3d"
     },
     "3v": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3b"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3d"
     },
     "3w": {
-      "key": "root.imports.connections",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3d"
     },
     "3x": {
-      "key": "root.imports.icons",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3d"
     },
     "3y": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3x"
+      "key": "root.imports.connections",
+      "~k_parent": "34"
     },
     "3z": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3y"
+      "key": "root.imports.icons",
+      "~k_parent": "34"
     },
     "4a": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3z"
     },
     "4b": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3z"
     },
     "4d": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3z"
     },
     "4f": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3z"
     },
     "4h": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3z"
     },
     "4j": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3z"
     },
     "4l": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3z"
     },
     "4n": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3z"
     },
     "4p": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3z"
     },
     "4r": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3z"
     },
     "4t": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3z"
     },
     "4v": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3z"
     },
     "4x": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3z"
     },
     "4z": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3z"
     },
     "5b": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3z"
     },
     "5d": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3z"
     },
     "5f": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3z"
     },
     "5h": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.requests",
-      "~k_parent": "33"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3z"
     },
     "5j": {
-      "key": "root.imports.websockets",
-      "~k_parent": "33"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.operators",
-      "~k_parent": "33"
+      "key": "root.imports.requests",
+      "~k_parent": "34"
     },
     "5l": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5k"
+      "key": "root.imports.websockets",
+      "~k_parent": "34"
     },
     "5m": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5l"
+      "key": "root.imports.operators",
+      "~k_parent": "34"
     },
     "5n": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5l"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5m"
     },
     "5o": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5n"
+    },
+    "5p": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5n"
+    },
+    "5q": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5k"
+      "~k_parent": "5m"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1136,6 +1144,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5638,6 +5647,9 @@
       "providers": {
         "~k": "28"
       },
+      "strategies": {
+        "~k": "29"
+      },
       "~k": "26"
     },
     "blocks": {
@@ -5645,135 +5657,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
-      "~k": "29"
+      "~k": "2a"
     },
     "connections": {
-      "~k": "2u"
-    },
-    "requests": {
       "~k": "2v"
     },
-    "websockets": {
+    "requests": {
       "~k": "2w"
     },
-    "api": {
+    "websockets": {
       "~k": "2x"
+    },
+    "api": {
+      "~k": "2y"
     },
     "operators": {
       "client": {
@@ -5781,20 +5793,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "30"
+          "~k": "31"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "31"
+          "~k": "32"
         },
-        "~k": "2z"
+        "~k": "30"
       },
       "server": {
-        "~k": "32"
+        "~k": "33"
       },
-      "~k": "2y"
+      "~k": "2z"
     },
     "~k": "21"
   }

--- a/packages/build/src/tests/success/61-module-multi-instance/snapshot.json
+++ b/packages/build/src/tests/success/61-module-multi-instance/snapshot.json
@@ -277,140 +277,148 @@
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "4h"
     },
     "51": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "4h"
     },
     "52": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "4h"
+    },
+    "53": {
       "key": "root.types.connections",
       "~k_parent": "48"
     },
-    "53": {
-      "key": "root.types.connections.MongoDBCollection",
-      "~k_parent": "52"
-    },
     "54": {
+      "key": "root.types.connections.MongoDBCollection",
+      "~k_parent": "53"
+    },
+    "55": {
       "key": "root.types.requests",
       "~k_parent": "48"
     },
-    "55": {
-      "key": "root.types.requests.MongoDBFind",
-      "~k_parent": "54"
-    },
     "56": {
+      "key": "root.types.requests.MongoDBFind",
+      "~k_parent": "55"
+    },
+    "57": {
       "key": "root.types.websockets",
       "~k_parent": "48"
     },
-    "57": {
+    "58": {
       "key": "root.types.api",
       "~k_parent": "48"
     },
-    "58": {
+    "59": {
       "key": "root.types.operators",
       "~k_parent": "48"
     },
-    "59": {
-      "key": "root.types.operators.client",
-      "~k_parent": "58"
-    },
     "60": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "5o"
     },
     "61": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "5o"
     },
     "62": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "5o"
     },
     "63": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "5o"
     },
     "64": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "5o"
     },
     "65": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "5o"
     },
     "66": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "5o"
     },
     "67": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "5o"
     },
     "68": {
-      "key": "root.imports.connections",
-      "~k_parent": "5e"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "5o"
     },
     "69": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "68"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "5o"
     },
     "70": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "6z"
     },
     "71": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "6c"
     },
     "72": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "71"
     },
     "73": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "6c"
     },
     "74": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "73"
     },
     "75": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "6c"
     },
     "76": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "75"
     },
     "77": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "6c"
     },
     "78": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "77"
     },
     "79": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "6c"
     },
     "80": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "7z"
+      "key": "root.imports.operators",
+      "~k_parent": "5f"
     },
     "81": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "7z"
+      "key": "root.imports.operators.client",
+      "~k_parent": "80"
     },
     "82": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "7y"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "81"
     },
     "83": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "81"
+    },
+    "84": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "80"
+    },
+    "85": {
       "key": "root.imports.operators.server[0]",
-      "~k_parent": "82"
+      "~k_parent": "84"
     },
     "a": {
       "key": "root.pages",
@@ -922,396 +930,396 @@
       "~k_parent": "4d"
     },
     "4g": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "4d"
+    },
+    "4h": {
       "key": "root.types.blocks",
       "~k_parent": "48"
     },
-    "4h": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "4g"
-    },
     "4i": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "4h"
     },
     "4k": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "4h"
     },
     "4l": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "4h"
     },
     "4m": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "4h"
     },
     "4n": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "4h"
     },
     "4o": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "4h"
     },
     "4p": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "4h"
     },
     "4q": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "4h"
     },
     "4r": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "4h"
     },
     "4s": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.List",
+      "~k_parent": "4h"
     },
     "4t": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "4h"
     },
     "4u": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "4h"
     },
     "4v": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "4h"
     },
     "4w": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "4h"
     },
     "4x": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "4h"
     },
     "4y": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "4h"
     },
     "4z": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "4g"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "4h"
     },
     "5a": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "59"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.types.operators.server",
-      "~k_parent": "58"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "5a"
     },
     "5d": {
-      "key": "root.types.operators.server._secret",
-      "~k_parent": "5c"
+      "key": "root.types.operators.server",
+      "~k_parent": "59"
     },
     "5e": {
+      "key": "root.types.operators.server._secret",
+      "~k_parent": "5d"
+    },
+    "5f": {
       "key": "root.imports",
       "~k_parent": "9"
     },
-    "5f": {
-      "key": "root.imports.actions",
-      "~k_parent": "5e"
-    },
     "5g": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "5f"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.agents",
-      "~k_parent": "5e"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "5g"
     },
     "5j": {
-      "key": "root.imports.auth",
-      "~k_parent": "5e"
+      "key": "root.imports.agents",
+      "~k_parent": "5f"
     },
     "5k": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "5j"
+      "key": "root.imports.auth",
+      "~k_parent": "5f"
     },
     "5l": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "5j"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.blocks",
-      "~k_parent": "5e"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "5k"
     },
     "5n": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "5m"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "5k"
     },
     "5o": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks",
+      "~k_parent": "5f"
     },
     "5p": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "5o"
     },
     "5r": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "5o"
     },
     "5s": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "5o"
     },
     "5t": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "5o"
     },
     "5u": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "5o"
     },
     "5v": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "5o"
     },
     "5w": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "5o"
     },
     "5x": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "5o"
     },
     "5y": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "5o"
     },
     "5z": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "5m"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "5o"
     },
     "6a": {
-      "key": "root.imports.icons",
-      "~k_parent": "5e"
+      "key": "root.imports.connections",
+      "~k_parent": "5f"
     },
     "6b": {
-      "key": "root.imports.icons[0]",
+      "key": "root.imports.connections[0]",
       "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "6b"
+      "key": "root.imports.icons",
+      "~k_parent": "5f"
     },
     "6d": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "6c"
     },
     "6g": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "6f"
     },
     "6h": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "6c"
     },
     "6i": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "6c"
     },
     "6k": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "6j"
     },
     "6l": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "6c"
     },
     "6m": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "6l"
     },
     "6n": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "6c"
     },
     "6o": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "6n"
     },
     "6p": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "6c"
     },
     "6q": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "6c"
     },
     "6s": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "6r"
     },
     "6t": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "6c"
     },
     "6u": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "6c"
     },
     "6w": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "6v"
     },
     "6x": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "6c"
     },
     "6y": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "6x"
     },
     "6z": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "6c"
     },
     "7a": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "79"
     },
     "7b": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "6c"
     },
     "7c": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "7b"
     },
     "7d": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "6c"
     },
     "7e": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "7d"
     },
     "7f": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "6c"
     },
     "7g": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "7f"
     },
     "7h": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "6c"
     },
     "7i": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "7h"
     },
     "7j": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "6c"
     },
     "7k": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "7j"
     },
     "7l": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "6c"
     },
     "7m": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "7l"
     },
     "7n": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "6c"
     },
     "7o": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "7n"
     },
     "7p": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "6c"
     },
     "7q": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "7p"
     },
     "7r": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "6c"
     },
     "7s": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "7r"
     },
     "7t": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "6a"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "6c"
     },
     "7u": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "7t"
     },
     "7v": {
-      "key": "root.imports.requests",
-      "~k_parent": "5e"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "6c"
     },
     "7w": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "7v"
     },
     "7x": {
-      "key": "root.imports.websockets",
-      "~k_parent": "5e"
+      "key": "root.imports.requests",
+      "~k_parent": "5f"
     },
     "7y": {
-      "key": "root.imports.operators",
-      "~k_parent": "5e"
+      "key": "root.imports.requests[0]",
+      "~k_parent": "7x"
     },
     "7z": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "7y"
+      "key": "root.imports.websockets",
+      "~k_parent": "5f"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1887,6 +1895,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -7237,6 +7246,9 @@
       "providers": {
         "~k": "4f"
       },
+      "strategies": {
+        "~k": "4g"
+      },
       "~k": "4d"
     },
     "blocks": {
@@ -7244,153 +7256,153 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 8,
-        "~k": "4h"
+        "~k": "4i"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "4i"
+        "~k": "4j"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "4j"
+        "~k": "4k"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "4k"
+        "~k": "4l"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "4l"
+        "~k": "4m"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4m"
+        "~k": "4n"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4n"
+        "~k": "4o"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4o"
+        "~k": "4p"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4p"
+        "~k": "4q"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4q"
+        "~k": "4r"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4r"
+        "~k": "4s"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4s"
+        "~k": "4t"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "4t"
+        "~k": "4u"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4u"
+        "~k": "4v"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4v"
+        "~k": "4w"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4w"
+        "~k": "4x"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4x"
+        "~k": "4y"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4y"
+        "~k": "4z"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "4z"
+        "~k": "50"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "50"
+        "~k": "51"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "51"
+        "~k": "52"
       },
-      "~k": "4g"
+      "~k": "4h"
     },
     "connections": {
       "MongoDBCollection": {
         "originalTypeName": "MongoDBCollection",
         "package": "@lowdefy/connection-mongodb",
         "count": 2,
-        "~k": "53"
+        "~k": "54"
       },
-      "~k": "52"
+      "~k": "53"
     },
     "requests": {
       "MongoDBFind": {
         "originalTypeName": "MongoDBFind",
         "package": "@lowdefy/connection-mongodb",
         "count": 2,
-        "~k": "55"
+        "~k": "56"
       },
-      "~k": "54"
+      "~k": "55"
     },
     "websockets": {
-      "~k": "56"
+      "~k": "57"
     },
     "api": {
-      "~k": "57"
+      "~k": "58"
     },
     "operators": {
       "client": {
@@ -7398,26 +7410,26 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5a"
+          "~k": "5b"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "5b"
+          "~k": "5c"
         },
-        "~k": "59"
+        "~k": "5a"
       },
       "server": {
         "_secret": {
           "originalTypeName": "_secret",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "5d"
+          "~k": "5e"
         },
-        "~k": "5c"
+        "~k": "5d"
       },
-      "~k": "58"
+      "~k": "59"
     },
     "~k": "48"
   }

--- a/packages/build/src/tests/success/62-module-with-connections/snapshot.json
+++ b/packages/build/src/tests/success/62-module-with-connections/snapshot.json
@@ -181,123 +181,123 @@
       "~k_parent": "25"
     },
     "30": {
-      "key": "root.types.requests.SendGridMailSend",
-      "~k_parent": "2z"
+      "key": "root.types.requests",
+      "~k_parent": "25"
     },
     "31": {
+      "key": "root.types.requests.SendGridMailSend",
+      "~k_parent": "30"
+    },
+    "32": {
       "key": "root.types.websockets",
       "~k_parent": "25"
     },
-    "32": {
+    "33": {
       "key": "root.types.api",
       "~k_parent": "25"
     },
-    "33": {
+    "34": {
       "key": "root.types.operators",
       "~k_parent": "25"
     },
-    "34": {
-      "key": "root.types.operators.client",
-      "~k_parent": "33"
-    },
     "35": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "34"
     },
     "36": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "34"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "35"
     },
     "37": {
-      "key": "root.types.operators.server",
-      "~k_parent": "33"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "35"
     },
     "38": {
-      "key": "root.types.operators.server._secret",
-      "~k_parent": "37"
+      "key": "root.types.operators.server",
+      "~k_parent": "34"
     },
     "39": {
-      "key": "root.imports",
-      "~k_parent": "5"
+      "key": "root.types.operators.server._secret",
+      "~k_parent": "38"
     },
     "40": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3j"
     },
     "41": {
-      "key": "root.imports.connections",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3j"
     },
     "42": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "41"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3j"
     },
     "43": {
-      "key": "root.imports.icons",
-      "~k_parent": "39"
+      "key": "root.imports.connections",
+      "~k_parent": "3a"
     },
     "44": {
-      "key": "root.imports.icons[0]",
+      "key": "root.imports.connections[0]",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "44"
+      "key": "root.imports.icons",
+      "~k_parent": "3a"
     },
     "46": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "45"
     },
     "49": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "45"
     },
     "51": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "45"
     },
     "53": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "45"
     },
     "55": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "45"
     },
     "57": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "45"
     },
     "59": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "58"
     },
     "a": {
@@ -533,396 +533,404 @@
       "~k_parent": "2a"
     },
     "2d": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2a"
+    },
+    "2e": {
       "key": "root.types.blocks",
       "~k_parent": "25"
     },
-    "2e": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2d"
-    },
     "2f": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2e"
     },
     "2g": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2e"
     },
     "2h": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2e"
     },
     "2i": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2e"
     },
     "2j": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2e"
     },
     "2k": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2e"
     },
     "2l": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2e"
     },
     "2m": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2e"
     },
     "2n": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2e"
     },
     "2o": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2e"
     },
     "2p": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2e"
     },
     "2q": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2e"
     },
     "2r": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2e"
     },
     "2s": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2e"
     },
     "2t": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2e"
     },
     "2u": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2e"
     },
     "2v": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2e"
     },
     "2w": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2d"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2e"
     },
     "2x": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2e"
+    },
+    "2y": {
       "key": "root.types.connections",
       "~k_parent": "25"
     },
-    "2y": {
-      "key": "root.types.connections.SendGridMail",
-      "~k_parent": "2x"
-    },
     "2z": {
-      "key": "root.types.requests",
-      "~k_parent": "25"
+      "key": "root.types.connections.SendGridMail",
+      "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.actions",
-      "~k_parent": "39"
+      "key": "root.imports",
+      "~k_parent": "5"
     },
     "3b": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3a"
     },
     "3c": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3a"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.imports.agents",
-      "~k_parent": "39"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3b"
     },
     "3e": {
-      "key": "root.imports.auth",
-      "~k_parent": "39"
+      "key": "root.imports.agents",
+      "~k_parent": "3a"
     },
     "3f": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3e"
+      "key": "root.imports.auth",
+      "~k_parent": "3a"
     },
     "3g": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3e"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.blocks",
-      "~k_parent": "39"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3f"
     },
     "3i": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3h"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks",
+      "~k_parent": "3a"
     },
     "3k": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3j"
     },
     "3l": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3j"
     },
     "3m": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3j"
     },
     "3n": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3j"
     },
     "3o": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3j"
     },
     "3p": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3j"
     },
     "3q": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3j"
     },
     "3r": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3j"
     },
     "3s": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3j"
     },
     "3t": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3j"
     },
     "3u": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3j"
     },
     "3v": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3j"
     },
     "3w": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3j"
     },
     "3x": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3j"
     },
     "3y": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3j"
     },
     "3z": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3h"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3j"
     },
     "4a": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "45"
     },
     "4b": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "45"
     },
     "4d": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "45"
     },
     "4f": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "45"
     },
     "4h": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "45"
     },
     "4j": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "45"
     },
     "4l": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "45"
     },
     "4n": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "45"
     },
     "4p": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "45"
     },
     "4r": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "45"
     },
     "4t": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "45"
     },
     "4v": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "45"
     },
     "4x": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "45"
     },
     "4z": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "45"
     },
     "5b": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "45"
     },
     "5d": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "45"
     },
     "5f": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "45"
     },
     "5h": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "45"
     },
     "5j": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "45"
     },
     "5l": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "43"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "45"
     },
     "5n": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.requests",
-      "~k_parent": "39"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "45"
     },
     "5p": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.websockets",
-      "~k_parent": "39"
+      "key": "root.imports.requests",
+      "~k_parent": "3a"
     },
     "5r": {
-      "key": "root.imports.operators",
-      "~k_parent": "39"
+      "key": "root.imports.requests[0]",
+      "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5r"
+      "key": "root.imports.websockets",
+      "~k_parent": "3a"
     },
     "5t": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5s"
+      "key": "root.imports.operators",
+      "~k_parent": "3a"
     },
     "5u": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5s"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "5r"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5u"
     },
     "5w": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5u"
+    },
+    "5x": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "5t"
+    },
+    "5y": {
       "key": "root.imports.operators.server[0]",
-      "~k_parent": "5v"
+      "~k_parent": "5x"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1200,6 +1208,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5743,6 +5752,9 @@
       "providers": {
         "~k": "2c"
       },
+      "strategies": {
+        "~k": "2d"
+      },
       "~k": "2a"
     },
     "blocks": {
@@ -5750,141 +5762,141 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
-      "~k": "2d"
+      "~k": "2e"
     },
     "connections": {
       "SendGridMail": {
         "originalTypeName": "SendGridMail",
         "package": "@lowdefy/connection-sendgrid",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
-      "~k": "2x"
+      "~k": "2y"
     },
     "requests": {
       "SendGridMailSend": {
         "originalTypeName": "SendGridMailSend",
         "package": "@lowdefy/connection-sendgrid",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
-      "~k": "2z"
+      "~k": "30"
     },
     "websockets": {
-      "~k": "31"
+      "~k": "32"
     },
     "api": {
-      "~k": "32"
+      "~k": "33"
     },
     "operators": {
       "client": {
@@ -5892,26 +5904,26 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "35"
+          "~k": "36"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "36"
+          "~k": "37"
         },
-        "~k": "34"
+        "~k": "35"
       },
       "server": {
         "_secret": {
           "originalTypeName": "_secret",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "38"
+          "~k": "39"
         },
-        "~k": "37"
+        "~k": "38"
       },
-      "~k": "33"
+      "~k": "34"
     },
     "~k": "25"
   }

--- a/packages/build/src/tests/success/63-module-connection-remapping/snapshot.json
+++ b/packages/build/src/tests/success/63-module-connection-remapping/snapshot.json
@@ -193,159 +193,159 @@
       "~k_parent": "2y"
     },
     "31": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2y"
+    },
+    "32": {
       "key": "root.types.blocks",
       "~k_parent": "2t"
     },
-    "32": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "31"
-    },
     "33": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "31"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "31"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "32"
     },
     "35": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "31"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "32"
     },
     "36": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "31"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "32"
     },
     "37": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "31"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "32"
     },
     "38": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "31"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "32"
     },
     "39": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "31"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "32"
     },
     "40": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3z"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.agents",
-      "~k_parent": "3y"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "40"
     },
     "43": {
-      "key": "root.imports.auth",
-      "~k_parent": "3y"
+      "key": "root.imports.agents",
+      "~k_parent": "3z"
     },
     "44": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "43"
+      "key": "root.imports.auth",
+      "~k_parent": "3z"
     },
     "45": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "43"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3y"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "44"
     },
     "47": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "46"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "44"
     },
     "48": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks",
+      "~k_parent": "3z"
     },
     "49": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4v"
     },
     "51": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4v"
     },
     "53": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4v"
     },
     "55": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4v"
     },
     "57": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4v"
     },
     "59": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4v"
     },
     "61": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4v"
     },
     "63": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4v"
     },
     "65": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4v"
     },
     "67": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4v"
     },
     "69": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "68"
     },
     "a": {
@@ -693,368 +693,376 @@
       "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "31"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "32"
     },
     "3b": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "31"
+      "key": "root.types.blocks.List",
+      "~k_parent": "32"
     },
     "3c": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "31"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "32"
     },
     "3d": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "31"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "32"
     },
     "3e": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "31"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "32"
     },
     "3f": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "31"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "32"
     },
     "3g": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "31"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "32"
     },
     "3h": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "31"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "32"
     },
     "3i": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "31"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "32"
     },
     "3j": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "31"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "32"
     },
     "3k": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "31"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "32"
     },
     "3l": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "32"
+    },
+    "3m": {
       "key": "root.types.connections",
       "~k_parent": "2t"
     },
-    "3m": {
-      "key": "root.types.connections.MongoDBCollection",
-      "~k_parent": "3l"
-    },
     "3n": {
-      "key": "root.types.connections.SendGridMail",
-      "~k_parent": "3l"
+      "key": "root.types.connections.MongoDBCollection",
+      "~k_parent": "3m"
     },
     "3o": {
+      "key": "root.types.connections.SendGridMail",
+      "~k_parent": "3m"
+    },
+    "3p": {
       "key": "root.types.requests",
       "~k_parent": "2t"
     },
-    "3p": {
-      "key": "root.types.requests.SendGridMailSend",
-      "~k_parent": "3o"
-    },
     "3q": {
+      "key": "root.types.requests.SendGridMailSend",
+      "~k_parent": "3p"
+    },
+    "3r": {
       "key": "root.types.websockets",
       "~k_parent": "2t"
     },
-    "3r": {
+    "3s": {
       "key": "root.types.api",
       "~k_parent": "2t"
     },
-    "3s": {
+    "3t": {
       "key": "root.types.operators",
       "~k_parent": "2t"
     },
-    "3t": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3s"
-    },
     "3u": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3t"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3s"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3u"
     },
     "3x": {
-      "key": "root.types.operators.server._secret",
-      "~k_parent": "3w"
+      "key": "root.types.operators.server",
+      "~k_parent": "3t"
     },
     "3y": {
+      "key": "root.types.operators.server._secret",
+      "~k_parent": "3x"
+    },
+    "3z": {
       "key": "root.imports",
       "~k_parent": "8"
     },
-    "3z": {
-      "key": "root.imports.actions",
-      "~k_parent": "3y"
-    },
     "4a": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "48"
     },
     "4b": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "48"
     },
     "4c": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "48"
     },
     "4d": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "48"
     },
     "4e": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "48"
     },
     "4f": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "48"
     },
     "4g": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "48"
     },
     "4h": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "48"
     },
     "4i": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "48"
     },
     "4j": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "48"
     },
     "4k": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "48"
     },
     "4l": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "48"
     },
     "4m": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "48"
     },
     "4n": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "48"
     },
     "4o": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "48"
     },
     "4p": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "48"
     },
     "4q": {
-      "key": "root.imports.connections",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "48"
     },
     "4r": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "4q"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "48"
     },
     "4s": {
-      "key": "root.imports.connections[1]",
-      "~k_parent": "4q"
+      "key": "root.imports.connections",
+      "~k_parent": "3z"
     },
     "4t": {
-      "key": "root.imports.icons",
-      "~k_parent": "3y"
+      "key": "root.imports.connections[0]",
+      "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4t"
+      "key": "root.imports.connections[1]",
+      "~k_parent": "4s"
     },
     "4v": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4u"
+      "key": "root.imports.icons",
+      "~k_parent": "3z"
     },
     "4w": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4v"
     },
     "4z": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4v"
     },
     "5b": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4v"
     },
     "5d": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4v"
     },
     "5f": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4v"
     },
     "5h": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4v"
     },
     "5j": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4v"
     },
     "5l": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4v"
     },
     "5n": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4v"
     },
     "5p": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4v"
     },
     "5r": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4v"
     },
     "5t": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4v"
     },
     "5v": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4v"
     },
     "5x": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4v"
     },
     "5z": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4v"
     },
     "6b": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4t"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4v"
     },
     "6d": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.requests",
-      "~k_parent": "3y"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4v"
     },
     "6f": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "6e"
     },
     "6g": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3y"
+      "key": "root.imports.requests",
+      "~k_parent": "3z"
     },
     "6h": {
-      "key": "root.imports.operators",
-      "~k_parent": "3y"
+      "key": "root.imports.requests[0]",
+      "~k_parent": "6g"
     },
     "6i": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6h"
+      "key": "root.imports.websockets",
+      "~k_parent": "3z"
     },
     "6j": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6i"
+      "key": "root.imports.operators",
+      "~k_parent": "3z"
     },
     "6k": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6i"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6j"
     },
     "6l": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "6h"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6k"
     },
     "6m": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6k"
+    },
+    "6n": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "6j"
+    },
+    "6o": {
       "key": "root.imports.operators.server[0]",
-      "~k_parent": "6l"
+      "~k_parent": "6n"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1411,6 +1419,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5967,6 +5976,9 @@
       "providers": {
         "~k": "30"
       },
+      "strategies": {
+        "~k": "31"
+      },
       "~k": "2y"
     },
     "blocks": {
@@ -5974,147 +5986,147 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "32"
+        "~k": "33"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "33"
+        "~k": "34"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3f"
+        "~k": "3g"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3h"
+        "~k": "3i"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3i"
+        "~k": "3j"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3j"
+        "~k": "3k"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3k"
+        "~k": "3l"
       },
-      "~k": "31"
+      "~k": "32"
     },
     "connections": {
       "MongoDBCollection": {
         "originalTypeName": "MongoDBCollection",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "3m"
+        "~k": "3n"
       },
       "SendGridMail": {
         "originalTypeName": "SendGridMail",
         "package": "@lowdefy/connection-sendgrid",
         "count": 2,
-        "~k": "3n"
+        "~k": "3o"
       },
-      "~k": "3l"
+      "~k": "3m"
     },
     "requests": {
       "SendGridMailSend": {
         "originalTypeName": "SendGridMailSend",
         "package": "@lowdefy/connection-sendgrid",
         "count": 2,
-        "~k": "3p"
+        "~k": "3q"
       },
-      "~k": "3o"
+      "~k": "3p"
     },
     "websockets": {
-      "~k": "3q"
+      "~k": "3r"
     },
     "api": {
-      "~k": "3r"
+      "~k": "3s"
     },
     "operators": {
       "client": {
@@ -6122,26 +6134,26 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3u"
+          "~k": "3v"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3v"
+          "~k": "3w"
         },
-        "~k": "3t"
+        "~k": "3u"
       },
       "server": {
         "_secret": {
           "originalTypeName": "_secret",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3x"
+          "~k": "3y"
         },
-        "~k": "3w"
+        "~k": "3x"
       },
-      "~k": "3s"
+      "~k": "3t"
     },
     "~k": "2t"
   }

--- a/packages/build/src/tests/success/64-module-exposed-component/snapshot.json
+++ b/packages/build/src/tests/success/64-module-exposed-component/snapshot.json
@@ -132,156 +132,156 @@
       "~k_parent": "1z"
     },
     "22": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1z"
+    },
+    "23": {
       "key": "root.types.blocks",
       "~k_parent": "1u"
     },
-    "23": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "22"
-    },
     "24": {
-      "key": "root.types.blocks.Badge",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "23"
     },
     "25": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Badge",
+      "~k_parent": "23"
     },
     "26": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "23"
     },
     "27": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "23"
     },
     "28": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "23"
     },
     "29": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "22"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "23"
     },
     "30": {
-      "key": "root.imports.agents",
-      "~k_parent": "2w"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2y"
     },
     "31": {
-      "key": "root.imports.auth",
-      "~k_parent": "2w"
+      "key": "root.imports.agents",
+      "~k_parent": "2x"
     },
     "32": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "31"
+      "key": "root.imports.auth",
+      "~k_parent": "2x"
     },
     "33": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "31"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2w"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "32"
     },
     "35": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "34"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "32"
     },
     "36": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks",
+      "~k_parent": "2x"
     },
     "37": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "36"
     },
     "38": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "36"
     },
     "39": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "36"
     },
     "40": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3s"
     },
     "42": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3s"
     },
     "44": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3s"
     },
     "46": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3s"
     },
     "48": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3s"
     },
     "50": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3s"
     },
     "52": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3s"
     },
     "54": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3s"
     },
     "56": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3s"
     },
     "58": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3s"
     },
     "a": {
       "key": "root.pages[0:dashboard:Box].blocks[0:header:Box]",
@@ -490,348 +490,356 @@
       "~k_parent": "1u"
     },
     "2a": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "23"
     },
     "2b": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "23"
     },
     "2c": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "23"
     },
     "2d": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "22"
+      "key": "root.types.blocks.List",
+      "~k_parent": "23"
     },
     "2e": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "23"
     },
     "2f": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "23"
     },
     "2g": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "22"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "23"
     },
     "2h": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "23"
     },
     "2i": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "22"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "23"
     },
     "2j": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "22"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "23"
     },
     "2k": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "22"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "23"
     },
     "2l": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "22"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "23"
     },
     "2m": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "22"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "23"
     },
     "2n": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "23"
+    },
+    "2o": {
       "key": "root.types.connections",
       "~k_parent": "1u"
     },
-    "2o": {
+    "2p": {
       "key": "root.types.requests",
       "~k_parent": "1u"
     },
-    "2p": {
+    "2q": {
       "key": "root.types.websockets",
       "~k_parent": "1u"
     },
-    "2q": {
+    "2r": {
       "key": "root.types.api",
       "~k_parent": "1u"
     },
-    "2r": {
+    "2s": {
       "key": "root.types.operators",
       "~k_parent": "1u"
     },
-    "2s": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2r"
-    },
     "2t": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2s"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2r"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2t"
     },
     "2w": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2s"
+    },
+    "2x": {
       "key": "root.imports",
       "~k_parent": "6"
     },
-    "2x": {
-      "key": "root.imports.actions",
-      "~k_parent": "2w"
-    },
     "2y": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2x"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "36"
     },
     "3b": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "36"
     },
     "3c": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "36"
     },
     "3d": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "36"
     },
     "3e": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "36"
     },
     "3f": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "36"
     },
     "3g": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "36"
     },
     "3h": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "36"
     },
     "3i": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "36"
     },
     "3j": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "36"
     },
     "3k": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "36"
     },
     "3l": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "36"
     },
     "3m": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "36"
     },
     "3n": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "36"
     },
     "3o": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "36"
     },
     "3p": {
-      "key": "root.imports.connections",
-      "~k_parent": "2w"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "36"
     },
     "3q": {
-      "key": "root.imports.icons",
-      "~k_parent": "2w"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "36"
     },
     "3r": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3q"
+      "key": "root.imports.connections",
+      "~k_parent": "2x"
     },
     "3s": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3r"
+      "key": "root.imports.icons",
+      "~k_parent": "2x"
     },
     "3t": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3s"
     },
     "3w": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3s"
     },
     "3y": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3s"
     },
     "4a": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3s"
     },
     "4c": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3s"
     },
     "4e": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3s"
     },
     "4g": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3s"
     },
     "4i": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3s"
     },
     "4k": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3s"
     },
     "4m": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3s"
     },
     "4o": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3s"
     },
     "4q": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3s"
     },
     "4s": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3s"
     },
     "4u": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3s"
     },
     "4w": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3s"
     },
     "4y": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3s"
     },
     "5a": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.requests",
-      "~k_parent": "2w"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3s"
     },
     "5c": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2w"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.operators",
-      "~k_parent": "2w"
+      "key": "root.imports.requests",
+      "~k_parent": "2x"
     },
     "5e": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5d"
+      "key": "root.imports.websockets",
+      "~k_parent": "2x"
     },
     "5f": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5e"
+      "key": "root.imports.operators",
+      "~k_parent": "2x"
     },
     "5g": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5e"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5f"
     },
     "5h": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5g"
+    },
+    "5i": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5g"
+    },
+    "5j": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5d"
+      "~k_parent": "5f"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1067,6 +1075,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5989,6 +5998,9 @@
       "providers": {
         "~k": "21"
       },
+      "strategies": {
+        "~k": "22"
+      },
       "~k": "1z"
     },
     "blocks": {
@@ -5996,135 +6008,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "23"
+        "~k": "24"
       },
       "Badge": {
         "originalTypeName": "Badge",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
-      "~k": "22"
+      "~k": "23"
     },
     "connections": {
-      "~k": "2n"
-    },
-    "requests": {
       "~k": "2o"
     },
-    "websockets": {
+    "requests": {
       "~k": "2p"
     },
-    "api": {
+    "websockets": {
       "~k": "2q"
+    },
+    "api": {
+      "~k": "2r"
     },
     "operators": {
       "client": {
@@ -6132,20 +6144,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2t"
+          "~k": "2u"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2u"
+          "~k": "2v"
         },
-        "~k": "2s"
+        "~k": "2t"
       },
       "server": {
-        "~k": "2v"
+        "~k": "2w"
       },
-      "~k": "2r"
+      "~k": "2s"
     },
     "~k": "1u"
   }

--- a/packages/build/src/tests/success/65-module-exposed-menu/snapshot.json
+++ b/packages/build/src/tests/success/65-module-exposed-menu/snapshot.json
@@ -167,124 +167,132 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2l"
     },
     "31": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2l"
     },
     "32": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2l"
     },
     "33": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2l"
     },
     "34": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2l"
     },
     "35": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2l"
+    },
+    "36": {
       "key": "root.types.connections",
       "~k_parent": "2c"
     },
-    "36": {
+    "37": {
       "key": "root.types.requests",
       "~k_parent": "2c"
     },
-    "37": {
+    "38": {
       "key": "root.types.websockets",
       "~k_parent": "2c"
     },
-    "38": {
+    "39": {
       "key": "root.types.api",
       "~k_parent": "2c"
     },
-    "39": {
-      "key": "root.types.operators",
-      "~k_parent": "2c"
-    },
     "40": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3o"
     },
     "41": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3o"
     },
     "42": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3o"
     },
     "43": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3o"
     },
     "44": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3o"
     },
     "45": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3o"
     },
     "46": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3o"
     },
     "47": {
-      "key": "root.imports.connections",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3o"
     },
     "48": {
-      "key": "root.imports.icons",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3o"
     },
     "49": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "48"
+      "key": "root.imports.connections",
+      "~k_parent": "3f"
     },
     "50": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4a"
     },
     "52": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4a"
     },
     "54": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4a"
     },
     "56": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4a"
     },
     "58": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4a"
+    },
+    "60": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5y"
+    },
+    "61": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "5x"
     },
     "a": {
       "key": "root.menus[0:main].links[0:home:MenuLink].properties",
@@ -559,380 +567,380 @@
       "~k_parent": "2h"
     },
     "2k": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2h"
+    },
+    "2l": {
       "key": "root.types.blocks",
       "~k_parent": "2c"
     },
-    "2l": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2k"
-    },
     "2m": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2l"
     },
     "2o": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2l"
     },
     "2p": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2l"
     },
     "2q": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2l"
     },
     "2r": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2l"
     },
     "2s": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2l"
     },
     "2t": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2l"
     },
     "2u": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2l"
     },
     "2v": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2l"
     },
     "2w": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2l"
     },
     "2x": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2l"
     },
     "2y": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2l"
     },
     "2z": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2l"
     },
     "3a": {
-      "key": "root.types.operators.client",
-      "~k_parent": "39"
+      "key": "root.types.operators",
+      "~k_parent": "2c"
     },
     "3b": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3a"
     },
     "3c": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3a"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.types.operators.server",
-      "~k_parent": "39"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3b"
     },
     "3e": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3a"
+    },
+    "3f": {
       "key": "root.imports",
       "~k_parent": "5"
     },
-    "3f": {
-      "key": "root.imports.actions",
-      "~k_parent": "3e"
-    },
     "3g": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3f"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.agents",
-      "~k_parent": "3e"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3g"
     },
     "3j": {
-      "key": "root.imports.auth",
-      "~k_parent": "3e"
+      "key": "root.imports.agents",
+      "~k_parent": "3f"
     },
     "3k": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3j"
+      "key": "root.imports.auth",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3j"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3e"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3k"
     },
     "3n": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3m"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3k"
     },
     "3o": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3o"
     },
     "3r": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3o"
     },
     "3s": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3o"
     },
     "3t": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3o"
     },
     "3u": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3o"
     },
     "3v": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3o"
     },
     "3w": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3o"
     },
     "3x": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3o"
     },
     "3y": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3o"
     },
     "3z": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3o"
     },
     "4a": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "49"
+      "key": "root.imports.icons",
+      "~k_parent": "3f"
     },
     "4b": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4a"
     },
     "4e": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4a"
     },
     "4g": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4a"
     },
     "4i": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4a"
     },
     "4k": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4a"
     },
     "4m": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4a"
     },
     "4o": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4a"
     },
     "4q": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4a"
     },
     "4s": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4a"
     },
     "4u": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4a"
     },
     "4w": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4a"
     },
     "4y": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4a"
     },
     "5a": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4a"
     },
     "5c": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4a"
     },
     "5e": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4a"
     },
     "5g": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4a"
     },
     "5i": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4a"
     },
     "5k": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4a"
     },
     "5m": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4a"
     },
     "5o": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4a"
     },
     "5q": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4a"
     },
     "5s": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.requests",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4a"
     },
     "5u": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.operators",
-      "~k_parent": "3e"
+      "key": "root.imports.requests",
+      "~k_parent": "3f"
     },
     "5w": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5v"
+      "key": "root.imports.websockets",
+      "~k_parent": "3f"
     },
     "5x": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5w"
+      "key": "root.imports.operators",
+      "~k_parent": "3f"
     },
     "5y": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5w"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "5v"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5y"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1243,6 +1251,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5765,6 +5774,9 @@
       "providers": {
         "~k": "2j"
       },
+      "strategies": {
+        "~k": "2k"
+      },
       "~k": "2h"
     },
     "blocks": {
@@ -5772,135 +5784,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
-      "~k": "2k"
+      "~k": "2l"
     },
     "connections": {
-      "~k": "35"
-    },
-    "requests": {
       "~k": "36"
     },
-    "websockets": {
+    "requests": {
       "~k": "37"
     },
-    "api": {
+    "websockets": {
       "~k": "38"
+    },
+    "api": {
+      "~k": "39"
     },
     "operators": {
       "client": {
@@ -5908,20 +5920,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3b"
+          "~k": "3c"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3c"
+          "~k": "3d"
         },
-        "~k": "3a"
+        "~k": "3b"
       },
       "server": {
-        "~k": "3d"
+        "~k": "3e"
       },
-      "~k": "39"
+      "~k": "3a"
     },
     "~k": "2c"
   }

--- a/packages/build/src/tests/success/66-module-with-api/snapshot.json
+++ b/packages/build/src/tests/success/66-module-with-api/snapshot.json
@@ -216,164 +216,164 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2p"
     },
     "31": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2p"
     },
     "32": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2p"
     },
     "33": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2p"
     },
     "34": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2p"
     },
     "35": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2p"
     },
     "36": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2p"
     },
     "37": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2p"
     },
     "38": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2p"
     },
     "39": {
-      "key": "root.types.connections",
-      "~k_parent": "2f"
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2p"
     },
     "40": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3x"
     },
     "41": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3x"
     },
     "42": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3x"
     },
     "43": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3x"
     },
     "44": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3x"
     },
     "45": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3x"
     },
     "46": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3x"
     },
     "47": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3x"
     },
     "48": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3x"
     },
     "49": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3x"
     },
     "50": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4k"
     },
     "52": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4k"
     },
     "54": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4k"
     },
     "56": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4k"
     },
     "58": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4k"
     },
     "60": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4k"
     },
     "62": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.requests",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4k"
     },
     "64": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3m"
+      "key": "root.imports.requests",
+      "~k_parent": "3n"
     },
     "66": {
-      "key": "root.imports.operators",
-      "~k_parent": "3m"
+      "key": "root.imports.requests[0]",
+      "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "66"
+      "key": "root.imports.websockets",
+      "~k_parent": "3n"
     },
     "68": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "67"
+      "key": "root.imports.operators",
+      "~k_parent": "3n"
     },
     "69": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "67"
+      "key": "root.imports.operators.client",
+      "~k_parent": "68"
     },
     "a": {
       "key": "root.pages[1:inviter/invite:Box].blocks[0:message:Paragraph]",
@@ -664,376 +664,384 @@
       "~k_parent": "2l"
     },
     "2o": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2l"
+    },
+    "2p": {
       "key": "root.types.blocks",
       "~k_parent": "2f"
     },
-    "2p": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2o"
-    },
     "2q": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2p"
     },
     "2r": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "2p"
     },
     "2s": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2p"
     },
     "2t": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2p"
     },
     "2u": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2p"
     },
     "2v": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2p"
     },
     "2w": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2p"
     },
     "2x": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2p"
     },
     "2y": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2p"
     },
     "2z": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2o"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2p"
     },
     "3a": {
-      "key": "root.types.connections.SendGridMail",
-      "~k_parent": "39"
+      "key": "root.types.connections",
+      "~k_parent": "2f"
     },
     "3b": {
+      "key": "root.types.connections.SendGridMail",
+      "~k_parent": "3a"
+    },
+    "3c": {
       "key": "root.types.requests",
       "~k_parent": "2f"
     },
-    "3c": {
-      "key": "root.types.requests.SendGridMailSend",
-      "~k_parent": "3b"
-    },
     "3d": {
+      "key": "root.types.requests.SendGridMailSend",
+      "~k_parent": "3c"
+    },
+    "3e": {
       "key": "root.types.websockets",
       "~k_parent": "2f"
     },
-    "3e": {
+    "3f": {
       "key": "root.types.api",
       "~k_parent": "2f"
     },
-    "3f": {
+    "3g": {
       "key": "root.types.operators",
       "~k_parent": "2f"
     },
-    "3g": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3f"
-    },
     "3h": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3g"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3f"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3h"
     },
     "3k": {
-      "key": "root.types.operators.server._secret",
-      "~k_parent": "3j"
+      "key": "root.types.operators.server",
+      "~k_parent": "3g"
     },
     "3l": {
-      "key": "root.types.operators.server._payload",
-      "~k_parent": "3j"
+      "key": "root.types.operators.server._secret",
+      "~k_parent": "3k"
     },
     "3m": {
+      "key": "root.types.operators.server._payload",
+      "~k_parent": "3k"
+    },
+    "3n": {
       "key": "root.imports",
       "~k_parent": "5"
     },
-    "3n": {
-      "key": "root.imports.actions",
-      "~k_parent": "3m"
-    },
     "3o": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3n"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.actions[2]",
-      "~k_parent": "3n"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3o"
     },
     "3r": {
-      "key": "root.imports.agents",
-      "~k_parent": "3m"
+      "key": "root.imports.actions[2]",
+      "~k_parent": "3o"
     },
     "3s": {
-      "key": "root.imports.auth",
-      "~k_parent": "3m"
+      "key": "root.imports.agents",
+      "~k_parent": "3n"
     },
     "3t": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3s"
+      "key": "root.imports.auth",
+      "~k_parent": "3n"
     },
     "3u": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3s"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3m"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3t"
     },
     "3w": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3v"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3t"
     },
     "3x": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks",
+      "~k_parent": "3n"
     },
     "3y": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3x"
     },
     "4a": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3x"
     },
     "4b": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3x"
     },
     "4c": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3x"
     },
     "4d": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3x"
     },
     "4e": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3x"
     },
     "4f": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3x"
     },
     "4g": {
-      "key": "root.imports.connections",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3x"
     },
     "4h": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3x"
     },
     "4i": {
-      "key": "root.imports.icons",
-      "~k_parent": "3m"
+      "key": "root.imports.connections",
+      "~k_parent": "3n"
     },
     "4j": {
-      "key": "root.imports.icons[0]",
+      "key": "root.imports.connections[0]",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4j"
+      "key": "root.imports.icons",
+      "~k_parent": "3n"
     },
     "4l": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4k"
     },
     "4o": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4k"
     },
     "4q": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4k"
     },
     "4s": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4k"
     },
     "4u": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4k"
     },
     "4w": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4k"
     },
     "4y": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4k"
     },
     "5a": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4k"
     },
     "5c": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4k"
     },
     "5e": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4k"
     },
     "5g": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4k"
     },
     "5i": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4k"
     },
     "5k": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4k"
     },
     "5m": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4k"
     },
     "5o": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4k"
     },
     "5q": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4k"
     },
     "5s": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4k"
     },
     "5u": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4k"
     },
     "5w": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4k"
     },
     "5y": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4k"
     },
     "6a": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "66"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.operators.server[0]",
-      "~k_parent": "6a"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "69"
     },
     "6c": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "68"
+    },
+    "6d": {
+      "key": "root.imports.operators.server[0]",
+      "~k_parent": "6c"
+    },
+    "6e": {
       "key": "root.imports.operators.server[1]",
-      "~k_parent": "6a"
+      "~k_parent": "6c"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1387,6 +1395,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5988,6 +5997,9 @@
       "providers": {
         "~k": "2n"
       },
+      "strategies": {
+        "~k": "2o"
+      },
       "~k": "2l"
     },
     "blocks": {
@@ -5995,147 +6007,147 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
-      "~k": "2o"
+      "~k": "2p"
     },
     "connections": {
       "SendGridMail": {
         "originalTypeName": "SendGridMail",
         "package": "@lowdefy/connection-sendgrid",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
-      "~k": "39"
+      "~k": "3a"
     },
     "requests": {
       "SendGridMailSend": {
         "originalTypeName": "SendGridMailSend",
         "package": "@lowdefy/connection-sendgrid",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
-      "~k": "3b"
+      "~k": "3c"
     },
     "websockets": {
-      "~k": "3d"
+      "~k": "3e"
     },
     "api": {
-      "~k": "3e"
+      "~k": "3f"
     },
     "operators": {
       "client": {
@@ -6143,32 +6155,32 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3h"
+          "~k": "3i"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3i"
+          "~k": "3j"
         },
-        "~k": "3g"
+        "~k": "3h"
       },
       "server": {
         "_secret": {
           "originalTypeName": "_secret",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3k"
+          "~k": "3l"
         },
         "_payload": {
           "originalTypeName": "_payload",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3l"
+          "~k": "3m"
         },
-        "~k": "3j"
+        "~k": "3k"
       },
-      "~k": "3f"
+      "~k": "3g"
     },
     "~k": "2f"
   }

--- a/packages/build/src/tests/success/67-module-var-defaults/snapshot.json
+++ b/packages/build/src/tests/success/67-module-var-defaults/snapshot.json
@@ -135,159 +135,159 @@
       "~k_parent": "1y"
     },
     "21": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1y"
+    },
+    "22": {
       "key": "root.types.blocks",
       "~k_parent": "1t"
     },
-    "22": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "21"
-    },
     "23": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "22"
     },
     "24": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "22"
     },
     "25": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "22"
     },
     "26": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "22"
     },
     "27": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "22"
     },
     "28": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "21"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "22"
     },
     "29": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "22"
     },
     "30": {
-      "key": "root.imports.auth",
-      "~k_parent": "2v"
+      "key": "root.imports.agents",
+      "~k_parent": "2w"
     },
     "31": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "30"
+      "key": "root.imports.auth",
+      "~k_parent": "2w"
     },
     "32": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "30"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "31"
     },
     "33": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2v"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "31"
     },
     "34": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "33"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "31"
     },
     "35": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks",
+      "~k_parent": "2w"
     },
     "36": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "35"
     },
     "37": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "35"
     },
     "38": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "35"
     },
     "39": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "35"
     },
     "40": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3r"
     },
     "41": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3r"
     },
     "43": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3r"
     },
     "45": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3r"
     },
     "47": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3r"
     },
     "49": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3r"
     },
     "51": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3r"
     },
     "53": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3r"
     },
     "55": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3r"
     },
     "57": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3r"
     },
     "59": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "58"
     },
     "a": {
@@ -501,344 +501,352 @@
       "~k_parent": "1y"
     },
     "2a": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "22"
     },
     "2b": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "22"
     },
     "2c": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "21"
+      "key": "root.types.blocks.List",
+      "~k_parent": "22"
     },
     "2d": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "22"
     },
     "2e": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "22"
     },
     "2f": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "21"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "22"
     },
     "2g": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "22"
     },
     "2h": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "21"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "22"
     },
     "2i": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "21"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "22"
     },
     "2j": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "21"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "22"
     },
     "2k": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "21"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "22"
     },
     "2l": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "21"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "22"
     },
     "2m": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "22"
+    },
+    "2n": {
       "key": "root.types.connections",
       "~k_parent": "1t"
     },
-    "2n": {
+    "2o": {
       "key": "root.types.requests",
       "~k_parent": "1t"
     },
-    "2o": {
+    "2p": {
       "key": "root.types.websockets",
       "~k_parent": "1t"
     },
-    "2p": {
+    "2q": {
       "key": "root.types.api",
       "~k_parent": "1t"
     },
-    "2q": {
+    "2r": {
       "key": "root.types.operators",
       "~k_parent": "1t"
     },
-    "2r": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2r"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2q"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2s"
     },
     "2v": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2r"
+    },
+    "2w": {
       "key": "root.imports",
       "~k_parent": "5"
     },
-    "2w": {
-      "key": "root.imports.actions",
-      "~k_parent": "2v"
-    },
     "2x": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2w"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.agents",
-      "~k_parent": "2v"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2x"
     },
     "3a": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "35"
     },
     "3b": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "35"
     },
     "3c": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "35"
     },
     "3d": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "35"
     },
     "3e": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "35"
     },
     "3f": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "35"
     },
     "3g": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "35"
     },
     "3h": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "35"
     },
     "3i": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "35"
     },
     "3j": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "35"
     },
     "3k": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "35"
     },
     "3l": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "35"
     },
     "3m": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "35"
     },
     "3n": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "33"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "35"
     },
     "3o": {
-      "key": "root.imports.connections",
-      "~k_parent": "2v"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "35"
     },
     "3p": {
-      "key": "root.imports.icons",
-      "~k_parent": "2v"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "35"
     },
     "3q": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3p"
+      "key": "root.imports.connections",
+      "~k_parent": "2w"
     },
     "3r": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3q"
+      "key": "root.imports.icons",
+      "~k_parent": "2w"
     },
     "3s": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3r"
     },
     "3v": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3r"
     },
     "3x": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3r"
     },
     "3z": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3r"
     },
     "4b": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3r"
     },
     "4d": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3r"
     },
     "4f": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3r"
     },
     "4h": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3r"
     },
     "4j": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3r"
     },
     "4l": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3r"
     },
     "4n": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3r"
     },
     "4p": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3r"
     },
     "4r": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3r"
     },
     "4t": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3r"
     },
     "4v": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3r"
     },
     "4x": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3r"
     },
     "4z": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.requests",
-      "~k_parent": "2v"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3r"
     },
     "5b": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2v"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.operators",
-      "~k_parent": "2v"
+      "key": "root.imports.requests",
+      "~k_parent": "2w"
     },
     "5d": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5c"
+      "key": "root.imports.websockets",
+      "~k_parent": "2w"
     },
     "5e": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5d"
+      "key": "root.imports.operators",
+      "~k_parent": "2w"
     },
     "5f": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5d"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5e"
     },
     "5g": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5f"
+    },
+    "5h": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5f"
+    },
+    "5i": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5c"
+      "~k_parent": "5e"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1076,6 +1084,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5578,6 +5587,9 @@
       "providers": {
         "~k": "20"
       },
+      "strategies": {
+        "~k": "21"
+      },
       "~k": "1y"
     },
     "blocks": {
@@ -5585,135 +5597,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "22"
+        "~k": "23"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "23"
+        "~k": "24"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
-      "~k": "21"
+      "~k": "22"
     },
     "connections": {
-      "~k": "2m"
-    },
-    "requests": {
       "~k": "2n"
     },
-    "websockets": {
+    "requests": {
       "~k": "2o"
     },
-    "api": {
+    "websockets": {
       "~k": "2p"
+    },
+    "api": {
+      "~k": "2q"
     },
     "operators": {
       "client": {
@@ -5721,20 +5733,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2s"
+          "~k": "2t"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2t"
+          "~k": "2u"
         },
-        "~k": "2r"
+        "~k": "2s"
       },
       "server": {
-        "~k": "2u"
+        "~k": "2v"
       },
-      "~k": "2q"
+      "~k": "2r"
     },
     "~k": "1t"
   }

--- a/packages/build/src/tests/success/68-module-nested-refs/snapshot.json
+++ b/packages/build/src/tests/success/68-module-nested-refs/snapshot.json
@@ -171,156 +171,164 @@
       "~k_parent": "22"
     },
     "30": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2r"
     },
     "31": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2r"
     },
     "32": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2r"
     },
     "33": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2r"
     },
     "34": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2r"
     },
     "35": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2r"
     },
     "36": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2r"
     },
     "37": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2r"
     },
     "38": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2r"
     },
     "39": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2r"
     },
     "40": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3v"
     },
     "41": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3v"
     },
     "42": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3v"
     },
     "43": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3v"
     },
     "44": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3v"
     },
     "45": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3v"
     },
     "46": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3v"
     },
     "47": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3v"
     },
     "48": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3v"
     },
     "49": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3v"
     },
     "50": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4i"
     },
     "52": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4i"
     },
     "54": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4i"
     },
     "56": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4i"
     },
     "58": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4i"
     },
     "60": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.requests",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4i"
     },
     "62": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.operators",
-      "~k_parent": "3l"
+      "key": "root.imports.requests",
+      "~k_parent": "3m"
     },
     "64": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "63"
+      "key": "root.imports.websockets",
+      "~k_parent": "3m"
     },
     "65": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "64"
+      "key": "root.imports.operators",
+      "~k_parent": "3m"
     },
     "66": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "64"
+      "key": "root.imports.operators.client",
+      "~k_parent": "65"
     },
     "67": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "66"
+    },
+    "68": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "66"
+    },
+    "69": {
       "key": "root.imports.operators.server",
-      "~k_parent": "63"
+      "~k_parent": "65"
     },
     "a": {
       "key": "root.pages[1:dash/overview:Box].blocks[0:page-title:Title]",
@@ -623,356 +631,356 @@
       "~k_parent": "2n"
     },
     "2q": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2n"
+    },
+    "2r": {
       "key": "root.types.blocks",
       "~k_parent": "2i"
     },
-    "2r": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2q"
-    },
     "2s": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2r"
     },
     "2t": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2r"
     },
     "2u": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "2r"
     },
     "2v": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2r"
     },
     "2w": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2r"
     },
     "2x": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2r"
     },
     "2y": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2r"
     },
     "2z": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2r"
     },
     "3a": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2r"
     },
     "3b": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2q"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2r"
     },
     "3c": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2r"
+    },
+    "3d": {
       "key": "root.types.connections",
       "~k_parent": "2i"
     },
-    "3d": {
+    "3e": {
       "key": "root.types.requests",
       "~k_parent": "2i"
     },
-    "3e": {
+    "3f": {
       "key": "root.types.websockets",
       "~k_parent": "2i"
     },
-    "3f": {
+    "3g": {
       "key": "root.types.api",
       "~k_parent": "2i"
     },
-    "3g": {
+    "3h": {
       "key": "root.types.operators",
       "~k_parent": "2i"
     },
-    "3h": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3g"
-    },
     "3i": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3h"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3g"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3i"
     },
     "3l": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3h"
+    },
+    "3m": {
       "key": "root.imports",
       "~k_parent": "5"
     },
-    "3m": {
-      "key": "root.imports.actions",
-      "~k_parent": "3l"
-    },
     "3n": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3m"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.agents",
-      "~k_parent": "3l"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3n"
     },
     "3q": {
-      "key": "root.imports.auth",
-      "~k_parent": "3l"
+      "key": "root.imports.agents",
+      "~k_parent": "3m"
     },
     "3r": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3q"
+      "key": "root.imports.auth",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3q"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3l"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3r"
     },
     "3u": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3t"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3r"
     },
     "3v": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks",
+      "~k_parent": "3m"
     },
     "3w": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3v"
     },
     "3y": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3v"
     },
     "3z": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3v"
     },
     "4a": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3v"
     },
     "4b": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3v"
     },
     "4c": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3v"
     },
     "4d": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3v"
     },
     "4e": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "3t"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3v"
     },
     "4f": {
-      "key": "root.imports.connections",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3v"
     },
     "4g": {
-      "key": "root.imports.icons",
-      "~k_parent": "3l"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "3v"
     },
     "4h": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4g"
+      "key": "root.imports.connections",
+      "~k_parent": "3m"
     },
     "4i": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4h"
+      "key": "root.imports.icons",
+      "~k_parent": "3m"
     },
     "4j": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4i"
     },
     "4m": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4i"
     },
     "4o": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4i"
     },
     "4q": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4i"
     },
     "4s": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4i"
     },
     "4u": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4i"
     },
     "4w": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4i"
     },
     "4y": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4i"
     },
     "5a": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4i"
     },
     "5c": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4i"
     },
     "5e": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4i"
     },
     "5g": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4i"
     },
     "5i": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4i"
     },
     "5k": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4i"
     },
     "5m": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4i"
     },
     "5o": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4i"
     },
     "5q": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4i"
     },
     "5s": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4i"
     },
     "5u": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4i"
     },
     "5w": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4i"
     },
     "5y": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4i"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1314,6 +1322,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5826,6 +5835,9 @@
       "providers": {
         "~k": "2p"
       },
+      "strategies": {
+        "~k": "2q"
+      },
       "~k": "2n"
     },
     "blocks": {
@@ -5833,141 +5845,141 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
-      "~k": "2q"
+      "~k": "2r"
     },
     "connections": {
-      "~k": "3c"
-    },
-    "requests": {
       "~k": "3d"
     },
-    "websockets": {
+    "requests": {
       "~k": "3e"
     },
-    "api": {
+    "websockets": {
       "~k": "3f"
+    },
+    "api": {
+      "~k": "3g"
     },
     "operators": {
       "client": {
@@ -5975,20 +5987,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3i"
+          "~k": "3j"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3j"
+          "~k": "3k"
         },
-        "~k": "3h"
+        "~k": "3i"
       },
       "server": {
-        "~k": "3k"
+        "~k": "3l"
       },
-      "~k": "3g"
+      "~k": "3h"
     },
     "~k": "2i"
   }

--- a/packages/build/src/tests/success/69-module-with-app-pages/snapshot.json
+++ b/packages/build/src/tests/success/69-module-with-app-pages/snapshot.json
@@ -215,136 +215,144 @@
       "~k_parent": "34"
     },
     "40": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3m"
     },
     "41": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3m"
     },
     "42": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3m"
     },
     "43": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3m"
     },
     "44": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3m"
     },
     "45": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3m"
     },
     "46": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3m"
     },
     "47": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3m"
+    },
+    "48": {
       "key": "root.types.connections",
       "~k_parent": "3d"
     },
-    "48": {
+    "49": {
       "key": "root.types.requests",
       "~k_parent": "3d"
     },
-    "49": {
-      "key": "root.types.websockets",
-      "~k_parent": "3d"
-    },
     "50": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "4q"
     },
     "51": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "4q"
     },
     "52": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "4q"
     },
     "53": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "4q"
     },
     "54": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "4q"
     },
     "55": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "4q"
     },
     "56": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "4q"
     },
     "57": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "4q"
     },
     "58": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "4q"
     },
     "59": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "4q"
     },
     "60": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "5d"
     },
     "61": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "5d"
     },
     "63": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "5d"
     },
     "65": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "5d"
     },
     "67": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "5d"
     },
     "69": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "68"
     },
     "70": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6z"
+      "key": "root.imports.operators",
+      "~k_parent": "4h"
     },
     "71": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6z"
+      "key": "root.imports.operators.client",
+      "~k_parent": "70"
     },
     "72": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "71"
+    },
+    "73": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "71"
+    },
+    "74": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6y"
+      "~k_parent": "70"
     },
     "a": {
       "key": "root.pages[0:home:Box].blocks[0:welcome:Title].properties",
@@ -740,376 +748,376 @@
       "~k_parent": "3i"
     },
     "3l": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "3i"
+    },
+    "3m": {
       "key": "root.types.blocks",
       "~k_parent": "3d"
     },
-    "3m": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "3l"
-    },
     "3n": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "3m"
     },
     "3p": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "3m"
     },
     "3r": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3m"
     },
     "3t": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3m"
     },
     "3u": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3m"
     },
     "3v": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3m"
     },
     "3w": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3m"
     },
     "3x": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3m"
     },
     "3y": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3m"
     },
     "3z": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "3l"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3m"
     },
     "4a": {
-      "key": "root.types.api",
+      "key": "root.types.websockets",
       "~k_parent": "3d"
     },
     "4b": {
-      "key": "root.types.operators",
+      "key": "root.types.api",
       "~k_parent": "3d"
     },
     "4c": {
-      "key": "root.types.operators.client",
-      "~k_parent": "4b"
+      "key": "root.types.operators",
+      "~k_parent": "3d"
     },
     "4d": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "4c"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.types.operators.server",
-      "~k_parent": "4b"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "4d"
     },
     "4g": {
+      "key": "root.types.operators.server",
+      "~k_parent": "4c"
+    },
+    "4h": {
       "key": "root.imports",
       "~k_parent": "5"
     },
-    "4h": {
-      "key": "root.imports.actions",
-      "~k_parent": "4g"
-    },
     "4i": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "4h"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.agents",
-      "~k_parent": "4g"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "4i"
     },
     "4l": {
-      "key": "root.imports.auth",
-      "~k_parent": "4g"
+      "key": "root.imports.agents",
+      "~k_parent": "4h"
     },
     "4m": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "4l"
+      "key": "root.imports.auth",
+      "~k_parent": "4h"
     },
     "4n": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "4l"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.blocks",
-      "~k_parent": "4g"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "4m"
     },
     "4p": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "4o"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "4m"
     },
     "4q": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks",
+      "~k_parent": "4h"
     },
     "4r": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "4q"
     },
     "4t": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "4q"
     },
     "4u": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "4q"
     },
     "4v": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "4q"
     },
     "4w": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "4q"
     },
     "4x": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "4q"
     },
     "4y": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "4q"
     },
     "4z": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "4o"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "4q"
     },
     "5a": {
-      "key": "root.imports.connections",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "4q"
     },
     "5b": {
-      "key": "root.imports.icons",
-      "~k_parent": "4g"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "4q"
     },
     "5c": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "5b"
+      "key": "root.imports.connections",
+      "~k_parent": "4h"
     },
     "5d": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "5c"
+      "key": "root.imports.icons",
+      "~k_parent": "4h"
     },
     "5e": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "5d"
     },
     "5h": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "5d"
     },
     "5j": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "5d"
     },
     "5l": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "5d"
     },
     "5n": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "5d"
     },
     "5p": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "5d"
     },
     "5r": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "5d"
     },
     "5t": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "5d"
     },
     "5v": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "5d"
     },
     "5x": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "5d"
     },
     "5z": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "5d"
     },
     "6b": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "5d"
     },
     "6d": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "5d"
     },
     "6f": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "6e"
     },
     "6g": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "5d"
     },
     "6h": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "6g"
     },
     "6i": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "5d"
     },
     "6j": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "6i"
     },
     "6k": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "5d"
     },
     "6l": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "6k"
     },
     "6m": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "5d"
     },
     "6n": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "6m"
     },
     "6o": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "5d"
     },
     "6p": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "6o"
     },
     "6q": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "5d"
     },
     "6r": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "6q"
     },
     "6s": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "5d"
     },
     "6t": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "6s"
     },
     "6u": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "5b"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "5d"
     },
     "6v": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6u"
     },
     "6w": {
-      "key": "root.imports.requests",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "5d"
     },
     "6x": {
-      "key": "root.imports.websockets",
-      "~k_parent": "4g"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6w"
     },
     "6y": {
-      "key": "root.imports.operators",
-      "~k_parent": "4g"
+      "key": "root.imports.requests",
+      "~k_parent": "4h"
     },
     "6z": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6y"
+      "key": "root.imports.websockets",
+      "~k_parent": "4h"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1584,6 +1592,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -6091,6 +6100,9 @@
       "providers": {
         "~k": "3k"
       },
+      "strategies": {
+        "~k": "3l"
+      },
       "~k": "3i"
     },
     "blocks": {
@@ -6098,141 +6110,141 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "3m"
+        "~k": "3n"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "3n"
+        "~k": "3o"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "3o"
+        "~k": "3p"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3p"
+        "~k": "3q"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3q"
+        "~k": "3r"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3r"
+        "~k": "3s"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3s"
+        "~k": "3t"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3t"
+        "~k": "3u"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3u"
+        "~k": "3v"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3v"
+        "~k": "3w"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3w"
+        "~k": "3x"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3x"
+        "~k": "3y"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3y"
+        "~k": "3z"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3z"
+        "~k": "40"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "40"
+        "~k": "41"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "41"
+        "~k": "42"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "42"
+        "~k": "43"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "43"
+        "~k": "44"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "44"
+        "~k": "45"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "45"
+        "~k": "46"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "46"
+        "~k": "47"
       },
-      "~k": "3l"
+      "~k": "3m"
     },
     "connections": {
-      "~k": "47"
-    },
-    "requests": {
       "~k": "48"
     },
-    "websockets": {
+    "requests": {
       "~k": "49"
     },
-    "api": {
+    "websockets": {
       "~k": "4a"
+    },
+    "api": {
+      "~k": "4b"
     },
     "operators": {
       "client": {
@@ -6240,20 +6252,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4d"
+          "~k": "4e"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4e"
+          "~k": "4f"
         },
-        "~k": "4c"
+        "~k": "4d"
       },
       "server": {
-        "~k": "4f"
+        "~k": "4g"
       },
-      "~k": "4b"
+      "~k": "4c"
     },
     "~k": "3d"
   }

--- a/packages/build/src/tests/success/70-cross-module-shared-layout/snapshot.json
+++ b/packages/build/src/tests/success/70-cross-module-shared-layout/snapshot.json
@@ -161,123 +161,123 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.operators",
+      "key": "root.types.api",
       "~k_parent": "23"
     },
     "31": {
-      "key": "root.types.operators.client",
-      "~k_parent": "30"
+      "key": "root.types.operators",
+      "~k_parent": "23"
     },
     "32": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "31"
     },
     "33": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "31"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.types.operators.server",
-      "~k_parent": "30"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "32"
     },
     "35": {
+      "key": "root.types.operators.server",
+      "~k_parent": "31"
+    },
+    "36": {
       "key": "root.imports",
       "~k_parent": "6"
     },
-    "36": {
-      "key": "root.imports.actions",
-      "~k_parent": "35"
-    },
     "37": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "36"
     },
     "38": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "36"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "37"
     },
     "39": {
-      "key": "root.imports.agents",
-      "~k_parent": "35"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "37"
     },
     "40": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3z"
+      "key": "root.imports.connections",
+      "~k_parent": "36"
     },
     "41": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "40"
+      "key": "root.imports.icons",
+      "~k_parent": "36"
     },
     "42": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "41"
     },
     "45": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "41"
     },
     "47": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "41"
     },
     "49": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "41"
     },
     "51": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "41"
     },
     "53": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "41"
     },
     "55": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "41"
     },
     "57": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "41"
     },
     "59": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "58"
     },
     "a": {
@@ -503,380 +503,388 @@
       "~k_parent": "28"
     },
     "2b": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "28"
+    },
+    "2c": {
       "key": "root.types.blocks",
       "~k_parent": "23"
     },
-    "2c": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2b"
-    },
     "2d": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2c"
     },
     "2e": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2c"
     },
     "2f": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2c"
     },
     "2g": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2c"
     },
     "2h": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2c"
     },
     "2i": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2c"
     },
     "2j": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2c"
     },
     "2k": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2c"
     },
     "2l": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2c"
     },
     "2m": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2c"
     },
     "2n": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2c"
     },
     "2o": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2c"
     },
     "2p": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2c"
     },
     "2q": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2c"
     },
     "2r": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2c"
     },
     "2s": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2c"
     },
     "2t": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2c"
     },
     "2u": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2c"
     },
     "2v": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2c"
     },
     "2w": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2c"
+    },
+    "2x": {
       "key": "root.types.connections",
       "~k_parent": "23"
     },
-    "2x": {
+    "2y": {
       "key": "root.types.requests",
       "~k_parent": "23"
     },
-    "2y": {
+    "2z": {
       "key": "root.types.websockets",
       "~k_parent": "23"
     },
-    "2z": {
-      "key": "root.types.api",
-      "~k_parent": "23"
-    },
     "3a": {
-      "key": "root.imports.auth",
-      "~k_parent": "35"
+      "key": "root.imports.agents",
+      "~k_parent": "36"
     },
     "3b": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3a"
+      "key": "root.imports.auth",
+      "~k_parent": "36"
     },
     "3c": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3a"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.imports.blocks",
-      "~k_parent": "35"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3b"
     },
     "3e": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3d"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3b"
     },
     "3f": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks",
+      "~k_parent": "36"
     },
     "3g": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3f"
     },
     "3i": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3f"
     },
     "3k": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3f"
     },
     "3m": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3f"
     },
     "3n": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3f"
     },
     "3o": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3f"
     },
     "3q": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3f"
     },
     "3r": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3f"
     },
     "3s": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3f"
     },
     "3t": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3f"
     },
     "3u": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3f"
     },
     "3v": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3f"
     },
     "3w": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3f"
     },
     "3x": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3f"
     },
     "3y": {
-      "key": "root.imports.connections",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3f"
     },
     "3z": {
-      "key": "root.imports.icons",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3f"
     },
     "4a": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "41"
     },
     "4b": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "41"
     },
     "4d": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "41"
     },
     "4f": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "41"
     },
     "4h": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "41"
     },
     "4j": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "41"
     },
     "4l": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "41"
     },
     "4n": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "41"
     },
     "4p": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "41"
     },
     "4r": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "41"
     },
     "4t": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "41"
     },
     "4v": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "41"
     },
     "4x": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "41"
     },
     "4z": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "41"
     },
     "5b": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "41"
     },
     "5d": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "41"
     },
     "5f": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "41"
     },
     "5h": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "41"
     },
     "5j": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.requests",
-      "~k_parent": "35"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "41"
     },
     "5l": {
-      "key": "root.imports.websockets",
-      "~k_parent": "35"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.operators",
-      "~k_parent": "35"
+      "key": "root.imports.requests",
+      "~k_parent": "36"
     },
     "5n": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5m"
+      "key": "root.imports.websockets",
+      "~k_parent": "36"
     },
     "5o": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5n"
+      "key": "root.imports.operators",
+      "~k_parent": "36"
     },
     "5p": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5n"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5o"
     },
     "5q": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5p"
+    },
+    "5r": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5p"
+    },
+    "5s": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5m"
+      "~k_parent": "5o"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1151,6 +1159,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5678,6 +5687,9 @@
       "providers": {
         "~k": "2a"
       },
+      "strategies": {
+        "~k": "2b"
+      },
       "~k": "28"
     },
     "blocks": {
@@ -5685,135 +5697,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
-      "~k": "2b"
+      "~k": "2c"
     },
     "connections": {
-      "~k": "2w"
-    },
-    "requests": {
       "~k": "2x"
     },
-    "websockets": {
+    "requests": {
       "~k": "2y"
     },
-    "api": {
+    "websockets": {
       "~k": "2z"
+    },
+    "api": {
+      "~k": "30"
     },
     "operators": {
       "client": {
@@ -5821,20 +5833,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "32"
+          "~k": "33"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "33"
+          "~k": "34"
         },
-        "~k": "31"
+        "~k": "32"
       },
       "server": {
-        "~k": "34"
+        "~k": "35"
       },
-      "~k": "30"
+      "~k": "31"
     },
     "~k": "23"
   }

--- a/packages/build/src/tests/success/71-cross-module-mutual-refs/snapshot.json
+++ b/packages/build/src/tests/success/71-cross-module-mutual-refs/snapshot.json
@@ -144,164 +144,164 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2u"
     },
     "31": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2u"
     },
     "32": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2u"
     },
     "33": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2u"
     },
     "34": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2u"
     },
     "35": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2u"
     },
     "36": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2u"
     },
     "37": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2u"
     },
     "38": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2u"
     },
     "39": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2u"
     },
     "40": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3y"
     },
     "41": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3y"
     },
     "42": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3y"
     },
     "43": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3y"
     },
     "44": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3y"
     },
     "45": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3y"
     },
     "46": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3y"
     },
     "47": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3y"
     },
     "48": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3y"
     },
     "49": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3y"
     },
     "50": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4l"
     },
     "51": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4l"
     },
     "53": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4l"
     },
     "55": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4l"
     },
     "57": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4l"
     },
     "59": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4l"
     },
     "61": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4l"
     },
     "63": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.requests",
-      "~k_parent": "3o"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4l"
     },
     "65": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3o"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.operators",
-      "~k_parent": "3o"
+      "key": "root.imports.requests",
+      "~k_parent": "3p"
     },
     "67": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "66"
+      "key": "root.imports.websockets",
+      "~k_parent": "3p"
     },
     "68": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "67"
+      "key": "root.imports.operators",
+      "~k_parent": "3p"
     },
     "69": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "67"
+      "key": "root.imports.operators.client",
+      "~k_parent": "68"
     },
     "a": {
       "key": "root",
@@ -615,348 +615,356 @@
       "~k_parent": "2q"
     },
     "2t": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2q"
+    },
+    "2u": {
       "key": "root.types.blocks",
       "~k_parent": "2l"
     },
-    "2u": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2t"
-    },
     "2v": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "2u"
     },
     "2y": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2u"
     },
     "2z": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2u"
     },
     "3b": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2u"
     },
     "3c": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2u"
     },
     "3d": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2u"
     },
     "3e": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2u"
     },
     "3f": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2u"
+    },
+    "3g": {
       "key": "root.types.connections",
       "~k_parent": "2l"
     },
-    "3g": {
+    "3h": {
       "key": "root.types.requests",
       "~k_parent": "2l"
     },
-    "3h": {
+    "3i": {
       "key": "root.types.websockets",
       "~k_parent": "2l"
     },
-    "3i": {
+    "3j": {
       "key": "root.types.api",
       "~k_parent": "2l"
     },
-    "3j": {
+    "3k": {
       "key": "root.types.operators",
       "~k_parent": "2l"
     },
-    "3k": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3j"
-    },
     "3l": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3k"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3l"
     },
     "3n": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3j"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3l"
     },
     "3o": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3k"
+    },
+    "3p": {
       "key": "root.imports",
       "~k_parent": "a"
     },
-    "3p": {
-      "key": "root.imports.actions",
-      "~k_parent": "3o"
-    },
     "3q": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3p"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.agents",
-      "~k_parent": "3o"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3q"
     },
     "3t": {
-      "key": "root.imports.auth",
-      "~k_parent": "3o"
+      "key": "root.imports.agents",
+      "~k_parent": "3p"
     },
     "3u": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3t"
+      "key": "root.imports.auth",
+      "~k_parent": "3p"
     },
     "3v": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3t"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3o"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3u"
     },
     "3x": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3w"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3u"
     },
     "3y": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks",
+      "~k_parent": "3p"
     },
     "3z": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3y"
     },
     "4b": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3y"
     },
     "4c": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3y"
     },
     "4d": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3y"
     },
     "4e": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3y"
     },
     "4f": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3y"
     },
     "4g": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3y"
     },
     "4h": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3y"
     },
     "4i": {
-      "key": "root.imports.connections",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3y"
     },
     "4j": {
-      "key": "root.imports.icons",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "3y"
     },
     "4k": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4j"
+      "key": "root.imports.connections",
+      "~k_parent": "3p"
     },
     "4l": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4k"
+      "key": "root.imports.icons",
+      "~k_parent": "3p"
     },
     "4m": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4l"
     },
     "4p": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4l"
     },
     "4r": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4l"
     },
     "4t": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4l"
     },
     "4v": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4l"
     },
     "4x": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4l"
     },
     "4z": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4l"
     },
     "5b": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4l"
     },
     "5d": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4l"
     },
     "5f": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4l"
     },
     "5h": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4l"
     },
     "5j": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4l"
     },
     "5l": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4l"
     },
     "5n": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4l"
     },
     "5p": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4l"
     },
     "5r": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4l"
     },
     "5t": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4l"
     },
     "5v": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4l"
     },
     "5x": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4l"
     },
     "5z": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5y"
     },
     "6a": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "69"
+    },
+    "6b": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "69"
+    },
+    "6c": {
       "key": "root.imports.operators.server",
-      "~k_parent": "66"
+      "~k_parent": "68"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1295,6 +1303,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -6797,6 +6806,9 @@
       "providers": {
         "~k": "2s"
       },
+      "strategies": {
+        "~k": "2t"
+      },
       "~k": "2q"
     },
     "blocks": {
@@ -6804,141 +6816,141 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
-      "~k": "2t"
+      "~k": "2u"
     },
     "connections": {
-      "~k": "3f"
-    },
-    "requests": {
       "~k": "3g"
     },
-    "websockets": {
+    "requests": {
       "~k": "3h"
     },
-    "api": {
+    "websockets": {
       "~k": "3i"
+    },
+    "api": {
+      "~k": "3j"
     },
     "operators": {
       "client": {
@@ -6946,20 +6958,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3l"
+          "~k": "3m"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3m"
+          "~k": "3n"
         },
-        "~k": "3k"
+        "~k": "3l"
       },
       "server": {
-        "~k": "3n"
+        "~k": "3o"
       },
-      "~k": "3j"
+      "~k": "3k"
     },
     "~k": "2l"
   }

--- a/packages/build/src/tests/success/72-cross-module-audit-events/snapshot.json
+++ b/packages/build/src/tests/success/72-cross-module-audit-events/snapshot.json
@@ -199,124 +199,132 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2h"
     },
     "31": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2h"
+    },
+    "32": {
       "key": "root.types.connections",
       "~k_parent": "28"
     },
-    "32": {
-      "key": "root.types.connections.AxiosHttp",
-      "~k_parent": "31"
-    },
     "33": {
+      "key": "root.types.connections.AxiosHttp",
+      "~k_parent": "32"
+    },
+    "34": {
       "key": "root.types.requests",
       "~k_parent": "28"
     },
-    "34": {
-      "key": "root.types.requests.AxiosHttp",
-      "~k_parent": "33"
-    },
     "35": {
+      "key": "root.types.requests.AxiosHttp",
+      "~k_parent": "34"
+    },
+    "36": {
       "key": "root.types.websockets",
       "~k_parent": "28"
     },
-    "36": {
+    "37": {
       "key": "root.types.api",
       "~k_parent": "28"
     },
-    "37": {
+    "38": {
       "key": "root.types.operators",
       "~k_parent": "28"
     },
-    "38": {
-      "key": "root.types.operators.client",
-      "~k_parent": "37"
-    },
     "39": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "38"
     },
     "40": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3m"
     },
     "41": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3m"
     },
     "42": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3m"
     },
     "43": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3m"
     },
     "44": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3m"
     },
     "45": {
-      "key": "root.imports.connections",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3m"
     },
     "46": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3m"
     },
     "47": {
-      "key": "root.imports.icons",
-      "~k_parent": "3c"
+      "key": "root.imports.connections",
+      "~k_parent": "3d"
     },
     "48": {
-      "key": "root.imports.icons[0]",
+      "key": "root.imports.connections[0]",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "48"
+      "key": "root.imports.icons",
+      "~k_parent": "3d"
     },
     "50": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "49"
     },
     "51": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "49"
     },
     "53": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "49"
     },
     "55": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "49"
     },
     "57": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "49"
     },
     "59": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "58"
+    },
+    "60": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5y"
+    },
+    "61": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "5x"
     },
     "a": {
       "key": "root.pages[1:companies/company-detail:Box].blocks",
@@ -567,396 +575,396 @@
       "~k_parent": "2d"
     },
     "2g": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2d"
+    },
+    "2h": {
       "key": "root.types.blocks",
       "~k_parent": "28"
     },
-    "2h": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2g"
-    },
     "2i": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2h"
     },
     "2j": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2h"
     },
     "2k": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2h"
     },
     "2l": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2h"
     },
     "2m": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2h"
     },
     "2n": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2h"
     },
     "2o": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2h"
     },
     "2p": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2h"
     },
     "2q": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2h"
     },
     "2r": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2h"
     },
     "2s": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2h"
     },
     "2t": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2h"
     },
     "2u": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2h"
     },
     "2v": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2h"
     },
     "2w": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2h"
     },
     "2x": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2h"
     },
     "2y": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2h"
     },
     "2z": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2g"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2h"
     },
     "3a": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "38"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "39"
     },
     "3b": {
-      "key": "root.types.operators.server",
-      "~k_parent": "37"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "39"
     },
     "3c": {
+      "key": "root.types.operators.server",
+      "~k_parent": "38"
+    },
+    "3d": {
       "key": "root.imports",
       "~k_parent": "6"
     },
-    "3d": {
-      "key": "root.imports.actions",
-      "~k_parent": "3c"
-    },
     "3e": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3d"
     },
     "3f": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3d"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.imports.agents",
-      "~k_parent": "3c"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3e"
     },
     "3h": {
-      "key": "root.imports.auth",
-      "~k_parent": "3c"
+      "key": "root.imports.agents",
+      "~k_parent": "3d"
     },
     "3i": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3h"
+      "key": "root.imports.auth",
+      "~k_parent": "3d"
     },
     "3j": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3h"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3c"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3i"
     },
     "3l": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3k"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3i"
     },
     "3m": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks",
+      "~k_parent": "3d"
     },
     "3n": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3m"
     },
     "3p": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3m"
     },
     "3r": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3m"
     },
     "3t": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3m"
     },
     "3u": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3m"
     },
     "3v": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3m"
     },
     "3w": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3m"
     },
     "3x": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3m"
     },
     "3y": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3m"
     },
     "3z": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3m"
     },
     "4a": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "49"
     },
     "4d": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "49"
     },
     "4f": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "49"
     },
     "4h": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "49"
     },
     "4j": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "49"
     },
     "4l": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "49"
     },
     "4n": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "49"
     },
     "4p": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "49"
     },
     "4r": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "49"
     },
     "4t": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "49"
     },
     "4v": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "49"
     },
     "4x": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "49"
     },
     "4z": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "49"
     },
     "5b": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "49"
     },
     "5d": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "49"
     },
     "5f": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "49"
     },
     "5h": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "49"
     },
     "5j": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "49"
     },
     "5l": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "49"
     },
     "5n": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "49"
     },
     "5p": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "47"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "49"
     },
     "5r": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.requests",
-      "~k_parent": "3c"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "49"
     },
     "5t": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3c"
+      "key": "root.imports.requests",
+      "~k_parent": "3d"
     },
     "5v": {
-      "key": "root.imports.operators",
-      "~k_parent": "3c"
+      "key": "root.imports.requests[0]",
+      "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5v"
+      "key": "root.imports.websockets",
+      "~k_parent": "3d"
     },
     "5x": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5w"
+      "key": "root.imports.operators",
+      "~k_parent": "3d"
     },
     "5y": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5w"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "5v"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5y"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1215,6 +1223,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5725,6 +5734,9 @@
       "providers": {
         "~k": "2f"
       },
+      "strategies": {
+        "~k": "2g"
+      },
       "~k": "2d"
     },
     "blocks": {
@@ -5732,147 +5744,147 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
-      "~k": "2g"
+      "~k": "2h"
     },
     "connections": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
-      "~k": "31"
+      "~k": "32"
     },
     "requests": {
       "AxiosHttp": {
         "originalTypeName": "AxiosHttp",
         "package": "@lowdefy/connection-axios-http",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
-      "~k": "33"
+      "~k": "34"
     },
     "websockets": {
-      "~k": "35"
+      "~k": "36"
     },
     "api": {
-      "~k": "36"
+      "~k": "37"
     },
     "operators": {
       "client": {
@@ -5880,20 +5892,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "39"
+          "~k": "3a"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3a"
+          "~k": "3b"
         },
-        "~k": "38"
+        "~k": "39"
       },
       "server": {
-        "~k": "3b"
+        "~k": "3c"
       },
-      "~k": "37"
+      "~k": "38"
     },
     "~k": "28"
   }

--- a/packages/build/src/tests/success/73-cross-module-diamond-deps/snapshot.json
+++ b/packages/build/src/tests/success/73-cross-module-diamond-deps/snapshot.json
@@ -149,164 +149,164 @@
       "~k_parent": "26"
     },
     "30": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2x"
     },
     "31": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2x"
     },
     "32": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2x"
     },
     "33": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2x"
     },
     "34": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2x"
     },
     "35": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2x"
     },
     "36": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2x"
     },
     "37": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2x"
     },
     "38": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2x"
     },
     "39": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2x"
     },
     "40": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks",
+      "~k_parent": "3r"
     },
     "41": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "40"
     },
     "43": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "40"
     },
     "44": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "40"
     },
     "45": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "40"
     },
     "46": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "40"
     },
     "47": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "40"
     },
     "48": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "40"
     },
     "49": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "40"
     },
     "50": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4m"
     },
     "52": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4m"
     },
     "54": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4m"
     },
     "56": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4m"
     },
     "58": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4m"
     },
     "60": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4m"
     },
     "62": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4m"
     },
     "64": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.requests",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4m"
     },
     "66": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.operators",
-      "~k_parent": "3q"
+      "key": "root.imports.requests",
+      "~k_parent": "3r"
     },
     "68": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "67"
+      "key": "root.imports.websockets",
+      "~k_parent": "3r"
     },
     "69": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "68"
+      "key": "root.imports.operators",
+      "~k_parent": "3r"
     },
     "a": {
       "key": "root.pages",
@@ -631,340 +631,348 @@
       "~k_parent": "2t"
     },
     "2w": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2t"
+    },
+    "2x": {
       "key": "root.types.blocks",
       "~k_parent": "2o"
     },
-    "2x": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2w"
-    },
     "2y": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2x"
     },
     "3a": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2x"
     },
     "3b": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2x"
     },
     "3c": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2x"
     },
     "3d": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2x"
     },
     "3e": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2x"
     },
     "3f": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2x"
     },
     "3g": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2x"
     },
     "3h": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2x"
+    },
+    "3i": {
       "key": "root.types.connections",
       "~k_parent": "2o"
     },
-    "3i": {
+    "3j": {
       "key": "root.types.requests",
       "~k_parent": "2o"
     },
-    "3j": {
+    "3k": {
       "key": "root.types.websockets",
       "~k_parent": "2o"
     },
-    "3k": {
+    "3l": {
       "key": "root.types.api",
       "~k_parent": "2o"
     },
-    "3l": {
+    "3m": {
       "key": "root.types.operators",
       "~k_parent": "2o"
     },
-    "3m": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3l"
-    },
     "3n": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3m"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3l"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3n"
     },
     "3q": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3m"
+    },
+    "3r": {
       "key": "root.imports",
       "~k_parent": "9"
     },
-    "3r": {
-      "key": "root.imports.actions",
-      "~k_parent": "3q"
-    },
     "3s": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3r"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.agents",
-      "~k_parent": "3q"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3s"
     },
     "3v": {
-      "key": "root.imports.auth",
-      "~k_parent": "3q"
+      "key": "root.imports.agents",
+      "~k_parent": "3r"
     },
     "3w": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3v"
+      "key": "root.imports.auth",
+      "~k_parent": "3r"
     },
     "3x": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3v"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3q"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3w"
     },
     "3z": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3y"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3w"
     },
     "4a": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "40"
     },
     "4b": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "40"
     },
     "4c": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "40"
     },
     "4d": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "40"
     },
     "4e": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "40"
     },
     "4f": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "40"
     },
     "4g": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "40"
     },
     "4h": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "40"
     },
     "4i": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "40"
     },
     "4j": {
-      "key": "root.imports.connections",
-      "~k_parent": "3q"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "40"
     },
     "4k": {
-      "key": "root.imports.icons",
-      "~k_parent": "3q"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "40"
     },
     "4l": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4k"
+      "key": "root.imports.connections",
+      "~k_parent": "3r"
     },
     "4m": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4l"
+      "key": "root.imports.icons",
+      "~k_parent": "3r"
     },
     "4n": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4m"
     },
     "4q": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4m"
     },
     "4s": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4m"
     },
     "4u": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4m"
     },
     "4w": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4m"
     },
     "4y": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4m"
     },
     "5a": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4m"
     },
     "5c": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4m"
     },
     "5e": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4m"
     },
     "5g": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4m"
     },
     "5i": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4m"
     },
     "5k": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4m"
     },
     "5m": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4m"
     },
     "5o": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4m"
     },
     "5q": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4m"
     },
     "5s": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4m"
     },
     "5u": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4m"
     },
     "5w": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4m"
     },
     "5y": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4m"
     },
     "6a": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "68"
+      "key": "root.imports.operators.client",
+      "~k_parent": "69"
     },
     "6b": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6a"
+    },
+    "6c": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6a"
+    },
+    "6d": {
       "key": "root.imports.operators.server",
-      "~k_parent": "67"
+      "~k_parent": "69"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1317,6 +1325,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5874,6 +5883,9 @@
       "providers": {
         "~k": "2v"
       },
+      "strategies": {
+        "~k": "2w"
+      },
       "~k": "2t"
     },
     "blocks": {
@@ -5881,135 +5893,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 6,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3f"
+        "~k": "3g"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
-      "~k": "2w"
+      "~k": "2x"
     },
     "connections": {
-      "~k": "3h"
-    },
-    "requests": {
       "~k": "3i"
     },
-    "websockets": {
+    "requests": {
       "~k": "3j"
     },
-    "api": {
+    "websockets": {
       "~k": "3k"
+    },
+    "api": {
+      "~k": "3l"
     },
     "operators": {
       "client": {
@@ -6017,20 +6029,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3n"
+          "~k": "3o"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3o"
+          "~k": "3p"
         },
-        "~k": "3m"
+        "~k": "3n"
       },
       "server": {
-        "~k": "3p"
+        "~k": "3q"
       },
-      "~k": "3l"
+      "~k": "3m"
     },
     "~k": "2o"
   }

--- a/packages/build/src/tests/success/74-cross-module-multi-instance/snapshot.json
+++ b/packages/build/src/tests/success/74-cross-module-multi-instance/snapshot.json
@@ -184,124 +184,124 @@
       "~k_parent": "38"
     },
     "40": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3j"
     },
     "41": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3j"
     },
     "42": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3j"
     },
     "43": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3j"
+    },
+    "44": {
       "key": "root.types.connections",
       "~k_parent": "3a"
     },
-    "44": {
+    "45": {
       "key": "root.types.requests",
       "~k_parent": "3a"
     },
-    "45": {
+    "46": {
       "key": "root.types.websockets",
       "~k_parent": "3a"
     },
-    "46": {
+    "47": {
       "key": "root.types.api",
       "~k_parent": "3a"
     },
-    "47": {
+    "48": {
       "key": "root.types.operators",
       "~k_parent": "3a"
     },
-    "48": {
-      "key": "root.types.operators.client",
-      "~k_parent": "47"
-    },
     "49": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "4m"
     },
     "51": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "4m"
     },
     "52": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "4m"
     },
     "53": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "4m"
     },
     "54": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "4m"
     },
     "55": {
-      "key": "root.imports.connections",
-      "~k_parent": "4c"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "4m"
     },
     "56": {
-      "key": "root.imports.icons",
-      "~k_parent": "4c"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "4m"
     },
     "57": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "56"
+      "key": "root.imports.connections",
+      "~k_parent": "4d"
     },
     "58": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "57"
+      "key": "root.imports.icons",
+      "~k_parent": "4d"
     },
     "59": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "58"
     },
     "62": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "58"
     },
     "64": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "58"
     },
     "66": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "58"
     },
     "68": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "58"
     },
     "b": {
       "key": "root",
@@ -687,380 +687,388 @@
       "~k_parent": "3f"
     },
     "3i": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "3f"
+    },
+    "3j": {
       "key": "root.types.blocks",
       "~k_parent": "3a"
     },
-    "3j": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "3i"
-    },
     "3k": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3j"
     },
     "3l": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "3j"
     },
     "3m": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3j"
     },
     "3n": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3j"
     },
     "3o": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3j"
     },
     "3p": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3j"
     },
     "3q": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3j"
     },
     "3r": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3j"
     },
     "3s": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3j"
     },
     "3t": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3j"
     },
     "3u": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3j"
     },
     "3v": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3j"
     },
     "3w": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3j"
     },
     "3x": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3j"
     },
     "3y": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3j"
     },
     "3z": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "3i"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3j"
     },
     "4a": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "48"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "49"
     },
     "4b": {
-      "key": "root.types.operators.server",
-      "~k_parent": "47"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "49"
     },
     "4c": {
+      "key": "root.types.operators.server",
+      "~k_parent": "48"
+    },
+    "4d": {
       "key": "root.imports",
       "~k_parent": "b"
     },
-    "4d": {
-      "key": "root.imports.actions",
-      "~k_parent": "4c"
-    },
     "4e": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "4d"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.agents",
-      "~k_parent": "4c"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "4e"
     },
     "4h": {
-      "key": "root.imports.auth",
-      "~k_parent": "4c"
+      "key": "root.imports.agents",
+      "~k_parent": "4d"
     },
     "4i": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "4h"
+      "key": "root.imports.auth",
+      "~k_parent": "4d"
     },
     "4j": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "4h"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.blocks",
-      "~k_parent": "4c"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "4i"
     },
     "4l": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "4k"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "4i"
     },
     "4m": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks",
+      "~k_parent": "4d"
     },
     "4n": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "4m"
     },
     "4p": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "4m"
     },
     "4q": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "4m"
     },
     "4r": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "4m"
     },
     "4s": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "4m"
     },
     "4t": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "4m"
     },
     "4u": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "4m"
     },
     "4v": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "4m"
     },
     "4w": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "4m"
     },
     "4x": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "4m"
     },
     "4y": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "4m"
     },
     "4z": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "4k"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "4m"
     },
     "5a": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "58"
     },
     "5c": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "58"
     },
     "5e": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "58"
     },
     "5g": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "58"
     },
     "5i": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "58"
     },
     "5k": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "58"
     },
     "5m": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "58"
     },
     "5o": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "58"
     },
     "5q": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "58"
     },
     "5s": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "58"
     },
     "5u": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "58"
     },
     "5w": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "58"
     },
     "5y": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "58"
     },
     "6a": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "58"
     },
     "6c": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "58"
     },
     "6e": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "58"
     },
     "6g": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "6f"
     },
     "6h": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "58"
     },
     "6i": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "58"
     },
     "6k": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "6j"
     },
     "6l": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "58"
     },
     "6m": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "6l"
     },
     "6n": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "58"
     },
     "6o": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "6n"
     },
     "6p": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "56"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "58"
     },
     "6q": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.requests",
-      "~k_parent": "4c"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "58"
     },
     "6s": {
-      "key": "root.imports.websockets",
-      "~k_parent": "4c"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6r"
     },
     "6t": {
-      "key": "root.imports.operators",
-      "~k_parent": "4c"
+      "key": "root.imports.requests",
+      "~k_parent": "4d"
     },
     "6u": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6t"
+      "key": "root.imports.websockets",
+      "~k_parent": "4d"
     },
     "6v": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6u"
+      "key": "root.imports.operators",
+      "~k_parent": "4d"
     },
     "6w": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6u"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6v"
     },
     "6x": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6w"
+    },
+    "6y": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6w"
+    },
+    "6z": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6t"
+      "~k_parent": "6v"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1501,6 +1509,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -6027,6 +6036,9 @@
       "providers": {
         "~k": "3h"
       },
+      "strategies": {
+        "~k": "3i"
+      },
       "~k": "3f"
     },
     "blocks": {
@@ -6034,135 +6046,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 6,
-        "~k": "3j"
+        "~k": "3k"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "3k"
+        "~k": "3l"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "3l"
+        "~k": "3m"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3m"
+        "~k": "3n"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3n"
+        "~k": "3o"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3o"
+        "~k": "3p"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3p"
+        "~k": "3q"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3q"
+        "~k": "3r"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3r"
+        "~k": "3s"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3s"
+        "~k": "3t"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3t"
+        "~k": "3u"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3u"
+        "~k": "3v"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3v"
+        "~k": "3w"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3w"
+        "~k": "3x"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3x"
+        "~k": "3y"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3y"
+        "~k": "3z"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3z"
+        "~k": "40"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "40"
+        "~k": "41"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "41"
+        "~k": "42"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "42"
+        "~k": "43"
       },
-      "~k": "3i"
+      "~k": "3j"
     },
     "connections": {
-      "~k": "43"
-    },
-    "requests": {
       "~k": "44"
     },
-    "websockets": {
+    "requests": {
       "~k": "45"
     },
-    "api": {
+    "websockets": {
       "~k": "46"
+    },
+    "api": {
+      "~k": "47"
     },
     "operators": {
       "client": {
@@ -6170,20 +6182,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "49"
+          "~k": "4a"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "4a"
+          "~k": "4b"
         },
-        "~k": "48"
+        "~k": "49"
       },
       "server": {
-        "~k": "4b"
+        "~k": "4c"
       },
-      "~k": "47"
+      "~k": "48"
     },
     "~k": "3a"
   }

--- a/packages/build/src/tests/success/75-cross-module-connection-remap/snapshot.json
+++ b/packages/build/src/tests/success/75-cross-module-connection-remap/snapshot.json
@@ -166,136 +166,144 @@
       "~k_parent": "26"
     },
     "30": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2m"
     },
     "31": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2m"
     },
     "32": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2m"
     },
     "33": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2m"
     },
     "34": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2m"
     },
     "35": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2m"
     },
     "36": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2m"
+    },
+    "37": {
       "key": "root.types.connections",
       "~k_parent": "2d"
     },
-    "37": {
-      "key": "root.types.connections.MongoDBCollection",
-      "~k_parent": "36"
-    },
     "38": {
+      "key": "root.types.connections.MongoDBCollection",
+      "~k_parent": "37"
+    },
+    "39": {
       "key": "root.types.requests",
       "~k_parent": "2d"
     },
-    "39": {
-      "key": "root.types.websockets",
-      "~k_parent": "2d"
-    },
     "40": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3q"
     },
     "41": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3q"
     },
     "42": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3q"
     },
     "43": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3q"
     },
     "44": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3q"
     },
     "45": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3q"
     },
     "46": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3q"
     },
     "47": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3q"
     },
     "48": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3q"
     },
     "49": {
-      "key": "root.imports.connections",
-      "~k_parent": "3g"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3q"
     },
     "50": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4d"
     },
     "51": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4d"
     },
     "53": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4d"
     },
     "55": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4d"
     },
     "57": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4d"
     },
     "59": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5z"
+      "key": "root.imports.operators",
+      "~k_parent": "3h"
     },
     "61": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5z"
+      "key": "root.imports.operators.client",
+      "~k_parent": "60"
     },
     "62": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "61"
+    },
+    "63": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "61"
+    },
+    "64": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5y"
+      "~k_parent": "60"
     },
     "a": {
       "key": "root.connections[0:shared-mongodb:MongoDBCollection].properties",
@@ -565,376 +573,376 @@
       "~k_parent": "2i"
     },
     "2l": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2i"
+    },
+    "2m": {
       "key": "root.types.blocks",
       "~k_parent": "2d"
     },
-    "2m": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2l"
-    },
     "2n": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2m"
     },
     "2p": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2m"
     },
     "2q": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2m"
     },
     "2r": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2m"
     },
     "2s": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2m"
     },
     "2t": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2m"
     },
     "2u": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2m"
     },
     "2v": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2m"
     },
     "2w": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2m"
     },
     "2x": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2m"
     },
     "2y": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2m"
     },
     "2z": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2m"
     },
     "3a": {
-      "key": "root.types.api",
+      "key": "root.types.websockets",
       "~k_parent": "2d"
     },
     "3b": {
-      "key": "root.types.operators",
+      "key": "root.types.api",
       "~k_parent": "2d"
     },
     "3c": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3b"
+      "key": "root.types.operators",
+      "~k_parent": "2d"
     },
     "3d": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3c"
     },
     "3e": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3c"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3d"
     },
     "3f": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3b"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3d"
     },
     "3g": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3c"
+    },
+    "3h": {
       "key": "root.imports",
       "~k_parent": "7"
     },
-    "3h": {
-      "key": "root.imports.actions",
-      "~k_parent": "3g"
-    },
     "3i": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3h"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.agents",
-      "~k_parent": "3g"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3i"
     },
     "3l": {
-      "key": "root.imports.auth",
-      "~k_parent": "3g"
+      "key": "root.imports.agents",
+      "~k_parent": "3h"
     },
     "3m": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3l"
+      "key": "root.imports.auth",
+      "~k_parent": "3h"
     },
     "3n": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3l"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3g"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3m"
     },
     "3p": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3o"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks",
+      "~k_parent": "3h"
     },
     "3r": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3q"
     },
     "3t": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3q"
     },
     "3u": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3q"
     },
     "3v": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3q"
     },
     "3w": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3q"
     },
     "3x": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3q"
     },
     "3y": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3q"
     },
     "3z": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3q"
     },
     "4a": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3q"
     },
     "4b": {
-      "key": "root.imports.icons",
-      "~k_parent": "3g"
+      "key": "root.imports.connections",
+      "~k_parent": "3h"
     },
     "4c": {
-      "key": "root.imports.icons[0]",
+      "key": "root.imports.connections[0]",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4c"
+      "key": "root.imports.icons",
+      "~k_parent": "3h"
     },
     "4e": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4d"
     },
     "4h": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4d"
     },
     "4j": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4d"
     },
     "4l": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4d"
     },
     "4n": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4d"
     },
     "4p": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4d"
     },
     "4r": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4d"
     },
     "4t": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4d"
     },
     "4v": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4d"
     },
     "4x": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4d"
     },
     "4z": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4d"
     },
     "5b": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4d"
     },
     "5d": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4d"
     },
     "5f": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4d"
     },
     "5h": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4d"
     },
     "5j": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4d"
     },
     "5l": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4d"
     },
     "5n": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4d"
     },
     "5p": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4d"
     },
     "5r": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4d"
     },
     "5t": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4b"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4d"
     },
     "5v": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.requests",
-      "~k_parent": "3g"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4d"
     },
     "5x": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3g"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.operators",
-      "~k_parent": "3g"
+      "key": "root.imports.requests",
+      "~k_parent": "3h"
     },
     "5z": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5y"
+      "key": "root.imports.websockets",
+      "~k_parent": "3h"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1234,6 +1242,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5749,6 +5758,9 @@
       "providers": {
         "~k": "2k"
       },
+      "strategies": {
+        "~k": "2l"
+      },
       "~k": "2i"
     },
     "blocks": {
@@ -5756,141 +5768,141 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2n"
+        "~k": "2o"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
-      "~k": "2l"
+      "~k": "2m"
     },
     "connections": {
       "MongoDBCollection": {
         "originalTypeName": "MongoDBCollection",
         "package": "@lowdefy/connection-mongodb",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
-      "~k": "36"
+      "~k": "37"
     },
     "requests": {
-      "~k": "38"
-    },
-    "websockets": {
       "~k": "39"
     },
-    "api": {
+    "websockets": {
       "~k": "3a"
+    },
+    "api": {
+      "~k": "3b"
     },
     "operators": {
       "client": {
@@ -5898,20 +5910,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3d"
+          "~k": "3e"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3e"
+          "~k": "3f"
         },
-        "~k": "3c"
+        "~k": "3d"
       },
       "server": {
-        "~k": "3f"
+        "~k": "3g"
       },
-      "~k": "3b"
+      "~k": "3c"
     },
     "~k": "2d"
   }

--- a/packages/build/src/tests/success/76-cross-module-nested-refs/snapshot.json
+++ b/packages/build/src/tests/success/76-cross-module-nested-refs/snapshot.json
@@ -149,164 +149,164 @@
       "~k_parent": "26"
     },
     "30": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2x"
     },
     "31": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2x"
     },
     "32": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2x"
     },
     "33": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2x"
     },
     "34": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2x"
     },
     "35": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2x"
     },
     "36": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2x"
     },
     "37": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2x"
     },
     "38": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2x"
     },
     "39": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2x"
     },
     "40": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks",
+      "~k_parent": "3r"
     },
     "41": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "40"
     },
     "43": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "40"
     },
     "44": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "40"
     },
     "45": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "40"
     },
     "46": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "40"
     },
     "47": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "40"
     },
     "48": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "40"
     },
     "49": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "40"
     },
     "50": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4m"
     },
     "52": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4m"
     },
     "54": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4m"
     },
     "56": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4m"
     },
     "58": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4m"
     },
     "60": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4m"
     },
     "62": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4m"
     },
     "64": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.requests",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4m"
     },
     "66": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3q"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.operators",
-      "~k_parent": "3q"
+      "key": "root.imports.requests",
+      "~k_parent": "3r"
     },
     "68": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "67"
+      "key": "root.imports.websockets",
+      "~k_parent": "3r"
     },
     "69": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "68"
+      "key": "root.imports.operators",
+      "~k_parent": "3r"
     },
     "a": {
       "key": "root.pages",
@@ -631,340 +631,348 @@
       "~k_parent": "2t"
     },
     "2w": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2t"
+    },
+    "2x": {
       "key": "root.types.blocks",
       "~k_parent": "2o"
     },
-    "2x": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2w"
-    },
     "2y": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2x"
     },
     "3a": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2x"
     },
     "3b": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2x"
     },
     "3c": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2x"
     },
     "3d": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2x"
     },
     "3e": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2x"
     },
     "3f": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2x"
     },
     "3g": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2w"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2x"
     },
     "3h": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2x"
+    },
+    "3i": {
       "key": "root.types.connections",
       "~k_parent": "2o"
     },
-    "3i": {
+    "3j": {
       "key": "root.types.requests",
       "~k_parent": "2o"
     },
-    "3j": {
+    "3k": {
       "key": "root.types.websockets",
       "~k_parent": "2o"
     },
-    "3k": {
+    "3l": {
       "key": "root.types.api",
       "~k_parent": "2o"
     },
-    "3l": {
+    "3m": {
       "key": "root.types.operators",
       "~k_parent": "2o"
     },
-    "3m": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3l"
-    },
     "3n": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3m"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3l"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3n"
     },
     "3q": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3m"
+    },
+    "3r": {
       "key": "root.imports",
       "~k_parent": "9"
     },
-    "3r": {
-      "key": "root.imports.actions",
-      "~k_parent": "3q"
-    },
     "3s": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3r"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.agents",
-      "~k_parent": "3q"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3s"
     },
     "3v": {
-      "key": "root.imports.auth",
-      "~k_parent": "3q"
+      "key": "root.imports.agents",
+      "~k_parent": "3r"
     },
     "3w": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3v"
+      "key": "root.imports.auth",
+      "~k_parent": "3r"
     },
     "3x": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3v"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3q"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3w"
     },
     "3z": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3y"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3w"
     },
     "4a": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "40"
     },
     "4b": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "40"
     },
     "4c": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "40"
     },
     "4d": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "40"
     },
     "4e": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "40"
     },
     "4f": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "40"
     },
     "4g": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "40"
     },
     "4h": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "40"
     },
     "4i": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3y"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "40"
     },
     "4j": {
-      "key": "root.imports.connections",
-      "~k_parent": "3q"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "40"
     },
     "4k": {
-      "key": "root.imports.icons",
-      "~k_parent": "3q"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "40"
     },
     "4l": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4k"
+      "key": "root.imports.connections",
+      "~k_parent": "3r"
     },
     "4m": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4l"
+      "key": "root.imports.icons",
+      "~k_parent": "3r"
     },
     "4n": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4m"
     },
     "4q": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4m"
     },
     "4s": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4m"
     },
     "4u": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4m"
     },
     "4w": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4m"
     },
     "4y": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4m"
     },
     "5a": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4m"
     },
     "5c": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4m"
     },
     "5e": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4m"
     },
     "5g": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4m"
     },
     "5i": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4m"
     },
     "5k": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4m"
     },
     "5m": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4m"
     },
     "5o": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4m"
     },
     "5q": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4m"
     },
     "5s": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4m"
     },
     "5u": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4m"
     },
     "5w": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4m"
     },
     "5y": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4k"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4m"
     },
     "6a": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "68"
+      "key": "root.imports.operators.client",
+      "~k_parent": "69"
     },
     "6b": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6a"
+    },
+    "6c": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6a"
+    },
+    "6d": {
       "key": "root.imports.operators.server",
-      "~k_parent": "67"
+      "~k_parent": "69"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1317,6 +1325,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5867,6 +5876,9 @@
       "providers": {
         "~k": "2v"
       },
+      "strategies": {
+        "~k": "2w"
+      },
       "~k": "2t"
     },
     "blocks": {
@@ -5874,135 +5886,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 6,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2z"
+        "~k": "30"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3f"
+        "~k": "3g"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
-      "~k": "2w"
+      "~k": "2x"
     },
     "connections": {
-      "~k": "3h"
-    },
-    "requests": {
       "~k": "3i"
     },
-    "websockets": {
+    "requests": {
       "~k": "3j"
     },
-    "api": {
+    "websockets": {
       "~k": "3k"
+    },
+    "api": {
+      "~k": "3l"
     },
     "operators": {
       "client": {
@@ -6010,20 +6022,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3n"
+          "~k": "3o"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3o"
+          "~k": "3p"
         },
-        "~k": "3m"
+        "~k": "3n"
       },
       "server": {
-        "~k": "3p"
+        "~k": "3q"
       },
-      "~k": "3l"
+      "~k": "3m"
     },
     "~k": "2o"
   }

--- a/packages/build/src/tests/success/77-cross-module-menu-refs/snapshot.json
+++ b/packages/build/src/tests/success/77-cross-module-menu-refs/snapshot.json
@@ -150,164 +150,164 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2w"
     },
     "31": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2w"
     },
     "32": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2w"
     },
     "33": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2w"
     },
     "34": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2w"
     },
     "35": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2w"
     },
     "36": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2w"
     },
     "37": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2w"
     },
     "38": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2w"
     },
     "39": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2w"
     },
     "40": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3z"
     },
     "42": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3z"
     },
     "43": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3z"
     },
     "44": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3z"
     },
     "45": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3z"
     },
     "46": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3z"
     },
     "47": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3z"
     },
     "48": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3z"
     },
     "49": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3z"
     },
     "50": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4l"
     },
     "51": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4l"
     },
     "53": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4l"
     },
     "55": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4l"
     },
     "57": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4l"
     },
     "59": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4l"
     },
     "61": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4l"
     },
     "63": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.requests",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4l"
     },
     "65": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.operators",
-      "~k_parent": "3p"
+      "key": "root.imports.requests",
+      "~k_parent": "3q"
     },
     "67": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "66"
+      "key": "root.imports.websockets",
+      "~k_parent": "3q"
     },
     "68": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "67"
+      "key": "root.imports.operators",
+      "~k_parent": "3q"
     },
     "69": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "67"
+      "key": "root.imports.operators.client",
+      "~k_parent": "68"
     },
     "a": {
       "key": "root.pages[0:home:Box]",
@@ -623,340 +623,348 @@
       "~k_parent": "2s"
     },
     "2v": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2s"
+    },
+    "2w": {
       "key": "root.types.blocks",
       "~k_parent": "2n"
     },
-    "2w": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2v"
-    },
     "2x": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2w"
     },
     "2z": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2w"
     },
     "3a": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2w"
     },
     "3b": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2w"
     },
     "3c": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2w"
     },
     "3d": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2w"
     },
     "3e": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2w"
     },
     "3f": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2v"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2w"
     },
     "3g": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2w"
+    },
+    "3h": {
       "key": "root.types.connections",
       "~k_parent": "2n"
     },
-    "3h": {
+    "3i": {
       "key": "root.types.requests",
       "~k_parent": "2n"
     },
-    "3i": {
+    "3j": {
       "key": "root.types.websockets",
       "~k_parent": "2n"
     },
-    "3j": {
+    "3k": {
       "key": "root.types.api",
       "~k_parent": "2n"
     },
-    "3k": {
+    "3l": {
       "key": "root.types.operators",
       "~k_parent": "2n"
     },
-    "3l": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3k"
-    },
     "3m": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3l"
     },
     "3n": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3l"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3k"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3m"
     },
     "3p": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3l"
+    },
+    "3q": {
       "key": "root.imports",
       "~k_parent": "8"
     },
-    "3q": {
-      "key": "root.imports.actions",
-      "~k_parent": "3p"
-    },
     "3r": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3q"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.agents",
-      "~k_parent": "3p"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3r"
     },
     "3u": {
-      "key": "root.imports.auth",
-      "~k_parent": "3p"
+      "key": "root.imports.agents",
+      "~k_parent": "3q"
     },
     "3v": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3u"
+      "key": "root.imports.auth",
+      "~k_parent": "3q"
     },
     "3w": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3u"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3p"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3v"
     },
     "3y": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3x"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3v"
     },
     "3z": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks",
+      "~k_parent": "3q"
     },
     "4a": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3z"
     },
     "4b": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3z"
     },
     "4c": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3z"
     },
     "4d": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3z"
     },
     "4e": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3z"
     },
     "4f": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3z"
     },
     "4g": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3z"
     },
     "4h": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3z"
     },
     "4i": {
-      "key": "root.imports.connections",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3z"
     },
     "4j": {
-      "key": "root.imports.icons",
-      "~k_parent": "3p"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3z"
     },
     "4k": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4j"
+      "key": "root.imports.connections",
+      "~k_parent": "3q"
     },
     "4l": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4k"
+      "key": "root.imports.icons",
+      "~k_parent": "3q"
     },
     "4m": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4l"
     },
     "4p": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4l"
     },
     "4r": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4l"
     },
     "4t": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4l"
     },
     "4v": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4l"
     },
     "4x": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4l"
     },
     "4z": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4l"
     },
     "5b": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4l"
     },
     "5d": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4l"
     },
     "5f": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4l"
     },
     "5h": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4l"
     },
     "5j": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4l"
     },
     "5l": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4l"
     },
     "5n": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4l"
     },
     "5p": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4l"
     },
     "5r": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4l"
     },
     "5t": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4l"
     },
     "5v": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4l"
     },
     "5x": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4l"
     },
     "5z": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5y"
     },
     "6a": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "69"
+    },
+    "6b": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "69"
+    },
+    "6c": {
       "key": "root.imports.operators.server",
-      "~k_parent": "66"
+      "~k_parent": "68"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1306,6 +1314,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5842,6 +5851,9 @@
       "providers": {
         "~k": "2u"
       },
+      "strategies": {
+        "~k": "2v"
+      },
       "~k": "2s"
     },
     "blocks": {
@@ -5849,135 +5861,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3f"
+        "~k": "3g"
       },
-      "~k": "2v"
+      "~k": "2w"
     },
     "connections": {
-      "~k": "3g"
-    },
-    "requests": {
       "~k": "3h"
     },
-    "websockets": {
+    "requests": {
       "~k": "3i"
     },
-    "api": {
+    "websockets": {
       "~k": "3j"
+    },
+    "api": {
+      "~k": "3k"
     },
     "operators": {
       "client": {
@@ -5985,20 +5997,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3m"
+          "~k": "3n"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3n"
+          "~k": "3o"
         },
-        "~k": "3l"
+        "~k": "3m"
       },
       "server": {
-        "~k": "3o"
+        "~k": "3p"
       },
-      "~k": "3k"
+      "~k": "3l"
     },
     "~k": "2n"
   }

--- a/packages/build/src/tests/success/78-cross-module-mutual-nested/snapshot.json
+++ b/packages/build/src/tests/success/78-cross-module-mutual-nested/snapshot.json
@@ -149,164 +149,164 @@
       "~k_parent": "22"
     },
     "30": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2t"
     },
     "31": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2t"
     },
     "32": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2t"
     },
     "33": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2t"
     },
     "34": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2t"
     },
     "35": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2t"
     },
     "36": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2t"
     },
     "37": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2t"
     },
     "38": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2t"
     },
     "39": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2t"
     },
     "40": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3x"
     },
     "41": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3x"
     },
     "42": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3x"
     },
     "43": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3x"
     },
     "44": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3x"
     },
     "45": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3x"
     },
     "46": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3x"
     },
     "47": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3x"
     },
     "48": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3x"
     },
     "49": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3x"
     },
     "50": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4k"
     },
     "52": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4k"
     },
     "54": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4k"
     },
     "56": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4k"
     },
     "58": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4k"
     },
     "60": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4k"
     },
     "62": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.requests",
-      "~k_parent": "3n"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4k"
     },
     "64": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3n"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.operators",
-      "~k_parent": "3n"
+      "key": "root.imports.requests",
+      "~k_parent": "3o"
     },
     "66": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "65"
+      "key": "root.imports.websockets",
+      "~k_parent": "3o"
     },
     "67": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "66"
+      "key": "root.imports.operators",
+      "~k_parent": "3o"
     },
     "68": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "66"
+      "key": "root.imports.operators.client",
+      "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "65"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "68"
     },
     "a": {
       "key": "root.pages",
@@ -611,348 +611,356 @@
       "~k_parent": "2p"
     },
     "2s": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2p"
+    },
+    "2t": {
       "key": "root.types.blocks",
       "~k_parent": "2k"
     },
-    "2t": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2s"
-    },
     "2u": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2t"
     },
     "2w": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "2t"
     },
     "2x": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2t"
     },
     "2y": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2t"
     },
     "2z": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2t"
     },
     "3a": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2t"
     },
     "3b": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2t"
     },
     "3c": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2t"
     },
     "3d": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2s"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2t"
     },
     "3e": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2t"
+    },
+    "3f": {
       "key": "root.types.connections",
       "~k_parent": "2k"
     },
-    "3f": {
+    "3g": {
       "key": "root.types.requests",
       "~k_parent": "2k"
     },
-    "3g": {
+    "3h": {
       "key": "root.types.websockets",
       "~k_parent": "2k"
     },
-    "3h": {
+    "3i": {
       "key": "root.types.api",
       "~k_parent": "2k"
     },
-    "3i": {
+    "3j": {
       "key": "root.types.operators",
       "~k_parent": "2k"
     },
-    "3j": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3i"
-    },
     "3k": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3j"
     },
     "3l": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3j"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3i"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3k"
     },
     "3n": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3j"
+    },
+    "3o": {
       "key": "root.imports",
       "~k_parent": "9"
     },
-    "3o": {
-      "key": "root.imports.actions",
-      "~k_parent": "3n"
-    },
     "3p": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3o"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.agents",
-      "~k_parent": "3n"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3p"
     },
     "3s": {
-      "key": "root.imports.auth",
-      "~k_parent": "3n"
+      "key": "root.imports.agents",
+      "~k_parent": "3o"
     },
     "3t": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3s"
+      "key": "root.imports.auth",
+      "~k_parent": "3o"
     },
     "3u": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3s"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3n"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3t"
     },
     "3w": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3v"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3t"
     },
     "3x": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks",
+      "~k_parent": "3o"
     },
     "3y": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3x"
     },
     "4a": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3x"
     },
     "4b": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3x"
     },
     "4c": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3x"
     },
     "4d": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3x"
     },
     "4e": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3x"
     },
     "4f": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3x"
     },
     "4g": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "3v"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3x"
     },
     "4h": {
-      "key": "root.imports.connections",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3x"
     },
     "4i": {
-      "key": "root.imports.icons",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "3x"
     },
     "4j": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4i"
+      "key": "root.imports.connections",
+      "~k_parent": "3o"
     },
     "4k": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4j"
+      "key": "root.imports.icons",
+      "~k_parent": "3o"
     },
     "4l": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4k"
     },
     "4o": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4k"
     },
     "4q": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4k"
     },
     "4s": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4k"
     },
     "4u": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4k"
     },
     "4w": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4k"
     },
     "4y": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4k"
     },
     "5a": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4k"
     },
     "5c": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4k"
     },
     "5e": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4k"
     },
     "5g": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4k"
     },
     "5i": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4k"
     },
     "5k": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4k"
     },
     "5m": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4k"
     },
     "5o": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4k"
     },
     "5q": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4k"
     },
     "5s": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4k"
     },
     "5u": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4k"
     },
     "5w": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4k"
     },
     "5y": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4i"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4k"
+    },
+    "6a": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "68"
+    },
+    "6b": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "67"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1288,6 +1296,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -6790,6 +6799,9 @@
       "providers": {
         "~k": "2r"
       },
+      "strategies": {
+        "~k": "2s"
+      },
       "~k": "2p"
     },
     "blocks": {
@@ -6797,141 +6809,141 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
-      "~k": "2s"
+      "~k": "2t"
     },
     "connections": {
-      "~k": "3e"
-    },
-    "requests": {
       "~k": "3f"
     },
-    "websockets": {
+    "requests": {
       "~k": "3g"
     },
-    "api": {
+    "websockets": {
       "~k": "3h"
+    },
+    "api": {
+      "~k": "3i"
     },
     "operators": {
       "client": {
@@ -6939,20 +6951,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3k"
+          "~k": "3l"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3l"
+          "~k": "3m"
         },
-        "~k": "3j"
+        "~k": "3k"
       },
       "server": {
-        "~k": "3m"
+        "~k": "3n"
       },
-      "~k": "3i"
+      "~k": "3j"
     },
     "~k": "2k"
   }

--- a/packages/build/src/tests/success/79-cross-module-build-op-wrapping/snapshot.json
+++ b/packages/build/src/tests/success/79-cross-module-build-op-wrapping/snapshot.json
@@ -153,135 +153,135 @@
       "~k_parent": "24"
     },
     "27": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "24"
+    },
+    "28": {
       "key": "root.types.blocks",
       "~k_parent": "1z"
     },
-    "28": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "27"
-    },
     "29": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2w"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2y"
     },
     "31": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2x"
+    },
+    "32": {
       "key": "root.imports",
       "~k_parent": "6"
     },
-    "32": {
-      "key": "root.imports.actions",
-      "~k_parent": "31"
-    },
     "33": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "32"
     },
     "34": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "32"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "33"
     },
     "35": {
-      "key": "root.imports.agents",
-      "~k_parent": "31"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "33"
     },
     "36": {
-      "key": "root.imports.auth",
-      "~k_parent": "31"
+      "key": "root.imports.agents",
+      "~k_parent": "32"
     },
     "37": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "36"
+      "key": "root.imports.auth",
+      "~k_parent": "32"
     },
     "38": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "36"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "37"
     },
     "39": {
-      "key": "root.imports.blocks",
-      "~k_parent": "31"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "37"
     },
     "40": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3x"
     },
     "41": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3x"
     },
     "43": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3x"
     },
     "45": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3x"
     },
     "47": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3x"
     },
     "49": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3x"
     },
     "51": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3x"
     },
     "53": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3x"
     },
     "55": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3x"
     },
     "57": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3x"
     },
     "59": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "58"
     },
     "a": {
@@ -495,368 +495,376 @@
       "~k_parent": "6"
     },
     "2a": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "28"
     },
     "2b": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "28"
     },
     "2c": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "28"
     },
     "2d": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "28"
     },
     "2e": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "27"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "28"
     },
     "2f": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "28"
     },
     "2g": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "28"
     },
     "2h": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "28"
     },
     "2i": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "27"
+      "key": "root.types.blocks.List",
+      "~k_parent": "28"
     },
     "2j": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "28"
     },
     "2k": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "28"
     },
     "2l": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "27"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "28"
     },
     "2m": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "28"
     },
     "2n": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "28"
     },
     "2o": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "28"
     },
     "2p": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "28"
     },
     "2q": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "27"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "28"
     },
     "2r": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "27"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "28"
     },
     "2s": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "28"
+    },
+    "2t": {
       "key": "root.types.connections",
       "~k_parent": "1z"
     },
-    "2t": {
+    "2u": {
       "key": "root.types.requests",
       "~k_parent": "1z"
     },
-    "2u": {
+    "2v": {
       "key": "root.types.websockets",
       "~k_parent": "1z"
     },
-    "2v": {
+    "2w": {
       "key": "root.types.api",
       "~k_parent": "1z"
     },
-    "2w": {
+    "2x": {
       "key": "root.types.operators",
       "~k_parent": "1z"
     },
-    "2x": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2w"
-    },
     "2y": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2x"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "39"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "37"
     },
     "3b": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks",
+      "~k_parent": "32"
     },
     "3c": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3b"
     },
     "3e": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3b"
     },
     "3f": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3b"
     },
     "3g": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3b"
     },
     "3h": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3b"
     },
     "3i": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3b"
     },
     "3j": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3b"
     },
     "3k": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3b"
     },
     "3l": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3b"
     },
     "3m": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3b"
     },
     "3n": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3b"
     },
     "3o": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3b"
     },
     "3p": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3b"
     },
     "3q": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3b"
     },
     "3r": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3b"
     },
     "3s": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3b"
     },
     "3t": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "39"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3b"
     },
     "3u": {
-      "key": "root.imports.connections",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3b"
     },
     "3v": {
-      "key": "root.imports.icons",
-      "~k_parent": "31"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3b"
     },
     "3w": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3v"
+      "key": "root.imports.connections",
+      "~k_parent": "32"
     },
     "3x": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3w"
+      "key": "root.imports.icons",
+      "~k_parent": "32"
     },
     "3y": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3x"
     },
     "4b": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3x"
     },
     "4d": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3x"
     },
     "4f": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3x"
     },
     "4h": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3x"
     },
     "4j": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3x"
     },
     "4l": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3x"
     },
     "4n": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3x"
     },
     "4p": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3x"
     },
     "4r": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3x"
     },
     "4t": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3x"
     },
     "4v": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3x"
     },
     "4x": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3x"
     },
     "4z": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3x"
     },
     "5b": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3x"
     },
     "5d": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3v"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3x"
     },
     "5f": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.requests",
-      "~k_parent": "31"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3x"
     },
     "5h": {
-      "key": "root.imports.websockets",
-      "~k_parent": "31"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.operators",
-      "~k_parent": "31"
+      "key": "root.imports.requests",
+      "~k_parent": "32"
     },
     "5j": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5i"
+      "key": "root.imports.websockets",
+      "~k_parent": "32"
     },
     "5k": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5j"
+      "key": "root.imports.operators",
+      "~k_parent": "32"
     },
     "5l": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5j"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5k"
     },
     "5m": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5l"
+    },
+    "5n": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5l"
+    },
+    "5o": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5i"
+      "~k_parent": "5k"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1114,6 +1122,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5633,6 +5642,9 @@
       "providers": {
         "~k": "26"
       },
+      "strategies": {
+        "~k": "27"
+      },
       "~k": "24"
     },
     "blocks": {
@@ -5640,135 +5652,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "28"
+        "~k": "29"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "29"
+        "~k": "2a"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
-      "~k": "27"
+      "~k": "28"
     },
     "connections": {
-      "~k": "2s"
-    },
-    "requests": {
       "~k": "2t"
     },
-    "websockets": {
+    "requests": {
       "~k": "2u"
     },
-    "api": {
+    "websockets": {
       "~k": "2v"
+    },
+    "api": {
+      "~k": "2w"
     },
     "operators": {
       "client": {
@@ -5776,20 +5788,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2y"
+          "~k": "2z"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2z"
+          "~k": "30"
         },
-        "~k": "2x"
+        "~k": "2y"
       },
       "server": {
-        "~k": "30"
+        "~k": "31"
       },
-      "~k": "2w"
+      "~k": "2x"
     },
     "~k": "1z"
   }

--- a/packages/build/src/tests/success/80-cross-module-ref-in-vars/snapshot.json
+++ b/packages/build/src/tests/success/80-cross-module-ref-in-vars/snapshot.json
@@ -145,124 +145,124 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2j"
     },
     "31": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2j"
     },
     "32": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2j"
     },
     "33": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2j"
+    },
+    "34": {
       "key": "root.types.connections",
       "~k_parent": "2a"
     },
-    "34": {
+    "35": {
       "key": "root.types.requests",
       "~k_parent": "2a"
     },
-    "35": {
+    "36": {
       "key": "root.types.websockets",
       "~k_parent": "2a"
     },
-    "36": {
+    "37": {
       "key": "root.types.api",
       "~k_parent": "2a"
     },
-    "37": {
+    "38": {
       "key": "root.types.operators",
       "~k_parent": "2a"
     },
-    "38": {
-      "key": "root.types.operators.client",
-      "~k_parent": "37"
-    },
     "39": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "38"
     },
     "40": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3m"
     },
     "41": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3m"
     },
     "42": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3m"
     },
     "43": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3m"
     },
     "44": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3m"
     },
     "45": {
-      "key": "root.imports.connections",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3m"
     },
     "46": {
-      "key": "root.imports.icons",
-      "~k_parent": "3c"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3m"
     },
     "47": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "46"
+      "key": "root.imports.connections",
+      "~k_parent": "3d"
     },
     "48": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "47"
+      "key": "root.imports.icons",
+      "~k_parent": "3d"
     },
     "49": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "48"
     },
     "52": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "48"
     },
     "54": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "48"
     },
     "56": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "48"
     },
     "58": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "48"
     },
     "a": {
       "key": "root.pages",
@@ -523,380 +523,388 @@
       "~k_parent": "2f"
     },
     "2i": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2f"
+    },
+    "2j": {
       "key": "root.types.blocks",
       "~k_parent": "2a"
     },
-    "2j": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2i"
-    },
     "2k": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2j"
     },
     "2l": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2j"
     },
     "2m": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2j"
     },
     "2n": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2j"
     },
     "2o": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2j"
     },
     "2p": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2j"
     },
     "2q": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2j"
     },
     "2r": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2j"
     },
     "2s": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2j"
     },
     "2t": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2j"
     },
     "2u": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2j"
     },
     "2v": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2j"
     },
     "2w": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2j"
     },
     "2x": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2j"
     },
     "2y": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2j"
     },
     "2z": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2i"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2j"
     },
     "3a": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "38"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "39"
     },
     "3b": {
-      "key": "root.types.operators.server",
-      "~k_parent": "37"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "39"
     },
     "3c": {
+      "key": "root.types.operators.server",
+      "~k_parent": "38"
+    },
+    "3d": {
       "key": "root.imports",
       "~k_parent": "9"
     },
-    "3d": {
-      "key": "root.imports.actions",
-      "~k_parent": "3c"
-    },
     "3e": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3d"
     },
     "3f": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3d"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.imports.agents",
-      "~k_parent": "3c"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3e"
     },
     "3h": {
-      "key": "root.imports.auth",
-      "~k_parent": "3c"
+      "key": "root.imports.agents",
+      "~k_parent": "3d"
     },
     "3i": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3h"
+      "key": "root.imports.auth",
+      "~k_parent": "3d"
     },
     "3j": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3h"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3i"
     },
     "3k": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3c"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3i"
     },
     "3l": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3k"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3i"
     },
     "3m": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks",
+      "~k_parent": "3d"
     },
     "3n": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3m"
     },
     "3p": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3m"
     },
     "3r": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3m"
     },
     "3t": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3m"
     },
     "3u": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3m"
     },
     "3v": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3m"
     },
     "3w": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3m"
     },
     "3x": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3m"
     },
     "3y": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3m"
     },
     "3z": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3k"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3m"
     },
     "4a": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "48"
     },
     "4c": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "48"
     },
     "4e": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "48"
     },
     "4g": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "48"
     },
     "4i": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "48"
     },
     "4k": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "48"
     },
     "4m": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "48"
     },
     "4o": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "48"
     },
     "4q": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "48"
     },
     "4s": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "48"
     },
     "4u": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "48"
     },
     "4w": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "48"
     },
     "4y": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "48"
     },
     "5a": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "48"
     },
     "5c": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "48"
     },
     "5e": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "48"
     },
     "5g": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "48"
     },
     "5i": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "48"
     },
     "5k": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "48"
     },
     "5m": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "48"
     },
     "5o": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "46"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "48"
     },
     "5q": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.requests",
-      "~k_parent": "3c"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "48"
     },
     "5s": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3c"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.operators",
-      "~k_parent": "3c"
+      "key": "root.imports.requests",
+      "~k_parent": "3d"
     },
     "5u": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5t"
+      "key": "root.imports.websockets",
+      "~k_parent": "3d"
     },
     "5v": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5u"
+      "key": "root.imports.operators",
+      "~k_parent": "3d"
     },
     "5w": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5u"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5v"
     },
     "5x": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5w"
+    },
+    "5y": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5w"
+    },
+    "5z": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5t"
+      "~k_parent": "5v"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1188,6 +1196,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5741,6 +5750,9 @@
       "providers": {
         "~k": "2h"
       },
+      "strategies": {
+        "~k": "2i"
+      },
       "~k": "2f"
     },
     "blocks": {
@@ -5748,135 +5760,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 5,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
-      "~k": "2i"
+      "~k": "2j"
     },
     "connections": {
-      "~k": "33"
-    },
-    "requests": {
       "~k": "34"
     },
-    "websockets": {
+    "requests": {
       "~k": "35"
     },
-    "api": {
+    "websockets": {
       "~k": "36"
+    },
+    "api": {
+      "~k": "37"
     },
     "operators": {
       "client": {
@@ -5884,20 +5896,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "39"
+          "~k": "3a"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3a"
+          "~k": "3b"
         },
-        "~k": "38"
+        "~k": "39"
       },
       "server": {
-        "~k": "3b"
+        "~k": "3c"
       },
-      "~k": "37"
+      "~k": "38"
     },
     "~k": "2a"
   }

--- a/packages/build/src/tests/success/81-cross-module-build-op-components/snapshot.json
+++ b/packages/build/src/tests/success/81-cross-module-build-op-components/snapshot.json
@@ -161,123 +161,123 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.operators",
+      "key": "root.types.api",
       "~k_parent": "23"
     },
     "31": {
-      "key": "root.types.operators.client",
-      "~k_parent": "30"
+      "key": "root.types.operators",
+      "~k_parent": "23"
     },
     "32": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "31"
     },
     "33": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "31"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.types.operators.server",
-      "~k_parent": "30"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "32"
     },
     "35": {
+      "key": "root.types.operators.server",
+      "~k_parent": "31"
+    },
+    "36": {
       "key": "root.imports",
       "~k_parent": "6"
     },
-    "36": {
-      "key": "root.imports.actions",
-      "~k_parent": "35"
-    },
     "37": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "36"
     },
     "38": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "36"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "37"
     },
     "39": {
-      "key": "root.imports.agents",
-      "~k_parent": "35"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "37"
     },
     "40": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3z"
+      "key": "root.imports.connections",
+      "~k_parent": "36"
     },
     "41": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "40"
+      "key": "root.imports.icons",
+      "~k_parent": "36"
     },
     "42": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "41"
     },
     "45": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "41"
     },
     "47": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "41"
     },
     "49": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "41"
     },
     "51": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "41"
     },
     "53": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "41"
     },
     "55": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "41"
     },
     "57": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "41"
     },
     "59": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "58"
     },
     "a": {
@@ -503,380 +503,388 @@
       "~k_parent": "28"
     },
     "2b": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "28"
+    },
+    "2c": {
       "key": "root.types.blocks",
       "~k_parent": "23"
     },
-    "2c": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2b"
-    },
     "2d": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2c"
     },
     "2e": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2c"
     },
     "2f": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2c"
     },
     "2g": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2c"
     },
     "2h": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2c"
     },
     "2i": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2c"
     },
     "2j": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2c"
     },
     "2k": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2c"
     },
     "2l": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2c"
     },
     "2m": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2c"
     },
     "2n": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2c"
     },
     "2o": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2c"
     },
     "2p": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2c"
     },
     "2q": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2c"
     },
     "2r": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2c"
     },
     "2s": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2c"
     },
     "2t": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2c"
     },
     "2u": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2c"
     },
     "2v": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2b"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2c"
     },
     "2w": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2c"
+    },
+    "2x": {
       "key": "root.types.connections",
       "~k_parent": "23"
     },
-    "2x": {
+    "2y": {
       "key": "root.types.requests",
       "~k_parent": "23"
     },
-    "2y": {
+    "2z": {
       "key": "root.types.websockets",
       "~k_parent": "23"
     },
-    "2z": {
-      "key": "root.types.api",
-      "~k_parent": "23"
-    },
     "3a": {
-      "key": "root.imports.auth",
-      "~k_parent": "35"
+      "key": "root.imports.agents",
+      "~k_parent": "36"
     },
     "3b": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3a"
+      "key": "root.imports.auth",
+      "~k_parent": "36"
     },
     "3c": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3a"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.imports.blocks",
-      "~k_parent": "35"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3b"
     },
     "3e": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3d"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3b"
     },
     "3f": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks",
+      "~k_parent": "36"
     },
     "3g": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3f"
     },
     "3i": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3f"
     },
     "3j": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3f"
     },
     "3k": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3f"
     },
     "3m": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3f"
     },
     "3n": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3f"
     },
     "3o": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3f"
     },
     "3q": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3f"
     },
     "3r": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3f"
     },
     "3s": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3f"
     },
     "3t": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3f"
     },
     "3u": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3f"
     },
     "3v": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3f"
     },
     "3w": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3f"
     },
     "3x": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3d"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3f"
     },
     "3y": {
-      "key": "root.imports.connections",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3f"
     },
     "3z": {
-      "key": "root.imports.icons",
-      "~k_parent": "35"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3f"
     },
     "4a": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "41"
     },
     "4b": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "41"
     },
     "4d": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "41"
     },
     "4f": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "41"
     },
     "4h": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "41"
     },
     "4j": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "41"
     },
     "4l": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "41"
     },
     "4n": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "41"
     },
     "4p": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "41"
     },
     "4r": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "41"
     },
     "4t": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "41"
     },
     "4v": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "41"
     },
     "4x": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "41"
     },
     "4z": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "41"
     },
     "5b": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "41"
     },
     "5d": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "41"
     },
     "5f": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "41"
     },
     "5h": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3z"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "41"
     },
     "5j": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.requests",
-      "~k_parent": "35"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "41"
     },
     "5l": {
-      "key": "root.imports.websockets",
-      "~k_parent": "35"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.operators",
-      "~k_parent": "35"
+      "key": "root.imports.requests",
+      "~k_parent": "36"
     },
     "5n": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5m"
+      "key": "root.imports.websockets",
+      "~k_parent": "36"
     },
     "5o": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5n"
+      "key": "root.imports.operators",
+      "~k_parent": "36"
     },
     "5p": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5n"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5o"
     },
     "5q": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5p"
+    },
+    "5r": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5p"
+    },
+    "5s": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5m"
+      "~k_parent": "5o"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1151,6 +1159,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5671,6 +5680,9 @@
       "providers": {
         "~k": "2a"
       },
+      "strategies": {
+        "~k": "2b"
+      },
       "~k": "28"
     },
     "blocks": {
@@ -5678,135 +5690,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
-      "~k": "2b"
+      "~k": "2c"
     },
     "connections": {
-      "~k": "2w"
-    },
-    "requests": {
       "~k": "2x"
     },
-    "websockets": {
+    "requests": {
       "~k": "2y"
     },
-    "api": {
+    "websockets": {
       "~k": "2z"
+    },
+    "api": {
+      "~k": "30"
     },
     "operators": {
       "client": {
@@ -5814,20 +5826,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "32"
+          "~k": "33"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "33"
+          "~k": "34"
         },
-        "~k": "31"
+        "~k": "32"
       },
       "server": {
-        "~k": "34"
+        "~k": "35"
       },
-      "~k": "30"
+      "~k": "31"
     },
     "~k": "23"
   }

--- a/packages/build/src/tests/success/82-cross-module-mutual-refs-reversed/snapshot.json
+++ b/packages/build/src/tests/success/82-cross-module-mutual-refs-reversed/snapshot.json
@@ -144,164 +144,164 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2u"
     },
     "31": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2u"
     },
     "32": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2u"
     },
     "33": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2u"
     },
     "34": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2u"
     },
     "35": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2u"
     },
     "36": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2u"
     },
     "37": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2u"
     },
     "38": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2u"
     },
     "39": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2u"
     },
     "40": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3y"
     },
     "41": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3y"
     },
     "42": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3y"
     },
     "43": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3y"
     },
     "44": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3y"
     },
     "45": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3y"
     },
     "46": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3y"
     },
     "47": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3y"
     },
     "48": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3y"
     },
     "49": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3y"
     },
     "50": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4l"
     },
     "51": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4l"
     },
     "53": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4l"
     },
     "55": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4l"
     },
     "57": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4l"
     },
     "59": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4l"
     },
     "61": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4l"
     },
     "63": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.requests",
-      "~k_parent": "3o"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4l"
     },
     "65": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3o"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.operators",
-      "~k_parent": "3o"
+      "key": "root.imports.requests",
+      "~k_parent": "3p"
     },
     "67": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "66"
+      "key": "root.imports.websockets",
+      "~k_parent": "3p"
     },
     "68": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "67"
+      "key": "root.imports.operators",
+      "~k_parent": "3p"
     },
     "69": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "67"
+      "key": "root.imports.operators.client",
+      "~k_parent": "68"
     },
     "a": {
       "key": "root",
@@ -615,348 +615,356 @@
       "~k_parent": "2q"
     },
     "2t": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2q"
+    },
+    "2u": {
       "key": "root.types.blocks",
       "~k_parent": "2l"
     },
-    "2u": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2t"
-    },
     "2v": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.types.blocks.Selector",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Selector",
+      "~k_parent": "2u"
     },
     "2y": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2u"
     },
     "2z": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2u"
     },
     "3b": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2u"
     },
     "3c": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2u"
     },
     "3d": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2u"
     },
     "3e": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2t"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2u"
     },
     "3f": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2u"
+    },
+    "3g": {
       "key": "root.types.connections",
       "~k_parent": "2l"
     },
-    "3g": {
+    "3h": {
       "key": "root.types.requests",
       "~k_parent": "2l"
     },
-    "3h": {
+    "3i": {
       "key": "root.types.websockets",
       "~k_parent": "2l"
     },
-    "3i": {
+    "3j": {
       "key": "root.types.api",
       "~k_parent": "2l"
     },
-    "3j": {
+    "3k": {
       "key": "root.types.operators",
       "~k_parent": "2l"
     },
-    "3k": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3j"
-    },
     "3l": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3k"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3l"
     },
     "3n": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3j"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3l"
     },
     "3o": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3k"
+    },
+    "3p": {
       "key": "root.imports",
       "~k_parent": "a"
     },
-    "3p": {
-      "key": "root.imports.actions",
-      "~k_parent": "3o"
-    },
     "3q": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3p"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.agents",
-      "~k_parent": "3o"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3q"
     },
     "3t": {
-      "key": "root.imports.auth",
-      "~k_parent": "3o"
+      "key": "root.imports.agents",
+      "~k_parent": "3p"
     },
     "3u": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3t"
+      "key": "root.imports.auth",
+      "~k_parent": "3p"
     },
     "3v": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3t"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3o"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3u"
     },
     "3x": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3w"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3u"
     },
     "3y": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks",
+      "~k_parent": "3p"
     },
     "3z": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3y"
     },
     "4b": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3y"
     },
     "4c": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3y"
     },
     "4d": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3y"
     },
     "4e": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3y"
     },
     "4f": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3y"
     },
     "4g": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3y"
     },
     "4h": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3y"
     },
     "4i": {
-      "key": "root.imports.connections",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3y"
     },
     "4j": {
-      "key": "root.imports.icons",
-      "~k_parent": "3o"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "3y"
     },
     "4k": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4j"
+      "key": "root.imports.connections",
+      "~k_parent": "3p"
     },
     "4l": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4k"
+      "key": "root.imports.icons",
+      "~k_parent": "3p"
     },
     "4m": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4l"
     },
     "4p": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4l"
     },
     "4r": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4l"
     },
     "4t": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4l"
     },
     "4v": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4l"
     },
     "4x": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4l"
     },
     "4z": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4l"
     },
     "5b": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4l"
     },
     "5d": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4l"
     },
     "5f": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4l"
     },
     "5h": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4l"
     },
     "5j": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4l"
     },
     "5l": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4l"
     },
     "5n": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4l"
     },
     "5p": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4l"
     },
     "5r": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4l"
     },
     "5t": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4l"
     },
     "5v": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4l"
     },
     "5x": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4j"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4l"
     },
     "5z": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5y"
     },
     "6a": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "69"
+    },
+    "6b": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "69"
+    },
+    "6c": {
       "key": "root.imports.operators.server",
-      "~k_parent": "66"
+      "~k_parent": "68"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1295,6 +1303,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -6797,6 +6806,9 @@
       "providers": {
         "~k": "2s"
       },
+      "strategies": {
+        "~k": "2t"
+      },
       "~k": "2q"
     },
     "blocks": {
@@ -6804,141 +6816,141 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Selector": {
         "originalTypeName": "Selector",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
-      "~k": "2t"
+      "~k": "2u"
     },
     "connections": {
-      "~k": "3f"
-    },
-    "requests": {
       "~k": "3g"
     },
-    "websockets": {
+    "requests": {
       "~k": "3h"
     },
-    "api": {
+    "websockets": {
       "~k": "3i"
+    },
+    "api": {
+      "~k": "3j"
     },
     "operators": {
       "client": {
@@ -6946,20 +6958,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3l"
+          "~k": "3m"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3m"
+          "~k": "3n"
         },
-        "~k": "3k"
+        "~k": "3l"
       },
       "server": {
-        "~k": "3n"
+        "~k": "3o"
       },
-      "~k": "3j"
+      "~k": "3k"
     },
     "~k": "2l"
   }

--- a/packages/build/src/tests/success/83-cross-module-multi-consumer-vars/snapshot.json
+++ b/packages/build/src/tests/success/83-cross-module-multi-consumer-vars/snapshot.json
@@ -145,124 +145,132 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2l"
     },
     "31": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2l"
     },
     "32": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2l"
     },
     "33": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2l"
     },
     "34": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2l"
     },
     "35": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2l"
+    },
+    "36": {
       "key": "root.types.connections",
       "~k_parent": "2c"
     },
-    "36": {
+    "37": {
       "key": "root.types.requests",
       "~k_parent": "2c"
     },
-    "37": {
+    "38": {
       "key": "root.types.websockets",
       "~k_parent": "2c"
     },
-    "38": {
+    "39": {
       "key": "root.types.api",
       "~k_parent": "2c"
     },
-    "39": {
-      "key": "root.types.operators",
-      "~k_parent": "2c"
-    },
     "40": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3o"
     },
     "41": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3o"
     },
     "42": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3o"
     },
     "43": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3o"
     },
     "44": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3o"
     },
     "45": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3o"
     },
     "46": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3o"
     },
     "47": {
-      "key": "root.imports.connections",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3o"
     },
     "48": {
-      "key": "root.imports.icons",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3o"
     },
     "49": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "48"
+      "key": "root.imports.connections",
+      "~k_parent": "3f"
     },
     "50": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4a"
     },
     "52": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4a"
     },
     "54": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4a"
     },
     "56": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4a"
     },
     "58": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4a"
+    },
+    "60": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5y"
+    },
+    "61": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "5x"
     },
     "a": {
       "key": "root.pages",
@@ -527,380 +535,380 @@
       "~k_parent": "2h"
     },
     "2k": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2h"
+    },
+    "2l": {
       "key": "root.types.blocks",
       "~k_parent": "2c"
     },
-    "2l": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2k"
-    },
     "2m": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2l"
     },
     "2n": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2l"
     },
     "2o": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2l"
     },
     "2p": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2l"
     },
     "2q": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2l"
     },
     "2r": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2l"
     },
     "2s": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2l"
     },
     "2t": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2l"
     },
     "2u": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2l"
     },
     "2v": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2l"
     },
     "2w": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2l"
     },
     "2x": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2l"
     },
     "2y": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2l"
     },
     "2z": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2k"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2l"
     },
     "3a": {
-      "key": "root.types.operators.client",
-      "~k_parent": "39"
+      "key": "root.types.operators",
+      "~k_parent": "2c"
     },
     "3b": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3a"
     },
     "3c": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3a"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.types.operators.server",
-      "~k_parent": "39"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3b"
     },
     "3e": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3a"
+    },
+    "3f": {
       "key": "root.imports",
       "~k_parent": "9"
     },
-    "3f": {
-      "key": "root.imports.actions",
-      "~k_parent": "3e"
-    },
     "3g": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3f"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.agents",
-      "~k_parent": "3e"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3g"
     },
     "3j": {
-      "key": "root.imports.auth",
-      "~k_parent": "3e"
+      "key": "root.imports.agents",
+      "~k_parent": "3f"
     },
     "3k": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3j"
+      "key": "root.imports.auth",
+      "~k_parent": "3f"
     },
     "3l": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3j"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3e"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3k"
     },
     "3n": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3m"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3k"
     },
     "3o": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks",
+      "~k_parent": "3f"
     },
     "3p": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3o"
     },
     "3r": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3o"
     },
     "3s": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3o"
     },
     "3t": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3o"
     },
     "3u": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3o"
     },
     "3v": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3o"
     },
     "3w": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3o"
     },
     "3x": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3o"
     },
     "3y": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3o"
     },
     "3z": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3o"
     },
     "4a": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "49"
+      "key": "root.imports.icons",
+      "~k_parent": "3f"
     },
     "4b": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4a"
     },
     "4e": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4a"
     },
     "4g": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4a"
     },
     "4i": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4a"
     },
     "4k": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4a"
     },
     "4m": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4a"
     },
     "4o": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4a"
     },
     "4q": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4a"
     },
     "4s": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4a"
     },
     "4u": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4a"
     },
     "4w": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4a"
     },
     "4y": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4a"
     },
     "5a": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4a"
     },
     "5c": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4a"
     },
     "5e": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4a"
     },
     "5g": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4a"
     },
     "5i": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4a"
     },
     "5k": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4a"
     },
     "5m": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4a"
     },
     "5o": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4a"
     },
     "5q": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4a"
     },
     "5s": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.requests",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4a"
     },
     "5u": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3e"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.operators",
-      "~k_parent": "3e"
+      "key": "root.imports.requests",
+      "~k_parent": "3f"
     },
     "5w": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5v"
+      "key": "root.imports.websockets",
+      "~k_parent": "3f"
     },
     "5x": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5w"
+      "key": "root.imports.operators",
+      "~k_parent": "3f"
     },
     "5y": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5w"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "5v"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5y"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1199,6 +1207,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5740,6 +5749,9 @@
       "providers": {
         "~k": "2j"
       },
+      "strategies": {
+        "~k": "2k"
+      },
       "~k": "2h"
     },
     "blocks": {
@@ -5747,135 +5759,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
-      "~k": "2k"
+      "~k": "2l"
     },
     "connections": {
-      "~k": "35"
-    },
-    "requests": {
       "~k": "36"
     },
-    "websockets": {
+    "requests": {
       "~k": "37"
     },
-    "api": {
+    "websockets": {
       "~k": "38"
+    },
+    "api": {
+      "~k": "39"
     },
     "operators": {
       "client": {
@@ -5883,20 +5895,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3b"
+          "~k": "3c"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3c"
+          "~k": "3d"
         },
-        "~k": "3a"
+        "~k": "3b"
       },
       "server": {
-        "~k": "3d"
+        "~k": "3e"
       },
-      "~k": "39"
+      "~k": "3a"
     },
     "~k": "2c"
   }

--- a/packages/build/src/tests/success/84-cross-module-multi-consumer-menus/snapshot.json
+++ b/packages/build/src/tests/success/84-cross-module-multi-consumer-menus/snapshot.json
@@ -177,132 +177,132 @@
       "~k_parent": "35"
     },
     "38": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "35"
+    },
+    "39": {
       "key": "root.types.blocks",
       "~k_parent": "30"
     },
-    "39": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "38"
-    },
     "40": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3y"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3z"
     },
     "41": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3x"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3z"
     },
     "42": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3y"
+    },
+    "43": {
       "key": "root.imports",
       "~k_parent": "9"
     },
-    "43": {
-      "key": "root.imports.actions",
-      "~k_parent": "42"
-    },
     "44": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "43"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.agents",
-      "~k_parent": "42"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "44"
     },
     "47": {
-      "key": "root.imports.auth",
-      "~k_parent": "42"
+      "key": "root.imports.agents",
+      "~k_parent": "43"
     },
     "48": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "47"
+      "key": "root.imports.auth",
+      "~k_parent": "43"
     },
     "49": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "47"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4y"
     },
     "52": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4y"
     },
     "54": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4y"
     },
     "56": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4y"
     },
     "58": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4y"
     },
     "60": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4y"
     },
     "62": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4y"
     },
     "64": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4y"
     },
     "66": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4y"
     },
     "68": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4y"
     },
     "a": {
       "key": "root.menus",
@@ -658,372 +658,380 @@
       "~k_parent": "2r"
     },
     "3a": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "38"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "39"
     },
     "3b": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "38"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "39"
     },
     "3c": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "38"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "39"
     },
     "3d": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "38"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "39"
     },
     "3e": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "38"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "39"
     },
     "3f": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "38"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "39"
     },
     "3g": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "38"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "39"
     },
     "3h": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "38"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "39"
     },
     "3i": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "38"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "39"
     },
     "3j": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "38"
+      "key": "root.types.blocks.List",
+      "~k_parent": "39"
     },
     "3k": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "38"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "39"
     },
     "3l": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "38"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "39"
     },
     "3m": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "38"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "39"
     },
     "3n": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "38"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "39"
     },
     "3o": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "38"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "39"
     },
     "3p": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "38"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "39"
     },
     "3q": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "38"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "39"
     },
     "3r": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "38"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "39"
     },
     "3s": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "38"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "39"
     },
     "3t": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "39"
+    },
+    "3u": {
       "key": "root.types.connections",
       "~k_parent": "30"
     },
-    "3u": {
+    "3v": {
       "key": "root.types.requests",
       "~k_parent": "30"
     },
-    "3v": {
+    "3w": {
       "key": "root.types.websockets",
       "~k_parent": "30"
     },
-    "3w": {
+    "3x": {
       "key": "root.types.api",
       "~k_parent": "30"
     },
-    "3x": {
+    "3y": {
       "key": "root.types.operators",
       "~k_parent": "30"
     },
-    "3y": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3x"
-    },
     "3z": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.blocks",
-      "~k_parent": "42"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "48"
     },
     "4b": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "4a"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "48"
     },
     "4c": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks",
+      "~k_parent": "43"
     },
     "4d": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "4c"
     },
     "4f": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "4c"
     },
     "4g": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "4c"
     },
     "4h": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "4c"
     },
     "4i": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "4c"
     },
     "4j": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "4c"
     },
     "4k": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "4c"
     },
     "4l": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "4c"
     },
     "4m": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "4c"
     },
     "4n": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "4c"
     },
     "4o": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "4c"
     },
     "4p": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "4c"
     },
     "4q": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "4c"
     },
     "4r": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "4c"
     },
     "4s": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "4c"
     },
     "4t": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "4c"
     },
     "4u": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "4a"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "4c"
     },
     "4v": {
-      "key": "root.imports.connections",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "4c"
     },
     "4w": {
-      "key": "root.imports.icons",
-      "~k_parent": "42"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "4c"
     },
     "4x": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4w"
+      "key": "root.imports.connections",
+      "~k_parent": "43"
     },
     "4y": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4x"
+      "key": "root.imports.icons",
+      "~k_parent": "43"
     },
     "4z": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4y"
     },
     "5c": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4y"
     },
     "5e": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4y"
     },
     "5g": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4y"
     },
     "5i": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4y"
     },
     "5k": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4y"
     },
     "5m": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4y"
     },
     "5o": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4y"
     },
     "5q": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4y"
     },
     "5s": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4y"
     },
     "5u": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4y"
     },
     "5w": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4y"
     },
     "5y": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4y"
     },
     "6a": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4y"
     },
     "6c": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4y"
     },
     "6e": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4w"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4y"
     },
     "6g": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6f"
     },
     "6h": {
-      "key": "root.imports.requests",
-      "~k_parent": "42"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4y"
     },
     "6i": {
-      "key": "root.imports.websockets",
-      "~k_parent": "42"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.operators",
-      "~k_parent": "42"
+      "key": "root.imports.requests",
+      "~k_parent": "43"
     },
     "6k": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6j"
+      "key": "root.imports.websockets",
+      "~k_parent": "43"
     },
     "6l": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6k"
+      "key": "root.imports.operators",
+      "~k_parent": "43"
     },
     "6m": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6k"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6l"
     },
     "6n": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6m"
+    },
+    "6o": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6m"
+    },
+    "6p": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6j"
+      "~k_parent": "6l"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1421,6 +1429,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5974,6 +5983,9 @@
       "providers": {
         "~k": "37"
       },
+      "strategies": {
+        "~k": "38"
+      },
       "~k": "35"
     },
     "blocks": {
@@ -5981,135 +5993,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "39"
+        "~k": "3a"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "3a"
+        "~k": "3b"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3f"
+        "~k": "3g"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3h"
+        "~k": "3i"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3i"
+        "~k": "3j"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3j"
+        "~k": "3k"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3k"
+        "~k": "3l"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3l"
+        "~k": "3m"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3m"
+        "~k": "3n"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3n"
+        "~k": "3o"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3o"
+        "~k": "3p"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3p"
+        "~k": "3q"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3q"
+        "~k": "3r"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3r"
+        "~k": "3s"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3s"
+        "~k": "3t"
       },
-      "~k": "38"
+      "~k": "39"
     },
     "connections": {
-      "~k": "3t"
-    },
-    "requests": {
       "~k": "3u"
     },
-    "websockets": {
+    "requests": {
       "~k": "3v"
     },
-    "api": {
+    "websockets": {
       "~k": "3w"
+    },
+    "api": {
+      "~k": "3x"
     },
     "operators": {
       "client": {
@@ -6117,20 +6129,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3z"
+          "~k": "40"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "40"
+          "~k": "41"
         },
-        "~k": "3y"
+        "~k": "3z"
       },
       "server": {
-        "~k": "41"
+        "~k": "42"
       },
-      "~k": "3x"
+      "~k": "3y"
     },
     "~k": "30"
   }

--- a/packages/build/src/tests/success/85-module-component-data-export/snapshot.json
+++ b/packages/build/src/tests/success/85-module-component-data-export/snapshot.json
@@ -159,128 +159,136 @@
       "~k_parent": "28"
     },
     "30": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2m"
     },
     "31": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2m"
     },
     "32": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2m"
     },
     "33": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2m"
     },
     "34": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2m"
     },
     "35": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2m"
+    },
+    "36": {
       "key": "root.types.connections",
       "~k_parent": "2d"
     },
-    "36": {
+    "37": {
       "key": "root.types.requests",
       "~k_parent": "2d"
     },
-    "37": {
+    "38": {
       "key": "root.types.websockets",
       "~k_parent": "2d"
     },
-    "38": {
+    "39": {
       "key": "root.types.api",
       "~k_parent": "2d"
     },
-    "39": {
-      "key": "root.types.operators",
-      "~k_parent": "2d"
-    },
     "40": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3p"
     },
     "41": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3p"
     },
     "42": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3p"
     },
     "43": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3p"
     },
     "44": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3p"
     },
     "45": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3p"
     },
     "46": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3p"
     },
     "47": {
-      "key": "root.imports.connections",
-      "~k_parent": "3f"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3p"
     },
     "48": {
-      "key": "root.imports.icons",
-      "~k_parent": "3f"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3p"
     },
     "49": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "48"
+      "key": "root.imports.connections",
+      "~k_parent": "3g"
     },
     "50": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4a"
     },
     "52": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4a"
     },
     "54": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4a"
     },
     "56": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4a"
     },
     "58": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4a"
     },
     "60": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5y"
+    },
+    "61": {
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "5y"
+    },
+    "62": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5v"
+      "~k_parent": "5x"
     },
     "a": {
       "key": "root.pages[0:dashboard:Box].blocks",
@@ -564,376 +572,376 @@
       "~k_parent": "2i"
     },
     "2l": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2i"
+    },
+    "2m": {
       "key": "root.types.blocks",
       "~k_parent": "2d"
     },
-    "2m": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2l"
-    },
     "2n": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2m"
     },
     "2o": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2m"
     },
     "2p": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2m"
     },
     "2q": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2m"
     },
     "2r": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2m"
     },
     "2s": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2m"
     },
     "2t": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2m"
     },
     "2u": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2m"
     },
     "2v": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2m"
     },
     "2w": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2m"
     },
     "2x": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2m"
     },
     "2y": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2m"
     },
     "2z": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2l"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2m"
     },
     "3a": {
-      "key": "root.types.operators.client",
-      "~k_parent": "39"
+      "key": "root.types.operators",
+      "~k_parent": "2d"
     },
     "3b": {
-      "key": "root.types.operators.client._user",
+      "key": "root.types.operators.client",
       "~k_parent": "3a"
     },
     "3c": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "3a"
+      "key": "root.types.operators.client._user",
+      "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3a"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3b"
     },
     "3e": {
-      "key": "root.types.operators.server",
-      "~k_parent": "39"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3b"
     },
     "3f": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3a"
+    },
+    "3g": {
       "key": "root.imports",
       "~k_parent": "7"
     },
-    "3g": {
-      "key": "root.imports.actions",
-      "~k_parent": "3f"
-    },
     "3h": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3g"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.imports.agents",
-      "~k_parent": "3f"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3h"
     },
     "3k": {
-      "key": "root.imports.auth",
-      "~k_parent": "3f"
+      "key": "root.imports.agents",
+      "~k_parent": "3g"
     },
     "3l": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3k"
+      "key": "root.imports.auth",
+      "~k_parent": "3g"
     },
     "3m": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3k"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3l"
     },
     "3n": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3f"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3l"
     },
     "3o": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3n"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3l"
     },
     "3p": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks",
+      "~k_parent": "3g"
     },
     "3q": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3p"
     },
     "3s": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3p"
     },
     "3t": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3p"
     },
     "3u": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3p"
     },
     "3v": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3p"
     },
     "3w": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3p"
     },
     "3x": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3p"
     },
     "3y": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3p"
     },
     "3z": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3n"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3p"
     },
     "4a": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "49"
+      "key": "root.imports.icons",
+      "~k_parent": "3g"
     },
     "4b": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4a"
     },
     "4e": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4a"
     },
     "4g": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4a"
     },
     "4i": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4a"
     },
     "4k": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4a"
     },
     "4m": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4a"
     },
     "4o": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4a"
     },
     "4q": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4a"
     },
     "4s": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4a"
     },
     "4u": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4a"
     },
     "4w": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4a"
     },
     "4y": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4a"
     },
     "5a": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4a"
     },
     "5c": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4a"
     },
     "5e": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4a"
     },
     "5g": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4a"
     },
     "5i": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4a"
     },
     "5k": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4a"
     },
     "5m": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4a"
     },
     "5o": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4a"
     },
     "5q": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "48"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4a"
     },
     "5s": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.requests",
-      "~k_parent": "3f"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4a"
     },
     "5u": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3f"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.operators",
-      "~k_parent": "3f"
+      "key": "root.imports.requests",
+      "~k_parent": "3g"
     },
     "5w": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5v"
+      "key": "root.imports.websockets",
+      "~k_parent": "3g"
     },
     "5x": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5w"
+      "key": "root.imports.operators",
+      "~k_parent": "3g"
     },
     "5y": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5w"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "5w"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5y"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1248,6 +1256,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5888,6 +5897,9 @@
       "providers": {
         "~k": "2k"
       },
+      "strategies": {
+        "~k": "2l"
+      },
       "~k": "2i"
     },
     "blocks": {
@@ -5895,129 +5907,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 8,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
-      "~k": "2l"
+      "~k": "2m"
     },
     "connections": {
-      "~k": "35"
-    },
-    "requests": {
       "~k": "36"
     },
-    "websockets": {
+    "requests": {
       "~k": "37"
     },
-    "api": {
+    "websockets": {
       "~k": "38"
+    },
+    "api": {
+      "~k": "39"
     },
     "operators": {
       "client": {
@@ -6025,26 +6037,26 @@
           "originalTypeName": "_user",
           "package": "@lowdefy/operators-js",
           "count": 5,
-          "~k": "3b"
+          "~k": "3c"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3c"
+          "~k": "3d"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3d"
+          "~k": "3e"
         },
-        "~k": "3a"
+        "~k": "3b"
       },
       "server": {
-        "~k": "3e"
+        "~k": "3f"
       },
-      "~k": "39"
+      "~k": "3a"
     },
     "~k": "2d"
   }

--- a/packages/build/src/tests/success/86-module-component-cross-ref-vars/snapshot.json
+++ b/packages/build/src/tests/success/86-module-component-cross-ref-vars/snapshot.json
@@ -173,139 +173,139 @@
       "~k_parent": "33"
     },
     "36": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "33"
+    },
+    "37": {
       "key": "root.types.blocks",
       "~k_parent": "2y"
     },
-    "37": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "36"
-    },
     "38": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "36"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "37"
     },
     "39": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "36"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "37"
     },
     "40": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3v"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3x"
     },
     "41": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3w"
+    },
+    "42": {
       "key": "root.imports",
       "~k_parent": "9"
     },
-    "42": {
-      "key": "root.imports.actions",
-      "~k_parent": "41"
-    },
     "43": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "42"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.agents",
-      "~k_parent": "41"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "43"
     },
     "46": {
-      "key": "root.imports.auth",
-      "~k_parent": "41"
+      "key": "root.imports.agents",
+      "~k_parent": "42"
     },
     "47": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "46"
+      "key": "root.imports.auth",
+      "~k_parent": "42"
     },
     "48": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "46"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.blocks",
-      "~k_parent": "41"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "47"
     },
     "50": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4x"
     },
     "51": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4x"
     },
     "53": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4x"
     },
     "55": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4x"
     },
     "57": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4x"
     },
     "59": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4x"
     },
     "61": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4x"
     },
     "63": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4x"
     },
     "65": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4x"
     },
     "67": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "66"
     },
     "68": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4x"
     },
     "69": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "68"
     },
     "a": {
@@ -654,372 +654,380 @@
       "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "36"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "37"
     },
     "3b": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "36"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "37"
     },
     "3c": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "36"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "37"
     },
     "3d": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "36"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "37"
     },
     "3e": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "36"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "37"
     },
     "3f": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "36"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "37"
     },
     "3g": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "36"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "37"
     },
     "3h": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "36"
+      "key": "root.types.blocks.List",
+      "~k_parent": "37"
     },
     "3i": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "36"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "37"
     },
     "3j": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "36"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "37"
     },
     "3k": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "36"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "37"
     },
     "3l": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "36"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "37"
     },
     "3m": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "36"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "37"
     },
     "3n": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "36"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "37"
     },
     "3o": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "36"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "37"
     },
     "3p": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "36"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "37"
     },
     "3q": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "36"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "37"
     },
     "3r": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "37"
+    },
+    "3s": {
       "key": "root.types.connections",
       "~k_parent": "2y"
     },
-    "3s": {
+    "3t": {
       "key": "root.types.requests",
       "~k_parent": "2y"
     },
-    "3t": {
+    "3u": {
       "key": "root.types.websockets",
       "~k_parent": "2y"
     },
-    "3u": {
+    "3v": {
       "key": "root.types.api",
       "~k_parent": "2y"
     },
-    "3v": {
+    "3w": {
       "key": "root.types.operators",
       "~k_parent": "2y"
     },
-    "3w": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3v"
-    },
     "3x": {
-      "key": "root.types.operators.client._user",
+      "key": "root.types.operators.client",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "3w"
+      "key": "root.types.operators.client._user",
+      "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3w"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3x"
     },
     "4a": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "49"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "47"
     },
     "4b": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks",
+      "~k_parent": "42"
     },
     "4c": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "4b"
     },
     "4e": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "4b"
     },
     "4f": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "4b"
     },
     "4g": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "4b"
     },
     "4h": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "4b"
     },
     "4i": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "4b"
     },
     "4j": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "4b"
     },
     "4k": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "4b"
     },
     "4l": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "4b"
     },
     "4m": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "4b"
     },
     "4n": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "4b"
     },
     "4o": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "4b"
     },
     "4p": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "4b"
     },
     "4q": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "4b"
     },
     "4r": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "4b"
     },
     "4s": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "4b"
     },
     "4t": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "49"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "4b"
     },
     "4u": {
-      "key": "root.imports.connections",
-      "~k_parent": "41"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "4b"
     },
     "4v": {
-      "key": "root.imports.icons",
-      "~k_parent": "41"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "4b"
     },
     "4w": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4v"
+      "key": "root.imports.connections",
+      "~k_parent": "42"
     },
     "4x": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4w"
+      "key": "root.imports.icons",
+      "~k_parent": "42"
     },
     "4y": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4x"
     },
     "5b": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4x"
     },
     "5d": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4x"
     },
     "5f": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4x"
     },
     "5h": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4x"
     },
     "5j": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4x"
     },
     "5l": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4x"
     },
     "5n": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4x"
     },
     "5p": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4x"
     },
     "5r": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4x"
     },
     "5t": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4x"
     },
     "5v": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4x"
     },
     "5x": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4x"
     },
     "5z": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4x"
     },
     "6b": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "6a"
     },
     "6c": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4x"
     },
     "6d": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "6c"
     },
     "6e": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4v"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4x"
     },
     "6f": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6e"
     },
     "6g": {
-      "key": "root.imports.requests",
-      "~k_parent": "41"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4x"
     },
     "6h": {
-      "key": "root.imports.websockets",
-      "~k_parent": "41"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6g"
     },
     "6i": {
-      "key": "root.imports.operators",
-      "~k_parent": "41"
+      "key": "root.imports.requests",
+      "~k_parent": "42"
     },
     "6j": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6i"
+      "key": "root.imports.websockets",
+      "~k_parent": "42"
     },
     "6k": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6j"
+      "key": "root.imports.operators",
+      "~k_parent": "42"
     },
     "6l": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6j"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6k"
     },
     "6m": {
-      "key": "root.imports.operators.client[2]",
-      "~k_parent": "6j"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6l"
     },
     "6n": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6l"
+    },
+    "6o": {
+      "key": "root.imports.operators.client[2]",
+      "~k_parent": "6l"
+    },
+    "6p": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6i"
+      "~k_parent": "6k"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1410,6 +1418,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -6049,6 +6058,9 @@
       "providers": {
         "~k": "35"
       },
+      "strategies": {
+        "~k": "36"
+      },
       "~k": "33"
     },
     "blocks": {
@@ -6056,135 +6068,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 8,
-        "~k": "37"
+        "~k": "38"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "38"
+        "~k": "39"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3f"
+        "~k": "3g"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3h"
+        "~k": "3i"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3i"
+        "~k": "3j"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3j"
+        "~k": "3k"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3k"
+        "~k": "3l"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3l"
+        "~k": "3m"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3m"
+        "~k": "3n"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3n"
+        "~k": "3o"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3o"
+        "~k": "3p"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3p"
+        "~k": "3q"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3q"
+        "~k": "3r"
       },
-      "~k": "36"
+      "~k": "37"
     },
     "connections": {
-      "~k": "3r"
-    },
-    "requests": {
       "~k": "3s"
     },
-    "websockets": {
+    "requests": {
       "~k": "3t"
     },
-    "api": {
+    "websockets": {
       "~k": "3u"
+    },
+    "api": {
+      "~k": "3v"
     },
     "operators": {
       "client": {
@@ -6192,26 +6204,26 @@
           "originalTypeName": "_user",
           "package": "@lowdefy/operators-js",
           "count": 6,
-          "~k": "3x"
+          "~k": "3y"
         },
         "_not": {
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3y"
+          "~k": "3z"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3z"
+          "~k": "40"
         },
-        "~k": "3w"
+        "~k": "3x"
       },
       "server": {
-        "~k": "40"
+        "~k": "41"
       },
-      "~k": "3v"
+      "~k": "3w"
     },
     "~k": "2y"
   }

--- a/packages/build/src/tests/success/87-module-default-plugin/snapshot.json
+++ b/packages/build/src/tests/success/87-module-default-plugin/snapshot.json
@@ -125,164 +125,164 @@
       "~k_parent": "13"
     },
     "20": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1z"
+      "key": "root.types.blocks",
+      "~k_parent": "1r"
     },
     "21": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "20"
     },
     "22": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "20"
     },
     "23": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "20"
     },
     "24": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "20"
     },
     "25": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "20"
     },
     "26": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "20"
     },
     "27": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "20"
     },
     "28": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "20"
     },
     "29": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.List",
+      "~k_parent": "20"
     },
     "30": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2s"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2y"
     },
     "31": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "30"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2y"
     },
     "32": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks",
+      "~k_parent": "2t"
     },
     "33": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "32"
     },
     "35": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "32"
     },
     "36": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "32"
     },
     "37": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "32"
     },
     "38": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "32"
     },
     "39": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "32"
     },
     "40": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3n"
     },
     "41": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3n"
     },
     "43": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3n"
     },
     "45": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3n"
     },
     "47": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3n"
     },
     "49": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3n"
     },
     "51": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3n"
     },
     "53": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3n"
     },
     "55": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.requests",
-      "~k_parent": "2s"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3n"
     },
     "57": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2s"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.operators",
-      "~k_parent": "2s"
+      "key": "root.imports.requests",
+      "~k_parent": "2t"
     },
     "59": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "58"
+      "key": "root.imports.websockets",
+      "~k_parent": "2t"
     },
     "a": {
       "key": "root.pages",
@@ -485,332 +485,340 @@
       "~k_parent": "1w"
     },
     "1z": {
-      "key": "root.types.blocks",
-      "~k_parent": "1r"
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1w"
     },
     "2a": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "20"
     },
     "2b": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "20"
     },
     "2c": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "20"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "20"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "20"
     },
     "2f": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "20"
     },
     "2g": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "20"
     },
     "2h": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "20"
     },
     "2i": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1z"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "20"
     },
     "2j": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "20"
+    },
+    "2k": {
       "key": "root.types.connections",
       "~k_parent": "1r"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.requests",
       "~k_parent": "1r"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.websockets",
       "~k_parent": "1r"
     },
-    "2m": {
+    "2n": {
       "key": "root.types.api",
       "~k_parent": "1r"
     },
-    "2n": {
+    "2o": {
       "key": "root.types.operators",
       "~k_parent": "1r"
     },
-    "2o": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2n"
-    },
     "2p": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2o"
     },
     "2q": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2o"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2p"
     },
     "2r": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2n"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2p"
     },
     "2s": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2o"
+    },
+    "2t": {
       "key": "root.imports",
       "~k_parent": "5"
     },
-    "2t": {
-      "key": "root.imports.actions",
-      "~k_parent": "2s"
-    },
     "2u": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2t"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2u"
     },
     "2w": {
-      "key": "root.imports.agents",
-      "~k_parent": "2s"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2u"
     },
     "2x": {
-      "key": "root.imports.auth",
-      "~k_parent": "2s"
+      "key": "root.imports.agents",
+      "~k_parent": "2t"
     },
     "2y": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2x"
+      "key": "root.imports.auth",
+      "~k_parent": "2t"
     },
     "2z": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2x"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "32"
     },
     "3b": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "32"
     },
     "3c": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "32"
     },
     "3d": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "32"
     },
     "3e": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "32"
     },
     "3f": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "32"
     },
     "3g": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "32"
     },
     "3h": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "32"
     },
     "3i": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "32"
     },
     "3j": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "30"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "32"
     },
     "3k": {
-      "key": "root.imports.connections",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "32"
     },
     "3l": {
-      "key": "root.imports.icons",
-      "~k_parent": "2s"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "32"
     },
     "3m": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3l"
+      "key": "root.imports.connections",
+      "~k_parent": "2t"
     },
     "3n": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3m"
+      "key": "root.imports.icons",
+      "~k_parent": "2t"
     },
     "3o": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3n"
     },
     "3r": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3n"
     },
     "3t": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3n"
     },
     "3v": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3n"
     },
     "3x": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3n"
     },
     "3z": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3n"
     },
     "4b": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3n"
     },
     "4d": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3n"
     },
     "4f": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3n"
     },
     "4h": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3n"
     },
     "4j": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3n"
     },
     "4l": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3n"
     },
     "4n": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3n"
     },
     "4p": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3n"
     },
     "4r": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3n"
     },
     "4t": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3n"
     },
     "4v": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3n"
     },
     "4x": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3l"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3n"
     },
     "4z": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "59"
+      "key": "root.imports.operators",
+      "~k_parent": "2t"
     },
     "5b": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "59"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5a"
     },
     "5c": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5b"
+    },
+    "5d": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5b"
+    },
+    "5e": {
       "key": "root.imports.operators.server",
-      "~k_parent": "58"
+      "~k_parent": "5a"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1037,6 +1045,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5539,6 +5548,9 @@
       "providers": {
         "~k": "1y"
       },
+      "strategies": {
+        "~k": "1z"
+      },
       "~k": "1w"
     },
     "blocks": {
@@ -5546,129 +5558,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 3,
-        "~k": "20"
+        "~k": "21"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
-      "~k": "1z"
+      "~k": "20"
     },
     "connections": {
-      "~k": "2j"
-    },
-    "requests": {
       "~k": "2k"
     },
-    "websockets": {
+    "requests": {
       "~k": "2l"
     },
-    "api": {
+    "websockets": {
       "~k": "2m"
+    },
+    "api": {
+      "~k": "2n"
     },
     "operators": {
       "client": {
@@ -5676,20 +5688,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2p"
+          "~k": "2q"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2q"
+          "~k": "2r"
         },
-        "~k": "2o"
+        "~k": "2p"
       },
       "server": {
-        "~k": "2r"
+        "~k": "2s"
       },
-      "~k": "2n"
+      "~k": "2o"
     },
     "~k": "1r"
   }

--- a/packages/build/src/tests/success/88-module-nested-var-properties/snapshot.json
+++ b/packages/build/src/tests/success/88-module-nested-var-properties/snapshot.json
@@ -171,124 +171,124 @@
       "~k_parent": "24"
     },
     "30": {
-      "key": "root.types.api",
+      "key": "root.types.websockets",
       "~k_parent": "24"
     },
     "31": {
-      "key": "root.types.operators",
+      "key": "root.types.api",
       "~k_parent": "24"
     },
     "32": {
-      "key": "root.types.operators.client",
-      "~k_parent": "31"
+      "key": "root.types.operators",
+      "~k_parent": "24"
     },
     "33": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "32"
     },
     "34": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "32"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "33"
     },
     "35": {
-      "key": "root.types.operators.server",
-      "~k_parent": "31"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "33"
     },
     "36": {
+      "key": "root.types.operators.server",
+      "~k_parent": "32"
+    },
+    "37": {
       "key": "root.imports",
       "~k_parent": "5"
     },
-    "37": {
-      "key": "root.imports.actions",
-      "~k_parent": "36"
-    },
     "38": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "37"
     },
     "39": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "37"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "38"
     },
     "40": {
-      "key": "root.imports.icons",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3g"
     },
     "41": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "40"
+      "key": "root.imports.connections",
+      "~k_parent": "37"
     },
     "42": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "41"
+      "key": "root.imports.icons",
+      "~k_parent": "37"
     },
     "43": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "42"
     },
     "46": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "42"
     },
     "48": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "42"
     },
     "50": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "42"
     },
     "52": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "42"
     },
     "54": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "42"
     },
     "56": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "42"
     },
     "58": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "42"
     },
     "a": {
       "key": "root.pages[0:dashboard/overview:Box].blocks[0:show-table:Paragraph].properties",
@@ -531,380 +531,388 @@
       "~k_parent": "29"
     },
     "2c": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "29"
+    },
+    "2d": {
       "key": "root.types.blocks",
       "~k_parent": "24"
     },
-    "2d": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2c"
-    },
     "2e": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2d"
     },
     "2f": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "2d"
     },
     "2g": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2d"
     },
     "2h": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2d"
     },
     "2i": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2d"
     },
     "2j": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2d"
     },
     "2k": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2d"
     },
     "2l": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2d"
     },
     "2m": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2d"
     },
     "2n": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2d"
     },
     "2o": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2d"
     },
     "2p": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2d"
     },
     "2q": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2d"
     },
     "2r": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2d"
     },
     "2s": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2d"
     },
     "2t": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2d"
     },
     "2u": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2d"
     },
     "2v": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2d"
     },
     "2w": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2c"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2d"
     },
     "2x": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2d"
+    },
+    "2y": {
       "key": "root.types.connections",
       "~k_parent": "24"
     },
-    "2y": {
+    "2z": {
       "key": "root.types.requests",
       "~k_parent": "24"
     },
-    "2z": {
-      "key": "root.types.websockets",
-      "~k_parent": "24"
-    },
     "3a": {
-      "key": "root.imports.agents",
-      "~k_parent": "36"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "38"
     },
     "3b": {
-      "key": "root.imports.auth",
-      "~k_parent": "36"
+      "key": "root.imports.agents",
+      "~k_parent": "37"
     },
     "3c": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3b"
+      "key": "root.imports.auth",
+      "~k_parent": "37"
     },
     "3d": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3b"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3c"
     },
     "3e": {
-      "key": "root.imports.blocks",
-      "~k_parent": "36"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3c"
     },
     "3f": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3e"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3c"
     },
     "3g": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks",
+      "~k_parent": "37"
     },
     "3h": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3g"
     },
     "3j": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3g"
     },
     "3k": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3g"
     },
     "3l": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3g"
     },
     "3m": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3g"
     },
     "3n": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3g"
     },
     "3o": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3g"
     },
     "3p": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3g"
     },
     "3q": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3g"
     },
     "3r": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3g"
     },
     "3s": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3g"
     },
     "3t": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3g"
     },
     "3u": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3g"
     },
     "3v": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3g"
     },
     "3w": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3g"
     },
     "3x": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3g"
     },
     "3y": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3e"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3g"
     },
     "3z": {
-      "key": "root.imports.connections",
-      "~k_parent": "36"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3g"
     },
     "4a": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "42"
     },
     "4c": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "42"
     },
     "4e": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "42"
     },
     "4g": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "42"
     },
     "4i": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "42"
     },
     "4k": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "42"
     },
     "4m": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "42"
     },
     "4o": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "42"
     },
     "4q": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "42"
     },
     "4s": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "42"
     },
     "4u": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "42"
     },
     "4w": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "42"
     },
     "4y": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "42"
     },
     "5a": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "42"
     },
     "5c": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "42"
     },
     "5e": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "42"
     },
     "5g": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "42"
     },
     "5i": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "40"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "42"
     },
     "5k": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.requests",
-      "~k_parent": "36"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "42"
     },
     "5m": {
-      "key": "root.imports.websockets",
-      "~k_parent": "36"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.operators",
-      "~k_parent": "36"
+      "key": "root.imports.requests",
+      "~k_parent": "37"
     },
     "5o": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5n"
+      "key": "root.imports.websockets",
+      "~k_parent": "37"
     },
     "5p": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5o"
+      "key": "root.imports.operators",
+      "~k_parent": "37"
     },
     "5q": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5o"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5p"
     },
     "5r": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5q"
+    },
+    "5s": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5q"
+    },
+    "5t": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5n"
+      "~k_parent": "5p"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1195,6 +1203,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5697,6 +5706,9 @@
       "providers": {
         "~k": "2b"
       },
+      "strategies": {
+        "~k": "2c"
+      },
       "~k": "29"
     },
     "blocks": {
@@ -5704,135 +5716,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 8,
-        "~k": "2e"
+        "~k": "2f"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2n"
+        "~k": "2o"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
-      "~k": "2c"
+      "~k": "2d"
     },
     "connections": {
-      "~k": "2x"
-    },
-    "requests": {
       "~k": "2y"
     },
-    "websockets": {
+    "requests": {
       "~k": "2z"
     },
-    "api": {
+    "websockets": {
       "~k": "30"
+    },
+    "api": {
+      "~k": "31"
     },
     "operators": {
       "client": {
@@ -5840,20 +5852,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "33"
+          "~k": "34"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "34"
+          "~k": "35"
         },
-        "~k": "32"
+        "~k": "33"
       },
       "server": {
-        "~k": "35"
+        "~k": "36"
       },
-      "~k": "31"
+      "~k": "32"
     },
     "~k": "24"
   }

--- a/packages/build/src/tests/success/89-module-null-namespace-defaults/snapshot.json
+++ b/packages/build/src/tests/success/89-module-null-namespace-defaults/snapshot.json
@@ -213,124 +213,124 @@
       "~k_parent": "34"
     },
     "40": {
-      "key": "root.types.api",
+      "key": "root.types.websockets",
       "~k_parent": "34"
     },
     "41": {
-      "key": "root.types.operators",
+      "key": "root.types.api",
       "~k_parent": "34"
     },
     "42": {
-      "key": "root.types.operators.client",
-      "~k_parent": "41"
+      "key": "root.types.operators",
+      "~k_parent": "34"
     },
     "43": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "42"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "43"
     },
     "45": {
-      "key": "root.types.operators.server",
-      "~k_parent": "41"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "43"
     },
     "46": {
+      "key": "root.types.operators.server",
+      "~k_parent": "42"
+    },
+    "47": {
       "key": "root.imports",
       "~k_parent": "8"
     },
-    "47": {
-      "key": "root.imports.actions",
-      "~k_parent": "46"
-    },
     "48": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "47"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "4g"
     },
     "51": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "50"
+      "key": "root.imports.connections",
+      "~k_parent": "47"
     },
     "52": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "51"
+      "key": "root.imports.icons",
+      "~k_parent": "47"
     },
     "53": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "52"
     },
     "56": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "52"
     },
     "58": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "52"
     },
     "60": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "52"
     },
     "62": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "52"
     },
     "64": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "52"
     },
     "66": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "52"
     },
     "68": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "52"
     },
     "a": {
       "key": "root.pages[0:widget-partial/main:Box]",
@@ -697,380 +697,388 @@
       "~k_parent": "39"
     },
     "3c": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "39"
+    },
+    "3d": {
       "key": "root.types.blocks",
       "~k_parent": "34"
     },
-    "3d": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "3c"
-    },
     "3e": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3d"
     },
     "3f": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "3d"
     },
     "3g": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3d"
     },
     "3h": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3d"
     },
     "3i": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3d"
     },
     "3j": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3d"
     },
     "3k": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3d"
     },
     "3l": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3d"
     },
     "3m": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3d"
     },
     "3n": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3d"
     },
     "3o": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3d"
     },
     "3p": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3d"
     },
     "3q": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3d"
     },
     "3r": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3d"
     },
     "3s": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3d"
     },
     "3t": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3d"
     },
     "3u": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3d"
     },
     "3v": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3d"
     },
     "3w": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "3c"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3d"
     },
     "3x": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3d"
+    },
+    "3y": {
       "key": "root.types.connections",
       "~k_parent": "34"
     },
-    "3y": {
+    "3z": {
       "key": "root.types.requests",
       "~k_parent": "34"
     },
-    "3z": {
-      "key": "root.types.websockets",
-      "~k_parent": "34"
-    },
     "4a": {
-      "key": "root.imports.agents",
-      "~k_parent": "46"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "48"
     },
     "4b": {
-      "key": "root.imports.auth",
-      "~k_parent": "46"
+      "key": "root.imports.agents",
+      "~k_parent": "47"
     },
     "4c": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "4b"
+      "key": "root.imports.auth",
+      "~k_parent": "47"
     },
     "4d": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "4b"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.blocks",
-      "~k_parent": "46"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "4c"
     },
     "4f": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "4e"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "4c"
     },
     "4g": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks",
+      "~k_parent": "47"
     },
     "4h": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "4g"
     },
     "4j": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "4g"
     },
     "4k": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "4g"
     },
     "4l": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "4g"
     },
     "4m": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "4g"
     },
     "4n": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "4g"
     },
     "4o": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "4g"
     },
     "4p": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "4g"
     },
     "4q": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "4g"
     },
     "4r": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "4g"
     },
     "4s": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "4g"
     },
     "4t": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "4g"
     },
     "4u": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "4g"
     },
     "4v": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "4g"
     },
     "4w": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "4g"
     },
     "4x": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "4g"
     },
     "4y": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "4e"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "4g"
     },
     "4z": {
-      "key": "root.imports.connections",
-      "~k_parent": "46"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "4g"
     },
     "5a": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "52"
     },
     "5c": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "52"
     },
     "5e": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "52"
     },
     "5g": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "52"
     },
     "5i": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "52"
     },
     "5k": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "52"
     },
     "5m": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "52"
     },
     "5o": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "52"
     },
     "5q": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "52"
     },
     "5s": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "52"
     },
     "5u": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "52"
     },
     "5w": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "52"
     },
     "5y": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "52"
     },
     "6a": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "52"
     },
     "6c": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "52"
     },
     "6e": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "52"
     },
     "6g": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "6f"
     },
     "6h": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "52"
     },
     "6i": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "50"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "52"
     },
     "6k": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6j"
     },
     "6l": {
-      "key": "root.imports.requests",
-      "~k_parent": "46"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "52"
     },
     "6m": {
-      "key": "root.imports.websockets",
-      "~k_parent": "46"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6l"
     },
     "6n": {
-      "key": "root.imports.operators",
-      "~k_parent": "46"
+      "key": "root.imports.requests",
+      "~k_parent": "47"
     },
     "6o": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6n"
+      "key": "root.imports.websockets",
+      "~k_parent": "47"
     },
     "6p": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6o"
+      "key": "root.imports.operators",
+      "~k_parent": "47"
     },
     "6q": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6o"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6p"
     },
     "6r": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6q"
+    },
+    "6s": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6q"
+    },
+    "6t": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6n"
+      "~k_parent": "6p"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1499,6 +1507,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -6019,6 +6028,9 @@
       "providers": {
         "~k": "3b"
       },
+      "strategies": {
+        "~k": "3c"
+      },
       "~k": "39"
     },
     "blocks": {
@@ -6026,135 +6038,135 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "3d"
+        "~k": "3e"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 10,
-        "~k": "3e"
+        "~k": "3f"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3f"
+        "~k": "3g"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3h"
+        "~k": "3i"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3i"
+        "~k": "3j"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3j"
+        "~k": "3k"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3k"
+        "~k": "3l"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3l"
+        "~k": "3m"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3m"
+        "~k": "3n"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3n"
+        "~k": "3o"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3o"
+        "~k": "3p"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3p"
+        "~k": "3q"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3q"
+        "~k": "3r"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3r"
+        "~k": "3s"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3s"
+        "~k": "3t"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3t"
+        "~k": "3u"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3u"
+        "~k": "3v"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3v"
+        "~k": "3w"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3w"
+        "~k": "3x"
       },
-      "~k": "3c"
+      "~k": "3d"
     },
     "connections": {
-      "~k": "3x"
-    },
-    "requests": {
       "~k": "3y"
     },
-    "websockets": {
+    "requests": {
       "~k": "3z"
     },
-    "api": {
+    "websockets": {
       "~k": "40"
+    },
+    "api": {
+      "~k": "41"
     },
     "operators": {
       "client": {
@@ -6162,20 +6174,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "43"
+          "~k": "44"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "44"
+          "~k": "45"
         },
-        "~k": "42"
+        "~k": "43"
       },
       "server": {
-        "~k": "45"
+        "~k": "46"
       },
-      "~k": "41"
+      "~k": "42"
     },
     "~k": "34"
   }

--- a/packages/build/src/tests/success/90-module-lazy-default-resolution/snapshot.json
+++ b/packages/build/src/tests/success/90-module-lazy-default-resolution/snapshot.json
@@ -148,156 +148,156 @@
       "~k_parent": "2z"
     },
     "32": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2z"
+    },
+    "33": {
       "key": "root.types.blocks",
       "~k_parent": "2u"
     },
-    "33": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "32"
-    },
     "34": {
-      "key": "root.types.blocks.Paragraph",
-      "~k_parent": "32"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "33"
     },
     "35": {
-      "key": "root.types.blocks.TextInput",
-      "~k_parent": "32"
+      "key": "root.types.blocks.Paragraph",
+      "~k_parent": "33"
     },
     "36": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "32"
+      "key": "root.types.blocks.TextInput",
+      "~k_parent": "33"
     },
     "37": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "32"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "33"
     },
     "38": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "32"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "33"
     },
     "39": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "32"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "33"
     },
     "40": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3y"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.agents",
-      "~k_parent": "3x"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3z"
     },
     "42": {
-      "key": "root.imports.auth",
-      "~k_parent": "3x"
+      "key": "root.imports.agents",
+      "~k_parent": "3y"
     },
     "43": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "42"
+      "key": "root.imports.auth",
+      "~k_parent": "3y"
     },
     "44": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "42"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3x"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "43"
     },
     "46": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "45"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "43"
     },
     "47": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks",
+      "~k_parent": "3y"
     },
     "48": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "47"
     },
     "50": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4u"
     },
     "52": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4u"
     },
     "54": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4u"
     },
     "56": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4u"
     },
     "58": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4u"
     },
     "60": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4u"
     },
     "62": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4u"
     },
     "64": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4u"
     },
     "66": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4u"
     },
     "68": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4u"
     },
     "a": {
       "key": "root",
@@ -657,356 +657,364 @@
       "~k_parent": "2u"
     },
     "3a": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "32"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "33"
     },
     "3b": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "32"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "33"
     },
     "3c": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "32"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "33"
     },
     "3d": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "32"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "33"
     },
     "3e": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "32"
+      "key": "root.types.blocks.List",
+      "~k_parent": "33"
     },
     "3f": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "32"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "33"
     },
     "3g": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "32"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "33"
     },
     "3h": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "32"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "33"
     },
     "3i": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "32"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "33"
     },
     "3j": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "32"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "33"
     },
     "3k": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "32"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "33"
     },
     "3l": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "32"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "33"
     },
     "3m": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "32"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "33"
     },
     "3n": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "32"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "33"
     },
     "3o": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "33"
+    },
+    "3p": {
       "key": "root.types.connections",
       "~k_parent": "2u"
     },
-    "3p": {
+    "3q": {
       "key": "root.types.requests",
       "~k_parent": "2u"
     },
-    "3q": {
+    "3r": {
       "key": "root.types.websockets",
       "~k_parent": "2u"
     },
-    "3r": {
+    "3s": {
       "key": "root.types.api",
       "~k_parent": "2u"
     },
-    "3s": {
+    "3t": {
       "key": "root.types.operators",
       "~k_parent": "2u"
     },
-    "3t": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3s"
-    },
     "3u": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3t"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3s"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3u"
     },
     "3x": {
+      "key": "root.types.operators.server",
+      "~k_parent": "3t"
+    },
+    "3y": {
       "key": "root.imports",
       "~k_parent": "a"
     },
-    "3y": {
-      "key": "root.imports.actions",
-      "~k_parent": "3x"
-    },
     "3z": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "47"
     },
     "4b": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "47"
     },
     "4c": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "47"
     },
     "4d": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "47"
     },
     "4e": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "47"
     },
     "4f": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "47"
     },
     "4g": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "47"
     },
     "4h": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "47"
     },
     "4i": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "47"
     },
     "4j": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "47"
     },
     "4k": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "47"
     },
     "4l": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "47"
     },
     "4m": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "47"
     },
     "4n": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "47"
     },
     "4o": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "47"
     },
     "4p": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "47"
     },
     "4q": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "47"
     },
     "4r": {
-      "key": "root.imports.connections",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "47"
     },
     "4s": {
-      "key": "root.imports.icons",
-      "~k_parent": "3x"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "47"
     },
     "4t": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "4s"
+      "key": "root.imports.connections",
+      "~k_parent": "3y"
     },
     "4u": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4t"
+      "key": "root.imports.icons",
+      "~k_parent": "3y"
     },
     "4v": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4u"
     },
     "4y": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4u"
     },
     "5a": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4u"
     },
     "5c": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4u"
     },
     "5e": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4u"
     },
     "5g": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4u"
     },
     "5i": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4u"
     },
     "5k": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4u"
     },
     "5m": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4u"
     },
     "5o": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4u"
     },
     "5q": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4u"
     },
     "5s": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4u"
     },
     "5u": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4u"
     },
     "5w": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4u"
     },
     "5y": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4u"
     },
     "6a": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4u"
     },
     "6c": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.requests",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4u"
     },
     "6e": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3x"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.operators",
-      "~k_parent": "3x"
+      "key": "root.imports.requests",
+      "~k_parent": "3y"
     },
     "6g": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6f"
+      "key": "root.imports.websockets",
+      "~k_parent": "3y"
     },
     "6h": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6g"
+      "key": "root.imports.operators",
+      "~k_parent": "3y"
     },
     "6i": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6g"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6h"
     },
     "6j": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6i"
+    },
+    "6k": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6i"
+    },
+    "6l": {
       "key": "root.imports.operators.server",
-      "~k_parent": "6f"
+      "~k_parent": "6h"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1383,6 +1391,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -6697,6 +6706,9 @@
       "providers": {
         "~k": "31"
       },
+      "strategies": {
+        "~k": "32"
+      },
       "~k": "2z"
     },
     "blocks": {
@@ -6704,141 +6716,141 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 7,
-        "~k": "33"
+        "~k": "34"
       },
       "Paragraph": {
         "originalTypeName": "Paragraph",
         "package": "@lowdefy/blocks-basic",
         "count": 4,
-        "~k": "34"
+        "~k": "35"
       },
       "TextInput": {
         "originalTypeName": "TextInput",
         "package": "@lowdefy/blocks-antd",
         "count": 2,
-        "~k": "35"
+        "~k": "36"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3f"
+        "~k": "3g"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3h"
+        "~k": "3i"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3i"
+        "~k": "3j"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3j"
+        "~k": "3k"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3k"
+        "~k": "3l"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3l"
+        "~k": "3m"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3m"
+        "~k": "3n"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3n"
+        "~k": "3o"
       },
-      "~k": "32"
+      "~k": "33"
     },
     "connections": {
-      "~k": "3o"
-    },
-    "requests": {
       "~k": "3p"
     },
-    "websockets": {
+    "requests": {
       "~k": "3q"
     },
-    "api": {
+    "websockets": {
       "~k": "3r"
+    },
+    "api": {
+      "~k": "3s"
     },
     "operators": {
       "client": {
@@ -6846,20 +6858,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3u"
+          "~k": "3v"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3v"
+          "~k": "3w"
         },
-        "~k": "3t"
+        "~k": "3u"
       },
       "server": {
-        "~k": "3w"
+        "~k": "3x"
       },
-      "~k": "3s"
+      "~k": "3t"
     },
     "~k": "2u"
   }

--- a/packages/build/src/tests/success/91-i18n-config/snapshot.json
+++ b/packages/build/src/tests/success/91-i18n-config/snapshot.json
@@ -196,164 +196,164 @@
       "~k_parent": "14"
     },
     "20": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "1z"
     },
     "21": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "1z"
     },
     "22": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "1z"
     },
     "23": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "1z"
     },
     "24": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "1z"
     },
     "25": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "1z"
     },
     "26": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "1z"
     },
     "27": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "1z"
     },
     "28": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.List",
+      "~k_parent": "1z"
     },
     "29": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "1z"
     },
     "30": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "2z"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "2x"
     },
     "31": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks",
+      "~k_parent": "2s"
     },
     "32": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "31"
     },
     "33": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "31"
     },
     "34": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "31"
     },
     "35": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "31"
     },
     "36": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "31"
     },
     "37": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "31"
     },
     "38": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "31"
     },
     "39": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "31"
     },
     "40": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "3z"
     },
     "41": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3m"
     },
     "42": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3m"
     },
     "44": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3m"
     },
     "46": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "45"
     },
     "47": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3m"
     },
     "48": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3m"
     },
     "50": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3m"
     },
     "52": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3m"
     },
     "54": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.requests",
-      "~k_parent": "2r"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3m"
     },
     "56": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2r"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.operators",
-      "~k_parent": "2r"
+      "key": "root.imports.requests",
+      "~k_parent": "2s"
     },
     "58": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "57"
+      "key": "root.imports.websockets",
+      "~k_parent": "2s"
     },
     "59": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "58"
+      "key": "root.imports.operators",
+      "~k_parent": "2s"
     },
     "a": {
       "key": "root.config.i18n.messages",
@@ -553,332 +553,340 @@
       "~k_parent": "1v"
     },
     "1y": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "1v"
+    },
+    "1z": {
       "key": "root.types.blocks",
       "~k_parent": "1q"
     },
-    "1z": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "1y"
-    },
     "2a": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "1z"
     },
     "2b": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "1z"
     },
     "2c": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "1z"
     },
     "2d": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "1z"
     },
     "2e": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "1z"
     },
     "2f": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "1z"
     },
     "2g": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "1z"
     },
     "2h": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "1y"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "1z"
     },
     "2i": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "1z"
+    },
+    "2j": {
       "key": "root.types.connections",
       "~k_parent": "1q"
     },
-    "2j": {
+    "2k": {
       "key": "root.types.requests",
       "~k_parent": "1q"
     },
-    "2k": {
+    "2l": {
       "key": "root.types.websockets",
       "~k_parent": "1q"
     },
-    "2l": {
+    "2m": {
       "key": "root.types.api",
       "~k_parent": "1q"
     },
-    "2m": {
+    "2n": {
       "key": "root.types.operators",
       "~k_parent": "1q"
     },
-    "2n": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2m"
-    },
     "2o": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2n"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2o"
     },
     "2q": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2m"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2o"
     },
     "2r": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2n"
+    },
+    "2s": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2s": {
-      "key": "root.imports.actions",
-      "~k_parent": "2r"
-    },
     "2t": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2s"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.imports.agents",
-      "~k_parent": "2r"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2t"
     },
     "2w": {
-      "key": "root.imports.auth",
-      "~k_parent": "2r"
+      "key": "root.imports.agents",
+      "~k_parent": "2s"
     },
     "2x": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "2w"
+      "key": "root.imports.auth",
+      "~k_parent": "2s"
     },
     "2y": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "2w"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2r"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "2x"
     },
     "3a": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "31"
     },
     "3b": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "31"
     },
     "3c": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "31"
     },
     "3d": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "31"
     },
     "3e": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "31"
     },
     "3f": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "31"
     },
     "3g": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "31"
     },
     "3h": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "31"
     },
     "3i": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "2z"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "31"
     },
     "3j": {
-      "key": "root.imports.connections",
-      "~k_parent": "2r"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "31"
     },
     "3k": {
-      "key": "root.imports.icons",
-      "~k_parent": "2r"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "31"
     },
     "3l": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3k"
+      "key": "root.imports.connections",
+      "~k_parent": "2s"
     },
     "3m": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3l"
+      "key": "root.imports.icons",
+      "~k_parent": "2s"
     },
     "3n": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3m"
     },
     "3s": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3m"
     },
     "3u": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3m"
     },
     "3w": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "3v"
     },
     "3x": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3m"
     },
     "3y": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3m"
     },
     "4a": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "49"
     },
     "4b": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3m"
     },
     "4c": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4b"
     },
     "4d": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3m"
     },
     "4e": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3m"
     },
     "4g": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4f"
     },
     "4h": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3m"
     },
     "4i": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3m"
     },
     "4k": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3m"
     },
     "4m": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4l"
     },
     "4n": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3m"
     },
     "4o": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3m"
     },
     "4q": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4p"
     },
     "4r": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3m"
     },
     "4s": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3m"
     },
     "4u": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4t"
     },
     "4v": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3m"
     },
     "4w": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3m"
     },
     "4y": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3k"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3m"
     },
     "5a": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "58"
+      "key": "root.imports.operators.client",
+      "~k_parent": "59"
     },
     "5b": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5a"
+    },
+    "5c": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5a"
+    },
+    "5d": {
       "key": "root.imports.operators.server",
-      "~k_parent": "57"
+      "~k_parent": "59"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1075,6 +1083,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5569,6 +5578,9 @@
       "providers": {
         "~k": "1x"
       },
+      "strategies": {
+        "~k": "1y"
+      },
       "~k": "1v"
     },
     "blocks": {
@@ -5576,129 +5588,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "1z"
+        "~k": "20"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "20"
+        "~k": "21"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "21"
+        "~k": "22"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "22"
+        "~k": "23"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "23"
+        "~k": "24"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "24"
+        "~k": "25"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
-      "~k": "1y"
+      "~k": "1z"
     },
     "connections": {
-      "~k": "2i"
-    },
-    "requests": {
       "~k": "2j"
     },
-    "websockets": {
+    "requests": {
       "~k": "2k"
     },
-    "api": {
+    "websockets": {
       "~k": "2l"
+    },
+    "api": {
+      "~k": "2m"
     },
     "operators": {
       "client": {
@@ -5706,20 +5718,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2o"
+          "~k": "2p"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2p"
+          "~k": "2q"
         },
-        "~k": "2n"
+        "~k": "2o"
       },
       "server": {
-        "~k": "2q"
+        "~k": "2r"
       },
-      "~k": "2m"
+      "~k": "2n"
     },
     "~k": "1q"
   }

--- a/packages/build/src/tests/success/92-api-with-schedules/snapshot.json
+++ b/packages/build/src/tests/success/92-api-with-schedules/snapshot.json
@@ -188,151 +188,151 @@
       "~k_parent": "20"
     },
     "23": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "20"
+    },
+    "24": {
       "key": "root.types.blocks",
       "~k_parent": "1v"
     },
-    "24": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "23"
-    },
     "25": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "24"
     },
     "26": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "24"
     },
     "27": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "24"
     },
     "28": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "24"
     },
     "29": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "23"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "24"
     },
     "30": {
-      "key": "root.imports.agents",
-      "~k_parent": "2w"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "2y"
     },
     "31": {
-      "key": "root.imports.auth",
-      "~k_parent": "2w"
+      "key": "root.imports.agents",
+      "~k_parent": "2x"
     },
     "32": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "31"
+      "key": "root.imports.auth",
+      "~k_parent": "2x"
     },
     "33": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "31"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.imports.blocks",
-      "~k_parent": "2w"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "32"
     },
     "35": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "34"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "32"
     },
     "36": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks",
+      "~k_parent": "2x"
     },
     "37": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "36"
     },
     "38": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "36"
     },
     "39": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "36"
     },
     "40": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "3r"
     },
     "41": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "40"
     },
     "42": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "3r"
     },
     "43": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "42"
     },
     "44": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "3r"
     },
     "45": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "44"
     },
     "46": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "3r"
     },
     "47": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "46"
     },
     "48": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "3r"
     },
     "49": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "48"
     },
     "50": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "3r"
     },
     "51": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "3r"
     },
     "53": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "3r"
     },
     "55": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "3r"
     },
     "57": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "3r"
     },
     "59": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "58"
     },
     "a": {
@@ -548,344 +548,352 @@
       "~k_parent": "1v"
     },
     "2a": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "24"
     },
     "2b": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "24"
     },
     "2c": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "24"
     },
     "2d": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "23"
+      "key": "root.types.blocks.List",
+      "~k_parent": "24"
     },
     "2e": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "24"
     },
     "2f": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "24"
     },
     "2g": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "23"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "24"
     },
     "2h": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "24"
     },
     "2i": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "23"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "24"
     },
     "2j": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "23"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "24"
     },
     "2k": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "23"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "24"
     },
     "2l": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "23"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "24"
     },
     "2m": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "23"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "24"
     },
     "2n": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "24"
+    },
+    "2o": {
       "key": "root.types.connections",
       "~k_parent": "1v"
     },
-    "2o": {
+    "2p": {
       "key": "root.types.requests",
       "~k_parent": "1v"
     },
-    "2p": {
+    "2q": {
       "key": "root.types.websockets",
       "~k_parent": "1v"
     },
-    "2q": {
+    "2r": {
       "key": "root.types.api",
       "~k_parent": "1v"
     },
-    "2r": {
+    "2s": {
       "key": "root.types.operators",
       "~k_parent": "1v"
     },
-    "2s": {
-      "key": "root.types.operators.client",
-      "~k_parent": "2r"
-    },
     "2t": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "2s"
     },
     "2u": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "2s"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "2t"
     },
     "2v": {
-      "key": "root.types.operators.server",
-      "~k_parent": "2r"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "2t"
     },
     "2w": {
+      "key": "root.types.operators.server",
+      "~k_parent": "2s"
+    },
+    "2x": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "2x": {
-      "key": "root.imports.actions",
-      "~k_parent": "2w"
-    },
     "2y": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "2x"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "2y"
     },
     "3a": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "36"
     },
     "3b": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "36"
     },
     "3c": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "36"
     },
     "3d": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "36"
     },
     "3e": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "36"
     },
     "3f": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "36"
     },
     "3g": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "36"
     },
     "3h": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "36"
     },
     "3i": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "36"
     },
     "3j": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "36"
     },
     "3k": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "36"
     },
     "3l": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "36"
     },
     "3m": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "36"
     },
     "3n": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "34"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "36"
     },
     "3o": {
-      "key": "root.imports.connections",
-      "~k_parent": "2w"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "36"
     },
     "3p": {
-      "key": "root.imports.icons",
-      "~k_parent": "2w"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "36"
     },
     "3q": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "3p"
+      "key": "root.imports.connections",
+      "~k_parent": "2x"
     },
     "3r": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "3q"
+      "key": "root.imports.icons",
+      "~k_parent": "2x"
     },
     "3s": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "3r"
     },
     "3v": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "3u"
     },
     "3w": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "3r"
     },
     "3x": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "3r"
     },
     "3z": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "3r"
     },
     "4b": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "4a"
     },
     "4c": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "3r"
     },
     "4d": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "4c"
     },
     "4e": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "3r"
     },
     "4f": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "4e"
     },
     "4g": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "3r"
     },
     "4h": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "4g"
     },
     "4i": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "3r"
     },
     "4j": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "4i"
     },
     "4k": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "3r"
     },
     "4l": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "3r"
     },
     "4n": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "3r"
     },
     "4p": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "3r"
     },
     "4r": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "3r"
     },
     "4t": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "3r"
     },
     "4v": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "3r"
     },
     "4x": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "3p"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "3r"
     },
     "4z": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.requests",
-      "~k_parent": "2w"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "3r"
     },
     "5b": {
-      "key": "root.imports.websockets",
-      "~k_parent": "2w"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.operators",
-      "~k_parent": "2w"
+      "key": "root.imports.requests",
+      "~k_parent": "2x"
     },
     "5d": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "5c"
+      "key": "root.imports.websockets",
+      "~k_parent": "2x"
     },
     "5e": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "5d"
+      "key": "root.imports.operators",
+      "~k_parent": "2x"
     },
     "5f": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "5d"
+      "key": "root.imports.operators.client",
+      "~k_parent": "5e"
     },
     "5g": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "5f"
+    },
+    "5h": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "5f"
+    },
+    "5i": {
       "key": "root.imports.operators.server",
-      "~k_parent": "5c"
+      "~k_parent": "5e"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1082,6 +1090,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5594,6 +5603,9 @@
       "providers": {
         "~k": "22"
       },
+      "strategies": {
+        "~k": "23"
+      },
       "~k": "20"
     },
     "blocks": {
@@ -5601,129 +5613,129 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "24"
+        "~k": "25"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "25"
+        "~k": "26"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "26"
+        "~k": "27"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "27"
+        "~k": "28"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "28"
+        "~k": "29"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "29"
+        "~k": "2a"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2a"
+        "~k": "2b"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2b"
+        "~k": "2c"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2c"
+        "~k": "2d"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2d"
+        "~k": "2e"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2e"
+        "~k": "2f"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2f"
+        "~k": "2g"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2g"
+        "~k": "2h"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2h"
+        "~k": "2i"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2i"
+        "~k": "2j"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2j"
+        "~k": "2k"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2k"
+        "~k": "2l"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2l"
+        "~k": "2m"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2m"
+        "~k": "2n"
       },
-      "~k": "23"
+      "~k": "24"
     },
     "connections": {
-      "~k": "2n"
-    },
-    "requests": {
       "~k": "2o"
     },
-    "websockets": {
+    "requests": {
       "~k": "2p"
     },
-    "api": {
+    "websockets": {
       "~k": "2q"
+    },
+    "api": {
+      "~k": "2r"
     },
     "operators": {
       "client": {
@@ -5731,20 +5743,20 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2t"
+          "~k": "2u"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "2u"
+          "~k": "2v"
         },
-        "~k": "2s"
+        "~k": "2t"
       },
       "server": {
-        "~k": "2v"
+        "~k": "2w"
       },
-      "~k": "2r"
+      "~k": "2s"
     },
     "~k": "1v"
   }

--- a/packages/build/src/tests/success/93-api-generate-requests/snapshot.json
+++ b/packages/build/src/tests/success/93-api-generate-requests/snapshot.json
@@ -282,164 +282,164 @@
       "~k_parent": "4"
     },
     "30": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2n"
     },
     "31": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2n"
     },
     "32": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2n"
     },
     "33": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2n"
     },
     "34": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2n"
     },
     "35": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2n"
     },
     "36": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2n"
     },
     "37": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2n"
+    },
+    "38": {
       "key": "root.types.connections",
       "~k_parent": "2e"
     },
-    "38": {
-      "key": "root.types.connections.Anthropic",
-      "~k_parent": "37"
-    },
     "39": {
-      "key": "root.types.requests",
-      "~k_parent": "2e"
+      "key": "root.types.connections.Anthropic",
+      "~k_parent": "38"
     },
     "40": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "3w"
     },
     "41": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "3w"
     },
     "42": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "3w"
     },
     "43": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "3w"
     },
     "44": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "3w"
     },
     "45": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "3w"
     },
     "46": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "3w"
     },
     "47": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "3w"
     },
     "48": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "3w"
     },
     "49": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "3w"
     },
     "50": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4j"
     },
     "51": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "50"
     },
     "52": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4j"
     },
     "53": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4j"
     },
     "55": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "54"
     },
     "56": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4j"
     },
     "57": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "56"
     },
     "58": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4j"
     },
     "59": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "58"
     },
     "60": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4j"
     },
     "61": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "60"
     },
     "62": {
-      "key": "root.imports.requests",
-      "~k_parent": "3m"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4j"
     },
     "63": {
-      "key": "root.imports.requests[0]",
+      "key": "root.imports.icons[27].icons",
       "~k_parent": "62"
     },
     "64": {
-      "key": "root.imports.requests[1]",
-      "~k_parent": "62"
+      "key": "root.imports.requests",
+      "~k_parent": "3n"
     },
     "65": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3m"
+      "key": "root.imports.requests[0]",
+      "~k_parent": "64"
     },
     "66": {
-      "key": "root.imports.operators",
-      "~k_parent": "3m"
+      "key": "root.imports.requests[1]",
+      "~k_parent": "64"
     },
     "67": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "66"
+      "key": "root.imports.websockets",
+      "~k_parent": "3n"
     },
     "68": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "67"
+      "key": "root.imports.operators",
+      "~k_parent": "3n"
     },
     "69": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "67"
+      "key": "root.imports.operators.client",
+      "~k_parent": "68"
     },
     "a": {
       "key": "root.api[0:summarize-text:Api]",
@@ -714,388 +714,396 @@
       "~k_parent": "2j"
     },
     "2m": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2j"
+    },
+    "2n": {
       "key": "root.types.blocks",
       "~k_parent": "2e"
     },
-    "2n": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2m"
-    },
     "2o": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2n"
     },
     "2p": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2n"
     },
     "2q": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2n"
     },
     "2r": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2n"
     },
     "2s": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2n"
     },
     "2t": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2n"
     },
     "2u": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2n"
     },
     "2v": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2n"
     },
     "2w": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2n"
     },
     "2x": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2n"
     },
     "2y": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2n"
     },
     "2z": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2m"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2n"
     },
     "3a": {
-      "key": "root.types.requests.GenerateText",
-      "~k_parent": "39"
+      "key": "root.types.requests",
+      "~k_parent": "2e"
     },
     "3b": {
-      "key": "root.types.requests.GenerateObject",
-      "~k_parent": "39"
+      "key": "root.types.requests.GenerateText",
+      "~k_parent": "3a"
     },
     "3c": {
+      "key": "root.types.requests.GenerateObject",
+      "~k_parent": "3a"
+    },
+    "3d": {
       "key": "root.types.websockets",
       "~k_parent": "2e"
     },
-    "3d": {
+    "3e": {
       "key": "root.types.api",
       "~k_parent": "2e"
     },
-    "3e": {
+    "3f": {
       "key": "root.types.operators",
       "~k_parent": "2e"
     },
-    "3f": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3e"
-    },
     "3g": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3f"
     },
     "3h": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3f"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3e"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3g"
     },
     "3j": {
-      "key": "root.types.operators.server._secret",
-      "~k_parent": "3i"
+      "key": "root.types.operators.server",
+      "~k_parent": "3f"
     },
     "3k": {
-      "key": "root.types.operators.server._payload",
-      "~k_parent": "3i"
+      "key": "root.types.operators.server._secret",
+      "~k_parent": "3j"
     },
     "3l": {
-      "key": "root.types.operators.server._step",
-      "~k_parent": "3i"
+      "key": "root.types.operators.server._payload",
+      "~k_parent": "3j"
     },
     "3m": {
+      "key": "root.types.operators.server._step",
+      "~k_parent": "3j"
+    },
+    "3n": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "3n": {
-      "key": "root.imports.actions",
-      "~k_parent": "3m"
-    },
     "3o": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3n"
     },
     "3p": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3n"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3o"
     },
     "3q": {
-      "key": "root.imports.agents",
-      "~k_parent": "3m"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3o"
     },
     "3r": {
-      "key": "root.imports.auth",
-      "~k_parent": "3m"
+      "key": "root.imports.agents",
+      "~k_parent": "3n"
     },
     "3s": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "3r"
+      "key": "root.imports.auth",
+      "~k_parent": "3n"
     },
     "3t": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "3r"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "3s"
     },
     "3u": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3m"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "3s"
     },
     "3v": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "3u"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "3s"
     },
     "3w": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks",
+      "~k_parent": "3n"
     },
     "3x": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "3w"
     },
     "3y": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "3w"
     },
     "3z": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "3w"
     },
     "4a": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "3w"
     },
     "4b": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "3w"
     },
     "4c": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "3w"
     },
     "4d": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "3w"
     },
     "4e": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "3u"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "3w"
     },
     "4f": {
-      "key": "root.imports.connections",
-      "~k_parent": "3m"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "3w"
     },
     "4g": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "4f"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "3w"
     },
     "4h": {
-      "key": "root.imports.icons",
-      "~k_parent": "3m"
+      "key": "root.imports.connections",
+      "~k_parent": "3n"
     },
     "4i": {
-      "key": "root.imports.icons[0]",
+      "key": "root.imports.connections[0]",
       "~k_parent": "4h"
     },
     "4j": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4i"
+      "key": "root.imports.icons",
+      "~k_parent": "3n"
     },
     "4k": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4j"
     },
     "4n": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4m"
     },
     "4o": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4j"
     },
     "4p": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4o"
     },
     "4q": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4j"
     },
     "4r": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "4q"
     },
     "4s": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4j"
     },
     "4t": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4j"
     },
     "4v": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4j"
     },
     "4x": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "4w"
     },
     "4y": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4j"
     },
     "4z": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "4y"
     },
     "5a": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4j"
     },
     "5b": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5a"
     },
     "5c": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4j"
     },
     "5d": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5c"
     },
     "5e": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4j"
     },
     "5f": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5e"
     },
     "5g": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4j"
     },
     "5h": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5g"
     },
     "5i": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4j"
     },
     "5j": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5i"
     },
     "5k": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4j"
     },
     "5l": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5k"
     },
     "5m": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4j"
     },
     "5n": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5m"
     },
     "5o": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4j"
     },
     "5p": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4j"
     },
     "5r": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4j"
     },
     "5t": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "5s"
     },
     "5u": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4j"
     },
     "5v": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "5u"
     },
     "5w": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4j"
     },
     "5x": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "5w"
     },
     "5y": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4h"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4j"
     },
     "5z": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "5y"
     },
     "6a": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "66"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.operators.server[0]",
-      "~k_parent": "6a"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "69"
     },
     "6c": {
-      "key": "root.imports.operators.server[1]",
-      "~k_parent": "6a"
+      "key": "root.imports.operators.server",
+      "~k_parent": "68"
     },
     "6d": {
+      "key": "root.imports.operators.server[0]",
+      "~k_parent": "6c"
+    },
+    "6e": {
+      "key": "root.imports.operators.server[1]",
+      "~k_parent": "6c"
+    },
+    "6f": {
       "key": "root.imports.operators.server[2]",
-      "~k_parent": "6a"
+      "~k_parent": "6c"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1313,6 +1321,7 @@
   "plugins/agents.js": "export default {\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -5937,6 +5946,9 @@
       "providers": {
         "~k": "2l"
       },
+      "strategies": {
+        "~k": "2m"
+      },
       "~k": "2j"
     },
     "blocks": {
@@ -5944,153 +5956,153 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2n"
+        "~k": "2o"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2o"
+        "~k": "2p"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "2p"
+        "~k": "2q"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2q"
+        "~k": "2r"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2r"
+        "~k": "2s"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2s"
+        "~k": "2t"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2t"
+        "~k": "2u"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2u"
+        "~k": "2v"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2v"
+        "~k": "2w"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2w"
+        "~k": "2x"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2x"
+        "~k": "2y"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "2y"
+        "~k": "2z"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "2z"
+        "~k": "30"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
-      "~k": "2m"
+      "~k": "2n"
     },
     "connections": {
       "Anthropic": {
         "originalTypeName": "Anthropic",
         "package": "@lowdefy/connection-anthropic",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
-      "~k": "37"
+      "~k": "38"
     },
     "requests": {
       "GenerateText": {
         "originalTypeName": "GenerateText",
         "package": "@lowdefy/connection-anthropic",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "GenerateObject": {
         "originalTypeName": "GenerateObject",
         "package": "@lowdefy/connection-anthropic",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
-      "~k": "39"
+      "~k": "3a"
     },
     "websockets": {
-      "~k": "3c"
+      "~k": "3d"
     },
     "api": {
-      "~k": "3d"
+      "~k": "3e"
     },
     "operators": {
       "client": {
@@ -6098,38 +6110,38 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3g"
+          "~k": "3h"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3h"
+          "~k": "3i"
         },
-        "~k": "3f"
+        "~k": "3g"
       },
       "server": {
         "_secret": {
           "originalTypeName": "_secret",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3j"
+          "~k": "3k"
         },
         "_payload": {
           "originalTypeName": "_payload",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "3k"
+          "~k": "3l"
         },
         "_step": {
           "originalTypeName": "_step",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "3l"
+          "~k": "3m"
         },
-        "~k": "3i"
+        "~k": "3j"
       },
-      "~k": "3e"
+      "~k": "3f"
     },
     "~k": "2e"
   }

--- a/packages/build/src/tests/success/94-api-call-agent/snapshot.json
+++ b/packages/build/src/tests/success/94-api-call-agent/snapshot.json
@@ -325,164 +325,164 @@
       "~k_parent": "23"
     },
     "30": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.Box",
+      "~k_parent": "2z"
     },
     "31": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "2z"
     },
     "32": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "2z"
     },
     "33": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "2z"
     },
     "34": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "2z"
     },
     "35": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "2z"
     },
     "36": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "2z"
     },
     "37": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "2z"
     },
     "38": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "2z"
     },
     "39": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.List",
+      "~k_parent": "2z"
     },
     "40": {
-      "key": "root.imports.agents",
-      "~k_parent": "3w"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "3y"
     },
     "41": {
-      "key": "root.imports.agents[0]",
-      "~k_parent": "40"
+      "key": "root.imports.agents",
+      "~k_parent": "3x"
     },
     "42": {
-      "key": "root.imports.auth",
-      "~k_parent": "3w"
+      "key": "root.imports.agents[0]",
+      "~k_parent": "41"
     },
     "43": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "42"
+      "key": "root.imports.auth",
+      "~k_parent": "3x"
     },
     "44": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "42"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "43"
     },
     "45": {
-      "key": "root.imports.blocks",
-      "~k_parent": "3w"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "43"
     },
     "46": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "45"
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "43"
     },
     "47": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks",
+      "~k_parent": "3x"
     },
     "48": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "47"
     },
     "49": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "47"
     },
     "50": {
-      "key": "root.imports.icons[3].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "4z"
     },
     "51": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "4u"
     },
     "52": {
-      "key": "root.imports.icons[4].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "51"
     },
     "53": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "4u"
     },
     "54": {
-      "key": "root.imports.icons[5].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "53"
     },
     "55": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "4u"
     },
     "56": {
-      "key": "root.imports.icons[6].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "55"
     },
     "57": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "4u"
     },
     "58": {
-      "key": "root.imports.icons[7].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "57"
     },
     "59": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "4u"
     },
     "60": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[20].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "4u"
     },
     "62": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[21].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[22]",
+      "~k_parent": "4u"
     },
     "64": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[22].icons",
       "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[23]",
+      "~k_parent": "4u"
     },
     "66": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[23].icons",
       "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[24]",
+      "~k_parent": "4u"
     },
     "68": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[24].icons",
       "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[25]",
+      "~k_parent": "4u"
     },
     "a": {
       "key": "root.agents[0:claude:ClaudeAgent]",
@@ -811,376 +811,384 @@
       "~k_parent": "2v"
     },
     "2y": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "2v"
+    },
+    "2z": {
       "key": "root.types.blocks",
       "~k_parent": "2p"
     },
-    "2z": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "2y"
-    },
     "3a": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "2z"
     },
     "3b": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "2z"
     },
     "3c": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "2z"
     },
     "3d": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "2z"
     },
     "3e": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "2z"
     },
     "3f": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "2z"
     },
     "3g": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "2z"
     },
     "3h": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "2z"
     },
     "3i": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "2y"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "2z"
     },
     "3j": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "2z"
+    },
+    "3k": {
       "key": "root.types.connections",
       "~k_parent": "2p"
     },
-    "3k": {
-      "key": "root.types.connections.Anthropic",
-      "~k_parent": "3j"
-    },
     "3l": {
+      "key": "root.types.connections.Anthropic",
+      "~k_parent": "3k"
+    },
+    "3m": {
       "key": "root.types.requests",
       "~k_parent": "2p"
     },
-    "3m": {
+    "3n": {
       "key": "root.types.websockets",
       "~k_parent": "2p"
     },
-    "3n": {
+    "3o": {
       "key": "root.types.api",
       "~k_parent": "2p"
     },
-    "3o": {
+    "3p": {
       "key": "root.types.operators",
       "~k_parent": "2p"
     },
-    "3p": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3o"
-    },
     "3q": {
-      "key": "root.types.operators.client._not",
+      "key": "root.types.operators.client",
       "~k_parent": "3p"
     },
     "3r": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3p"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "3q"
     },
     "3s": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3o"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "3q"
     },
     "3t": {
-      "key": "root.types.operators.server._secret",
-      "~k_parent": "3s"
+      "key": "root.types.operators.server",
+      "~k_parent": "3p"
     },
     "3u": {
-      "key": "root.types.operators.server._payload",
-      "~k_parent": "3s"
+      "key": "root.types.operators.server._secret",
+      "~k_parent": "3t"
     },
     "3v": {
-      "key": "root.types.operators.server._step",
-      "~k_parent": "3s"
+      "key": "root.types.operators.server._payload",
+      "~k_parent": "3t"
     },
     "3w": {
+      "key": "root.types.operators.server._step",
+      "~k_parent": "3t"
+    },
+    "3x": {
       "key": "root.imports",
       "~k_parent": "4"
     },
-    "3x": {
-      "key": "root.imports.actions",
-      "~k_parent": "3w"
-    },
     "3y": {
-      "key": "root.imports.actions[0]",
+      "key": "root.imports.actions",
       "~k_parent": "3x"
     },
     "3z": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "3x"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "3y"
     },
     "4a": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "47"
     },
     "4b": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "47"
     },
     "4c": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "47"
     },
     "4d": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "47"
     },
     "4e": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "47"
     },
     "4f": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "47"
     },
     "4g": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "47"
     },
     "4h": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "47"
     },
     "4i": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "47"
     },
     "4j": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "47"
     },
     "4k": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "47"
     },
     "4l": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "47"
     },
     "4m": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "47"
     },
     "4n": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "47"
     },
     "4o": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "47"
     },
     "4p": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "47"
     },
     "4q": {
-      "key": "root.imports.connections",
-      "~k_parent": "3w"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "47"
     },
     "4r": {
-      "key": "root.imports.connections[0]",
-      "~k_parent": "4q"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "47"
     },
     "4s": {
-      "key": "root.imports.icons",
-      "~k_parent": "3w"
+      "key": "root.imports.connections",
+      "~k_parent": "3x"
     },
     "4t": {
-      "key": "root.imports.icons[0]",
+      "key": "root.imports.connections[0]",
       "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "4t"
+      "key": "root.imports.icons",
+      "~k_parent": "3x"
     },
     "4v": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "4u"
     },
     "4w": {
-      "key": "root.imports.icons[1].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "4u"
     },
     "4y": {
-      "key": "root.imports.icons[2].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "4u"
     },
     "5a": {
-      "key": "root.imports.icons[8].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "59"
     },
     "5b": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "4u"
     },
     "5c": {
-      "key": "root.imports.icons[9].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "5b"
     },
     "5d": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "4u"
     },
     "5e": {
-      "key": "root.imports.icons[10].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "5d"
     },
     "5f": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "4u"
     },
     "5g": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "5f"
     },
     "5h": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "4u"
     },
     "5i": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "5h"
     },
     "5j": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "4u"
     },
     "5k": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "5j"
     },
     "5l": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "4u"
     },
     "5m": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "5l"
     },
     "5n": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "4u"
     },
     "5o": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "5n"
     },
     "5p": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "4u"
     },
     "5q": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "5p"
     },
     "5r": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "4u"
     },
     "5s": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "4u"
     },
     "5u": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[17].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "4u"
     },
     "5w": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[18].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "4u"
     },
     "5y": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "4u"
     },
     "6a": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[25].icons",
       "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "4s"
+      "key": "root.imports.icons[26]",
+      "~k_parent": "4u"
     },
     "6c": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[26].icons",
       "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.requests",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[27]",
+      "~k_parent": "4u"
     },
     "6e": {
-      "key": "root.imports.websockets",
-      "~k_parent": "3w"
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.operators",
-      "~k_parent": "3w"
+      "key": "root.imports.requests",
+      "~k_parent": "3x"
     },
     "6g": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6f"
+      "key": "root.imports.websockets",
+      "~k_parent": "3x"
     },
     "6h": {
-      "key": "root.imports.operators.client[0]",
-      "~k_parent": "6g"
+      "key": "root.imports.operators",
+      "~k_parent": "3x"
     },
     "6i": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6g"
+      "key": "root.imports.operators.client",
+      "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "6f"
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "6i"
     },
     "6k": {
-      "key": "root.imports.operators.server[0]",
-      "~k_parent": "6j"
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "6i"
     },
     "6l": {
-      "key": "root.imports.operators.server[1]",
-      "~k_parent": "6j"
+      "key": "root.imports.operators.server",
+      "~k_parent": "6h"
     },
     "6m": {
+      "key": "root.imports.operators.server[0]",
+      "~k_parent": "6l"
+    },
+    "6n": {
+      "key": "root.imports.operators.server[1]",
+      "~k_parent": "6l"
+    },
+    "6o": {
       "key": "root.imports.operators.server[2]",
-      "~k_parent": "6j"
+      "~k_parent": "6l"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
@@ -1398,6 +1406,7 @@
   "plugins/agents.js": "import { ClaudeAgent as ClaudeAgent } from '@lowdefy/connection-anthropic/agents';\nexport default {\n  ClaudeAgent,\n  };",
   "plugins/auth/adapters.js": "export default {\n  };",
   "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "export default {\n  };",
   "plugins/blockMetas.json": {
     "Box": {
       "category": "container"
@@ -6028,6 +6037,9 @@
       "providers": {
         "~k": "2x"
       },
+      "strategies": {
+        "~k": "2y"
+      },
       "~k": "2v"
     },
     "blocks": {
@@ -6035,141 +6047,141 @@
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
         "count": 2,
-        "~k": "2z"
+        "~k": "30"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "30"
+        "~k": "31"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "31"
+        "~k": "32"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "32"
+        "~k": "33"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "33"
+        "~k": "34"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "34"
+        "~k": "35"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "35"
+        "~k": "36"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "36"
+        "~k": "37"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "37"
+        "~k": "38"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "38"
+        "~k": "39"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "39"
+        "~k": "3a"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3a"
+        "~k": "3b"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3b"
+        "~k": "3c"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3c"
+        "~k": "3d"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3d"
+        "~k": "3e"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3e"
+        "~k": "3f"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3f"
+        "~k": "3g"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3g"
+        "~k": "3h"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3h"
+        "~k": "3i"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3i"
+        "~k": "3j"
       },
-      "~k": "2y"
+      "~k": "2z"
     },
     "connections": {
       "Anthropic": {
         "originalTypeName": "Anthropic",
         "package": "@lowdefy/connection-anthropic",
         "count": 1,
-        "~k": "3k"
+        "~k": "3l"
       },
-      "~k": "3j"
+      "~k": "3k"
     },
     "requests": {
-      "~k": "3l"
-    },
-    "websockets": {
       "~k": "3m"
     },
-    "api": {
+    "websockets": {
       "~k": "3n"
+    },
+    "api": {
+      "~k": "3o"
     },
     "operators": {
       "client": {
@@ -6177,38 +6189,38 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3q"
+          "~k": "3r"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3r"
+          "~k": "3s"
         },
-        "~k": "3p"
+        "~k": "3q"
       },
       "server": {
         "_secret": {
           "originalTypeName": "_secret",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3t"
+          "~k": "3u"
         },
         "_payload": {
           "originalTypeName": "_payload",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "3u"
+          "~k": "3v"
         },
         "_step": {
           "originalTypeName": "_step",
           "package": "@lowdefy/operators-js",
           "count": 2,
-          "~k": "3v"
+          "~k": "3w"
         },
-        "~k": "3s"
+        "~k": "3t"
       },
-      "~k": "3o"
+      "~k": "3p"
     },
     "~k": "2p"
   }

--- a/packages/build/src/tests/success/95-auth-strategies-app/lowdefy.yaml
+++ b/packages/build/src/tests/success/95-auth-strategies-app/lowdefy.yaml
@@ -1,0 +1,93 @@
+# 95: Strategies-only auth app - API auth strategies with no database and
+# no login method (auth-upgrade phase 4). strategies.length > 0 counts as
+# the authentication mechanism, so this block is validly configured.
+name: auth-strategies-app
+lowdefy: local
+
+auth:
+  secret:
+    _secret: BETTER_AUTH_SECRET
+
+  strategies:
+    - id: partner-access
+      type: apiKey
+      properties:
+        keys:
+          - id: acme
+            value:
+              _secret: PARTNER_KEY_ACME
+          - value:
+              _secret: PARTNER_KEY_UNNAMED
+      roles:
+        - partner
+      attributes:
+        branches: [north, east]
+
+    - id: service-jwt
+      type: jwt
+      properties:
+        secret:
+          _secret: JWT_SIGNING_SECRET
+        algorithms:
+          - HS256
+        issuer: https://auth.example.test
+        audience: strategies-app-api
+        claimMapping:
+          id: sub
+          email: email
+          roles: roles
+      roles:
+        - api-user
+
+    - id: external-idp
+      type: jwt
+      properties:
+        jwksUri: https://idp.example.test/.well-known/jwks.json
+        algorithms:
+          - RS256
+        issuer: https://idp.example.test
+        audience: strategies-app-api
+        claimMapping:
+          id: sub
+          roles: realm_access.roles
+          attributes.branches: resource_access.branches
+
+  api:
+    protected: true
+    public:
+      - health
+    roles:
+      partner:
+        - partner-data
+      api-user:
+        - service-data
+
+api:
+  - id: health
+    type: Api
+    routine:
+      - ':return':
+          ok: true
+
+  - id: partner-data
+    type: Api
+    routine:
+      - ':return':
+          data: partner-report
+          caller:
+            _user: id
+
+  - id: service-data
+    type: Api
+    routine:
+      - ':return':
+          data: service-report
+
+pages:
+  - id: home
+    type: Box
+    blocks:
+      - id: title
+        type: Title
+        properties:
+          content: Strategies-only app

--- a/packages/build/src/tests/success/95-auth-strategies-app/snapshot.json
+++ b/packages/build/src/tests/success/95-auth-strategies-app/snapshot.json
@@ -1,0 +1,6337 @@
+{
+  "agentFileSystems.json": [],
+  "api/health.json": {
+    "id": "endpoint:health",
+    "type": "Api",
+    "routine": {
+      "~arr": [
+        {
+          ":return": {
+            "ok": true,
+            "~k": "11"
+          },
+          "~k": "10"
+        }
+      ],
+      "~k": "z"
+    },
+    "auth": {
+      "public": true,
+      "~k": "2k"
+    },
+    "endpointId": "health",
+    "~k": "y"
+  },
+  "api/partner-data.json": {
+    "id": "endpoint:partner-data",
+    "type": "Api",
+    "routine": {
+      "~arr": [
+        {
+          ":return": {
+            "data": "partner-report",
+            "caller": {
+              "_user": "id",
+              "~k": "16"
+            },
+            "~k": "15"
+          },
+          "~k": "14"
+        }
+      ],
+      "~k": "13"
+    },
+    "auth": {
+      "public": false,
+      "roles": {
+        "~arr": [
+          "partner"
+        ],
+        "~k": "2m"
+      },
+      "~k": "2l"
+    },
+    "endpointId": "partner-data",
+    "~k": "12"
+  },
+  "api/service-data.json": {
+    "id": "endpoint:service-data",
+    "type": "Api",
+    "routine": {
+      "~arr": [
+        {
+          ":return": {
+            "data": "service-report",
+            "~k": "1a"
+          },
+          "~k": "19"
+        }
+      ],
+      "~k": "18"
+    },
+    "auth": {
+      "public": false,
+      "roles": {
+        "~arr": [
+          "api-user"
+        ],
+        "~k": "2o"
+      },
+      "~k": "2n"
+    },
+    "endpointId": "service-data",
+    "~k": "17"
+  },
+  "app.json": {
+    "html": {
+      "appendBody": "",
+      "appendHead": "",
+      "~k": "1w"
+    },
+    "~k": "1v"
+  },
+  "appMeta.json": {
+    "slug": null,
+    "name": "auth-strategies-app",
+    "version": null,
+    "description": null,
+    "license": null,
+    "lowdefyVersion": "local",
+    "gitSha": "test-git-sha-for-snapshots",
+    "~k": "1x"
+  },
+  "auth.json": {
+    "secret": {
+      "_secret": "BETTER_AUTH_SECRET",
+      "~k": "6"
+    },
+    "strategies": {
+      "~arr": [
+        {
+          "id": "partner-access",
+          "type": "apiKey",
+          "properties": {
+            "keys": {
+              "~arr": [
+                {
+                  "id": "acme",
+                  "value": {
+                    "_secret": "PARTNER_KEY_ACME",
+                    "~k": "c"
+                  },
+                  "~k": "b"
+                },
+                {
+                  "value": {
+                    "_secret": "PARTNER_KEY_UNNAMED",
+                    "~k": "e"
+                  },
+                  "~k": "d"
+                }
+              ],
+              "~k": "a"
+            },
+            "headerName": "X-API-Key",
+            "~k": "9"
+          },
+          "roles": {
+            "~arr": [
+              "partner"
+            ],
+            "~k": "f"
+          },
+          "attributes": {
+            "branches": {
+              "~arr": [
+                "north",
+                "east"
+              ],
+              "~k": "h"
+            },
+            "~k": "g"
+          },
+          "~k": "8"
+        },
+        {
+          "id": "service-jwt",
+          "type": "jwt",
+          "properties": {
+            "secret": {
+              "_secret": "JWT_SIGNING_SECRET",
+              "~k": "k"
+            },
+            "algorithms": {
+              "~arr": [
+                "HS256"
+              ],
+              "~k": "l"
+            },
+            "issuer": "https://auth.example.test",
+            "audience": "strategies-app-api",
+            "claimMapping": {
+              "id": "sub",
+              "email": "email",
+              "roles": "roles",
+              "~k": "m"
+            },
+            "~k": "j"
+          },
+          "roles": {
+            "~arr": [
+              "api-user"
+            ],
+            "~k": "n"
+          },
+          "attributes": {
+            "~k": "21"
+          },
+          "~k": "i"
+        },
+        {
+          "id": "external-idp",
+          "type": "jwt",
+          "properties": {
+            "jwksUri": "https://idp.example.test/.well-known/jwks.json",
+            "algorithms": {
+              "~arr": [
+                "RS256"
+              ],
+              "~k": "q"
+            },
+            "issuer": "https://idp.example.test",
+            "audience": "strategies-app-api",
+            "claimMapping": {
+              "id": "sub",
+              "roles": "realm_access.roles",
+              "attributes.branches": "resource_access.branches",
+              "~k": "r"
+            },
+            "~k": "p"
+          },
+          "roles": {
+            "~arr": [],
+            "~k": "22"
+          },
+          "attributes": {
+            "~k": "23"
+          },
+          "~k": "o"
+        }
+      ],
+      "~k": "7"
+    },
+    "api": {
+      "protected": true,
+      "public": {
+        "~arr": [
+          "health"
+        ],
+        "~k": "t"
+      },
+      "roles": {
+        "partner": {
+          "~arr": [
+            "partner-data"
+          ],
+          "~k": "v"
+        },
+        "api-user": {
+          "~arr": [
+            "service-data"
+          ],
+          "~k": "w"
+        },
+        "~k": "u"
+      },
+      "~k": "s"
+    },
+    "configured": true,
+    "pages": {
+      "roles": {
+        "~k": "25"
+      },
+      "~k": "24"
+    },
+    "websockets": {
+      "roles": {
+        "~k": "27"
+      },
+      "~k": "26"
+    },
+    "providers": {
+      "~arr": [],
+      "~k": "28"
+    },
+    "hooks": {
+      "~arr": [],
+      "~k": "29"
+    },
+    "organizations": {
+      "policy": "pinned",
+      "org": "default",
+      "signup": "invite-only",
+      "~k": "2a"
+    },
+    "authPages": {
+      "signIn": "/login",
+      "signUp": "/signup",
+      "error": "/auth/error",
+      "forgotPassword": "/forgot-password",
+      "resetPassword": "/reset-password",
+      "verifyEmail": "/verify-email",
+      "~k": "2b"
+    },
+    "session": {
+      "expiresIn": 604800,
+      "updateAge": 86400,
+      "cookieCache": {
+        "enabled": false,
+        "maxAge": 300,
+        "~k": "2d"
+      },
+      "crossSubDomainCookies": {
+        "enabled": false,
+        "~k": "2e"
+      },
+      "~k": "2c"
+    },
+    "account": {
+      "accountLinking": {
+        "enabled": true,
+        "trustedProviders": {
+          "~arr": [],
+          "~k": "2h"
+        },
+        "~k": "2g"
+      },
+      "~k": "2f"
+    },
+    "rateLimit": {
+      "enabled": true,
+      "window": 60,
+      "max": 100,
+      "~k": "2i"
+    },
+    "roles": {
+      "~arr": [
+        "api-user",
+        "partner"
+      ],
+      "~k": "2j"
+    },
+    "~k": "5"
+  },
+  "blockPackages.json": [
+    "@lowdefy/blocks-basic",
+    "@lowdefy/blocks-antd",
+    "@lowdefy/blocks-loaders"
+  ],
+  "config.json": {
+    "~k": "1z"
+  },
+  "global.json": {},
+  "globals.css": "/* Generated by Lowdefy build */\n\n/* Layer order — locks cascade priority before Tailwind declares its own layers */\n@layer theme, base, antd, components, utilities;\n\n/* source(none) disables Tailwind's automatic source detection — without it the\n   oxide scanner walks the entire server directory tree (node_modules and all,\n   ~50s cold) on the first CSS compile. The explicit @source globs below are\n   the only scan inputs Lowdefy needs. */\n@import \"tailwindcss\" source(none);\n@import \"@lowdefy/layout/grid.css\";\n\n/* Imported CSS file — when this changes, PostCSS re-runs and Tailwind re-scans @source.\n   This import is the ONLY recompile trigger in dev: the @source .html files below are\n   deliberately excluded from Vite's watcher (server.watch.ignored in the dev server's\n   vite.config.js) because watched .html changes force full browser reloads. The JIT\n   page builder touches this file whenever tailwind content changes. */\n@import \"./tailwind-candidates.css\";\n\n/* Content sources for Tailwind JIT — block JS content collected at build time */\n@source \"../lowdefy-build/tailwind/*.html\";\n\n/* Themed scrollbars — opts out of the browser default that clashes on dark surfaces,\n   especially on Windows/Linux where scrollbars are always visible and native-chrome.\n   Colors use antd CSS custom properties so they auto-swap with dark/light mode. */\n@layer base {\n  * {\n    scrollbar-width: thin;\n    scrollbar-color: var(--ant-color-border-secondary, rgba(0, 0, 0, 0.15)) transparent;\n  }\n  *::-webkit-scrollbar {\n    width: 10px;\n    height: 10px;\n  }\n  *::-webkit-scrollbar-track {\n    background: transparent;\n  }\n  *::-webkit-scrollbar-thumb {\n    background-color: var(--ant-color-border-secondary, rgba(0, 0, 0, 0.15));\n    background-clip: padding-box;\n    border: 2px solid transparent;\n    border-radius: 10px;\n  }\n  *::-webkit-scrollbar-thumb:hover {\n    background-color: var(--ant-color-text-tertiary, rgba(0, 0, 0, 0.45));\n  }\n  *::-webkit-scrollbar-corner {\n    background: transparent;\n  }\n}\n\n/* Antd-to-Tailwind theme bridge — extends default Tailwind theme with antd design tokens */\n@theme inline {\n  --color-primary: var(--ant-color-primary);\n  --color-primary-hover: var(--ant-color-primary-hover);\n  --color-primary-active: var(--ant-color-primary-active);\n  --color-primary-bg: var(--ant-color-primary-bg);\n  --color-success: var(--ant-color-success);\n  --color-warning: var(--ant-color-warning);\n  --color-error: var(--ant-color-error);\n  --color-info: var(--ant-color-info);\n  --color-text-primary: var(--ant-color-text);\n  --color-text-secondary: var(--ant-color-text-secondary);\n  --color-bg-container: var(--ant-color-bg-container);\n  --color-bg-layout: var(--ant-color-bg-layout);\n  --color-border: var(--ant-color-border);\n  --radius-DEFAULT: var(--ant-border-radius);\n  --radius-sm: var(--ant-border-radius-sm);\n  --radius-lg: var(--ant-border-radius-lg);\n  --font-size-DEFAULT: var(--ant-font-size);\n  --font-size-sm: var(--ant-font-size-sm);\n  --font-size-lg: var(--ant-font-size-lg);\n  --font-family-sans: var(--ant-font-family);\n}\n",
+  "i18n.json": {},
+  "i18n/antdLocales.js": "// Generated by @lowdefy/build. Do not edit.\nconst loaders = {\n\n};\nexport default loaders;\n",
+  "i18n/antdXLocales.js": "// Generated by @lowdefy/build. Do not edit.\nconst loaders = {\n\n};\nexport default loaders;\n",
+  "i18n/dayjsLocales.js": "// Generated by @lowdefy/build. Do not edit.\n\nconst localeMap = {\n\n};\nexport default localeMap;\n",
+  "keyMap.json": {
+    "4": {
+      "key": "root",
+      "~k_parent": "3",
+      "~l": 4
+    },
+    "5": {
+      "key": "root.auth",
+      "~k_parent": "4",
+      "~l": 7
+    },
+    "6": {
+      "key": "root.auth.secret",
+      "~k_parent": "5",
+      "~l": 8
+    },
+    "7": {
+      "key": "root.auth.strategies",
+      "~k_parent": "5",
+      "~l": 11
+    },
+    "8": {
+      "key": "root.auth.strategies[0:partner-access:apiKey]",
+      "~k_parent": "7",
+      "~l": 12
+    },
+    "9": {
+      "key": "root.auth.strategies[0:partner-access:apiKey].properties",
+      "~k_parent": "8",
+      "~l": 14
+    },
+    "10": {
+      "key": "root.api[0:health:Api].routine[0]",
+      "~k_parent": "z",
+      "~l": 69
+    },
+    "11": {
+      "key": "root.api[0:health:Api].routine[0].:return",
+      "~k_parent": "10",
+      "~l": 69
+    },
+    "12": {
+      "key": "root.api[1:partner-data:Api]",
+      "~k_parent": "x",
+      "~l": 72
+    },
+    "13": {
+      "key": "root.api[1:partner-data:Api].routine",
+      "~k_parent": "12",
+      "~l": 74
+    },
+    "14": {
+      "key": "root.api[1:partner-data:Api].routine[0]",
+      "~k_parent": "13",
+      "~l": 75
+    },
+    "15": {
+      "key": "root.api[1:partner-data:Api].routine[0].:return",
+      "~k_parent": "14",
+      "~l": 75
+    },
+    "16": {
+      "key": "root.api[1:partner-data:Api].routine[0].:return.caller",
+      "~k_parent": "15",
+      "~l": 77
+    },
+    "17": {
+      "key": "root.api[2:service-data:Api]",
+      "~k_parent": "x",
+      "~l": 80
+    },
+    "18": {
+      "key": "root.api[2:service-data:Api].routine",
+      "~k_parent": "17",
+      "~l": 82
+    },
+    "19": {
+      "key": "root.api[2:service-data:Api].routine[0]",
+      "~k_parent": "18",
+      "~l": 83
+    },
+    "21": {
+      "key": "root.auth.strategies[1:service-jwt:jwt].attributes",
+      "~k_parent": "i"
+    },
+    "22": {
+      "key": "root.auth.strategies[2:external-idp:jwt].roles",
+      "~k_parent": "o"
+    },
+    "23": {
+      "key": "root.auth.strategies[2:external-idp:jwt].attributes",
+      "~k_parent": "o"
+    },
+    "24": {
+      "key": "root.auth.pages",
+      "~k_parent": "5"
+    },
+    "25": {
+      "key": "root.auth.pages.roles",
+      "~k_parent": "24"
+    },
+    "26": {
+      "key": "root.auth.websockets",
+      "~k_parent": "5"
+    },
+    "27": {
+      "key": "root.auth.websockets.roles",
+      "~k_parent": "26"
+    },
+    "28": {
+      "key": "root.auth.providers",
+      "~k_parent": "5"
+    },
+    "29": {
+      "key": "root.auth.hooks",
+      "~k_parent": "5"
+    },
+    "30": {
+      "key": "root.pages[1:404:Result].slots.extra.blocks[0:home:Button].events.onClick.catch",
+      "~k_parent": "2z"
+    },
+    "31": {
+      "key": "root.pages[1:404:Result].auth",
+      "~k_parent": "2w"
+    },
+    "32": {
+      "key": "root.pages[1:404:Result].subscriptions",
+      "~k_parent": "2w"
+    },
+    "33": {
+      "key": "root.pages[1:404:Result].requests",
+      "~k_parent": "2w"
+    },
+    "34": {
+      "key": "root.menus",
+      "~k_parent": "4"
+    },
+    "35": {
+      "key": "root.menus[0:default]",
+      "~k_parent": "34"
+    },
+    "36": {
+      "key": "root.menus[0:default].links",
+      "~k_parent": "35"
+    },
+    "37": {
+      "key": "root.menus[0:default].links[0:0:MenuLink]",
+      "~k_parent": "36"
+    },
+    "38": {
+      "key": "root.menus[0:default].links[0:0:MenuLink].auth",
+      "~k_parent": "37"
+    },
+    "39": {
+      "key": "root.types",
+      "~k_parent": "4"
+    },
+    "40": {
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3k"
+    },
+    "41": {
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3k"
+    },
+    "42": {
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3k"
+    },
+    "43": {
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3k"
+    },
+    "44": {
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3k"
+    },
+    "45": {
+      "key": "root.types.connections",
+      "~k_parent": "39"
+    },
+    "46": {
+      "key": "root.types.requests",
+      "~k_parent": "39"
+    },
+    "47": {
+      "key": "root.types.websockets",
+      "~k_parent": "39"
+    },
+    "48": {
+      "key": "root.types.api",
+      "~k_parent": "39"
+    },
+    "49": {
+      "key": "root.types.operators",
+      "~k_parent": "39"
+    },
+    "50": {
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "4q"
+    },
+    "51": {
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "4q"
+    },
+    "52": {
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "4q"
+    },
+    "53": {
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "4q"
+    },
+    "54": {
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "4q"
+    },
+    "55": {
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "4q"
+    },
+    "56": {
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "4q"
+    },
+    "57": {
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "4q"
+    },
+    "58": {
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "4q"
+    },
+    "59": {
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "4q"
+    },
+    "60": {
+      "key": "root.imports.icons[11].icons",
+      "~k_parent": "5z"
+    },
+    "61": {
+      "key": "root.imports.icons[12]",
+      "~k_parent": "5c"
+    },
+    "62": {
+      "key": "root.imports.icons[12].icons",
+      "~k_parent": "61"
+    },
+    "63": {
+      "key": "root.imports.icons[13]",
+      "~k_parent": "5c"
+    },
+    "64": {
+      "key": "root.imports.icons[13].icons",
+      "~k_parent": "63"
+    },
+    "65": {
+      "key": "root.imports.icons[14]",
+      "~k_parent": "5c"
+    },
+    "66": {
+      "key": "root.imports.icons[14].icons",
+      "~k_parent": "65"
+    },
+    "67": {
+      "key": "root.imports.icons[15]",
+      "~k_parent": "5c"
+    },
+    "68": {
+      "key": "root.imports.icons[15].icons",
+      "~k_parent": "67"
+    },
+    "69": {
+      "key": "root.imports.icons[16]",
+      "~k_parent": "5c"
+    },
+    "70": {
+      "key": "root.imports.operators.client",
+      "~k_parent": "6z"
+    },
+    "71": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "70"
+    },
+    "72": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "70"
+    },
+    "73": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "6z"
+    },
+    "74": {
+      "key": "root.imports.operators.server[0]",
+      "~k_parent": "73"
+    },
+    "a": {
+      "key": "root.auth.strategies[0:partner-access:apiKey].properties.keys",
+      "~k_parent": "9",
+      "~l": 15
+    },
+    "b": {
+      "key": "root.auth.strategies[0:partner-access:apiKey].properties.keys[0:acme]",
+      "~k_parent": "a",
+      "~l": 16
+    },
+    "c": {
+      "key": "root.auth.strategies[0:partner-access:apiKey].properties.keys[0:acme].value",
+      "~k_parent": "b",
+      "~l": 17
+    },
+    "d": {
+      "key": "root.auth.strategies[0:partner-access:apiKey].properties.keys[1]",
+      "~k_parent": "a",
+      "~l": 19
+    },
+    "e": {
+      "key": "root.auth.strategies[0:partner-access:apiKey].properties.keys[1].value",
+      "~k_parent": "d",
+      "~l": 19
+    },
+    "f": {
+      "key": "root.auth.strategies[0:partner-access:apiKey].roles",
+      "~k_parent": "8",
+      "~l": 21
+    },
+    "g": {
+      "key": "root.auth.strategies[0:partner-access:apiKey].attributes",
+      "~k_parent": "8",
+      "~l": 23
+    },
+    "h": {
+      "key": "root.auth.strategies[0:partner-access:apiKey].attributes.branches",
+      "~k_parent": "g",
+      "~l": 24
+    },
+    "i": {
+      "key": "root.auth.strategies[1:service-jwt:jwt]",
+      "~k_parent": "7",
+      "~l": 26
+    },
+    "j": {
+      "key": "root.auth.strategies[1:service-jwt:jwt].properties",
+      "~k_parent": "i",
+      "~l": 28
+    },
+    "k": {
+      "key": "root.auth.strategies[1:service-jwt:jwt].properties.secret",
+      "~k_parent": "j",
+      "~l": 29
+    },
+    "l": {
+      "key": "root.auth.strategies[1:service-jwt:jwt].properties.algorithms",
+      "~k_parent": "j",
+      "~l": 31
+    },
+    "m": {
+      "key": "root.auth.strategies[1:service-jwt:jwt].properties.claimMapping",
+      "~k_parent": "j",
+      "~l": 35
+    },
+    "n": {
+      "key": "root.auth.strategies[1:service-jwt:jwt].roles",
+      "~k_parent": "i",
+      "~l": 39
+    },
+    "o": {
+      "key": "root.auth.strategies[2:external-idp:jwt]",
+      "~k_parent": "7",
+      "~l": 42
+    },
+    "p": {
+      "key": "root.auth.strategies[2:external-idp:jwt].properties",
+      "~k_parent": "o",
+      "~l": 44
+    },
+    "q": {
+      "key": "root.auth.strategies[2:external-idp:jwt].properties.algorithms",
+      "~k_parent": "p",
+      "~l": 46
+    },
+    "r": {
+      "key": "root.auth.strategies[2:external-idp:jwt].properties.claimMapping",
+      "~k_parent": "p",
+      "~l": 50
+    },
+    "s": {
+      "key": "root.auth.api",
+      "~k_parent": "5",
+      "~l": 55
+    },
+    "t": {
+      "key": "root.auth.api.public",
+      "~k_parent": "s",
+      "~l": 57
+    },
+    "u": {
+      "key": "root.auth.api.roles",
+      "~k_parent": "s",
+      "~l": 59
+    },
+    "v": {
+      "key": "root.auth.api.roles.partner",
+      "~k_parent": "u",
+      "~l": 60
+    },
+    "w": {
+      "key": "root.auth.api.roles.api-user",
+      "~k_parent": "u",
+      "~l": 62
+    },
+    "x": {
+      "key": "root.api",
+      "~k_parent": "4",
+      "~l": 65
+    },
+    "y": {
+      "key": "root.api[0:health:Api]",
+      "~k_parent": "x",
+      "~l": 66
+    },
+    "z": {
+      "key": "root.api[0:health:Api].routine",
+      "~k_parent": "y",
+      "~l": 68
+    },
+    "1a": {
+      "key": "root.api[2:service-data:Api].routine[0].:return",
+      "~k_parent": "19",
+      "~l": 83
+    },
+    "1b": {
+      "key": "root.pages",
+      "~k_parent": "4",
+      "~l": 86
+    },
+    "1c": {
+      "key": "root.pages[0:home:Box]",
+      "~k_parent": "1b",
+      "~l": 87
+    },
+    "1d": {
+      "key": "root.pages[0:home:Box].blocks",
+      "~k_parent": "1c",
+      "~l": 89
+    },
+    "1e": {
+      "key": "root.pages[0:home:Box].blocks[0:title:Title]",
+      "~k_parent": "1d",
+      "~l": 90
+    },
+    "1f": {
+      "key": "root.pages[0:home:Box].blocks[0:title:Title].properties",
+      "~k_parent": "1e",
+      "~l": 92
+    },
+    "1h": {
+      "key": "root.pages",
+      "~k_parent": "4"
+    },
+    "1i": {
+      "key": "root.pages[1:404:Result]",
+      "~k_parent": "1h"
+    },
+    "1j": {
+      "key": "root.pages[1:404:Result].style",
+      "~k_parent": "1i"
+    },
+    "1k": {
+      "key": "root.pages[1:404:Result].properties",
+      "~k_parent": "1i"
+    },
+    "1l": {
+      "key": "root.pages[1:404:Result].properties.icon",
+      "~k_parent": "1k"
+    },
+    "1m": {
+      "key": "root.pages[1:404:Result].slots",
+      "~k_parent": "1i"
+    },
+    "1n": {
+      "key": "root.pages[1:404:Result].slots.extra",
+      "~k_parent": "1m"
+    },
+    "1o": {
+      "key": "root.pages[1:404:Result].slots.extra.blocks",
+      "~k_parent": "1n"
+    },
+    "1p": {
+      "key": "root.pages[1:404:Result].slots.extra.blocks[0:home:Button]",
+      "~k_parent": "1o"
+    },
+    "1q": {
+      "key": "root.pages[1:404:Result].slots.extra.blocks[0:home:Button].properties",
+      "~k_parent": "1p"
+    },
+    "1r": {
+      "key": "root.pages[1:404:Result].slots.extra.blocks[0:home:Button].events",
+      "~k_parent": "1p"
+    },
+    "1s": {
+      "key": "root.pages[1:404:Result].slots.extra.blocks[0:home:Button].events.onClick",
+      "~k_parent": "1r"
+    },
+    "1t": {
+      "key": "root.pages[1:404:Result].slots.extra.blocks[0:home:Button].events.onClick[0:home:Link]",
+      "~k_parent": "1s"
+    },
+    "1u": {
+      "key": "root.pages[1:404:Result].slots.extra.blocks[0:home:Button].events.onClick[0:home:Link].params",
+      "~k_parent": "1t"
+    },
+    "1v": {
+      "key": "root.app",
+      "~k_parent": "4"
+    },
+    "1w": {
+      "key": "root.app.html",
+      "~k_parent": "1v"
+    },
+    "1x": {
+      "key": "root.appMeta",
+      "~k_parent": "4"
+    },
+    "1y": {
+      "key": "root.logger",
+      "~k_parent": "4"
+    },
+    "1z": {
+      "key": "root.config",
+      "~k_parent": "4"
+    },
+    "2a": {
+      "key": "root.auth.organizations",
+      "~k_parent": "5"
+    },
+    "2b": {
+      "key": "root.auth.authPages",
+      "~k_parent": "5"
+    },
+    "2c": {
+      "key": "root.auth.session",
+      "~k_parent": "5"
+    },
+    "2d": {
+      "key": "root.auth.session.cookieCache",
+      "~k_parent": "2c"
+    },
+    "2e": {
+      "key": "root.auth.session.crossSubDomainCookies",
+      "~k_parent": "2c"
+    },
+    "2f": {
+      "key": "root.auth.account",
+      "~k_parent": "5"
+    },
+    "2g": {
+      "key": "root.auth.account.accountLinking",
+      "~k_parent": "2f"
+    },
+    "2h": {
+      "key": "root.auth.account.accountLinking.trustedProviders",
+      "~k_parent": "2g"
+    },
+    "2i": {
+      "key": "root.auth.rateLimit",
+      "~k_parent": "5"
+    },
+    "2j": {
+      "key": "root.auth.roles",
+      "~k_parent": "5"
+    },
+    "2k": {
+      "key": "root.api[0:health:Api].auth",
+      "~k_parent": "y"
+    },
+    "2l": {
+      "key": "root.api[1:partner-data:Api].auth",
+      "~k_parent": "12"
+    },
+    "2m": {
+      "key": "root.api[1:partner-data:Api].auth.roles",
+      "~k_parent": "2l"
+    },
+    "2n": {
+      "key": "root.api[2:service-data:Api].auth",
+      "~k_parent": "17"
+    },
+    "2o": {
+      "key": "root.api[2:service-data:Api].auth.roles",
+      "~k_parent": "2n"
+    },
+    "2p": {
+      "key": "root.pages",
+      "~k_parent": "4"
+    },
+    "2q": {
+      "key": "root.pages[0:home:Box]",
+      "~k_parent": "2p"
+    },
+    "2r": {
+      "key": "root.pages[0:home:Box].auth",
+      "~k_parent": "2q"
+    },
+    "2s": {
+      "key": "root.pages[0:home:Box].slots",
+      "~k_parent": "2q"
+    },
+    "2t": {
+      "key": "root.pages[0:home:Box].slots.content",
+      "~k_parent": "2s"
+    },
+    "2u": {
+      "key": "root.pages[0:home:Box].subscriptions",
+      "~k_parent": "2q"
+    },
+    "2v": {
+      "key": "root.pages[0:home:Box].requests",
+      "~k_parent": "2q"
+    },
+    "2w": {
+      "key": "root.pages[1:404:Result]",
+      "~k_parent": "2p"
+    },
+    "2x": {
+      "key": "root.pages[1:404:Result].style",
+      "~k_parent": "2w"
+    },
+    "2y": {
+      "key": "root.pages[1:404:Result].style.block",
+      "~k_parent": "2x"
+    },
+    "2z": {
+      "key": "root.pages[1:404:Result].slots.extra.blocks[0:home:Button].events.onClick",
+      "~k_parent": "1r"
+    },
+    "3a": {
+      "key": "root.types.actions",
+      "~k_parent": "39"
+    },
+    "3b": {
+      "key": "root.types.actions.Link",
+      "~k_parent": "3a"
+    },
+    "3c": {
+      "key": "root.types.actions.SetDarkMode",
+      "~k_parent": "3a"
+    },
+    "3d": {
+      "key": "root.types.agents",
+      "~k_parent": "39"
+    },
+    "3e": {
+      "key": "root.types.auth",
+      "~k_parent": "39"
+    },
+    "3f": {
+      "key": "root.types.auth.adapters",
+      "~k_parent": "3e"
+    },
+    "3g": {
+      "key": "root.types.auth.providers",
+      "~k_parent": "3e"
+    },
+    "3h": {
+      "key": "root.types.auth.strategies",
+      "~k_parent": "3e"
+    },
+    "3i": {
+      "key": "root.types.auth.strategies.apiKey",
+      "~k_parent": "3h"
+    },
+    "3j": {
+      "key": "root.types.auth.strategies.jwt",
+      "~k_parent": "3h"
+    },
+    "3k": {
+      "key": "root.types.blocks",
+      "~k_parent": "39"
+    },
+    "3l": {
+      "key": "root.types.blocks.Box",
+      "~k_parent": "3k"
+    },
+    "3m": {
+      "key": "root.types.blocks.Title",
+      "~k_parent": "3k"
+    },
+    "3n": {
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3k"
+    },
+    "3o": {
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3k"
+    },
+    "3p": {
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3k"
+    },
+    "3q": {
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3k"
+    },
+    "3r": {
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3k"
+    },
+    "3s": {
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3k"
+    },
+    "3t": {
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3k"
+    },
+    "3u": {
+      "key": "root.types.blocks.List",
+      "~k_parent": "3k"
+    },
+    "3v": {
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3k"
+    },
+    "3w": {
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3k"
+    },
+    "3x": {
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3k"
+    },
+    "3y": {
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3k"
+    },
+    "3z": {
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3k"
+    },
+    "4a": {
+      "key": "root.types.operators.client",
+      "~k_parent": "49"
+    },
+    "4b": {
+      "key": "root.types.operators.client._not",
+      "~k_parent": "4a"
+    },
+    "4c": {
+      "key": "root.types.operators.client._type",
+      "~k_parent": "4a"
+    },
+    "4d": {
+      "key": "root.types.operators.server",
+      "~k_parent": "49"
+    },
+    "4e": {
+      "key": "root.types.operators.server._user",
+      "~k_parent": "4d"
+    },
+    "4f": {
+      "key": "root.imports",
+      "~k_parent": "4"
+    },
+    "4g": {
+      "key": "root.imports.actions",
+      "~k_parent": "4f"
+    },
+    "4h": {
+      "key": "root.imports.actions[0]",
+      "~k_parent": "4g"
+    },
+    "4i": {
+      "key": "root.imports.actions[1]",
+      "~k_parent": "4g"
+    },
+    "4j": {
+      "key": "root.imports.agents",
+      "~k_parent": "4f"
+    },
+    "4k": {
+      "key": "root.imports.auth",
+      "~k_parent": "4f"
+    },
+    "4l": {
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "4k"
+    },
+    "4m": {
+      "key": "root.imports.auth.providers",
+      "~k_parent": "4k"
+    },
+    "4n": {
+      "key": "root.imports.auth.strategies",
+      "~k_parent": "4k"
+    },
+    "4o": {
+      "key": "root.imports.auth.strategies[0]",
+      "~k_parent": "4n"
+    },
+    "4p": {
+      "key": "root.imports.auth.strategies[1]",
+      "~k_parent": "4n"
+    },
+    "4q": {
+      "key": "root.imports.blocks",
+      "~k_parent": "4f"
+    },
+    "4r": {
+      "key": "root.imports.blocks[0]",
+      "~k_parent": "4q"
+    },
+    "4s": {
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "4q"
+    },
+    "4t": {
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "4q"
+    },
+    "4u": {
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "4q"
+    },
+    "4v": {
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "4q"
+    },
+    "4w": {
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "4q"
+    },
+    "4x": {
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "4q"
+    },
+    "4y": {
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "4q"
+    },
+    "4z": {
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "4q"
+    },
+    "5a": {
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "4q"
+    },
+    "5b": {
+      "key": "root.imports.connections",
+      "~k_parent": "4f"
+    },
+    "5c": {
+      "key": "root.imports.icons",
+      "~k_parent": "4f"
+    },
+    "5d": {
+      "key": "root.imports.icons[0]",
+      "~k_parent": "5c"
+    },
+    "5e": {
+      "key": "root.imports.icons[0].icons",
+      "~k_parent": "5d"
+    },
+    "5f": {
+      "key": "root.imports.icons[1]",
+      "~k_parent": "5c"
+    },
+    "5g": {
+      "key": "root.imports.icons[1].icons",
+      "~k_parent": "5f"
+    },
+    "5h": {
+      "key": "root.imports.icons[2]",
+      "~k_parent": "5c"
+    },
+    "5i": {
+      "key": "root.imports.icons[2].icons",
+      "~k_parent": "5h"
+    },
+    "5j": {
+      "key": "root.imports.icons[3]",
+      "~k_parent": "5c"
+    },
+    "5k": {
+      "key": "root.imports.icons[3].icons",
+      "~k_parent": "5j"
+    },
+    "5l": {
+      "key": "root.imports.icons[4]",
+      "~k_parent": "5c"
+    },
+    "5m": {
+      "key": "root.imports.icons[4].icons",
+      "~k_parent": "5l"
+    },
+    "5n": {
+      "key": "root.imports.icons[5]",
+      "~k_parent": "5c"
+    },
+    "5o": {
+      "key": "root.imports.icons[5].icons",
+      "~k_parent": "5n"
+    },
+    "5p": {
+      "key": "root.imports.icons[6]",
+      "~k_parent": "5c"
+    },
+    "5q": {
+      "key": "root.imports.icons[6].icons",
+      "~k_parent": "5p"
+    },
+    "5r": {
+      "key": "root.imports.icons[7]",
+      "~k_parent": "5c"
+    },
+    "5s": {
+      "key": "root.imports.icons[7].icons",
+      "~k_parent": "5r"
+    },
+    "5t": {
+      "key": "root.imports.icons[8]",
+      "~k_parent": "5c"
+    },
+    "5u": {
+      "key": "root.imports.icons[8].icons",
+      "~k_parent": "5t"
+    },
+    "5v": {
+      "key": "root.imports.icons[9]",
+      "~k_parent": "5c"
+    },
+    "5w": {
+      "key": "root.imports.icons[9].icons",
+      "~k_parent": "5v"
+    },
+    "5x": {
+      "key": "root.imports.icons[10]",
+      "~k_parent": "5c"
+    },
+    "5y": {
+      "key": "root.imports.icons[10].icons",
+      "~k_parent": "5x"
+    },
+    "5z": {
+      "key": "root.imports.icons[11]",
+      "~k_parent": "5c"
+    },
+    "6a": {
+      "key": "root.imports.icons[16].icons",
+      "~k_parent": "69"
+    },
+    "6b": {
+      "key": "root.imports.icons[17]",
+      "~k_parent": "5c"
+    },
+    "6c": {
+      "key": "root.imports.icons[17].icons",
+      "~k_parent": "6b"
+    },
+    "6d": {
+      "key": "root.imports.icons[18]",
+      "~k_parent": "5c"
+    },
+    "6e": {
+      "key": "root.imports.icons[18].icons",
+      "~k_parent": "6d"
+    },
+    "6f": {
+      "key": "root.imports.icons[19]",
+      "~k_parent": "5c"
+    },
+    "6g": {
+      "key": "root.imports.icons[19].icons",
+      "~k_parent": "6f"
+    },
+    "6h": {
+      "key": "root.imports.icons[20]",
+      "~k_parent": "5c"
+    },
+    "6i": {
+      "key": "root.imports.icons[20].icons",
+      "~k_parent": "6h"
+    },
+    "6j": {
+      "key": "root.imports.icons[21]",
+      "~k_parent": "5c"
+    },
+    "6k": {
+      "key": "root.imports.icons[21].icons",
+      "~k_parent": "6j"
+    },
+    "6l": {
+      "key": "root.imports.icons[22]",
+      "~k_parent": "5c"
+    },
+    "6m": {
+      "key": "root.imports.icons[22].icons",
+      "~k_parent": "6l"
+    },
+    "6n": {
+      "key": "root.imports.icons[23]",
+      "~k_parent": "5c"
+    },
+    "6o": {
+      "key": "root.imports.icons[23].icons",
+      "~k_parent": "6n"
+    },
+    "6p": {
+      "key": "root.imports.icons[24]",
+      "~k_parent": "5c"
+    },
+    "6q": {
+      "key": "root.imports.icons[24].icons",
+      "~k_parent": "6p"
+    },
+    "6r": {
+      "key": "root.imports.icons[25]",
+      "~k_parent": "5c"
+    },
+    "6s": {
+      "key": "root.imports.icons[25].icons",
+      "~k_parent": "6r"
+    },
+    "6t": {
+      "key": "root.imports.icons[26]",
+      "~k_parent": "5c"
+    },
+    "6u": {
+      "key": "root.imports.icons[26].icons",
+      "~k_parent": "6t"
+    },
+    "6v": {
+      "key": "root.imports.icons[27]",
+      "~k_parent": "5c"
+    },
+    "6w": {
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "6v"
+    },
+    "6x": {
+      "key": "root.imports.requests",
+      "~k_parent": "4f"
+    },
+    "6y": {
+      "key": "root.imports.websockets",
+      "~k_parent": "4f"
+    },
+    "6z": {
+      "key": "root.imports.operators",
+      "~k_parent": "4f"
+    }
+  },
+  "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
+  "logger.json": {
+    "~k": "1y"
+  },
+  "menus.json": {
+    "~arr": [
+      {
+        "id": "menu:default",
+        "links": {
+          "~arr": [
+            {
+              "id": "menuitem:default:0",
+              "type": "MenuLink",
+              "pageId": "home",
+              "auth": {
+                "public": true,
+                "~k": "38"
+              },
+              "menuItemId": "0",
+              "~k": "37"
+            }
+          ],
+          "~k": "36"
+        },
+        "menuId": "default",
+        "~k": "35"
+      }
+    ],
+    "~k": "34"
+  },
+  "pages/404.json": {
+    "id": "page:404",
+    "type": "Result",
+    "style": {
+      "block": {
+        "minHeight": "100vh",
+        "background": "var(--ant-color-bg-layout)",
+        "~k": "2y"
+      },
+      "~k": "2x"
+    },
+    "properties": {
+      "status": "info",
+      "icon": {
+        "name": "AiOutlineFileSearch",
+        "size": 80,
+        "color": "var(--ant-color-primary)",
+        "~k": "1l"
+      },
+      "title": "404",
+      "subTitle": "Sorry, the page you are visiting does not exist.",
+      "~k": "1k"
+    },
+    "slots": {
+      "extra": {
+        "blocks": {
+          "~arr": [
+            {
+              "id": "block:404:home:0",
+              "type": "Button",
+              "properties": {
+                "title": "Go to home page",
+                "~k": "1q"
+              },
+              "events": {
+                "onClick": {
+                  "try": {
+                    "~arr": [
+                      {
+                        "id": "home",
+                        "type": "Link",
+                        "params": {
+                          "home": true,
+                          "~k": "1u"
+                        },
+                        "~k": "1t"
+                      }
+                    ],
+                    "~k": "1s"
+                  },
+                  "catch": {
+                    "~arr": [],
+                    "~k": "30"
+                  },
+                  "~k": "2z"
+                },
+                "~k": "1r"
+              },
+              "blockId": "home",
+              "~k": "1p"
+            }
+          ],
+          "~k": "1o"
+        },
+        "~k": "1n"
+      },
+      "~k": "1m"
+    },
+    "auth": {
+      "public": true,
+      "~k": "31"
+    },
+    "pageId": "404",
+    "blockId": "404",
+    "subscriptions": {
+      "~arr": [],
+      "~k": "32"
+    },
+    "requests": {
+      "~arr": [],
+      "~k": "33"
+    },
+    "~k": "2w"
+  },
+  "pages/home.json": {
+    "id": "page:home",
+    "type": "Box",
+    "auth": {
+      "public": true,
+      "~k": "2r"
+    },
+    "pageId": "home",
+    "blockId": "home",
+    "slots": {
+      "content": {
+        "blocks": {
+          "~arr": [
+            {
+              "id": "block:home:title:0",
+              "type": "Title",
+              "properties": {
+                "content": "Strategies-only app",
+                "~k": "1f"
+              },
+              "blockId": "title",
+              "~k": "1e"
+            }
+          ],
+          "~k": "1d"
+        },
+        "~k": "2t"
+      },
+      "~k": "2s"
+    },
+    "subscriptions": {
+      "~arr": [],
+      "~k": "2u"
+    },
+    "requests": {
+      "~arr": [],
+      "~k": "2v"
+    },
+    "~k": "2q"
+  },
+  "plugins/actionSchemas.json": {
+    "Link": {
+      "type": "object",
+      "params": {
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "Shorthand for pageId."
+          },
+          {
+            "type": "object",
+            "description": "Link parameters.",
+            "properties": {
+              "pageId": {
+                "type": "string",
+                "description": "The pageId to link to."
+              },
+              "url": {
+                "type": "string",
+                "description": "An external URL to link to."
+              },
+              "newWindow": {
+                "type": "boolean",
+                "description": "Open the link in a new window."
+              },
+              "urlQuery": {
+                "type": "object",
+                "description": "URL query parameters."
+              },
+              "input": {
+                "type": "object",
+                "description": "Input to pass to the linked page."
+              }
+            }
+          }
+        ]
+      }
+    },
+    "SetDarkMode": {
+      "type": "object",
+      "params": {
+        "type": "object",
+        "properties": {
+          "darkMode": {
+            "type": "string",
+            "enum": [
+              "system",
+              "light",
+              "dark"
+            ],
+            "description": "Set dark mode preference. When not provided, cycles through light, dark, and system."
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "plugins/actions.js": "import { Link as Link } from '@lowdefy/actions-core/actions';\nimport { SetDarkMode as SetDarkMode } from '@lowdefy/actions-core/actions';\nexport default {\n  Link,\n  SetDarkMode,\n  };",
+  "plugins/agents.js": "export default {\n  };",
+  "plugins/auth/adapters.js": "export default {\n  };",
+  "plugins/auth/providers.js": "export default {\n  };",
+  "plugins/auth/strategies.js": "import { apiKey as apiKey } from '@lowdefy/plugin-better-auth/auth/strategies';\nimport { jwt as jwt } from '@lowdefy/plugin-better-auth/auth/strategies';\nexport default {\n  apiKey,\n  jwt,\n  };",
+  "plugins/blockMetas.json": {
+    "Box": {
+      "category": "container"
+    },
+    "Result": {
+      "category": "container"
+    },
+    "Anchor": {
+      "category": "display"
+    },
+    "DangerousHtml": {
+      "category": "display"
+    },
+    "Html": {
+      "category": "display"
+    },
+    "Icon": {
+      "category": "display"
+    },
+    "Img": {
+      "category": "display"
+    },
+    "List": {
+      "category": "list",
+      "valueType": "array"
+    },
+    "Span": {
+      "category": "container"
+    },
+    "Throw": {
+      "category": "display"
+    },
+    "ProgressBar": {
+      "category": "display"
+    },
+    "Skeleton": {
+      "category": "display"
+    },
+    "SkeletonAvatar": {
+      "category": "display"
+    },
+    "SkeletonButton": {
+      "category": "display"
+    },
+    "SkeletonInput": {
+      "category": "display"
+    },
+    "SkeletonParagraph": {
+      "category": "display"
+    },
+    "Spinner": {
+      "category": "display"
+    },
+    "Message": {
+      "category": "display"
+    }
+  },
+  "plugins/blockSchemas.json": {
+    "Box": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "content": {
+              "type": "string",
+              "description": "Box content string. Overrides the \"content\" content area."
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The Box element."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "type": "object",
+                  "description": "The Box element."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "onClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the Box is clicked."
+                },
+                "onPaste": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the element is focused and a paste event is triggered."
+                }
+              }
+            }
+          ]
+        },
+        "blocks": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "areas": {
+          "type": "object"
+        }
+      }
+    },
+    "Anchor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "ariaLabel": {
+              "type": "string",
+              "description": "Arial-label to apply to link tag."
+            },
+            "back": {
+              "type": "boolean",
+              "description": "When the link is clicked, trigger the browser back."
+            },
+            "home": {
+              "type": "boolean",
+              "description": "When the link is clicked, route to the home page."
+            },
+            "input": {
+              "type": "object",
+              "description": "When the link is clicked, pass data as the input object to the next Lowdefy page.  Can only be used with pageId link and newTab false.",
+              "docs": {
+                "displayType": "yaml"
+              }
+            },
+            "urlQuery": {
+              "type": "object",
+              "description": "When the link is clicked, pass data as a url query to the next page.",
+              "docs": {
+                "displayType": "yaml"
+              }
+            },
+            "disabled": {
+              "type": "boolean",
+              "default": false,
+              "description": "Disable the anchor if true."
+            },
+            "icon": {
+              "type": [
+                "string",
+                "object"
+              ],
+              "description": "Name of an React-Icon (See <a href='https://react-icons.github.io/react-icons/'>all icons</a>) or properties of an Icon block for anchor icon.",
+              "docs": {
+                "displayType": "icon"
+              }
+            },
+            "pageId": {
+              "type": "string",
+              "description": "When the link is clicked, route to the provided Lowdefy page."
+            },
+            "href": {
+              "type": "string",
+              "description": "The href to link to when the anchor link is clicked."
+            },
+            "url": {
+              "type": "string",
+              "description": "External url to link to when the anchor link is clicked."
+            },
+            "rel": {
+              "type": "string",
+              "default": "noopener noreferrer",
+              "description": "The relationship of the linked URL as space-separated link types."
+            },
+            "newTab": {
+              "type": "boolean",
+              "default": false,
+              "description": "Open link in a new tab when the anchor link is clicked."
+            },
+            "replace": {
+              "type": "boolean",
+              "default": false,
+              "description": "Prevent adding a new entry into browser history by replacing the url instead of pushing into history. Can only be used with pageId link and newTab false."
+            },
+            "scroll": {
+              "type": "boolean",
+              "default": false,
+              "description": "Disable scrolling to the top of the page after page transition. Can only be used with pageId link and newTab false."
+            },
+            "title": {
+              "type": "string",
+              "description": "Text to display in the anchor."
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The anchor element."
+                },
+                ".icon": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The icon in the Anchor."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "type": "object",
+                  "description": "The anchor element."
+                },
+                ".icon": {
+                  "type": "object",
+                  "description": "The icon in the Anchor."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "onClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Called when Anchor is clicked. Renders a shortcut badge when a shortcut is configured."
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "DangerousHtml": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "html": {
+              "type": "string",
+              "description": "Content to be rendered as Html.",
+              "docs": {
+                "displayType": "text-area"
+              }
+            },
+            "DOMPurifyOptions": {
+              "type": "object",
+              "description": "Customize DOMPurify options. Options are only applied when the block is mounted, thus any parsed settings is only applied at first render.",
+              "docs": {
+                "displayType": "yaml"
+              }
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The DangerousHtml element."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "type": "object",
+                  "description": "The DangerousHtml element."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      }
+    },
+    "Html": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "html": {
+              "type": "string",
+              "description": "Content to be rendered as Html.",
+              "docs": {
+                "displayType": "text-area"
+              }
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The Html element."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "type": "object",
+                  "description": "The Html element."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "onTextSelection": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger action when text is selected and pass selected text to the event object."
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "Icon": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "type": "string",
+              "description": "Primary icon color.",
+              "docs": {
+                "displayType": "color"
+              }
+            },
+            "name": {
+              "type": "string",
+              "default": "AiOutlineCloseCircle",
+              "description": "Name of icon to be displayed."
+            },
+            "rotate": {
+              "type": "number",
+              "description": "Number of degrees to rotate the icon."
+            },
+            "size": {
+              "type": [
+                "string",
+                "number"
+              ],
+              "description": "Size of the icon.",
+              "docs": {
+                "displayType": "number"
+              }
+            },
+            "spin": {
+              "type": "boolean",
+              "default": false,
+              "description": "Continuously spin icon with animation."
+            },
+            "title": {
+              "type": "string",
+              "description": "Icon hover title for accessibility."
+            },
+            "disableLoadingIcon": {
+              "type": "boolean",
+              "default": false,
+              "description": "While loading after the icon has been clicked, don't render the loading icon."
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The Icon element."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "type": "object",
+                  "description": "The Icon element."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "onClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when icon is clicked."
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "Img": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "src"
+          ],
+          "properties": {
+            "src": {
+              "type": "string",
+              "description": "The image URL."
+            },
+            "alt": {
+              "type": "string",
+              "description": "Alternative text description of the image."
+            },
+            "crossOrigin": {
+              "type": "string",
+              "enum": [
+                "anonymous",
+                "use-credentials"
+              ],
+              "description": "Indicates if the fetching of the image must be done using a CORS request."
+            },
+            "decoding": {
+              "type": "string",
+              "enum": [
+                "sync",
+                "async",
+                "auto"
+              ],
+              "description": "An image decoding hint to the browser. Sync for atomic presentation with other content, async,  to reduce delay in presenting other content and auto leave to browser to decide."
+            },
+            "height": {
+              "type": "number",
+              "description": "Height of the image."
+            },
+            "loading": {
+              "type": "string",
+              "enum": [
+                "eager",
+                "lazy"
+              ],
+              "description": "How the browser should load the image. Eager loads the image immediately, lazy, defers loading until the image it reaches a calculated distance from the viewport, as defined by the browser."
+            },
+            "sizes": {
+              "type": "string",
+              "description": "Indicating a set of source sizes of strings separated by commas."
+            },
+            "srcSet": {
+              "type": "string",
+              "description": "Possible image sources for the user agent to use, strings separated by commas.",
+              "docs": {
+                "displayType": "text-area"
+              }
+            },
+            "width": {
+              "type": "number",
+              "description": "Width of the image."
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The Img element."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "type": "object",
+                  "description": "The Img element."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      }
+    },
+    "List": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "direction": {
+              "type": "string",
+              "enum": [
+                "row",
+                "column",
+                "row-reverse",
+                "column-reverse"
+              ],
+              "description": "List content along a 'row' or down a 'column'. Applies the 'flex-direction' css property to the List block."
+            },
+            "wrap": {
+              "type": "string",
+              "enum": [
+                "wrap",
+                "nowrap",
+                "wrap-reverse"
+              ],
+              "description": "Specifies wrapping style to be applied to List block as 'wrap', 'nowrap' or 'wrap-reverse'. Applies the 'flex-wrap' css property to the List block - defaults to 'wrap', requires List direction to be set."
+            },
+            "scroll": {
+              "type": "boolean",
+              "description": "Specifies whether scrolling should be applied to the List, can be true or false. Applies the 'overflow' css property to the List block - defaults to 'visible', requires List direction to be set."
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The List element."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "type": "object",
+                  "description": "The List element."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "onClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the List is clicked."
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "Span": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "content": {
+              "type": "string",
+              "description": "Span content string. Overrides the \"content\" content area."
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The Span element."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "type": "object",
+                  "description": "The Span element."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "onClick": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when the Span is clicked."
+                }
+              }
+            }
+          ]
+        },
+        "blocks": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "areas": {
+          "type": "object"
+        }
+      }
+    },
+    "Throw": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Error message to throw.",
+              "default": "Intentional error thrown by Throw block"
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      }
+    },
+    "Result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "icon": {
+              "type": [
+                "string",
+                "object"
+              ],
+              "description": "Name of an React-Icon (See <a href='https://react-icons.github.io/react-icons/'>all icons</a>) or properties of an Icon block to customize icon to use as result image.",
+              "docs": {
+                "displayType": "icon"
+              }
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "success",
+                "error",
+                "info",
+                "warning",
+                "404",
+                "403",
+                "500"
+              ],
+              "default": "info",
+              "description": "Status of the result. Determines image and color."
+            },
+            "subTitle": {
+              "type": "string",
+              "description": "Result subtitle or secondary text - supports html."
+            },
+            "title": {
+              "type": "string",
+              "description": "Result title or primary text - supports html."
+            },
+            "theme": {
+              "type": "object",
+              "description": "Antd design token overrides for this block. See <a href=\"https://ant.design/components/overview#design-token\">antd design tokens</a>.",
+              "docs": {
+                "displayType": "yaml",
+                "link": "https://ant.design/components/result#design-token"
+              },
+              "properties": {
+                "titleFontSize": {
+                  "type": "number",
+                  "default": 24,
+                  "description": "Font size of the result title."
+                },
+                "subtitleFontSize": {
+                  "type": "number",
+                  "default": 14,
+                  "description": "Font size of the result subtitle."
+                },
+                "iconFontSize": {
+                  "type": "number",
+                  "default": 72,
+                  "description": "Font size of the result status icon."
+                },
+                "extraMargin": {
+                  "type": "string",
+                  "default": "24px 0 0 0",
+                  "description": "Margin applied to the extra content area."
+                },
+                "colorSuccess": {
+                  "type": "string",
+                  "description": "Color used for the success status icon."
+                },
+                "colorError": {
+                  "type": "string",
+                  "description": "Color used for the error status icon."
+                },
+                "colorInfo": {
+                  "type": "string",
+                  "description": "Color used for the info status icon."
+                },
+                "colorWarning": {
+                  "type": "string",
+                  "description": "Color used for the warning status icon."
+                },
+                "colorTextHeading": {
+                  "type": "string",
+                  "description": "Color of the result title text."
+                },
+                "colorTextDescription": {
+                  "type": "string",
+                  "description": "Color of the result subtitle text."
+                },
+                "paddingLG": {
+                  "type": "number",
+                  "default": 24,
+                  "description": "Large padding value applied to the result container."
+                },
+                "lineHeight": {
+                  "type": "number",
+                  "default": 1.5714285714285714,
+                  "description": "Line height used for result text content."
+                }
+              }
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The Result element."
+                },
+                ".icon": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The icon in the Result."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "type": "object",
+                  "description": "The Result element."
+                },
+                ".icon": {
+                  "type": "object",
+                  "description": "The icon in the Result."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        },
+        "blocks": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "areas": {
+          "type": "object"
+        }
+      }
+    },
+    "Message": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "content": {
+              "type": "string",
+              "description": "The content of the message - supports html."
+            },
+            "duration": {
+              "type": "number",
+              "default": 4.5,
+              "description": "Time(seconds) before auto-dismiss, don't dismiss if set to 0."
+            },
+            "icon": {
+              "type": [
+                "string",
+                "object"
+              ],
+              "description": "Name of an React-Icon (See <a href='https://react-icons.github.io/react-icons/'>all icons</a>) or properties of an Icon block to customize message icon.",
+              "docs": {
+                "displayType": "icon"
+              }
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "success",
+                "error",
+                "info",
+                "warning",
+                "loading"
+              ],
+              "default": "info",
+              "description": "Message status type."
+            },
+            "theme": {
+              "type": "object",
+              "description": "Antd design token overrides for this block. See <a href=\"https://ant.design/components/overview#design-token\">antd design tokens</a>.",
+              "docs": {
+                "displayType": "yaml",
+                "link": "https://ant.design/components/message#design-token"
+              },
+              "properties": {
+                "zIndexPopup": {
+                  "type": "number",
+                  "default": 1080,
+                  "description": "Z-index of the message popup."
+                },
+                "contentBg": {
+                  "type": "string",
+                  "description": "Background color of the message content."
+                },
+                "contentPadding": {
+                  "type": "string",
+                  "description": "Padding of the message content. Calculated from controlHeightLG, fontSize, lineHeight, and paddingSM."
+                }
+              }
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The Message element."
+                },
+                ".icon": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The icon in the Message."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "type": "object",
+                  "description": "The Message element."
+                },
+                ".icon": {
+                  "type": "object",
+                  "description": "The icon in the Message."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "onClose": {
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "Trigger actions when message is closed."
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ProgressBar": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "height": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Height of the skeleton."
+            },
+            "width": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Width of the skeleton."
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The ProgressBar element."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "type": "object",
+                  "description": "The ProgressBar element."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      }
+    },
+    "Skeleton": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "height": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Height of the skeleton.",
+              "docs": {
+                "displayType": "string"
+              }
+            },
+            "width": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Width of the skeleton.",
+              "docs": {
+                "displayType": "string"
+              }
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The Skeleton element."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "type": "object",
+                  "description": "The Skeleton element."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      }
+    },
+    "SkeletonAvatar": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "size": {
+              "type": "string",
+              "default": "medium",
+              "description": "Size of the skeleton.",
+              "enum": [
+                "small",
+                "medium",
+                "large"
+              ]
+            },
+            "shape": {
+              "type": "string",
+              "default": "round",
+              "description": "Shape of the skeleton.",
+              "enum": [
+                "square",
+                "round"
+              ]
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The SkeletonAvatar element."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "type": "object",
+                  "description": "The SkeletonAvatar element."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      }
+    },
+    "SkeletonButton": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "size": {
+              "type": "string",
+              "default": "medium",
+              "description": "Size of the skeleton.",
+              "enum": [
+                "small",
+                "medium",
+                "large"
+              ]
+            },
+            "width": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Width of the skeleton.",
+              "docs": {
+                "displayType": "string"
+              }
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The SkeletonButton element."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "type": "object",
+                  "description": "The SkeletonButton element."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      }
+    },
+    "SkeletonInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "size": {
+              "type": "string",
+              "default": "medium",
+              "description": "Size of the skeleton.",
+              "enum": [
+                "small",
+                "medium",
+                "large"
+              ]
+            },
+            "width": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Width of the skeleton.",
+              "docs": {
+                "displayType": "string"
+              }
+            },
+            "labelHeight": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Height of the skeleton.",
+              "docs": {
+                "displayType": "string"
+              }
+            },
+            "labelWidth": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Width of the skeleton.",
+              "docs": {
+                "displayType": "string"
+              }
+            },
+            "inputHeight": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Height of the skeleton.",
+              "docs": {
+                "displayType": "string"
+              }
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The outer container."
+                },
+                ".input": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The input skeleton."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "type": "object",
+                  "description": "The outer container."
+                },
+                ".input": {
+                  "type": "object",
+                  "description": "The input skeleton."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      }
+    },
+    "SkeletonParagraph": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "lines": {
+              "type": "number",
+              "default": 4,
+              "description": "Number of paragraph lines of the skeleton."
+            },
+            "width": {
+              "type": [
+                "number",
+                "string"
+              ],
+              "description": "Width of the skeleton.",
+              "docs": {
+                "displayType": "string"
+              }
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The SkeletonParagraph element."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "type": "object",
+                  "description": "The SkeletonParagraph element."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      }
+    },
+    "Spinner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "layout": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "visible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "size": {
+              "type": "string",
+              "description": "Size of the icon spinner.",
+              "enum": [
+                "small",
+                "medium",
+                "large"
+              ]
+            }
+          }
+        },
+        "class": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^_": {}
+                      },
+                      "additionalProperties": false,
+                      "minProperties": 1,
+                      "maxProperties": 1
+                    }
+                  ],
+                  "description": "The Spinner element."
+                }
+              }
+            }
+          ]
+        },
+        "style": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                ".block": {
+                  "type": "object",
+                  "description": "The block layout wrapper."
+                },
+                ".element": {
+                  "type": "object",
+                  "description": "The Spinner element."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                "^(?!_)(?!\\.)": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1
+            }
+          ]
+        },
+        "events": {
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                "^_": {}
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "maxProperties": 1
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      }
+    }
+  },
+  "plugins/blocks.js": "import { Box as Box } from '@lowdefy/blocks-basic/blocks';\nimport { Title as Title } from '@lowdefy/blocks-basic/blocks';\nimport { Result as Result } from '@lowdefy/blocks-antd/blocks';\nimport { Button as Button } from '@lowdefy/blocks-basic/blocks';\nimport { Anchor as Anchor } from '@lowdefy/blocks-basic/blocks';\nimport { DangerousHtml as DangerousHtml } from '@lowdefy/blocks-basic/blocks';\nimport { Html as Html } from '@lowdefy/blocks-basic/blocks';\nimport { Icon as Icon } from '@lowdefy/blocks-basic/blocks';\nimport { Img as Img } from '@lowdefy/blocks-basic/blocks';\nimport { List as List } from '@lowdefy/blocks-basic/blocks';\nimport { Span as Span } from '@lowdefy/blocks-basic/blocks';\nimport { Throw as Throw } from '@lowdefy/blocks-basic/blocks';\nimport { ProgressBar as ProgressBar } from '@lowdefy/blocks-loaders/blocks';\nimport { Skeleton as Skeleton } from '@lowdefy/blocks-loaders/blocks';\nimport { SkeletonAvatar as SkeletonAvatar } from '@lowdefy/blocks-loaders/blocks';\nimport { SkeletonButton as SkeletonButton } from '@lowdefy/blocks-loaders/blocks';\nimport { SkeletonInput as SkeletonInput } from '@lowdefy/blocks-loaders/blocks';\nimport { SkeletonParagraph as SkeletonParagraph } from '@lowdefy/blocks-loaders/blocks';\nimport { Spinner as Spinner } from '@lowdefy/blocks-loaders/blocks';\nimport { Message as Message } from '@lowdefy/blocks-antd/blocks';\nexport default {\n  Box,\n  Title,\n  Result,\n  Button,\n  Anchor,\n  DangerousHtml,\n  Html,\n  Icon,\n  Img,\n  List,\n  Span,\n  Throw,\n  ProgressBar,\n  Skeleton,\n  SkeletonAvatar,\n  SkeletonButton,\n  SkeletonInput,\n  SkeletonParagraph,\n  Spinner,\n  Message,\n  };",
+  "plugins/connections.js": "export default {\n  };",
+  "plugins/icons.js": "import { AiOutlineExclamationCircle, AiOutlineLoading3Quarters, AiOutlineFileSearch } from 'react-icons/ai';\nexport default {\n  AiOutlineExclamationCircle,\n  AiOutlineLoading3Quarters,\n  AiOutlineFileSearch,\n};",
+  "plugins/operatorSchemas.json": {
+    "_not": {
+      "type": "object",
+      "params": {
+        "type": "boolean",
+        "description": "Boolean value to negate."
+      }
+    },
+    "_type": {
+      "type": "object",
+      "params": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "string",
+              "array",
+              "date",
+              "object",
+              "boolean",
+              "number",
+              "integer",
+              "null",
+              "undefined",
+              "none",
+              "primitive"
+            ],
+            "description": "Type name to test against state value at current location."
+          },
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "string",
+                  "array",
+                  "date",
+                  "object",
+                  "boolean",
+                  "number",
+                  "integer",
+                  "null",
+                  "undefined",
+                  "none",
+                  "primitive"
+                ],
+                "description": "Type name to test."
+              },
+              "on": {
+                "description": "Value to test the type of."
+              },
+              "key": {
+                "type": "string",
+                "description": "State key to test the type of."
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "_user": {
+      "type": "object",
+      "params": {
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "Dot-notation path to value in user object, or a role name when used with a role method."
+          },
+          {
+            "type": "integer",
+            "description": "Index to access in user object."
+          },
+          {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "description": "Return all user data."
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Array of role names when used with a role method."
+          },
+          {
+            "type": "object",
+            "properties": {
+              "key": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "description": "Dot-notation path to value in user object."
+                  },
+                  {
+                    "type": "integer",
+                    "description": "Index to access in user object."
+                  }
+                ]
+              },
+              "default": {
+                "description": "Default value if key does not exist."
+              },
+              "all": {
+                "type": "boolean",
+                "description": "Return all user data."
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  },
+  "plugins/operators/client.js": "import { _not as _not } from '@lowdefy/operators-js/operators/client';\nimport { _type as _type } from '@lowdefy/operators-js/operators/client';\nexport default {\n  _not,\n  _type,\n  };",
+  "plugins/operators/clientJsMap.js": "\nexport default {\n  };",
+  "plugins/operators/server.js": "import { _user as _user } from '@lowdefy/operators-js/operators/server';\nexport default {\n  _user,\n  };",
+  "plugins/operators/serverJsMap.js": "\nexport default {\n  };",
+  "plugins/websockets.js": "export default {\n  };",
+  "refMap.json": {
+    "1": {
+      "parent": null
+    },
+    "2": {
+      "parent": null
+    }
+  },
+  "tailwind-candidates.css": "/* Generated by Lowdefy build — rewritten on page changes to trigger CSS recompilation */\n",
+  "theme.json": {
+    "darkMode": "system"
+  },
+  "types.json": {
+    "actions": {
+      "Link": {
+        "originalTypeName": "Link",
+        "package": "@lowdefy/actions-core",
+        "count": 1,
+        "~k": "3b"
+      },
+      "SetDarkMode": {
+        "originalTypeName": "SetDarkMode",
+        "package": "@lowdefy/actions-core",
+        "count": 1,
+        "~k": "3c"
+      },
+      "~k": "3a"
+    },
+    "agents": {
+      "~k": "3d"
+    },
+    "auth": {
+      "adapters": {
+        "~k": "3f"
+      },
+      "providers": {
+        "~k": "3g"
+      },
+      "strategies": {
+        "apiKey": {
+          "originalTypeName": "apiKey",
+          "package": "@lowdefy/plugin-better-auth",
+          "count": 1,
+          "~k": "3i"
+        },
+        "jwt": {
+          "originalTypeName": "jwt",
+          "package": "@lowdefy/plugin-better-auth",
+          "count": 2,
+          "~k": "3j"
+        },
+        "~k": "3h"
+      },
+      "~k": "3e"
+    },
+    "blocks": {
+      "Box": {
+        "originalTypeName": "Box",
+        "package": "@lowdefy/blocks-basic",
+        "count": 2,
+        "~k": "3l"
+      },
+      "Title": {
+        "originalTypeName": "Title",
+        "package": "@lowdefy/blocks-basic",
+        "count": 1,
+        "~k": "3m"
+      },
+      "Result": {
+        "originalTypeName": "Result",
+        "package": "@lowdefy/blocks-antd",
+        "count": 1,
+        "~k": "3n"
+      },
+      "Button": {
+        "originalTypeName": "Button",
+        "package": "@lowdefy/blocks-basic",
+        "count": 1,
+        "~k": "3o"
+      },
+      "Anchor": {
+        "originalTypeName": "Anchor",
+        "package": "@lowdefy/blocks-basic",
+        "count": 1,
+        "~k": "3p"
+      },
+      "DangerousHtml": {
+        "originalTypeName": "DangerousHtml",
+        "package": "@lowdefy/blocks-basic",
+        "count": 1,
+        "~k": "3q"
+      },
+      "Html": {
+        "originalTypeName": "Html",
+        "package": "@lowdefy/blocks-basic",
+        "count": 1,
+        "~k": "3r"
+      },
+      "Icon": {
+        "originalTypeName": "Icon",
+        "package": "@lowdefy/blocks-basic",
+        "count": 1,
+        "~k": "3s"
+      },
+      "Img": {
+        "originalTypeName": "Img",
+        "package": "@lowdefy/blocks-basic",
+        "count": 1,
+        "~k": "3t"
+      },
+      "List": {
+        "originalTypeName": "List",
+        "package": "@lowdefy/blocks-basic",
+        "count": 1,
+        "~k": "3u"
+      },
+      "Span": {
+        "originalTypeName": "Span",
+        "package": "@lowdefy/blocks-basic",
+        "count": 1,
+        "~k": "3v"
+      },
+      "Throw": {
+        "originalTypeName": "Throw",
+        "package": "@lowdefy/blocks-basic",
+        "count": 1,
+        "~k": "3w"
+      },
+      "ProgressBar": {
+        "originalTypeName": "ProgressBar",
+        "package": "@lowdefy/blocks-loaders",
+        "count": 1,
+        "~k": "3x"
+      },
+      "Skeleton": {
+        "originalTypeName": "Skeleton",
+        "package": "@lowdefy/blocks-loaders",
+        "count": 1,
+        "~k": "3y"
+      },
+      "SkeletonAvatar": {
+        "originalTypeName": "SkeletonAvatar",
+        "package": "@lowdefy/blocks-loaders",
+        "count": 1,
+        "~k": "3z"
+      },
+      "SkeletonButton": {
+        "originalTypeName": "SkeletonButton",
+        "package": "@lowdefy/blocks-loaders",
+        "count": 1,
+        "~k": "40"
+      },
+      "SkeletonInput": {
+        "originalTypeName": "SkeletonInput",
+        "package": "@lowdefy/blocks-loaders",
+        "count": 1,
+        "~k": "41"
+      },
+      "SkeletonParagraph": {
+        "originalTypeName": "SkeletonParagraph",
+        "package": "@lowdefy/blocks-loaders",
+        "count": 1,
+        "~k": "42"
+      },
+      "Spinner": {
+        "originalTypeName": "Spinner",
+        "package": "@lowdefy/blocks-loaders",
+        "count": 1,
+        "~k": "43"
+      },
+      "Message": {
+        "originalTypeName": "Message",
+        "package": "@lowdefy/blocks-antd",
+        "count": 1,
+        "~k": "44"
+      },
+      "~k": "3k"
+    },
+    "connections": {
+      "~k": "45"
+    },
+    "requests": {
+      "~k": "46"
+    },
+    "websockets": {
+      "~k": "47"
+    },
+    "api": {
+      "~k": "48"
+    },
+    "operators": {
+      "client": {
+        "_not": {
+          "originalTypeName": "_not",
+          "package": "@lowdefy/operators-js",
+          "count": 1,
+          "~k": "4b"
+        },
+        "_type": {
+          "originalTypeName": "_type",
+          "package": "@lowdefy/operators-js",
+          "count": 1,
+          "~k": "4c"
+        },
+        "~k": "4a"
+      },
+      "server": {
+        "_user": {
+          "originalTypeName": "_user",
+          "package": "@lowdefy/operators-js",
+          "count": 1,
+          "~k": "4e"
+        },
+        "~k": "4d"
+      },
+      "~k": "49"
+    },
+    "~k": "39"
+  }
+}

--- a/packages/build/src/utils/createPluginTypesMap.js
+++ b/packages/build/src/utils/createPluginTypesMap.js
@@ -62,6 +62,14 @@ function createPluginTypesMap({ packageName, packageTypes, typePrefix = '', type
   });
 
   createTypeDefinitions({
+    typeNames: type.isObject(packageTypes.auth) ? packageTypes.auth.strategies : [],
+    store: typesMap.auth.strategies,
+    packageName,
+    typePrefix,
+    version,
+  });
+
+  createTypeDefinitions({
     typeNames: packageTypes.blocks,
     store: typesMap.blocks,
     packageName,

--- a/packages/plugins/plugins/plugin-better-auth/jest.config.js
+++ b/packages/plugins/plugins/plugin-better-auth/jest.config.js
@@ -1,0 +1,19 @@
+export default {
+  clearMocks: true,
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.js'],
+  coverageDirectory: 'coverage',
+  coveragePathIgnorePatterns: [
+    '<rootDir>/dist/',
+    '<rootDir>/src/types.js',
+    '<rootDir>/src/auth/providers.js',
+    '<rootDir>/src/auth/strategies.js',
+  ],
+  coverageReporters: [['lcov', { projectRoot: '../../../..' }], 'text', 'clover'],
+  errorOnDeprecated: true,
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['<rootDir>/dist/'],
+  transform: {
+    '^.+\\.(t|j)sx?$': ['@swc/jest', { configFile: '../../../../.swcrc.test' }],
+  },
+};

--- a/packages/plugins/plugins/plugin-better-auth/package.json
+++ b/packages/plugins/plugins/plugin-better-auth/package.json
@@ -28,6 +28,7 @@
   "type": "module",
   "exports": {
     "./auth/providers": "./dist/auth/providers.js",
+    "./auth/strategies": "./dist/auth/strategies.js",
     "./types": "./dist/types.js"
   },
   "files": [
@@ -37,12 +38,18 @@
     "build": "swc src --out-dir dist --config-file ../../../../.swcrc --cli-config-file ../../../../.swc-cli.json --copy-files",
     "clean": "rm -rf dist",
     "prepublishOnly": "pnpm build",
-    "test": "echo \"No tests\""
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+  },
+  "dependencies": {
+    "@lowdefy/helpers": "5.3.0",
+    "jose": "^6.2.3"
   },
   "devDependencies": {
     "@swc/cli": "0.8.1",
     "@swc/core": "1.15.32",
-    "jest": "28.1.3"
+    "@swc/jest": "0.2.39",
+    "jest": "28.1.3",
+    "jest-environment-node": "28.1.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugins/plugins/plugin-better-auth/src/auth/strategies.js
+++ b/packages/plugins/plugins/plugin-better-auth/src/auth/strategies.js
@@ -1,0 +1,22 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// API auth strategy verifier factories. Each factory receives a strategy's
+// resolved properties at startup and returns an async verify({ headers,
+// logger }) that resolves a match or null - strategy order and caller
+// assembly live in @lowdefy/api's resolveStrategyCaller.
+export { default as apiKey } from './strategies/apiKey.js';
+export { default as jwt } from './strategies/jwt.js';

--- a/packages/plugins/plugins/plugin-better-auth/src/auth/strategies/apiKey.js
+++ b/packages/plugins/plugins/plugin-better-auth/src/auth/strategies/apiKey.js
@@ -1,0 +1,63 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { type } from '@lowdefy/helpers';
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest();
+}
+
+// Static API key strategy - reads a dedicated header (default X-API-Key, set
+// by build) and compares against the configured keys. Both sides are hashed
+// to SHA-256 before timingSafeEqual: the digests are a fixed 32 bytes, so the
+// comparison runs in constant time without a length fast-path that would leak
+// key length through timing.
+function apiKey({ logger, properties, strategyId }) {
+  const headerName = properties.headerName;
+  const keys = properties.keys.map((key, index) => {
+    const keyId = type.isNone(key.id) ? String(index) : key.id;
+    if (!type.isString(key.value)) {
+      throw new Error(
+        `Auth strategy "${strategyId}" key "${keyId}" did not resolve to a string. Check the _secret operator reference and that the secret is set.`
+      );
+    }
+    // Secrets are opaque at build time; strength checks are startup warnings.
+    if (key.value.length < 32) {
+      logger.warn(
+        `Auth strategy "${strategyId}" key "${keyId}" is shorter than 32 characters. Use a long random value, e.g. \`openssl rand -hex 32\`.`
+      );
+    }
+    return { digest: sha256(key.value), id: keyId };
+  });
+
+  return async function verify({ headers }) {
+    const presented = headers.get(headerName);
+    if (!presented) {
+      return null;
+    }
+    const presentedDigest = sha256(presented);
+    const match = keys.find((key) => timingSafeEqual(presentedDigest, key.digest));
+    if (type.isNone(match)) {
+      return null;
+    }
+    // Synthetic caller id with per-key audit identity - the key index stands
+    // in when the config sets no key id.
+    return { user: { id: `apiKey:${strategyId}:${match.id}` } };
+  };
+}
+
+export default apiKey;

--- a/packages/plugins/plugins/plugin-better-auth/src/auth/strategies/apiKey.test.js
+++ b/packages/plugins/plugins/plugin-better-auth/src/auth/strategies/apiKey.test.js
@@ -1,0 +1,124 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+
+import apiKey from './apiKey.js';
+
+const longKey = 'k'.repeat(32);
+const otherLongKey = 'o'.repeat(32);
+
+function mockLogger() {
+  return { debug: jest.fn(), warn: jest.fn() };
+}
+
+test('apiKey verify matches a configured key and returns the synthetic caller id', async () => {
+  const logger = mockLogger();
+  const verify = apiKey({
+    logger,
+    properties: { headerName: 'X-API-Key', keys: [{ id: 'acme', value: longKey }] },
+    strategyId: 'partner-access',
+  });
+  const match = await verify({ headers: new Headers({ 'X-API-Key': longKey }), logger });
+  expect(match).toEqual({ user: { id: 'apiKey:partner-access:acme' } });
+});
+
+test('apiKey verify returns null when the header is absent', async () => {
+  const logger = mockLogger();
+  const verify = apiKey({
+    logger,
+    properties: { headerName: 'X-API-Key', keys: [{ id: 'acme', value: longKey }] },
+    strategyId: 'partner-access',
+  });
+  expect(await verify({ headers: new Headers({}), logger })).toBe(null);
+});
+
+test('apiKey verify returns null when the presented key does not match', async () => {
+  const logger = mockLogger();
+  const verify = apiKey({
+    logger,
+    properties: { headerName: 'X-API-Key', keys: [{ id: 'acme', value: longKey }] },
+    strategyId: 'partner-access',
+  });
+  expect(await verify({ headers: new Headers({ 'X-API-Key': otherLongKey }), logger })).toBe(null);
+});
+
+test('apiKey verify compares keys of different lengths without throwing', async () => {
+  const logger = mockLogger();
+  const verify = apiKey({
+    logger,
+    properties: { headerName: 'X-API-Key', keys: [{ id: 'acme', value: longKey }] },
+    strategyId: 'partner-access',
+  });
+  expect(await verify({ headers: new Headers({ 'X-API-Key': 'short' }), logger })).toBe(null);
+});
+
+test('apiKey verify reads a custom header name', async () => {
+  const logger = mockLogger();
+  const verify = apiKey({
+    logger,
+    properties: { headerName: 'X-Partner-Key', keys: [{ id: 'acme', value: longKey }] },
+    strategyId: 'partner-access',
+  });
+  const match = await verify({ headers: new Headers({ 'X-Partner-Key': longKey }), logger });
+  expect(match).toEqual({ user: { id: 'apiKey:partner-access:acme' } });
+});
+
+test('apiKey verify falls back to the key index when the key has no id', async () => {
+  const logger = mockLogger();
+  const verify = apiKey({
+    logger,
+    properties: { headerName: 'X-API-Key', keys: [{ value: otherLongKey }, { value: longKey }] },
+    strategyId: 'partner-access',
+  });
+  const match = await verify({ headers: new Headers({ 'X-API-Key': longKey }), logger });
+  expect(match).toEqual({ user: { id: 'apiKey:partner-access:1' } });
+});
+
+test('apiKey warns at startup for keys shorter than 32 characters', () => {
+  const logger = mockLogger();
+  apiKey({
+    logger,
+    properties: { headerName: 'X-API-Key', keys: [{ id: 'acme', value: 'short-key' }] },
+    strategyId: 'partner-access',
+  });
+  expect(logger.warn).toHaveBeenCalledWith(
+    'Auth strategy "partner-access" key "acme" is shorter than 32 characters. Use a long random value, e.g. `openssl rand -hex 32`.'
+  );
+});
+
+test('apiKey does not warn for keys of 32 characters or longer', () => {
+  const logger = mockLogger();
+  apiKey({
+    logger,
+    properties: { headerName: 'X-API-Key', keys: [{ id: 'acme', value: longKey }] },
+    strategyId: 'partner-access',
+  });
+  expect(logger.warn).not.toHaveBeenCalled();
+});
+
+test('apiKey throws at startup when a key value did not resolve to a string', () => {
+  const logger = mockLogger();
+  expect(() =>
+    apiKey({
+      logger,
+      properties: { headerName: 'X-API-Key', keys: [{ id: 'acme', value: undefined }] },
+      strategyId: 'partner-access',
+    })
+  ).toThrow(
+    'Auth strategy "partner-access" key "acme" did not resolve to a string. Check the _secret operator reference and that the secret is set.'
+  );
+});

--- a/packages/plugins/plugins/plugin-better-auth/src/auth/strategies/jwt.js
+++ b/packages/plugins/plugins/plugin-better-auth/src/auth/strategies/jwt.js
@@ -1,0 +1,99 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { get, type } from '@lowdefy/helpers';
+
+function toRoles(value) {
+  if (type.isArray(value)) {
+    return value.filter((role) => type.isString(role));
+  }
+  if (type.isString(value)) {
+    return [value];
+  }
+  return [];
+}
+
+// JWT strategy - verifies third-party Bearer tokens locally with jose, HMAC
+// (secret) or JWKS (jwksUri; createRemoteJWKSet caches keys and handles
+// rotation). Build guarantees exactly one of secret/jwksUri and a non-empty
+// algorithms allowlist - the allowlist is what stops an `alg: none` or
+// downgraded-algorithm token from verifying.
+function jwt({ logger, properties, strategyId }) {
+  const { algorithms, audience, issuer, jwksUri, secret } = properties;
+  const claimMapping = properties.claimMapping ?? {};
+  let key;
+  if (!type.isNone(secret)) {
+    if (!type.isString(secret)) {
+      throw new Error(
+        `Auth strategy "${strategyId}" "secret" did not resolve to a string. Check the _secret operator reference and that the secret is set.`
+      );
+    }
+    // Secrets are opaque at build time; strength checks are startup warnings.
+    if (secret.length < 32) {
+      logger.warn(
+        `Auth strategy "${strategyId}" "secret" is shorter than 32 characters. Use a long random value, e.g. \`openssl rand -base64 32\`.`
+      );
+    }
+    key = new TextEncoder().encode(secret);
+  } else {
+    key = createRemoteJWKSet(new URL(jwksUri));
+  }
+
+  return async function verify({ headers, logger: requestLogger }) {
+    const authorization = headers.get('authorization');
+    if (!authorization || !authorization.startsWith('Bearer ')) {
+      return null;
+    }
+    const token = authorization.slice('Bearer '.length).trim();
+    let payload;
+    try {
+      ({ payload } = await jwtVerify(token, key, { algorithms, audience, issuer }));
+    } catch (error) {
+      // An invalid token is not this strategy's caller - resolution moves on
+      // to the next strategy instead of failing the request.
+      (requestLogger ?? logger).debug(
+        { event: 'auth_strategy_token_rejected', strategyId, err: error },
+        `Auth strategy "${strategyId}" rejected a Bearer token: ${error.message}`
+      );
+      return null;
+    }
+    const user = { id: get(payload, claimMapping.id ?? 'sub') };
+    const attributes = {};
+    let roles = [];
+    Object.entries(claimMapping).forEach(([field, claimPath]) => {
+      if (field === 'id') {
+        return;
+      }
+      const value = get(payload, claimPath);
+      if (field === 'roles') {
+        roles = toRoles(value);
+        return;
+      }
+      if (type.isNone(value)) {
+        return;
+      }
+      if (field.startsWith('attributes.')) {
+        attributes[field.slice('attributes.'.length)] = value;
+        return;
+      }
+      user[field] = value;
+    });
+    return { attributes, roles, user };
+  };
+}
+
+export default jwt;

--- a/packages/plugins/plugins/plugin-better-auth/src/auth/strategies/jwt.test.js
+++ b/packages/plugins/plugins/plugin-better-auth/src/auth/strategies/jwt.test.js
@@ -1,0 +1,293 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import http from 'node:http';
+import { jest } from '@jest/globals';
+import { exportJWK, generateKeyPair, SignJWT } from 'jose';
+
+import jwt from './jwt.js';
+
+const hmacSecret = 's'.repeat(32);
+const encodedSecret = new TextEncoder().encode(hmacSecret);
+
+function mockLogger() {
+  return { debug: jest.fn(), warn: jest.fn() };
+}
+
+async function signHmac(payload, { alg = 'HS256', ...options } = {}) {
+  let builder = new SignJWT(payload).setProtectedHeader({ alg }).setIssuedAt();
+  if (options.expirationTime !== null) {
+    builder = builder.setExpirationTime(options.expirationTime ?? '5m');
+  }
+  if (options.issuer) {
+    builder = builder.setIssuer(options.issuer);
+  }
+  if (options.audience) {
+    builder = builder.setAudience(options.audience);
+  }
+  return builder.sign(encodedSecret);
+}
+
+function bearer(token) {
+  return new Headers({ Authorization: `Bearer ${token}` });
+}
+
+test('jwt verify accepts a valid HMAC token and defaults id to the sub claim', async () => {
+  const logger = mockLogger();
+  const verify = jwt({
+    logger,
+    properties: { secret: hmacSecret, algorithms: ['HS256'] },
+    strategyId: 'service-jwt',
+  });
+  const token = await signHmac({ sub: 'service-1' });
+  const match = await verify({ headers: bearer(token), logger });
+  expect(match).toEqual({ attributes: {}, roles: [], user: { id: 'service-1' } });
+});
+
+test('jwt verify maps claims per claimMapping including nested role and attribute paths', async () => {
+  const logger = mockLogger();
+  const verify = jwt({
+    logger,
+    properties: {
+      secret: hmacSecret,
+      algorithms: ['HS256'],
+      claimMapping: {
+        id: 'sub',
+        email: 'email',
+        roles: 'realm_access.roles',
+        'attributes.branches': 'resource_access.branches',
+      },
+    },
+    strategyId: 'service-jwt',
+  });
+  const token = await signHmac({
+    sub: 'service-1',
+    email: 'svc@example.com',
+    realm_access: { roles: ['api-user', 'reporting'] },
+    resource_access: { branches: ['north', 'east'] },
+  });
+  const match = await verify({ headers: bearer(token), logger });
+  expect(match).toEqual({
+    attributes: { branches: ['north', 'east'] },
+    roles: ['api-user', 'reporting'],
+    user: { id: 'service-1', email: 'svc@example.com' },
+  });
+});
+
+test('jwt verify wraps a single string roles claim in an array and drops non-string entries', async () => {
+  const logger = mockLogger();
+  const verify = jwt({
+    logger,
+    properties: {
+      secret: hmacSecret,
+      algorithms: ['HS256'],
+      claimMapping: { roles: 'role' },
+    },
+    strategyId: 'service-jwt',
+  });
+  const single = await verify({
+    headers: bearer(await signHmac({ sub: 's', role: 'api-user' })),
+    logger,
+  });
+  expect(single.roles).toEqual(['api-user']);
+  const mixed = await verify({
+    headers: bearer(await signHmac({ sub: 's', role: ['api-user', 7, null] })),
+    logger,
+  });
+  expect(mixed.roles).toEqual(['api-user']);
+  const invalid = await verify({
+    headers: bearer(await signHmac({ sub: 's', role: { nested: true } })),
+    logger,
+  });
+  expect(invalid.roles).toEqual([]);
+});
+
+test('jwt verify skips claim-mapped fields whose claims are missing', async () => {
+  const logger = mockLogger();
+  const verify = jwt({
+    logger,
+    properties: {
+      secret: hmacSecret,
+      algorithms: ['HS256'],
+      claimMapping: { email: 'email', 'attributes.branches': 'branches' },
+    },
+    strategyId: 'service-jwt',
+  });
+  const match = await verify({ headers: bearer(await signHmac({ sub: 's' })), logger });
+  expect(match).toEqual({ attributes: {}, roles: [], user: { id: 's' } });
+});
+
+test('jwt verify rejects an expired token', async () => {
+  const logger = mockLogger();
+  const verify = jwt({
+    logger,
+    properties: { secret: hmacSecret, algorithms: ['HS256'] },
+    strategyId: 'service-jwt',
+  });
+  const token = await new SignJWT({ sub: 's' })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setExpirationTime(Math.floor(Date.now() / 1000) - 60)
+    .sign(encodedSecret);
+  expect(await verify({ headers: bearer(token), logger })).toBe(null);
+  expect(logger.debug).toHaveBeenCalled();
+});
+
+test('jwt verify rejects a token signed with an algorithm outside the allowlist', async () => {
+  const logger = mockLogger();
+  const verify = jwt({
+    logger,
+    properties: { secret: hmacSecret, algorithms: ['HS256'] },
+    strategyId: 'service-jwt',
+  });
+  const token = await signHmac({ sub: 's' }, { alg: 'HS384' });
+  expect(await verify({ headers: bearer(token), logger })).toBe(null);
+});
+
+test('jwt verify rejects an unsigned alg none token', async () => {
+  const logger = mockLogger();
+  const verify = jwt({
+    logger,
+    properties: { secret: hmacSecret, algorithms: ['HS256'] },
+    strategyId: 'service-jwt',
+  });
+  const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ sub: 's' })).toString('base64url');
+  expect(await verify({ headers: bearer(`${header}.${payload}.`), logger })).toBe(null);
+});
+
+test('jwt verify rejects wrong issuer and wrong audience', async () => {
+  const logger = mockLogger();
+  const verify = jwt({
+    logger,
+    properties: {
+      secret: hmacSecret,
+      algorithms: ['HS256'],
+      issuer: 'https://auth.example.com',
+      audience: 'my-api',
+    },
+    strategyId: 'service-jwt',
+  });
+  const wrongIssuer = await signHmac(
+    { sub: 's' },
+    { issuer: 'https://evil.example.com', audience: 'my-api' }
+  );
+  expect(await verify({ headers: bearer(wrongIssuer), logger })).toBe(null);
+  const wrongAudience = await signHmac(
+    { sub: 's' },
+    { issuer: 'https://auth.example.com', audience: 'other-api' }
+  );
+  expect(await verify({ headers: bearer(wrongAudience), logger })).toBe(null);
+  const valid = await signHmac(
+    { sub: 's' },
+    { issuer: 'https://auth.example.com', audience: 'my-api' }
+  );
+  expect(await verify({ headers: bearer(valid), logger })).not.toBe(null);
+});
+
+test('jwt verify returns null without an Authorization Bearer header', async () => {
+  const logger = mockLogger();
+  const verify = jwt({
+    logger,
+    properties: { secret: hmacSecret, algorithms: ['HS256'] },
+    strategyId: 'service-jwt',
+  });
+  expect(await verify({ headers: new Headers({}), logger })).toBe(null);
+  expect(
+    await verify({ headers: new Headers({ Authorization: 'Basic dXNlcjpwYXNz' }), logger })
+  ).toBe(null);
+});
+
+test('jwt warns at startup for an HMAC secret shorter than 32 characters', () => {
+  const logger = mockLogger();
+  jwt({
+    logger,
+    properties: { secret: 'short-secret', algorithms: ['HS256'] },
+    strategyId: 'service-jwt',
+  });
+  expect(logger.warn).toHaveBeenCalledWith(
+    'Auth strategy "service-jwt" "secret" is shorter than 32 characters. Use a long random value, e.g. `openssl rand -base64 32`.'
+  );
+});
+
+test('jwt throws at startup when the secret did not resolve to a string', () => {
+  const logger = mockLogger();
+  expect(() =>
+    jwt({
+      logger,
+      properties: { secret: { _secret: 'MISSING' }, algorithms: ['HS256'] },
+      strategyId: 'service-jwt',
+    })
+  ).toThrow(
+    'Auth strategy "service-jwt" "secret" did not resolve to a string. Check the _secret operator reference and that the secret is set.'
+  );
+});
+
+describe('jwt verify with a JWKS endpoint', () => {
+  let server;
+  let jwksUri;
+  let privateKey;
+
+  beforeAll(async () => {
+    const pair = await generateKeyPair('RS256');
+    privateKey = pair.privateKey;
+    const jwk = await exportJWK(pair.publicKey);
+    jwk.alg = 'RS256';
+    jwk.use = 'sig';
+    jwk.kid = 'test-key';
+    server = http.createServer((req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ keys: [jwk] }));
+    });
+    await new Promise((resolve) => server.listen(0, resolve));
+    jwksUri = `http://127.0.0.1:${server.address().port}/jwks.json`;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  test('jwt verify accepts a token signed by the JWKS key', async () => {
+    const logger = mockLogger();
+    const verify = jwt({
+      logger,
+      properties: { jwksUri, algorithms: ['RS256'] },
+      strategyId: 'external-idp',
+    });
+    const token = await new SignJWT({ sub: 'idp-user' })
+      .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+      .setIssuedAt()
+      .setExpirationTime('5m')
+      .sign(privateKey);
+    const match = await verify({ headers: bearer(token), logger });
+    expect(match).toEqual({ attributes: {}, roles: [], user: { id: 'idp-user' } });
+  });
+
+  test('jwt verify rejects a token signed by a different key', async () => {
+    const logger = mockLogger();
+    const verify = jwt({
+      logger,
+      properties: { jwksUri, algorithms: ['RS256'] },
+      strategyId: 'external-idp',
+    });
+    const otherPair = await generateKeyPair('RS256');
+    const token = await new SignJWT({ sub: 'idp-user' })
+      .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+      .setIssuedAt()
+      .setExpirationTime('5m')
+      .sign(otherPair.privateKey);
+    expect(await verify({ headers: bearer(token), logger })).toBe(null);
+  });
+});

--- a/packages/plugins/plugins/plugin-better-auth/src/types.js
+++ b/packages/plugins/plugins/plugin-better-auth/src/types.js
@@ -54,5 +54,6 @@ export default {
       'WeChat',
       'Zoom',
     ],
+    strategies: ['apiKey', 'jwt'],
   },
 };

--- a/packages/servers/server-dev/lib/server/auth/getStrategies.js
+++ b/packages/servers/server-dev/lib/server/auth/getStrategies.js
@@ -1,0 +1,40 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { getAuthStrategies } from '@lowdefy/api';
+import { getSecretsFromEnv } from '@lowdefy/node-utils';
+
+import appMeta from '../../build/appMeta.js';
+import authJson from '../../build/auth.js';
+import strategyTypes from '../../../build/plugins/auth/strategies.js';
+
+// Returns the API auth strategy verifiers (memoized in @lowdefy/api), or an
+// empty list when auth is not configured - resolveAuthentication tries them
+// in config order when no session resolves.
+function getStrategies({ logger }) {
+  if (authJson.configured !== true) {
+    return [];
+  }
+  return getAuthStrategies({
+    appMeta,
+    authJson,
+    logger,
+    plugins: { strategies: strategyTypes },
+    secrets: getSecretsFromEnv(),
+  });
+}
+
+export default getStrategies;

--- a/packages/servers/server-dev/manager/utils/createCustomPluginTypesMap.mjs
+++ b/packages/servers/server-dev/manager/utils/createCustomPluginTypesMap.mjs
@@ -43,6 +43,7 @@ async function createCustomPluginTypesMap({ directories, logger }) {
     auth: {
       adapters: {},
       providers: {},
+      strategies: {},
     },
     blockMetas: {},
     blocks: {},

--- a/packages/servers/server-dev/src/middleware/apiContext.js
+++ b/packages/servers/server-dev/src/middleware/apiContext.js
@@ -28,6 +28,7 @@ import createLogger from '../../lib/server/log/createLogger.js';
 import fileCache from '../../lib/server/fileCache.js';
 import getAuth from '../../lib/server/auth/getAuth.js';
 import getMockUser from '../../lib/server/auth/getMockUser.js';
+import getStrategies from '../../lib/server/auth/getStrategies.js';
 import i18nConfig from '../../lib/build/i18n.js';
 import loadDynamicJsMap from '../../lib/server/loadDynamicJsMap.js';
 import logRequest from '../../lib/server/log/logRequest.js';
@@ -84,6 +85,7 @@ function apiContext() {
         await resolveAuthentication(context, {
           auth: getAuth({ logger: context.logger }),
           headers: c.req.raw.headers,
+          strategies: getStrategies({ logger: context.logger }),
         });
       }
     }

--- a/packages/servers/server-dev/src/middleware/errorHandler.js
+++ b/packages/servers/server-dev/src/middleware/errorHandler.js
@@ -21,13 +21,24 @@ import { serializer } from '@lowdefy/helpers';
 // JSON the old apiWrapper returned; page routes get a plain 500.
 function createErrorHandler({ basePath = '', logger }) {
   return async function errorHandler(error, c) {
+    const path = basePath ? c.req.path.replace(basePath, '') : c.req.path;
+    // Unauthenticated requests to protected endpoints are expected traffic -
+    // one warning line and a 401, skipping the structured error log so
+    // probing cannot flood it. Keys strictly on the error name; the 500 path
+    // below is untouched.
+    if (error.name === 'AuthenticationError') {
+      logger.warn(`Unauthenticated request: ${c.req.method} ${c.req.path}`);
+      if (path.startsWith('/api/')) {
+        return c.json({ name: error.name, message: error.message }, 401);
+      }
+      return c.text('Unauthorized', 401);
+    }
     const context = c.get('lowdefyContext');
     if (context) {
       await context.handleError(error);
     } else {
       logger.error(error);
     }
-    const path = basePath ? c.req.path.replace(basePath, '') : c.req.path;
     if (path.startsWith('/api/')) {
       const serialized = serializer.serialize(error);
       if (serialized?.['~e']) {

--- a/packages/servers/server-e2e/lowdefy/createCustomPluginTypesMap.mjs
+++ b/packages/servers/server-e2e/lowdefy/createCustomPluginTypesMap.mjs
@@ -43,6 +43,7 @@ async function createCustomPluginTypesMap({ directories }) {
     auth: {
       adapters: {},
       providers: {},
+      strategies: {},
     },
     blockMetas: {},
     blocks: {},

--- a/packages/servers/server/lib/server/auth/getStrategies.js
+++ b/packages/servers/server/lib/server/auth/getStrategies.js
@@ -1,0 +1,40 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { getAuthStrategies } from '@lowdefy/api';
+import { getSecretsFromEnv } from '@lowdefy/node-utils';
+
+import appMeta from '../../build/appMeta.js';
+import authJson from '../../build/auth.js';
+import strategyTypes from '../../../build/plugins/auth/strategies.js';
+
+// Returns the API auth strategy verifiers (memoized in @lowdefy/api), or an
+// empty list when auth is not configured - resolveAuthentication tries them
+// in config order when no session resolves.
+function getStrategies({ logger }) {
+  if (authJson.configured !== true) {
+    return [];
+  }
+  return getAuthStrategies({
+    appMeta,
+    authJson,
+    logger,
+    plugins: { strategies: strategyTypes },
+    secrets: getSecretsFromEnv(),
+  });
+}
+
+export default getStrategies;

--- a/packages/servers/server/lowdefy/createCustomPluginTypesMap.mjs
+++ b/packages/servers/server/lowdefy/createCustomPluginTypesMap.mjs
@@ -43,6 +43,7 @@ async function createCustomPluginTypesMap({ directories }) {
     auth: {
       adapters: {},
       providers: {},
+      strategies: {},
     },
     blockMetas: {},
     blocks: {},

--- a/packages/servers/server/src/middleware/apiContext.js
+++ b/packages/servers/server/src/middleware/apiContext.js
@@ -27,6 +27,7 @@ import createHandleError from '../../lib/server/log/createHandleError.js';
 import createLogger from '../../lib/server/log/createLogger.js';
 import fileCache from '../../lib/server/fileCache.js';
 import getAuth from '../../lib/server/auth/getAuth.js';
+import getStrategies from '../../lib/server/auth/getStrategies.js';
 import i18nConfig from '../../lib/build/i18n.js';
 import jsMap from '../../build/plugins/operators/serverJsMap.js';
 import logRequest from '../../lib/server/log/logRequest.js';
@@ -79,6 +80,7 @@ function apiContext() {
       await resolveAuthentication(context, {
         auth: getAuth({ logger: context.logger }),
         headers: c.req.raw.headers,
+        strategies: getStrategies({ logger: context.logger }),
       });
       // Set Sentry user context for authenticated requests
       setSentryUser({

--- a/packages/servers/server/src/middleware/errorHandler.js
+++ b/packages/servers/server/src/middleware/errorHandler.js
@@ -23,6 +23,18 @@ import { serializer } from '@lowdefy/helpers';
 // page routes get a plain 500.
 function createErrorHandler({ basePath = '', logger }) {
   return async function errorHandler(error, c) {
+    const path = basePath ? c.req.path.replace(basePath, '') : c.req.path;
+    // Unauthenticated requests to protected endpoints are expected traffic -
+    // one warning line and a 401, skipping the structured error log and the
+    // Sentry capture so probing cannot flood either. Keys strictly on the
+    // error name; the 500 path below is untouched.
+    if (error.name === 'AuthenticationError') {
+      logger.warn(`Unauthenticated request: ${c.req.method} ${c.req.path}`);
+      if (path.startsWith('/api/')) {
+        return c.json({ name: error.name, message: error.message }, 401);
+      }
+      return c.text('Unauthorized', 401);
+    }
     const context = c.get('lowdefyContext');
     if (context) {
       await context.handleError(error);
@@ -32,7 +44,6 @@ function createErrorHandler({ basePath = '', logger }) {
     if (process.env.SENTRY_DSN) {
       Sentry.captureException(error);
     }
-    const path = basePath ? c.req.path.replace(basePath, '') : c.req.path;
     if (path.startsWith('/api/')) {
       const serialized = serializer.serialize(error);
       if (serialized?.['~e']) {

--- a/packages/utils/errors/src/AuthenticationError.js
+++ b/packages/utils/errors/src/AuthenticationError.js
@@ -1,0 +1,29 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Thrown when a request to a protected endpoint carries no successful
+// authentication - the caller should fix its credentials (401). The server
+// error handlers branch on the name before the structured-log and Sentry
+// pipeline, so probing traffic produces a one-line warning, not error logs.
+class AuthenticationError extends Error {
+  constructor(message = 'Authentication required.', { cause } = {}) {
+    super(message, { cause });
+    this.name = 'AuthenticationError';
+    this.isLowdefyError = true;
+  }
+}
+
+export default AuthenticationError;

--- a/packages/utils/errors/src/index.js
+++ b/packages/utils/errors/src/index.js
@@ -49,6 +49,11 @@
  *    - Caught: Caller of the action/resolver; signals "the called routine deliberately failed" as distinct from a system fault
  *    - Format: [User Error] message
  *
+ * 7. AuthenticationError - Unauthenticated request to a protected endpoint
+ *    - Thrown: API/request authorization when no caller resolved
+ *    - Caught: Server error handlers, before structured logging and Sentry (401)
+ *    - Format: [AuthenticationError] message
+ *
  * Location Resolution Utilities:
  *   resolveConfigLocation     - Sync: configKey → {source, config} via keyMap/refMap
  *   resolveErrorLocation      - Sync: unified resolver (configKey or filePath/lineNumber)
@@ -57,6 +62,7 @@
  */
 
 import ActionError from './ActionError.js';
+import AuthenticationError from './AuthenticationError.js';
 import BlockError from './BlockError.js';
 import BuildError from './BuildError.js';
 import ConfigError from './ConfigError.js';
@@ -75,6 +81,7 @@ import UserError from './UserError.js';
 
 export {
   ActionError,
+  AuthenticationError,
   BlockError,
   BuildError,
   ConfigError,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
     dependencies:
       '@better-auth/passkey':
         specifier: ^1.6.23
-        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.2.0)(mysql2@3.22.3(@types/node@24.13.2))(next@14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(pg@8.20.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(better-call@1.3.7(zod@4.3.6))(nanostores@1.4.0)
+        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.2.0)(mysql2@3.22.3(@types/node@24.13.2))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(pg@8.20.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(better-call@1.3.7(zod@4.3.6))(nanostores@1.4.0)
       '@lowdefy/ajv':
         specifier: 5.3.0
         version: link:../utils/ajv
@@ -86,7 +86,7 @@ importers:
         version: link:../plugins/operators/operators-js
       better-auth:
         specifier: ^1.6.23
-        version: 1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.2.0)(mysql2@3.22.3(@types/node@24.13.2))(next@14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(pg@8.20.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.2.0)(mysql2@3.22.3(@types/node@24.13.2))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(pg@8.20.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       nodemailer:
         specifier: 9.0.3
         version: 9.0.3
@@ -1996,6 +1996,13 @@ importers:
         version: 7.1.0
 
   packages/plugins/plugins/plugin-better-auth:
+    dependencies:
+      '@lowdefy/helpers':
+        specifier: 5.3.0
+        version: link:../../../utils/helpers
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
     devDependencies:
       '@swc/cli':
         specifier: 0.8.1
@@ -2003,9 +2010,15 @@ importers:
       '@swc/core':
         specifier: 1.15.32
         version: 1.15.32
+      '@swc/jest':
+        specifier: 0.2.39
+        version: 0.2.39(@swc/core@1.15.32)
       jest:
         specifier: 28.1.3
         version: 28.1.3(@types/node@24.13.2)
+      jest-environment-node:
+        specifier: 28.1.3
+        version: 28.1.3
 
   packages/plugins/plugins/plugin-csv:
     devDependencies:
@@ -13878,14 +13891,14 @@ snapshots:
     optionalDependencies:
       mongodb: 7.2.0
 
-  '@better-auth/passkey@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.2.0)(mysql2@3.22.3(@types/node@24.13.2))(next@14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(pg@8.20.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(better-call@1.3.7(zod@4.3.6))(nanostores@1.4.0)':
+  '@better-auth/passkey@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.2.0)(mysql2@3.22.3(@types/node@24.13.2))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(pg@8.20.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(better-call@1.3.7(zod@4.3.6))(nanostores@1.4.0)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@simplewebauthn/browser': 13.3.0
       '@simplewebauthn/server': 13.3.2
-      better-auth: 1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.2.0)(mysql2@3.22.3(@types/node@24.13.2))(next@14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(pg@8.20.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      better-auth: 1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.2.0)(mysql2@3.22.3(@types/node@24.13.2))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(pg@8.20.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       better-call: 1.3.7(zod@4.3.6)
       nanostores: 1.4.0
       zod: 4.3.6
@@ -17673,6 +17686,37 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.9.19: {}
+
+  better-auth@1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.2.0)(mysql2@3.22.3(@types/node@24.13.2))(next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(pg@8.20.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
+      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(mongodb@7.2.0)
+      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@noble/ciphers': 2.2.0
+      '@noble/hashes': 2.2.0
+      better-call: 1.3.7(zod@4.3.6)
+      defu: 6.1.7
+      jose: 6.2.3
+      kysely: 0.29.2
+      nanostores: 1.4.0
+      zod: 4.3.6
+    optionalDependencies:
+      better-sqlite3: 12.11.1
+      mongodb: 7.2.0
+      mysql2: 3.22.3(@types/node@24.13.2)
+      next: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      pg: 8.20.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
 
   better-auth@1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.2.0)(mysql2@3.22.3(@types/node@24.13.2))(next@14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(pg@8.20.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -22007,6 +22051,34 @@ snapshots:
 
   next-tick@1.1.0: {}
 
+  next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@next/env': 14.2.35
+      '@swc/helpers': 0.5.5
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001769
+      graceful-fs: 4.2.11
+      postcss: 8.4.31
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.29.0)(react@18.2.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 14.2.33
+      '@next/swc-darwin-x64': 14.2.33
+      '@next/swc-linux-arm64-gnu': 14.2.33
+      '@next/swc-linux-arm64-musl': 14.2.33
+      '@next/swc-linux-x64-gnu': 14.2.33
+      '@next/swc-linux-x64-musl': 14.2.33
+      '@next/swc-win32-arm64-msvc': 14.2.33
+      '@next/swc-win32-ia32-msvc': 14.2.33
+      '@next/swc-win32-x64-msvc': 14.2.33
+      '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.59.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    optional: true
+
   next@14.2.35(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.2.35
@@ -22017,7 +22089,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.29.0)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.33
       '@next/swc-darwin-x64': 14.2.33
@@ -22044,7 +22116,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.29.0)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.33
       '@next/swc-darwin-x64': 14.2.33
@@ -23777,10 +23849,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.1(react@18.2.0):
+  styled-jsx@5.1.1(@babel/core@7.29.0)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
+    optionalDependencies:
+      '@babel/core': 7.29.0
 
   stylis@4.3.6: {}
 


### PR DESCRIPTION
Phase 4 of the auth upgrade: API auth strategies per [api-strategies/design.md](https://github.com/lowdefy/lowdefy-design/blob/main/designs/auth-upgrade/api-strategies/design.md). External callers authenticate to Lowdefy API endpoints with a static API key (`X-API-Key`, configurable) or a Bearer JWT (HMAC or JWKS); strategies grant roles and the unchanged role check authorizes. Stacked on #2217 (phase 3) like the other phase PRs — phases 2–3 were already complete on this line, so the parallel-worktree option in the prompt no longer applied and the strategy loop integrates directly against the real phase-3 `resolveAuthentication` seam.

## What changed per package

- **`@lowdefy/errors`** — new `AuthenticationError` (name-keyed, `isLowdefyError`), exported and documented in the class hierarchy.
- **`@lowdefy/build`** — `auth.strategies` registered in the closed auth schema; new `buildAuthStrategies` validates ids unique, types known (`apiKey`, `jwt`), `apiKey` keys present, `jwt` `secret` XOR `jwksUri`, `algorithms` required and non-empty, and writes per-entry defaults (`roles: []`, `attributes: {}`, `headerName: X-API-Key`); `strategies.length > 0` now counts as an authentication mechanism, so a strategies-only block is validly configured with **no database and no login method**; strategy types flow through the plugin type system into a new `plugins/auth/strategies.js` artifact (counters, buildTypes, imports, writeAuthImports, typesMap plumbing); success fixture `95-auth-strategies-app` locks the strategies-only build.
- **`@lowdefy/plugin-better-auth`** — `apiKey` and `jwt` verifier factories exported as `auth/strategies` plugin types. `apiKey`: SHA-256-then-`timingSafeEqual` (constant-time, length-blind), per-key audit identity in the synthetic caller id, startup warning on short keys. `jwt`: `jose` (`^6.2.3`, latest) with HMAC or `createRemoteJWKSet` JWKS, required `algorithms` allowlist, `issuer`/`audience`, `claimMapping` with nested role paths and `attributes.*` paths. Package gains a real jest setup (22 tests, including a live local-JWKS verification).
- **`@lowdefy/api`** — `resolveStrategyCaller` tries strategies in config order when no session resolves (first match wins; session branch stays terminal — a walled-out member never falls through to strategies); caller shape `{ id, authMethod, strategyId, roles, attributes }` with roles = static ∪ claim-derived (deduped) and attributes = static ⊕ claim-mapped (claim wins); the authenticating strategy is logged (`auth_strategy_authenticated`); `createAuthStrategies`/`getAuthStrategies` build verifiers once at startup, resolving `_secret`; `getBetterAuthConfig` constructs BetterAuth **without** a database adapter for strategies-only apps (stateless mode — verified against `better-auth@1.6.23` source: no `database` option → memory adapter, so `getSession` runs guard-free) and skips pinned-org seeding with no database; `authorizeRequest`/`authorizeApiEndpoint` throw `AuthenticationError` for unauthenticated callers on protected routes, keeping the opaque "does not exist" for wrong roles.
- **`@lowdefy/server` / `@lowdefy/server-dev`** — `getStrategies` accessor beside `getAuth`; `apiContext` passes strategies into `resolveAuthentication`; `createErrorHandler` gains the early branch keyed strictly on `error.name === 'AuthenticationError'`: one warning line + 401, before `handleError` and `Sentry.captureException`; custom plugin types maps (incl. server-e2e's) carry the `auth.strategies` store. server-e2e's cookie caller is untouched (pre-resolved carve-out).
- **Fixtures** — `apps/auth-strategies`: strategies-only reference app (no database, no login method) with role-gated `Api` endpoints, a bundled mock IdP (`jwks-server.mjs`: JWKS + RS256 token minting incl. bad-token modes) and HMAC minter (`mint-jwt.mjs`), and a step-by-step README walkthrough. `apps/auth-reference`: strategies block, role-gated `partner-data` + public `whoami` endpoints, walkthrough scenarios 29–32 (session-wins, walled-out-session, claim-derived roles).

## Gate

- ✅ **Authenticates via `X-API-Key`, Bearer JWT HMAC, and JWKS** — verified live against the served `auth-strategies` app: `partner-data` 200 with the key (`caller: "apiKey:partner-access:acme"`), `service-data` 200 with an HMAC token (`caller: "service-1"`), and a JWKS RS256 token from the mock IdP resolving `strategyId: "external-idp"`.
- ✅ **A logged-in session wins over a presented API key** — unit-verified: with a resolved session the strategy verifier is never called, and a session rejected by the membership wall also never falls through (`resolveAuthentication.test.js`). The live two-credential walkthrough is reference-app scenario 30 (needs MongoDB, not available in this run's environment).
- ✅ **No credentials on a protected endpoint → 401, one warning line, no Sentry, no structured log** — verified live: body `{"name":"AuthenticationError","message":...}`, exactly one `⚠ Unauthenticated request: POST /api/endpoints/partner-data` line per request in the server log, zero stack traces or structured error entries.
- ✅ **Valid credentials, wrong roles → opaque "does not exist"** — verified live: partner key on the `api-user`-gated endpoint returns the existing opaque ConfigError, no 403.
- ✅ **Disallowed algorithm / expired / wrong `iss`/`aud` rejected** — verified live: HS384-against-[HS256], expired, wrong-issuer, wrong-audience, and (JWKS) rogue-key tokens all → 401.
- ✅ **Strategy attributes on `_user.attributes`; `id`/`authMethod`/`strategyId` per the design shapes** — verified live via the `caller` endpoint for apiKey (static bag) and JWKS jwt (claim-mapped `attributes.branches: ["west"]`, nested `realm_access.roles`).
- ✅ **Strategies-only fixture builds and serves with no database** — verified live end-to-end; also locked by build fixture 95 (auth.json with `_secret` preserved, no database, artifact emitted).
- ✅ **Build rejects invalid strategy configs** — `buildAuthStrategies.test.js`: both/neither of `secret`/`jwksUri`, missing/empty `algorithms`, missing/empty `keys`, key without `value`, duplicate ids, unknown types.
- ✅ **Full suite passes** — `pnpm test` green across the monorepo (build 1577, api 519, plugin-better-auth 22, servers, errors).

## Design learnings / deviations

- **`jose` lives in `@lowdefy/plugin-better-auth`, not `@lowdefy/api`.** The design's package list puts jose in `@lowdefy/api`, but the `plugins/auth/strategies.js` build artifact resolves types to plugin packages through the same import machinery as adapters/providers — so the verifier factories (the only jose consumers) live with the plugin type declarations, and `@lowdefy/api` hosts the strategy loop, startup construction, and caller assembly. Pinned `jose@^6.2.3` (latest; dedupes with better-auth's `^6.1.3` peer range).
- **Session callers carry no `authMethod: 'session'`.** The engine design's flow diagram annotates the session branch with `authMethod: 'session'`, but phase 3's session branch doesn't set it, and changing the session branch is explicitly out of scope here. Recommend settling in the designs whether the session caller should carry `authMethod`/parity fields — routines that "branch on `_user.authMethod`" currently see `undefined` for session users.
- **Key id fallback.** The design leaves the synthetic id unspecified for keys without an `id`; the key's array index stands in: `apiKey:<strategyId>:<index>`.
- **Short-key warnings** use the engine's existing 32-character bar (`auth.secret` precedent) and also cover a short `jwt` HMAC `secret`, which is equally a static key.
- **Observation for the designs:** static strategy `attributes`/config values keep their build `~k` markers, so raw endpoint JSON shows serializer-wrapped arrays (`{"~arr": [...]}`) to external callers — server-side values are real arrays and the Lowdefy client deserializes transparently, and object-level `~k` noise already exists on every endpoint response, but array wrapping changes the JSON shape an external (non-Lowdefy) consumer sees. Worth a design note on external response hygiene (predates this phase; strategies just make external callers first-class consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
