### PR TITLE
fix(build): Stop re-resolving module entry config in the app buildRefs pass

### DIFF
--- a/packages/build/src/build/buildRefs/buildRefs.js
+++ b/packages/build/src/build/buildRefs/buildRefs.js
@@ -46,13 +46,22 @@ async function buildRefs({ context, shallowOptions }) {
     env: process.env,
     lowdefyApp: context.appMeta,
     dynamicIdentifiers,
-    shouldStop: shallowOptions
-      ? // Strip page content (blocks, events, etc.) from ref-backed pages so
+    shouldStop: (path, refId) => {
+      // Module entry vars/connections were already resolved by parseLowdefyYaml
+      // (same predicate) and live on context.modules — preserve the raw blobs so
+      // the app pass doesn't pull and walk their refs a second time. buildModules
+      // reads entry ids only and deletes components.modules before testSchema.
+      if (/^modules\.\d+\.vars$/.test(path)) return 'preserve';
+      if (/^modules\.\d+\.connections$/.test(path)) return 'preserve';
+      if (shallowOptions) {
+        // Strip page content (blocks, events, etc.) from ref-backed pages so
         // JIT can re-resolve them from source files. Inline pages (defined
         // directly in lowdefy.yaml) live in the root ref and have no separate
         // source file — their content must be preserved for buildShallowPages.
-        (path, refId) => isPageContentPath(path) && refId !== refDef.id
-      : null,
+        return isPageContentPath(path) && refId !== refDef.id;
+      }
+      return null;
+    },
   });
 
   const content = await getRefContent({

--- a/packages/build/src/build/buildRefs/buildRefs.test.js
+++ b/packages/build/src/build/buildRefs/buildRefs.test.js
@@ -2746,3 +2746,69 @@ blocks:
     });
   });
 });
+
+describe('module entry config preservation', () => {
+  test('preserves modules.<i>.vars and connections without resolving their refs', async () => {
+    const files = [
+      {
+        path: 'lowdefy.yaml',
+        content: `
+modules:
+  - id: team-users
+    source: "file:../team-users"
+    vars:
+      slot:
+        _ref: shared-vars.yaml
+    connections:
+      users-db: my-app-mongodb
+pages:
+  - id: home
+    type: Box
+`,
+      },
+      {
+        path: 'shared-vars.yaml',
+        content: `title: Shared`,
+      },
+    ];
+    mockReadConfigFile.mockImplementation(readConfigFileMockImplementation(files));
+    const res = await buildRefs({ context });
+    expect(context.errors).toHaveLength(0);
+    // Raw blobs preserved — parseLowdefyYaml already resolved these onto
+    // context.modules; the app pass must not resolve them a second time.
+    expect(res.modules[0].vars).toEqual({ slot: { _ref: 'shared-vars.yaml' } });
+    expect(res.modules[0].connections).toEqual({ 'users-db': 'my-app-mongodb' });
+    // The var ref's file was never pulled by the app pass.
+    const pulledPaths = mockReadConfigFile.mock.calls.map(([filePath]) => filePath);
+    expect(pulledPaths).not.toContain('shared-vars.yaml');
+  });
+
+  test('refs outside module entry config still resolve in the app pass', async () => {
+    const files = [
+      {
+        path: 'lowdefy.yaml',
+        content: `
+modules:
+  - id: team-users
+    source: "file:../team-users"
+    vars:
+      title: My Title
+pages:
+  - _ref: page.yaml
+`,
+      },
+      {
+        path: 'page.yaml',
+        content: `
+id: home
+type: Box
+`,
+      },
+    ];
+    mockReadConfigFile.mockImplementation(readConfigFileMockImplementation(files));
+    const res = await buildRefs({ context });
+    expect(context.errors).toHaveLength(0);
+    expect(res.pages).toEqual([{ id: 'home', type: 'Box' }]);
+    expect(res.modules[0].vars).toEqual({ title: 'My Title' });
+  });
+});


### PR DESCRIPTION
## What

`parseLowdefyYaml` resolves `modules.<i>.vars` and `modules.<i>.connections` once, preserving them onto `context.modules` — but the app `buildRefs` pass re-read and re-resolved the whole of `lowdefy.yaml`, pulling and walking cross-module refs a second time. The result was discarded: `buildModules` reads entry ids only and takes everything else from `context.modules`. Cost: duplicate file pulls, duplicate walks, duplicate `refMap`/`unresolvedRefVars` writes, and a second resolution that could diverge from the one the modules actually use.

The app pass now `'preserve'`s those two paths using the same predicate `parseLowdefyYaml` uses, composed with (not replacing) the shallow/JIT page-content predicate. Schema safety is by ordering: `buildModules` runs before `testSchema` and deletes `components.modules`, so the preserved raw blobs are never validated.

Implements item 5 of the buildrefs-cleanups design (its own PR per the design's sequencing, with snapshot verification). Stacked on #2221; independent of #2222.

## Tests

- New: raw blobs preserved and the var-ref file never pulled by the app pass; refs outside module entry config still resolve.
- Full `packages/build` suite green including artifact snapshots (parity): 118 suites / 1447 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3yfNz71wS5NPBihMf7YHH