### PR TITLE
refactor(build): clone unification — cloneWithMarkers, ~deferredFrom deleted

### DIFF
--- a/.changeset/feat-deferred-content-records.md
+++ b/.changeset/feat-deferred-content-records.md
@@ -1,0 +1,31 @@
+---
+'@lowdefy/build': minor
+'@lowdefy/server-dev': patch
+---
+
+feat(build): Deferred-content records — one registry for all module deferral.
+
+Module deferral (component bodies, menu links, var defaults, entry
+vars/connections) moves from fragile in-tree markers onto a build-level record
+registry with demand-driven, wait-graph-guarded resolution. Entry order no
+longer matters for mutually-embedding modules, cycle errors name the actual
+value chain (e.g. `a:consumerVars.x → b:vars.y.default → a:consumerVars.x`),
+and the entry state machine, `~deferredModuleRef`/`~deferredFrom` markers, and
+per-context resolve chains are deleted. A new `deferredRecords.json` build
+artifact carries record bodies for JIT; the dev server hydrates the registry
+from it.
+
+User-visible changes:
+- New config errors: `~deferred` is a reserved key; `_module.var` in manifest
+  headers or component/menu ids errors (export names are module-static); `_var`
+  inside an operator-generated `components:` section errors (var-free operator
+  composition keeps working).
+- Module ref errors now list available component/menu ids and distinguish a
+  missing export from an empty one.
+- Lazy semantics: a broken var default or a cyclic menu that nothing consumes
+  no longer fails the build — errors surface at consumption.
+
+Also includes the buildRefs cleanups: single marker-preserving clone
+(`cloneWithMarkers`), no redundant clones or duplicate `lowdefy.yaml`
+re-resolution in the app pass, `validateModuleSecrets` walks instead of
+cloning, and a shared `expectTerminates` test guard.

--- a/packages/build/src/build/buildModuleDefs.js
+++ b/packages/build/src/build/buildModuleDefs.js
@@ -60,11 +60,12 @@ async function parseLowdefyYaml({ context }) {
     dynamicIdentifiers,
     shouldStop: (path) => {
       // Defer entry vars and connections: they may contain cross-module
-      // refs that require modules to be registered first.
-      if (/^modules\.\d+\.vars$/.test(path)) return 'preserve';
-      if (/^modules\.\d+\.connections$/.test(path)) return 'preserve';
+      // refs that require modules to be registered first. Non-modules keys
+      // stay raw for the app buildRefs pass.
+      if (/^modules\.\d+\.vars$/.test(path)) return 'skip';
+      if (/^modules\.\d+\.connections$/.test(path)) return 'skip';
       if (path.startsWith('modules')) return false;
-      return 'preserve';
+      return 'skip';
     },
   });
 

--- a/packages/build/src/build/buildModuleDefs.test.js
+++ b/packages/build/src/build/buildModuleDefs.test.js
@@ -1728,3 +1728,138 @@ pages:
     }
   );
 });
+
+describe('build operators over deferred operands', () => {
+  const mockModulePaths3 = (ids) =>
+    Object.fromEntries(
+      ids.map((id) => [id, { packageRoot: `/${id}`, moduleRoot: `/${id}`, isLocal: true }])
+    );
+
+  test('a _build operator with a nested module-ref operand folds after demand, not during prepare', async () => {
+    const context = createTestContext();
+    const files = [
+      {
+        path: 'lowdefy.yaml',
+        content: `
+lowdefy: 4.0.0
+modules:
+  - id: companies
+    source: "file:../companies"
+    vars:
+      slot:
+        _ref:
+          module: layout
+          component: wrapper
+          vars:
+            on_complete:
+              _build.array.concat:
+                - _ref:
+                    module: actions
+                    component: complete-actions
+                - - id: extra
+                    type: SetState
+  - id: layout
+    source: "file:../layout"
+  - id: actions
+    source: "file:../actions"
+`,
+      },
+      {
+        path: '/companies/module.lowdefy.yaml',
+        content: `
+vars:
+  slot: {}
+pages: []
+`,
+      },
+      {
+        path: '/layout/module.lowdefy.yaml',
+        content: `
+components:
+  - id: wrapper
+    component:
+      type: Box
+      events:
+        onComplete:
+          _var: on_complete
+pages: []
+`,
+      },
+      {
+        path: '/actions/module.lowdefy.yaml',
+        content: `
+components:
+  - id: complete-actions
+    component:
+      - id: notify
+        type: Message
+pages: []
+`,
+      },
+    ];
+    mockReadConfigFile.mockImplementation(readConfigFileMockImplementation(files));
+    mockFetchModules.mockResolvedValue(mockModulePaths3(['companies', 'layout', 'actions']));
+
+    await expectTerminates(buildModuleDefs({ context }), 4000, 'deferred operand fold hang');
+
+    expect(context.errors).toEqual([]);
+    expect(context.modules['companies'].consumerVars.slot.events.onComplete).toEqual([
+      { id: 'notify', type: 'Message' },
+      { id: 'extra', type: 'SetState' },
+    ]);
+  });
+
+  test('a _build operator with a deferred operand directly in entry vars folds at the sweep', async () => {
+    const context = createTestContext();
+    const files = [
+      {
+        path: 'lowdefy.yaml',
+        content: `
+lowdefy: 4.0.0
+modules:
+  - id: companies
+    source: "file:../companies"
+    vars:
+      merged:
+        _build.array.concat:
+          - _ref:
+              module: actions
+              component: complete-actions
+          - - id: extra
+              type: SetState
+  - id: actions
+    source: "file:../actions"
+`,
+      },
+      {
+        path: '/companies/module.lowdefy.yaml',
+        content: `
+vars:
+  merged: {}
+pages: []
+`,
+      },
+      {
+        path: '/actions/module.lowdefy.yaml',
+        content: `
+components:
+  - id: complete-actions
+    component:
+      - id: notify
+        type: Message
+pages: []
+`,
+      },
+    ];
+    mockReadConfigFile.mockImplementation(readConfigFileMockImplementation(files));
+    mockFetchModules.mockResolvedValue(mockModulePaths3(['companies', 'actions']));
+
+    await expectTerminates(buildModuleDefs({ context }), 4000, 'deferred operand fold hang');
+
+    expect(context.errors).toEqual([]);
+    expect(context.modules['companies'].consumerVars.merged).toEqual([
+      { id: 'notify', type: 'Message' },
+      { id: 'extra', type: 'SetState' },
+    ]);
+  });
+});

--- a/packages/build/src/build/buildRefs/cloneWithMarkers.js
+++ b/packages/build/src/build/buildRefs/cloneWithMarkers.js
@@ -1,0 +1,54 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { type } from '@lowdefy/helpers';
+
+import setNonEnumerableProperty from '../../utils/setNonEnumerableProperty.js';
+
+// THE deep clone for config subtrees inside buildRefs — preserves the
+// non-enumerable provenance markers (~r ~l ~k ~arr), and with assignRefId set
+// stamps ~r on nodes that have none (pass nothing to preserve the template's
+// existing markers only). Non-plain values (Date) pass by reference; nothing
+// in the build mutates them.
+//
+// Do not use serializer.copy on config subtrees in buildRefs: it round-trips
+// the same markers but pays a JSON round-trip and re-instantiates Dates — the
+// serializer is the artifact boundary, this is the in-memory clone.
+function cloneWithMarkers(value, { assignRefId = null } = {}) {
+  if (!type.isObject(value) && !type.isArray(value)) return value;
+  let clone;
+  if (type.isArray(value)) {
+    clone = value.map((item) => cloneWithMarkers(item, { assignRefId }));
+  } else {
+    clone = {};
+    for (const key of Object.keys(value)) {
+      clone[key] = cloneWithMarkers(value[key], { assignRefId });
+    }
+  }
+  if (value['~r'] !== undefined) {
+    setNonEnumerableProperty(clone, '~r', value['~r']);
+  } else if (assignRefId) {
+    setNonEnumerableProperty(clone, '~r', assignRefId);
+  }
+  for (const marker of ['~l', '~k', '~arr']) {
+    if (value[marker] !== undefined) {
+      setNonEnumerableProperty(clone, marker, value[marker]);
+    }
+  }
+  return clone;
+}
+
+export default cloneWithMarkers;

--- a/packages/build/src/build/buildRefs/cloneWithMarkers.test.js
+++ b/packages/build/src/build/buildRefs/cloneWithMarkers.test.js
@@ -1,0 +1,65 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import cloneWithMarkers from './cloneWithMarkers.js';
+import setNonEnumerableProperty from '../../utils/setNonEnumerableProperty.js';
+
+test('deep-clones objects and arrays preserving ~r/~l/~k/~arr non-enumerably', () => {
+  const inner = { type: 'Box' };
+  setNonEnumerableProperty(inner, '~r', 'ref_1');
+  setNonEnumerableProperty(inner, '~l', 7);
+  const list = [inner];
+  setNonEnumerableProperty(list, '~k', 'k_2');
+  setNonEnumerableProperty(list, '~arr', 'a_3');
+  const value = { blocks: list };
+
+  const clone = cloneWithMarkers(value);
+
+  expect(clone).not.toBe(value);
+  expect(clone.blocks).not.toBe(list);
+  expect(clone.blocks[0]).not.toBe(inner);
+  expect(clone.blocks[0]).toEqual({ type: 'Box' });
+  expect(clone.blocks[0]['~r']).toBe('ref_1');
+  expect(clone.blocks[0]['~l']).toBe(7);
+  expect(clone.blocks['~k']).toBe('k_2');
+  expect(clone.blocks['~arr']).toBe('a_3');
+  // Markers stay non-enumerable.
+  expect(Object.keys(clone.blocks[0])).toEqual(['type']);
+});
+
+test('assignRefId stamps ~r only on nodes that have none', () => {
+  const tagged = { a: 1 };
+  setNonEnumerableProperty(tagged, '~r', 'template_ref');
+  const value = { tagged, untagged: { b: 2 } };
+
+  const clone = cloneWithMarkers(value, { assignRefId: 'consumer_ref' });
+
+  expect(clone['~r']).toBe('consumer_ref');
+  expect(clone.tagged['~r']).toBe('template_ref');
+  expect(clone.untagged['~r']).toBe('consumer_ref');
+});
+
+test('without assignRefId, untagged nodes stay untagged', () => {
+  const clone = cloneWithMarkers({ a: { b: 1 } });
+  expect(clone['~r']).toBeUndefined();
+  expect(clone.a['~r']).toBeUndefined();
+});
+
+test('non-plain values pass by reference', () => {
+  const date = new Date('2026-01-01');
+  const clone = cloneWithMarkers({ stamp: date });
+  expect(clone.stamp).toBe(date);
+});

--- a/packages/build/src/build/buildRefs/deferredRegistry.js
+++ b/packages/build/src/build/buildRefs/deferredRegistry.js
@@ -21,6 +21,7 @@ import { serializer, type } from '@lowdefy/helpers';
 // resolveDeferred, and resolveDeferred walks record bodies. Both modules only
 // reference each other's bindings at call time, after evaluation completes.
 import { loadAndWalkRef, resolve, WalkContext } from './walker.js';
+import cloneWithMarkers from './cloneWithMarkers.js';
 
 // The deferred-content record registry. Every deferred region of module config
 // becomes a record { kind, body, env, slot } in context.deferred; the config
@@ -201,33 +202,13 @@ async function resolveRecordBody(ctx, id, record) {
     // varDefault and connRemap bodies are raw config subtrees. Clone before
     // walking — the raw body must stay pristine in the registry
     // (deferredRecords.json serializes it, and demand order must not change it).
-    value = await resolve(cloneRecordBody(record.body), recordCtx);
+    value = await resolve(cloneWithMarkers(record.body), recordCtx);
   }
   record.value = value;
   record.done = true;
   return value;
 }
 
-// Marker-preserving deep clone for record bodies (~r ~l ~k ~arr). Kept local
-// to avoid a second circular binding on the walker's clone family; clone
-// unification replaces both with cloneWithMarkers.
-function cloneRecordBody(value) {
-  if (!type.isObject(value) && !type.isArray(value)) return value;
-  const clone = type.isArray(value)
-    ? value.map((item) => cloneRecordBody(item))
-    : Object.fromEntries(Object.keys(value).map((key) => [key, cloneRecordBody(value[key])]));
-  for (const marker of ['~r', '~l', '~k', '~arr']) {
-    if (value[marker] !== undefined) {
-      Object.defineProperty(clone, marker, {
-        value: value[marker],
-        enumerable: false,
-        writable: true,
-        configurable: true,
-      });
-    }
-  }
-  return clone;
-}
 
 // Placeholder lifetime differs by record kind: component and menuLinks
 // placeholders persist by design (per-consumer resolution; JIT consumes them

--- a/packages/build/src/build/buildRefs/walker.js
+++ b/packages/build/src/build/buildRefs/walker.js
@@ -979,12 +979,32 @@ async function resolve(node, ctx) {
 
   // 9. _build.* operator
   if (isBuildOperator(node)) {
+    // Under prepare (deferModuleRefs), an operand subtree can hold a deferred
+    // placeholder where a module ref used to be — the operator cannot fold
+    // over it. Leave the node unevaluated: the finalize/demand walk (deferral
+    // off) splices concrete values via the placeholder dispatch before this
+    // branch runs, and the fold happens then, in the same enclosing scope.
+    if (ctx.deferModuleRefs && findPlaceholderInSubtree(node)) {
+      return node;
+    }
     const result = evaluateBuildOperator(node, ctx);
     tagRefDeep(result, ctx.refId);
     return result;
   }
 
   return node;
+}
+
+// Does any node in the subtree carry a deferred-record placeholder?
+function findPlaceholderInSubtree(node) {
+  if (getPlaceholderId(node) !== undefined) return true;
+  if (type.isArray(node)) {
+    return node.some((item) => findPlaceholderInSubtree(item));
+  }
+  if (type.isObject(node)) {
+    return Object.keys(node).some((key) => findPlaceholderInSubtree(node[key]));
+  }
+  return false;
 }
 
 export { resolve, loadAndWalkRef, WalkContext, tagRefDeep };

--- a/packages/build/src/build/buildRefs/walker.js
+++ b/packages/build/src/build/buildRefs/walker.js
@@ -27,6 +27,7 @@ import getKey from './getKey.js';
 import { scopeMenuItemIds } from './scopeMenuItemIds.js';
 import resolveDepTarget from '../resolveDepTarget.js';
 import setNonEnumerableProperty from '../../utils/setNonEnumerableProperty.js';
+import cloneWithMarkers from './cloneWithMarkers.js';
 import collectExceptions from '../../utils/collectExceptions.js';
 import {
   createRecord,
@@ -195,66 +196,6 @@ function tagRefDeep(node, refId) {
   }
 }
 
-// Deep clone preserving non-enumerable build markers (~r, ~l, ~k, ~arr, ~deferredFrom).
-// Used before resolving ref def path/vars to prevent mutation of stored originals.
-function cloneForResolve(value) {
-  if (!type.isObject(value) && !type.isArray(value)) return value;
-  if (type.isArray(value)) {
-    const clone = value.map((item) => cloneForResolve(item));
-    if (value['~r'] !== undefined) setNonEnumerableProperty(clone, '~r', value['~r']);
-    if (value['~l'] !== undefined) setNonEnumerableProperty(clone, '~l', value['~l']);
-    if (value['~k'] !== undefined) setNonEnumerableProperty(clone, '~k', value['~k']);
-    if (value['~arr'] !== undefined) setNonEnumerableProperty(clone, '~arr', value['~arr']);
-    if (value['~deferredFrom'] !== undefined)
-      setNonEnumerableProperty(clone, '~deferredFrom', value['~deferredFrom']);
-    return clone;
-  }
-  const clone = {};
-  for (const key of Object.keys(value)) {
-    clone[key] = cloneForResolve(value[key]);
-  }
-  if (value['~r'] !== undefined) setNonEnumerableProperty(clone, '~r', value['~r']);
-  if (value['~l'] !== undefined) setNonEnumerableProperty(clone, '~l', value['~l']);
-  if (value['~k'] !== undefined) setNonEnumerableProperty(clone, '~k', value['~k']);
-  if (value['~deferredFrom'] !== undefined)
-    setNonEnumerableProperty(clone, '~deferredFrom', value['~deferredFrom']);
-  return clone;
-}
-
-// Deep clone a var value, preserving markers and setting ~r provenance.
-// When sourceRefId is null, preserves the template's existing ~r markers.
-function cloneVarValue(value, sourceRefId) {
-  if (!type.isObject(value) && !type.isArray(value)) return value;
-  return cloneDeepWithProvenance(value, sourceRefId);
-}
-
-function cloneDeepWithProvenance(node, sourceRefId) {
-  if (!type.isObject(node) && !type.isArray(node)) return node;
-  if (type.isArray(node)) {
-    const clone = node.map((item) => cloneDeepWithProvenance(item, sourceRefId));
-    if (node['~r'] !== undefined) {
-      setNonEnumerableProperty(clone, '~r', node['~r']);
-    } else if (sourceRefId) {
-      setNonEnumerableProperty(clone, '~r', sourceRefId);
-    }
-    if (node['~l'] !== undefined) setNonEnumerableProperty(clone, '~l', node['~l']);
-    if (node['~k'] !== undefined) setNonEnumerableProperty(clone, '~k', node['~k']);
-    if (node['~arr'] !== undefined) setNonEnumerableProperty(clone, '~arr', node['~arr']);
-    return clone;
-  }
-  const clone = {};
-  for (const key of Object.keys(node)) {
-    clone[key] = cloneDeepWithProvenance(node[key], sourceRefId);
-  }
-  if (node['~r'] !== undefined) {
-    setNonEnumerableProperty(clone, '~r', node['~r']);
-  } else if (sourceRefId) {
-    setNonEnumerableProperty(clone, '~r', sourceRefId);
-  }
-  if (node['~l'] !== undefined) setNonEnumerableProperty(clone, '~l', node['~l']);
-  if (node['~k'] !== undefined) setNonEnumerableProperty(clone, '~k', node['~k']);
-  return clone;
-}
 
 // Evaluate a _build.* operator using evaluateOperators
 function evaluateBuildOperator(node, ctx) {
@@ -282,7 +223,7 @@ function resolveVar(node, ctx) {
   // String form: { _var: "key" }
   if (type.isString(varDef)) {
     const value = get(ctx.vars, varDef, { default: null });
-    return cloneVarValue(value, ctx.sourceRefId);
+    return cloneWithMarkers(value, { assignRefId: ctx.sourceRefId });
   }
 
   // Object form: { _var: { key, default } }
@@ -291,12 +232,12 @@ function resolveVar(node, ctx) {
 
     // Var provided (even if null) → use parent's sourceRefId for location
     if (!type.isUndefined(varFromParent)) {
-      return cloneVarValue(varFromParent, ctx.sourceRefId);
+      return cloneWithMarkers(varFromParent, { assignRefId: ctx.sourceRefId });
     }
 
     // Not provided → use default, preserve template's ~r
     const defaultValue = type.isNone(varDef.default) ? null : varDef.default;
-    return cloneVarValue(defaultValue, null);
+    return cloneWithMarkers(defaultValue);
   }
 
   throw new ConfigError('_var operator takes a string or object with "key" field as arguments.', {
@@ -315,7 +256,7 @@ async function resolveModuleVar(node, ctx) {
   }
 
   const value = await resolveEffectiveVar(key, ctx.moduleEntry, ctx);
-  return cloneVarValue(value, ctx.sourceRefId);
+  return cloneWithMarkers(value, { assignRefId: ctx.sourceRefId });
 }
 
 // Navigate the var definitions tree by dot-path key, following `properties` nesting.
@@ -345,7 +286,7 @@ function getVarDef(varDefs, key) {
 async function deepForcePlaceholders(value, ctx) {
   const rootId = getPlaceholderId(value);
   if (rootId !== undefined) {
-    return cloneVarValue(await resolveDeferred(ctx, rootId), null);
+    return cloneWithMarkers(await resolveDeferred(ctx, rootId));
   }
   if (type.isArray(value)) {
     for (let i = 0; i < value.length; i++) {
@@ -387,7 +328,7 @@ async function readConsumerValue(moduleEntry, key, ctx) {
   const rootPlaceholderId = getPlaceholderId(moduleEntry.consumerVars);
   if (rootPlaceholderId !== undefined) {
     moduleEntry.consumerVars =
-      cloneVarValue(await resolveDeferred(ctx, rootPlaceholderId), null) ?? {};
+      cloneWithMarkers(await resolveDeferred(ctx, rootPlaceholderId)) ?? {};
   }
   const parts = key.split('.');
   let parent = moduleEntry.consumerVars;
@@ -396,7 +337,7 @@ async function readConsumerValue(moduleEntry, key, ctx) {
     let node = parent[parts[i]];
     const placeholderId = getPlaceholderId(node);
     if (placeholderId !== undefined) {
-      node = cloneVarValue(await resolveDeferred(ctx, placeholderId), null);
+      node = cloneWithMarkers(await resolveDeferred(ctx, placeholderId));
       parent[parts[i]] = node;
     }
     if (i === parts.length - 1) return node;
@@ -490,7 +431,7 @@ async function resolveModuleConnectionId(arg, moduleEntry, ctx, configKey) {
     const remapping = entry.connections ?? {};
     const placeholderId = getPlaceholderId(remapping[id]);
     if (placeholderId !== undefined) {
-      remapping[id] = cloneVarValue(await resolveDeferred(ctx, placeholderId), null);
+      remapping[id] = cloneWithMarkers(await resolveDeferred(ctx, placeholderId));
     }
     return remapping[id];
   };
@@ -651,12 +592,12 @@ async function prepareRef(node, ctx) {
   const varKeys = Object.keys(refDef.vars);
   if (varKeys.length > 0) {
     ctx.unresolvedRefVars[refDef.id] = refDef.vars;
-    refDef.vars = cloneForResolve(refDef.vars);
+    refDef.vars = cloneWithMarkers(refDef.vars);
   }
 
   // 3. Resolve dynamic path/vars/key
   if (type.isObject(refDef.path)) {
-    refDef.path = await resolve(cloneForResolve(refDef.path), ctx);
+    refDef.path = await resolve(cloneWithMarkers(refDef.path), ctx);
   }
   await Promise.all(
     varKeys.map(async (varKey) => {
@@ -673,7 +614,7 @@ async function prepareRef(node, ctx) {
     }),
   );
   if (type.isObject(refDef.key)) {
-    refDef.key = await resolve(cloneForResolve(refDef.key), ctx);
+    refDef.key = await resolve(cloneWithMarkers(refDef.key), ctx);
   }
 
   // 4. Module path resolution: resolve relative paths from the module root
@@ -727,11 +668,10 @@ async function prepareRef(node, ctx) {
 // applies the shared tail (steps 13–16). Replayed deferred sentinels route here
 // too — `fromFile` carries their original provenance.
 async function resolveModuleExportRef(refDef, ctx, { configKey, fromFile }) {
-  // 8. Load content. Components dereference a deferred record and clone its
-  // immutable body — the record env names the source file explicitly. Menus
-  // (and scalar legacy bodies) still return live content preserved in place,
-  // where ~deferredFrom carries the source file when the body came from a
-  // ref'd file.
+  // 8. Load content. Components and menus dereference a deferred record and
+  // clone its immutable body — the record env names the source file
+  // explicitly. Legacy live content (scalar bodies, sections produced inline
+  // by static operators) resolves against the manifest file.
   const result = await getModuleRefContent({
     context: ctx.buildContext,
     refDef,
@@ -746,12 +686,11 @@ async function resolveModuleExportRef(refDef, ctx, { configKey, fromFile }) {
   let sourceFile;
   if (result.recordId !== undefined) {
     const record = getRecord(ctx.buildContext, result.recordId);
-    content = cloneForResolve(record.body);
+    content = cloneWithMarkers(record.body);
     sourceFile = record.env.file;
   } else {
-    content = cloneForResolve(result.content);
-    const deferredFrom = content['~deferredFrom'];
-    sourceFile = deferredFrom ?? path.join(moduleEntry.moduleRoot, 'module.lowdefy.yaml');
+    content = cloneWithMarkers(result.content);
+    sourceFile = path.join(moduleEntry.moduleRoot, 'module.lowdefy.yaml');
   }
 
   // 9. Circular detection for cross-module component/menu refs.
@@ -929,7 +868,7 @@ async function resolve(node, ctx) {
       if (record.kind === 'component' || record.kind === 'menuLinks') {
         return node;
       }
-      return cloneVarValue(await resolveDeferred(ctx, deferredId), null);
+      return cloneWithMarkers(await resolveDeferred(ctx, deferredId));
     }
   }
 
@@ -959,15 +898,10 @@ async function resolve(node, ctx) {
           delete node[key];
           return;
         }
-        if (stopMode === 'preserve') {
-          if (type.isObject(node[key]) || type.isArray(node[key])) {
-            setNonEnumerableProperty(node[key], '~deferredFrom', ctx.currentFile);
-          }
-          return;
-        }
-        if (stopMode === 'skip') {
-          // Leave raw, no marker — a later phase walks this region with its
-          // own predicate (Phase A/C.5 masking per the deferred-regions table).
+        if (stopMode === 'skip' || stopMode === 'preserve') {
+          // Leave raw — a later phase or consumer handles this region.
+          // 'preserve' is a legacy synonym: the ~deferredFrom marker it used
+          // to stamp is gone (records carry the source file in env.file).
           return;
         }
         if (type.isString(stopMode) && stopMode.startsWith('record:')) {
@@ -1053,4 +987,4 @@ async function resolve(node, ctx) {
   return node;
 }
 
-export { resolve, loadAndWalkRef, WalkContext, cloneForResolve, tagRefDeep };
+export { resolve, loadAndWalkRef, WalkContext, tagRefDeep };

--- a/packages/build/src/build/buildRefs/walker.test.js
+++ b/packages/build/src/build/buildRefs/walker.test.js
@@ -1606,11 +1606,11 @@ describe('deferModuleRefs record deferral', () => {
     expect(result === null || result['~deferred'] === undefined).toBe(true);
   });
 
-  test('cloneForResolve carries placeholders through unchanged', async () => {
-    const { cloneForResolve } = await import('./walker.js');
+  test('cloneWithMarkers carries placeholders through unchanged', async () => {
+    const { default: cloneWithMarkers } = await import('./cloneWithMarkers.js');
 
     const placeholder = { '~deferred': 'consumer-entry:consumerVars.slot' };
-    const cloned = cloneForResolve({ wrapper: placeholder });
+    const cloned = cloneWithMarkers({ wrapper: placeholder });
 
     // Plain enumerable data — the whole point of the record placeholder.
     expect(cloned.wrapper).toEqual({ '~deferred': 'consumer-entry:consumerVars.slot' });

--- a/packages/build/src/build/jit/buildPageJit.js
+++ b/packages/build/src/build/jit/buildPageJit.js
@@ -35,7 +35,8 @@ import precomputeRuntimeOperators from '../buildRefs/precomputeRuntimeOperators.
 import getRefContent from '../buildRefs/getRefContent.js';
 import jsMapParser from '../buildJs/jsMapParser.js';
 import makeRefDefinition from '../buildRefs/makeRefDefinition.js';
-import { resolve, WalkContext, cloneForResolve, tagRefDeep } from '../buildRefs/walker.js';
+import { resolve, WalkContext, tagRefDeep } from '../buildRefs/walker.js';
+import cloneWithMarkers from '../buildRefs/cloneWithMarkers.js';
 import validateOperatorsDynamic from '../validateOperatorsDynamic.js';
 import writeMaps from '../writeMaps.js';
 import detectMissingIcons from './detectMissingIcons.js';
@@ -145,7 +146,7 @@ async function buildPageJit({ pageId, pageRegistry, context, directories, logger
         dynamicIdentifiers,
         shouldStop: null,
       });
-      resolvedVars = await resolve(cloneForResolve(unresolvedVars), varCtx);
+      resolvedVars = await resolve(cloneWithMarkers(unresolvedVars), varCtx);
     }
 
     let refDef;

--- a/packages/build/src/build/jit/shallowBuild.js
+++ b/packages/build/src/build/jit/shallowBuild.js
@@ -38,6 +38,7 @@ import buildMenu from '../buildMenu.js';
 import buildModuleDefs from '../buildModuleDefs.js';
 import buildModules from '../buildModules.js';
 import buildRefs from '../buildRefs/buildRefs.js';
+import precomputeRuntimeOperators from '../buildRefs/precomputeRuntimeOperators.js';
 import { serializeRegistry } from '../buildRefs/deferredRegistry.js';
 import buildTypes from '../buildTypes.js';
 import cleanBuildDirectory from '../cleanBuildDirectory.js';
@@ -110,6 +111,19 @@ async function shallowBuild(options) {
     buildModules({ components, context });
     // Collect skeleton source files while ~r markers still exist on objects.
     const skeletonSourceFiles = collectSkeletonSourceFiles({ components, context });
+
+    // Phase 3.5: Constant-fold static runtime operators, mirroring the full
+    // build (index.js). Without this, content preserved at skeleton — inline
+    // pages, slot content, module components consumed into them — reaches
+    // testSchema (spurious warnings) and the served dev artifacts (broken
+    // block ids: the client never operator-evaluates id positions) with raw
+    // runtime operators. Ref-backed page content is already stripped here and
+    // folds per page in buildPageJit.
+    components = precomputeRuntimeOperators({
+      context,
+      input: components,
+      refDef: context.rootRefDef,
+    });
 
     // addKeys + testSchema first for error location info
     tryBuildStep(addKeys, 'addKeys', { components, context });

--- a/packages/build/src/build/jit/shallowBuildPrecompute.integration.test.js
+++ b/packages/build/src/build/jit/shallowBuildPrecompute.integration.test.js
@@ -1,0 +1,130 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Regression: the skeleton (shallow/dev) build must run the
+// precomputeRuntimeOperators phase like the full build does. Without it,
+// content preserved at skeleton — inline pages defined directly in
+// lowdefy.yaml — reaches testSchema with raw runtime operators (spurious
+// "Block id should be a string" warnings) and, worse, is SERVED that way in
+// dev: the client never operator-evaluates id positions, so a _string.concat
+// block id works in prod and breaks in dev.
+
+import { jest } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { serializer } from '@lowdefy/helpers';
+
+process.env.NEXTAUTH_SECRET = 'test-secret-for-integration-test';
+
+jest.unstable_mockModule('../buildApp.js', () => ({
+  default: ({ components }) => {
+    components.app = components.app ?? {};
+    components.app.html = components.app.html ?? {};
+    components.app.html.appendBody = components.app.html.appendBody ?? '';
+    components.app.html.appendHead = components.app.html.appendHead ?? '';
+    components.appMeta = {
+      slug: components.slug ?? null,
+      name: components.name ?? null,
+      version: components.version ?? null,
+      description: components.description ?? null,
+      license: components.license ?? null,
+      lowdefyVersion: components.lowdefy ?? null,
+      gitSha: 'test-git-sha',
+    };
+    return components;
+  },
+}));
+jest.unstable_mockModule('../full/updateServerPackageJson.js', () => ({
+  default: jest.fn(async () => {}),
+}));
+jest.unstable_mockModule('../copyPublicFolder.js', () => ({
+  default: jest.fn(async () => {}),
+}));
+jest.unstable_mockModule('../copyAgentFileSystems.js', () => ({
+  default: jest.fn(async () => {}),
+}));
+
+const { default: shallowBuild } = await import('./shallowBuild.js');
+const { snapshotTypesMap } = await import('../../test-utils/runBuildForSnapshots.js');
+
+test('skeleton build folds static runtime operators in preserved inline pages', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ldf-shallow-precompute-'));
+  const configDir = path.join(root, 'config');
+  const buildDir = path.join(root, '.lowdefy', 'server', 'build');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.mkdirSync(buildDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(configDir, 'lowdefy.yaml'),
+    `lowdefy: local
+name: Shallow Precompute Test
+
+pages:
+  - id: inline
+    type: Box
+    blocks:
+      - id:
+          _string.concat:
+            - inline
+            - _block
+        type: Box
+        blocks:
+          _if:
+            test:
+              _if_none:
+                - null
+                - true
+            then:
+              - id: nested
+                type: Box
+            else: []
+`
+  );
+
+  const warnings = [];
+  await shallowBuild({
+    customTypesMap: snapshotTypesMap,
+    directories: {
+      config: configDir,
+      build: buildDir,
+      server: path.join(root, '.lowdefy', 'server'),
+    },
+    logger: {
+      info: () => {},
+      log: () => {},
+      warn: (arg) => warnings.push(typeof arg === 'string' ? arg : (arg?.msg ?? '')),
+      error: () => {},
+      succeed: () => {},
+    },
+    stage: 'dev',
+  });
+
+  // No spurious schema warnings about unfolded operators.
+  const schemaWarnings = warnings.filter(
+    (w) => String(w).includes('should be a string') || String(w).includes('should be an array')
+  );
+  expect(schemaWarnings).toEqual([]);
+
+  // The served inline page artifact holds folded, concrete values — the same
+  // shape prod produces (built pages nest blocks under slots.content.blocks).
+  const page = serializer.deserialize(
+    JSON.parse(fs.readFileSync(path.join(buildDir, 'pages', 'inline.json'), 'utf8'))
+  );
+  const outer = page.slots.content.blocks[0];
+  expect(outer.blockId).toBe('inline_block');
+  expect(outer.slots.content.blocks[0].blockId).toBe('nested');
+});


### PR DESCRIPTION
## What

Task 10 of the deferred-content-records design — the final task.

- **`cloneWithMarkers(value, { assignRefId })`** replaces the four-way clone family (`cloneForResolve`, `cloneVarValue`/`cloneDeepWithProvenance`, and the registry's local `cloneRecordBody`): one function preserving `~r ~l ~k ~arr` non-enumerably, optionally stamping `~r` provenance on untagged nodes, passing non-plain values (`Date`) by reference. `serializer.copy` remains the artifact boundary — its ban from config subtrees is about one correct way and the JSON round-trip cost, not marker safety (per review-2's corrected premise).
- **`~deferredFrom` is deleted** — the last fragile in-tree deferral marker. Records carry source files in `env.file`; nothing stamped or read the marker anymore, so the `'preserve'` `shouldStop` mode loses its stamp and becomes a synonym of `'skip'` (kept for compatibility with #2223, which returns `'preserve'` — collapse the synonym once the stack merges), and the legacy live-content consumption fallback resolves against the manifest file directly.

With this, the design's Part 4 is fully implemented: `~deferredModuleRef` (task 07) and `~deferredFrom` (here) are gone; `~r/~l/~k` remain as stable provenance with a single safe clone path.

Stacked on #2231 → … → #2221. **This completes the deferred-content-records implementation** — all 10 tasks landed.

## Tests

4 new `cloneWithMarkers` unit tests; full `packages/build` suite green: 120 suites / 1498 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3yfNz71wS5NPBihMf7YHH