### PR TITLE
fix(build): Error on _var inside operator-generated components sections

### DIFF
--- a/packages/build/src/build/registerModules.js
+++ b/packages/build/src/build/registerModules.js
@@ -76,6 +76,53 @@ function suggestBuildOperator(operatorKey) {
   return `_build.${operatorKey.slice(1)}`;
 }
 
+// Component bodies are preserved by config path (components.<i>.component), so
+// bodies under an operator object at `components` itself or at an array element
+// escape preservation and resolve eagerly during the manifest walk. That is
+// harmless for static bodies (operator-composed component lists are supported —
+// pinned by fixture 81-cross-module-build-op-components), but a _var in such a
+// body resolves against the manifest walk's scope instead of the consumer's
+// per-ref vars — a silently wrong value. Error on that combination explicitly.
+// A _ref at either position is fully safe: it resolves top-down, so paths
+// inside the ref'd file still match the preserve regex. An operator at
+// components.<i>.component itself is inside the preserved body and is fine.
+function findVarNode(value) {
+  if (type.isArray(value)) {
+    for (const item of value) {
+      const found = findVarNode(item);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (!type.isObject(value)) return null;
+  if (getRuntimeOperatorKey(value) === '_var') return value;
+  for (const key of Object.keys(value)) {
+    const found = findVarNode(value[key]);
+    if (found) return found;
+  }
+  return null;
+}
+
+function assertStaticComponentsList({ components, entryId, filePath }) {
+  if (!type.isObject(components) && !type.isArray(components)) return;
+  const check = (value, position) => {
+    const operatorKey = getRuntimeOperatorKey(value);
+    if (operatorKey && operatorKey !== '_ref' && findVarNode(value)) {
+      throw new ConfigError(
+        `Module "${entryId}": _var inside an operator-generated components section ` +
+          `cannot resolve per consumer. Found "${operatorKey}" at ${position} with a _var ` +
+          `in its content. Define components whose bodies use _var as static ` +
+          `{ id, component } list items so the bodies are preserved.`,
+        { filePath }
+      );
+    }
+  };
+  check(components, '"components"');
+  if (type.isArray(components)) {
+    components.forEach((item, i) => check(item, `"components.${i}"`));
+  }
+}
+
 function validateVarTypes(varDefs, resolvedVarCache, entryId, source, prefix = '') {
   for (const [varName, varDef] of Object.entries(varDefs)) {
     const fullName = prefix ? `${prefix}.${varName}` : varName;
@@ -140,6 +187,14 @@ async function resolveLocalManifest({ entry, resolvedPaths, context }) {
   // The absolute path works because path.resolve(configDir, absolutePath) = absolutePath.
   const refDef = makeRefDefinition(moduleYamlPath, null, context.refMap);
   const content = await getRefContent({ context, refDef, referencedFrom: null });
+
+  if (type.isObject(content)) {
+    assertStaticComponentsList({
+      components: content.components,
+      entryId: entry.id,
+      filePath: moduleYamlPath,
+    });
+  }
 
   // Run walker with shouldStop preserving content that may contain cross-module refs
   const ctx = new WalkContext({
@@ -249,6 +304,14 @@ async function resolveFullManifest({ entryId, context }) {
   const { manifest, packageRoot, moduleRoot, moduleDependencies, refDef } = moduleEntry;
 
   const moduleYamlPath = path.join(moduleRoot, 'module.lowdefy.yaml');
+
+  if (type.isObject(manifest)) {
+    assertStaticComponentsList({
+      components: manifest.components,
+      entryId,
+      filePath: moduleYamlPath,
+    });
+  }
 
   const ctx = new WalkContext({
     buildContext: context,

--- a/packages/build/src/build/registerModules.test.js
+++ b/packages/build/src/build/registerModules.test.js
@@ -851,3 +851,135 @@ pages:
     expect.objectContaining({ id: 'good-page', type: 'Box' }),
   ]);
 });
+
+describe('operator-generated components sections', () => {
+  const resolveLocal = async (context, manifestContent) => {
+    const files = [
+      { path: '/modules/team-users/module.lowdefy.yaml', content: manifestContent },
+    ];
+    mockReadConfigFile.mockImplementation(readConfigFileMockImplementation(files));
+    return resolveLocalManifest({
+      entry: { id: 'team-users', source: 'file:../modules/team-users', vars: {} },
+      resolvedPaths: {
+        packageRoot: '/modules/team-users',
+        moduleRoot: '/modules/team-users',
+        isLocal: true,
+      },
+      context,
+    });
+  };
+
+  test('throws when the components value is an operator whose content uses _var', async () => {
+    const context = createTestContext();
+    await expect(
+      resolveLocal(
+        context,
+        `
+components:
+  _build.array.map:
+    on: [a, b]
+    map:
+      id: { _var: item }
+      component: { type: Box }
+`
+      )
+    ).rejects.toThrow(
+      'Module "team-users": _var inside an operator-generated components section ' +
+        'cannot resolve per consumer. Found "_build.array.map" at "components" with a _var'
+    );
+  });
+
+  test('throws when a components array element is an operator whose content uses _var', async () => {
+    const context = createTestContext();
+    await expect(
+      resolveLocal(
+        context,
+        `
+components:
+  - id: static-one
+    component: { type: Box }
+  - _build.if:
+      test: true
+      then:
+        id: dyn
+        component:
+          type: Box
+          properties: { content: { _var: text } }
+`
+      )
+    ).rejects.toThrow(
+      'Module "team-users": _var inside an operator-generated components section ' +
+        'cannot resolve per consumer. Found "_build.if" at "components.1" with a _var'
+    );
+  });
+
+  test('allows var-free operator-composed components sections (fixture 81 contract)', async () => {
+    const context = createTestContext();
+    await resolveLocal(
+      context,
+      `
+components:
+  _build.array.concat:
+    - - id: inline-one
+        component: { type: Box }
+    - - id: inline-two
+        component: { type: Title }
+`
+    );
+    expect(context.errors).toEqual([]);
+    const components = context.modules['team-users'].manifest.components;
+    expect(components.map((c) => c.id)).toEqual(['inline-one', 'inline-two']);
+  });
+
+  test('allows _var inside a preserved body at components.<i>.component', async () => {
+    const context = createTestContext();
+    await resolveLocal(
+      context,
+      `
+components:
+  - id: dynamic-body
+    component:
+      type: Box
+      blocks:
+        - _var: content
+`
+    );
+    // Body preserved raw — the _var survives un-resolved for per-consumer resolution.
+    const body = context.modules['team-users'].manifest.components[0].component;
+    expect(body.blocks[0]).toEqual({ _var: 'content' });
+  });
+
+  test('allows components section composed via _ref', async () => {
+    const context = createTestContext();
+    const files = [
+      {
+        path: '/modules/team-users/module.lowdefy.yaml',
+        content: `
+components:
+  _ref: components.yaml
+`,
+      },
+      {
+        path: '/modules/team-users/components.yaml',
+        content: `
+- id: from-file
+  component: { type: Box }
+`,
+      },
+    ];
+    mockReadConfigFile.mockImplementation(readConfigFileMockImplementation(files));
+    await resolveLocalManifest({
+      entry: { id: 'team-users', source: 'file:../modules/team-users', vars: {} },
+      resolvedPaths: {
+        packageRoot: '/modules/team-users',
+        moduleRoot: '/modules/team-users',
+        isLocal: true,
+      },
+      context,
+    });
+    expect(context.modules['team-users'].manifest.components[0].id).toBe('from-file');
+    expect(context.modules['team-users'].manifest.components[0].component).toEqual({
+      type: 'Box',
+    });
+  });
+});


### PR DESCRIPTION
## What

The preserve regex `/^components\.\d+\.component$/` matches by config path, so bodies under an operator-generated components section (e.g. `_build.array.map` / `_build.array.concat` at the section value or an array element) escape preservation and resolve eagerly during the manifest walk.

**Implementation discovery that narrowed the design's boundary:** the success fixture `81-cross-module-build-op-components` snapshot-pins *var-free* operator-composed components sections as supported behavior — the blanket "dynamic component lists are not supported" error from the design broke it. The eager resolution is harmless for static bodies; the silent wrong-value the design targets happens only when a **`_var`** sits in the escaped subtree (it resolves against the manifest walk's scope instead of the consumer's per-ref vars).

So the boundary is now: a pre-walk scan in `resolveLocalManifest`/`resolveFullManifest` errors **only when an operator-generated section contains a `_var`**:

- operator at `components` (or `components.<i>`) with a `_var` in its content → `ConfigError`
- var-free operator composition → allowed (fixture-81 contract, plus a unit test pinning it)
- `_var` inside a preserved `components.<i>.component` body → allowed (that's the supported per-consumer mechanism)
- `_ref` at any position → allowed (resolves top-down; preserve paths stay intact)

Known residual (interim boundary): a `_ref`-wrapped body *inside* the operator content whose target file uses `_var` can't be seen by the static scan — the deferred-content-records design's Phase C.5 owns the complete fix. The buildrefs-cleanups design doc (item 4) is being updated to record this revised decision.

Implements item 4 of the buildrefs-cleanups design. Stacked on #2221; independent of #2222/#2223.

## Tests

Four boundary cases (two error, two allowed); full `packages/build` suite green including the fixture-81 snapshot: 118 suites / 1450 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3yfNz71wS5NPBihMf7YHH