### PR TITLE
Group mentions for TiptapMentionInput

### DIFF
--- a/.changeset/feat-tiptap-group-mentions.md
+++ b/.changeset/feat-tiptap-group-mentions.md
@@ -1,0 +1,14 @@
+---
+'@lowdefy/blocks-tiptap': minor
+---
+
+feat: Group mentions for TiptapMentionInput
+
+`TiptapMentionInput` can now treat mention options as app-defined **groups** (roles, teams, queues, segments) in addition to individual people. All group data — which groups exist, their labels, colours, and members — comes from your config; the block ships no groups of its own.
+
+- **Menu sections** — options with a `tag.section` are grouped under headings in the suggestion dropdown; options without one render flat, as before.
+- **Group chips** — an option with `tag.group` renders a distinct chip carrying `class="tiptap-mention tiptap-mention-group"` and `data-mention-group="<group>"`, coloured inline from `tag.color` so the colour travels with the saved HTML.
+- **Hover member popover** — `mentions.groupMembers` (a `{ '<group>': [{ name, email }] }` map, which may be loaded from a request) shows a group's current members when you hover its chip in the live editor.
+- **Configurable suggestion cap** — `mentions.limit` (default 5) caps results, applied per section when sections are used so a large section can't crowd out a small one.
+
+Also fixes a latent `getHref` bug: the element is now chosen by the function's return value, so a nullish return renders a plain `<span>` instead of `<a href="null">`. Options with no `tag.section`, `tag.group`, or `tag.color` are unaffected and render exactly as before.

--- a/packages/docs/blocks/input/TiptapMentionInput.yaml
+++ b/packages/docs/blocks/input/TiptapMentionInput.yaml
@@ -26,3 +26,8 @@ _ref:
     description: >
       Rich-text editor with @-mention support. Same feature set as TiptapInput,
       plus a mention dropdown populated from a static options list or a request.
+      Mention options can be marked as groups (roles, teams, queues) to render
+      under their own menu section, as distinctly coloured chips, and with a
+      hover popover listing the group's current members. See the guide below.
+    guide:
+      _ref: blocks/input/TiptapMentionInputGuide.md

--- a/packages/docs/blocks/input/TiptapMentionInputGuide.md
+++ b/packages/docs/blocks/input/TiptapMentionInputGuide.md
@@ -3,7 +3,7 @@
 Beyond the flat mention list, `TiptapMentionInput` can treat some mention options as **groups** — an app-defined kind such as a role, a team, a queue, or a saved segment. A group mention:
 
 - sits under its own heading in the suggestion menu (`tag.section`),
-- renders as a distinctly coloured chip (`tag.color` / `mentions.groupColors`), and
+- renders as a distinctly coloured chip (`tag.color`), and
 - shows the group's current members in a hover popover in the live editor (`mentions.groupMembers`).
 
 The block hardcodes no group. Your app decides which groups exist, what they are called, how they are coloured, and who belongs to them — the block only reflects that data onto the chip and the menu.
@@ -25,7 +25,7 @@ The `tag` fields are not listed in the properties table above, because `options`
 | `tag.title`   | Chip text — `@Finance` renders from `tag.title: Finance`. Falls back to `label`.                                    |
 | `tag.section` | Menu heading this option sits under. Options without a section render flat, with no heading.                        |
 | `tag.group`   | Marks this option a **group** chip. An opaque, app-defined string — it becomes the chip class, the `data-mention-group` attribute, and the hover lookup key. |
-| `tag.color`   | Chip colour for this option. Overrides `mentions.groupColors` for the option's group.                               |
+| `tag.color`   | Chip colour for this option (any CSS colour). Inlined on the chip, so it travels with the saved HTML.                |
 
 An individual-person option simply omits `section`, `group`, and `color`, and renders exactly as before.
 
@@ -35,20 +35,21 @@ Sections and groups are **orthogonal**: a section is a menu heading, a group is 
 
 `limit` (integer, default `5`) caps how many suggestions the menu shows. When at least one visible option declares a `tag.section`, the cap is applied **per section**, so a large "People" section can't crowd every "Roles" option out of the list. When no option declares a section, the same limit caps the flat list, matching the pre-group behaviour.
 
-### `mentions.groupColors` — static, available at mount
+### Group chip colour
 
-`groupColors` is a `{ '<group>': '<cssColor>' }` map that colours every chip of a given group in one place:
+A group chip's colour comes from `tag.color` on the option — any CSS colour string:
 
 ```yaml
-mentions:
-  groupColors:
-    finance: '#722ed1'
-    devs: '#13c2c2'
+options:
+  - label: Finance
+    value: { role: finance-admin }
+    tag: { section: Roles, group: finance, color: '#722ed1' }
+  - label: Developers
+    value: { role: developer }
+    tag: { section: Roles, group: devs, color: '#13c2c2' }
 ```
 
-The resolved colour is written as an inline `style` on the chip, so it travels with the saved HTML — a group chip looks right anywhere the stored content is rendered, with no per-app stylesheet.
-
-> **`groupColors` must be static config available when the block mounts.** It is read once, where the mention extension is created, and is **not** refreshed afterwards. A `groupColors` map loaded from a request that resolves after the block mounts will produce uncoloured chips. Supply it as static config (a colour palette is naturally static). For any colour that arrives dynamically, use per-option `tag.color` instead — it rides on the selected option, so it is always current. The same mount-time capture applies to `mentions.limit` and `mentions.char`.
+The colour is written as an inline `style` on the chip, so it travels with the saved HTML — a group chip looks right anywhere the stored content is rendered, with no per-app stylesheet. Because `tag.color` rides on the selected option, it is always current even when options load from a request. If you prefer to control colour from CSS instead, omit `tag.color` and target `.tiptap-mention-group[data-mention-group="finance"]` in your own stylesheet.
 
 ### `mentions.groupMembers` — may be async
 
@@ -63,7 +64,7 @@ mentions:
       - { name: Ada Lovelace, email: ada@example.com }
 ```
 
-Unlike `groupColors`, `groupMembers` **may be loaded from a request** — it is read live, at hover time, so it does not need to be present at mount. This asymmetry is intentional: colour is captured once when the editor is created, member lists are looked up on each hover.
+`groupMembers` **may be loaded from a request** — it is read live, at hover time, so it does not need to be present when the block mounts. (This is the one piece of group data read on each hover rather than captured up front.)
 
 Hover is scoped to the live editor only. If the group has no entry in `groupMembers`, no popover shows.
 
@@ -90,7 +91,7 @@ A group chip renders as:
 
 ### Worked example
 
-A mixed `options` array — people with no group alongside group options carrying `tag.section`, `tag.group`, and optionally `tag.color` — a `groupColors` map, a `groupMembers` map, and a `getHref` that returns `null` for groups:
+A mixed `options` array — people alongside group options carrying `tag.section`, `tag.group`, and `tag.color` — a `groupMembers` map, and a `getHref` that returns a link for people and nothing for groups:
 
 ```yaml
 - id: comment
@@ -99,52 +100,39 @@ A mixed `options` array — people with no group alongside group options carryin
     mentions:
       char: '@'
       limit: 8 # per-section result cap
+      # people carry value.href → <a>; groups omit it → nullish → <span>
       getHref:
         _function:
-          # people carry value.contact_id and link to a profile;
-          # groups don't → null href → chip renders as a <span>
-          __if:
-            test:
-              __type:
-                type: string
-                on:
-                  __args: 0.value.contact_id
-            then:
-              __string.concat: ['/contacts?_id=', __args: 0.value.contact_id]
-            else: null
+          __args: 0.value.href
       options:
         - label: Jane Doe # person — no tag.group, links to a profile
           value:
             contact_id: c_001
+            href: '/contacts?_id=c_001'
           tag:
-            title: Jane Doe
             section: People
         - label: Ada Lovelace
           value:
             contact_id: c_002
+            href: '/contacts?_id=c_002'
           tag:
-            title: Ada Lovelace
             section: People
-        - label: Finance # group — no profile link, coloured chip, hover members
+        - label: Finance # group — no href, coloured chip, hover members
           value:
             type: role
             role: finance-admin
           tag:
-            title: Finance
             section: Roles
             group: finance
-            color: '#722ed1' # overrides groupColors.finance for this option
+            color: '#722ed1'
         - label: Developers
           value:
             type: role
             role: developers
           tag:
-            title: Developers
             section: Roles
             group: devs
-      groupColors: # colour each group once; tag.color overrides per option
-        finance: '#722ed1'
-        devs: '#13c2c2'
+            color: '#13c2c2'
       groupMembers: # shown on chip hover in the live editor; may come from a request
         finance:
           - { name: Jane Doe, email: jane@example.com }
@@ -152,4 +140,4 @@ A mixed `options` array — people with no group alongside group options carryin
           - { name: Ada Lovelace, email: ada@example.com }
 ```
 
-`options` and `groupMembers` are typically populated from requests (`_request: mention_options`, `_request: group_members`). How that data is built, and how the stored `value` is later expanded to notification recipients, are entirely app-side — the block only records the mention.
+`options` and `groupMembers` are typically populated from requests (`_request: mention_options`, `_request: group_members`). How that data is built, and how the stored `value` is later expanded to notification recipients, are entirely app-side — the block only records the mention. If a group's colour is itself dynamic, it rides safely on `tag.color` because that value is stored on the selected option.

--- a/packages/docs/blocks/input/TiptapMentionInputGuide.md
+++ b/packages/docs/blocks/input/TiptapMentionInputGuide.md
@@ -1,0 +1,155 @@
+## Group mentions
+
+Beyond the flat mention list, `TiptapMentionInput` can treat some mention options as **groups** — an app-defined kind such as a role, a team, a queue, or a saved segment. A group mention:
+
+- sits under its own heading in the suggestion menu (`tag.section`),
+- renders as a distinctly coloured chip (`tag.color` / `mentions.groupColors`), and
+- shows the group's current members in a hover popover in the live editor (`mentions.groupMembers`).
+
+The block hardcodes no group. Your app decides which groups exist, what they are called, how they are coloured, and who belongs to them — the block only reflects that data onto the chip and the menu.
+
+### Presentation lives on `tag`, storage lives on `value`
+
+Each mention option is an object of the form `{ label, value, tag }`:
+
+- `label` — the text matched against what the author types (unchanged).
+- `value` — the **opaque payload** stored on the mention node and emitted in the block's `mentions` value. Its shape is entirely yours; the block never reads it for presentation.
+- `tag` — the presentation fields the block reads to render the chip and menu.
+
+All group behaviour is driven from `tag`, never from `value`. This keeps `value` free to hold whatever your app needs to expand the mention later (a role slug, a queue id, a segment query), while the block stays a pure presentation layer.
+
+The `tag` fields are not listed in the properties table above, because `options` has no per-item schema. They are:
+
+| Field         | Purpose                                                                                                             |
+| ------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `tag.title`   | Chip text — `@Finance` renders from `tag.title: Finance`. Falls back to `label`.                                    |
+| `tag.section` | Menu heading this option sits under. Options without a section render flat, with no heading.                        |
+| `tag.group`   | Marks this option a **group** chip. An opaque, app-defined string — it becomes the chip class, the `data-mention-group` attribute, and the hover lookup key. |
+| `tag.color`   | Chip colour for this option. Overrides `mentions.groupColors` for the option's group.                               |
+
+An individual-person option simply omits `section`, `group`, and `color`, and renders exactly as before.
+
+Sections and groups are **orthogonal**: a section is a menu heading, a group is a chip identity. You may put several group options under one "Roles" section, give each group its own section, or use sections purely to group people with no group chips at all.
+
+### `mentions.limit`
+
+`limit` (integer, default `5`) caps how many suggestions the menu shows. When at least one visible option declares a `tag.section`, the cap is applied **per section**, so a large "People" section can't crowd every "Roles" option out of the list. When no option declares a section, the same limit caps the flat list, matching the pre-group behaviour.
+
+### `mentions.groupColors` — static, available at mount
+
+`groupColors` is a `{ '<group>': '<cssColor>' }` map that colours every chip of a given group in one place:
+
+```yaml
+mentions:
+  groupColors:
+    finance: '#722ed1'
+    devs: '#13c2c2'
+```
+
+The resolved colour is written as an inline `style` on the chip, so it travels with the saved HTML — a group chip looks right anywhere the stored content is rendered, with no per-app stylesheet.
+
+> **`groupColors` must be static config available when the block mounts.** It is read once, where the mention extension is created, and is **not** refreshed afterwards. A `groupColors` map loaded from a request that resolves after the block mounts will produce uncoloured chips. Supply it as static config (a colour palette is naturally static). For any colour that arrives dynamically, use per-option `tag.color` instead — it rides on the selected option, so it is always current. The same mount-time capture applies to `mentions.limit` and `mentions.char`.
+
+### `mentions.groupMembers` — may be async
+
+`groupMembers` is a `{ '<group>': [{ name, email }] }` map. Hovering a group chip in the **live editor** shows a popover listing that group's current members:
+
+```yaml
+mentions:
+  groupMembers:
+    finance:
+      - { name: Jane Doe, email: jane@example.com }
+    devs:
+      - { name: Ada Lovelace, email: ada@example.com }
+```
+
+Unlike `groupColors`, `groupMembers` **may be loaded from a request** — it is read live, at hover time, so it does not need to be present at mount. This asymmetry is intentional: colour is captured once when the editor is created, member lists are looked up on each hover.
+
+Hover is scoped to the live editor only. If the group has no entry in `groupMembers`, no popover shows.
+
+### `getHref` — nullish renders a `<span>`
+
+`getHref` is an optional `_function` that receives the selected option and returns an href. Its **return value** decides the element:
+
+- a non-nullish return renders the mention as an `<a>`;
+- a nullish return (`null`/`undefined`) renders a plain `<span>`.
+
+Return `null` for group options — a group has no profile page — and a URL for people.
+
+> Return `null` or `undefined`, **not** an empty string. `''` is not nullish, so `getHref` returning `''` still renders `<a href="">`.
+
+### Emitted chip markup
+
+A group chip renders as:
+
+```html
+<span class="tiptap-mention tiptap-mention-group" data-mention-group="finance" style="color: #722ed1">@Finance</span>
+```
+
+(or an `<a>` with the same classes and attributes when `getHref` returns a link). The colour is inlined via `style`, and the group key is exposed as `data-mention-group`. An app that renders saved comment HTML elsewhere — a comment timeline, a notification email — can style these chips or attach its own hover behaviour by targeting the `data-mention-group` attribute. The block's own hover popover is live-editor-only, so any hover on saved content is the app's to build against the same attribute.
+
+### Worked example
+
+A mixed `options` array — people with no group alongside group options carrying `tag.section`, `tag.group`, and optionally `tag.color` — a `groupColors` map, a `groupMembers` map, and a `getHref` that returns `null` for groups:
+
+```yaml
+- id: comment
+  type: TiptapMentionInput
+  properties:
+    mentions:
+      char: '@'
+      limit: 8 # per-section result cap
+      getHref:
+        _function:
+          # people carry value.contact_id and link to a profile;
+          # groups don't → null href → chip renders as a <span>
+          __if:
+            test:
+              __type:
+                type: string
+                on:
+                  __args: 0.value.contact_id
+            then:
+              __string.concat: ['/contacts?_id=', __args: 0.value.contact_id]
+            else: null
+      options:
+        - label: Jane Doe # person — no tag.group, links to a profile
+          value:
+            contact_id: c_001
+          tag:
+            title: Jane Doe
+            section: People
+        - label: Ada Lovelace
+          value:
+            contact_id: c_002
+          tag:
+            title: Ada Lovelace
+            section: People
+        - label: Finance # group — no profile link, coloured chip, hover members
+          value:
+            type: role
+            role: finance-admin
+          tag:
+            title: Finance
+            section: Roles
+            group: finance
+            color: '#722ed1' # overrides groupColors.finance for this option
+        - label: Developers
+          value:
+            type: role
+            role: developers
+          tag:
+            title: Developers
+            section: Roles
+            group: devs
+      groupColors: # colour each group once; tag.color overrides per option
+        finance: '#722ed1'
+        devs: '#13c2c2'
+      groupMembers: # shown on chip hover in the live editor; may come from a request
+        finance:
+          - { name: Jane Doe, email: jane@example.com }
+        devs:
+          - { name: Ada Lovelace, email: ada@example.com }
+```
+
+`options` and `groupMembers` are typically populated from requests (`_request: mention_options`, `_request: group_members`). How that data is built, and how the stored `value` is later expanded to notification recipients, are entirely app-side — the block only records the mention.

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/MentionList.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/MentionList.js
@@ -16,23 +16,49 @@
 
 import React, { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 import { renderHtml } from '@lowdefy/block-utils';
+import { type } from '@lowdefy/helpers';
+
+import itemSection from './itemSection.js';
+
+function groupItems(items) {
+  const groups = [];
+  const bySection = new Map();
+  items.forEach((item) => {
+    const section = itemSection(item);
+    if (!bySection.has(section)) {
+      const group = { section, items: [] };
+      bySection.set(section, group);
+      groups.push(group);
+    }
+    bySection.get(section).items.push(item);
+  });
+  let startIndex = 0;
+  groups.forEach((group) => {
+    group.startIndex = startIndex;
+    startIndex += group.items.length;
+  });
+  return groups;
+}
 
 const MentionList = forwardRef((props, ref) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
 
+  const groups = groupItems(props.items);
+  const flatItems = groups.flatMap((group) => group.items);
+
   const selectItem = (index) => {
-    const item = props.items[index];
+    const item = flatItems[index];
     if (item) {
       props.command({ id: item });
     }
   };
 
   const upHandler = () => {
-    setSelectedIndex((selectedIndex + props.items.length - 1) % props.items.length);
+    setSelectedIndex((selectedIndex + flatItems.length - 1) % flatItems.length);
   };
 
   const downHandler = () => {
-    setSelectedIndex((selectedIndex + 1) % props.items.length);
+    setSelectedIndex((selectedIndex + 1) % flatItems.length);
   };
 
   const enterHandler = () => {
@@ -61,15 +87,25 @@ const MentionList = forwardRef((props, ref) => {
 
   return (
     <div className="tiptap-mention-items">
-      {props.items.length ? (
-        props.items.map((item, index) => (
-          <button
-            className={`tiptap-mention-item ${index === selectedIndex ? 'is-selected' : ''}`}
-            key={index}
-            onClick={() => selectItem(index)}
-          >
-            {renderHtml({ html: item?.label ?? item, methods: props.methods })}
-          </button>
+      {flatItems.length ? (
+        groups.map((group) => (
+          <React.Fragment key={group.startIndex}>
+            {!type.isNone(group.section) && (
+              <div className="tiptap-mention-section">{group.section}</div>
+            )}
+            {group.items.map((item, itemIndex) => {
+              const index = group.startIndex + itemIndex;
+              return (
+                <button
+                  className={`tiptap-mention-item ${index === selectedIndex ? 'is-selected' : ''}`}
+                  key={index}
+                  onClick={() => selectItem(index)}
+                >
+                  {renderHtml({ html: item?.label ?? item, methods: props.methods })}
+                </button>
+              );
+            })}
+          </React.Fragment>
         ))
       ) : (
         <div className="tiptap-mention-item secondary">No matching results</div>

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/TiptapMentionInput.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/TiptapMentionInput.js
@@ -52,6 +52,7 @@ const TiptapMentionInput = ({
   const uploadEnabled = !type.isNone(properties.s3PostPolicyRequestId);
   const char = properties.mentions?.char ?? '@';
   const allowSpaces = properties.mentions?.allowSpaces !== false;
+  const limit = properties.mentions?.limit ?? 5;
 
   const mentionExtension = Mention.configure({
     HTMLAttributes: { class: 'tiptap-mention' },
@@ -75,7 +76,7 @@ const TiptapMentionInput = ({
     renderText({ node }) {
       return `${char}${mentionLabel(node.attrs.id)}`;
     },
-    suggestion: suggestion({ methods, char, allowSpaces }),
+    suggestion: suggestion({ methods, char, allowSpaces, limit }),
   });
 
   const extensions = buildExtensions({

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/TiptapMentionInput.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/TiptapMentionInput.js
@@ -66,8 +66,7 @@ const TiptapMentionInput = ({
         modifier.class = 'tiptap-mention-group';
         modifier['data-mention-group'] = group;
       }
-      // per-option tag.color overrides the central groupColors map
-      const color = id?.tag?.color ?? properties.mentions?.groupColors?.[group];
+      const color = id?.tag?.color;
       if (!type.isNone(color)) {
         modifier.style = `color: ${color}`;
       }

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/TiptapMentionInput.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/TiptapMentionInput.js
@@ -57,21 +57,30 @@ const TiptapMentionInput = ({
   const mentionExtension = Mention.configure({
     HTMLAttributes: { class: 'tiptap-mention' },
     renderHTML({ options, node }) {
-      const label = mentionLabel(node.attrs.id);
-      if (type.isFunction(properties.mentions?.getHref)) {
+      const id = node.attrs.id;
+      const label = mentionLabel(id);
+      const group = id?.tag?.group;
+      const modifier = {};
+      if (!type.isNone(group)) {
+        modifier.class = 'tiptap-mention-group';
+        modifier['data-mention-group'] = group;
+      }
+      // per-option tag.color overrides the central groupColors map
+      const color = id?.tag?.color ?? properties.mentions?.groupColors?.[group];
+      if (!type.isNone(color)) {
+        modifier.style = `color: ${color}`;
+      }
+      const href = type.isFunction(properties.mentions?.getHref)
+        ? properties.mentions.getHref(id)
+        : undefined;
+      if (!type.isNone(href)) {
         return [
           'a',
-          mergeAttributes(
-            {
-              href: properties.mentions.getHref(node.attrs.id),
-              'data-id': node.attrs.id?._id,
-            },
-            options.HTMLAttributes
-          ),
+          mergeAttributes({ href, 'data-id': id?._id }, options.HTMLAttributes, modifier),
           `${char}${label}`,
         ];
       }
-      return ['span', mergeAttributes(options.HTMLAttributes), `${char}${label}`];
+      return ['span', mergeAttributes(options.HTMLAttributes, modifier), `${char}${label}`];
     },
     renderText({ node }) {
       return `${char}${mentionLabel(node.attrs.id)}`;

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/TiptapMentionInput.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/TiptapMentionInput.js
@@ -28,6 +28,7 @@ import buildExtensions from '../utils/buildExtensions.js';
 import computeHeightStyle from '../utils/computeHeightStyle.js';
 import statusClass from '../utils/statusClass.js';
 import suggestion from './suggestion.js';
+import useGroupMembersPopover from './useGroupMembersPopover.js';
 import useTiptapMentionState from './useTiptapMentionState.js';
 
 import './style.module.css';
@@ -112,6 +113,8 @@ const TiptapMentionInput = ({
       methods.triggerEvent({ name: 'onChange' });
     },
   });
+
+  useGroupMembersPopover({ editor, properties });
 
   useEffect(() => {
     if (editor) {

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/gallery.yaml
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/gallery.yaml
@@ -219,6 +219,60 @@
               tag:
                 section: Roles
 
+- title: Group mentions
+  fullWidth: true
+  blocks:
+    - id: tiptap_mention_groups
+      type: TiptapMentionInput
+      properties:
+        title: Mention people or groups
+        placeholder: 'Type @ — groups render as coloured chips, people as links.'
+        mentions:
+          # devs colour comes from this central map; finance overrides via tag.color
+          groupColors:
+            devs: '#13c2c2'
+          getHref:
+            _function:
+              # people carry value.contact_id and link to a profile;
+              # groups have no contact_id → null href → chip renders as <span>
+              __if:
+                test:
+                  __type:
+                    type: string
+                    on:
+                      __args: 0.value.contact_id
+                then:
+                  __string.concat:
+                    - '/contacts?_id='
+                    - __args: 0.value.contact_id
+                else: null
+          options:
+            - label: Alice
+              value:
+                contact_id: user_1
+                name: Alice
+              tag:
+                section: People
+            - label: Bob
+              value:
+                contact_id: user_2
+                name: Bob
+              tag:
+                section: People
+            - label: Finance
+              value:
+                role: finance-admin
+              tag:
+                section: Roles
+                group: finance
+                color: '#722ed1'
+            - label: Developers
+              value:
+                role: developer
+              tag:
+                section: Roles
+                group: devs
+
 - title: Minimal — tables and images disabled
   fullWidth: true
   blocks:

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/gallery.yaml
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/gallery.yaml
@@ -228,10 +228,7 @@
         title: Mention people or groups
         placeholder: 'Type @ — groups render as coloured chips, people as links.'
         mentions:
-          # devs colour comes from this central map; finance overrides via tag.color
-          groupColors:
-            devs: '#13c2c2'
-          # shown on hover of a group chip, keyed by tag.group
+          # shown on hover of a group chip, keyed by tag.group; may load from a request
           groupMembers:
             finance:
               - name: Jane Doe
@@ -243,32 +240,21 @@
                 email: ada@example.com
               - name: Alan Turing
                 email: alan@example.com
+          # people carry value.href → <a>; groups omit it → nullish → <span>
           getHref:
             _function:
-              # people carry value.contact_id and link to a profile;
-              # groups have no contact_id → null href → chip renders as <span>
-              __if:
-                test:
-                  __type:
-                    type: string
-                    on:
-                      __args: 0.value.contact_id
-                then:
-                  __string.concat:
-                    - '/contacts?_id='
-                    - __args: 0.value.contact_id
-                else: null
+              __args: 0.value.href
           options:
             - label: Alice
               value:
-                contact_id: user_1
                 name: Alice
+                href: '/contacts?_id=user_1'
               tag:
                 section: People
             - label: Bob
               value:
-                contact_id: user_2
                 name: Bob
+                href: '/contacts?_id=user_2'
               tag:
                 section: People
             - label: Finance
@@ -284,6 +270,7 @@
               tag:
                 section: Roles
                 group: devs
+                color: '#13c2c2'
 
 - title: Minimal — tables and images disabled
   fullWidth: true

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/gallery.yaml
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/gallery.yaml
@@ -177,6 +177,48 @@
         title: Read only
         disabled: true
 
+- title: Sectioned menu
+  fullWidth: true
+  blocks:
+    - id: tiptap_mention_sectioned
+      type: TiptapMentionInput
+      properties:
+        title: Mention people or roles
+        placeholder: 'Type @ — options are grouped, each section capped at 3.'
+        mentions:
+          limit: 3
+          options:
+            - label: Alice
+              value:
+                _id: user_1
+              tag:
+                section: People
+            - label: Bob
+              value:
+                _id: user_2
+              tag:
+                section: People
+            - label: Carol
+              value:
+                _id: user_3
+              tag:
+                section: People
+            - label: Dave
+              value:
+                _id: user_4
+              tag:
+                section: People
+            - label: Finance
+              value:
+                _id: role_finance
+              tag:
+                section: Roles
+            - label: Developers
+              value:
+                _id: role_devs
+              tag:
+                section: Roles
+
 - title: Minimal — tables and images disabled
   fullWidth: true
   blocks:

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/gallery.yaml
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/gallery.yaml
@@ -231,6 +231,18 @@
           # devs colour comes from this central map; finance overrides via tag.color
           groupColors:
             devs: '#13c2c2'
+          # shown on hover of a group chip, keyed by tag.group
+          groupMembers:
+            finance:
+              - name: Jane Doe
+                email: jane@example.com
+              - name: John Smith
+                email: john@example.com
+            devs:
+              - name: Ada Lovelace
+                email: ada@example.com
+              - name: Alan Turing
+                email: alan@example.com
           getHref:
             _function:
               # people carry value.contact_id and link to a profile;

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/itemSection.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/itemSection.js
@@ -1,0 +1,21 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+function itemSection(item) {
+  return item?.tag?.section;
+}
+
+export default itemSection;

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/meta.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/meta.js
@@ -135,6 +135,31 @@ export default {
               'Optional function (_function operator) that receives a selected mention id and returns an href. When provided, mentions render as <a> tags.',
             docs: { displayType: 'yaml' },
           },
+          limit: {
+            type: 'integer',
+            minimum: 1,
+            default: 5,
+            description:
+              'Maximum suggestions shown — per section when options declare sections, otherwise across the flat list.',
+          },
+          groupColors: {
+            type: 'object',
+            additionalProperties: { type: 'string' },
+            description:
+              "Map of group key → CSS colour applied to that group's mention chips. Overridden per option by tag.color.",
+          },
+          groupMembers: {
+            type: 'object',
+            additionalProperties: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: { name: { type: 'string' }, email: { type: 'string' } },
+              },
+            },
+            description:
+              "Map of group key → array of { name, email } shown in a hover popover on that group's chips (live editor only).",
+          },
         },
       },
       mentionsRequestId: {

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/meta.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/meta.js
@@ -142,12 +142,6 @@ export default {
             description:
               'Maximum suggestions shown — per section when options declare sections, otherwise across the flat list.',
           },
-          groupColors: {
-            type: 'object',
-            additionalProperties: { type: 'string' },
-            description:
-              "Map of group key → CSS colour applied to that group's mention chips. Overridden per option by tag.color.",
-          },
           groupMembers: {
             type: 'object',
             additionalProperties: {

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/meta.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/meta.js
@@ -132,7 +132,7 @@ export default {
           getHref: {
             type: 'object',
             description:
-              'Optional function (_function operator) that receives a selected mention id and returns an href. When provided, mentions render as <a> tags.',
+              'Optional _function that receives the selected mention option and returns an href. A non-nullish return renders the mention as an <a>; a nullish return renders a plain <span> (use this for options with no link, e.g. group mentions).',
             docs: { displayType: 'yaml' },
           },
           limit: {

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/style.module.css
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/style.module.css
@@ -108,3 +108,41 @@
 :global(.tiptap-table) :global(th) :global(p) {
   margin: 0;
 }
+
+:global(.tiptap-mention-group-popover) {
+  background: var(--ant-color-bg-container);
+  border-radius: var(--ant-border-radius, 8px);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.05),
+    0px 10px 20px rgba(0, 0, 0, 0.1);
+  color: var(--ant-color-text);
+  font-size: var(--ant-font-size-sm, 12px);
+  max-width: 240px;
+  padding: 0.3rem 0.6rem;
+}
+
+:global(.tiptap-mention-group-popover-header) {
+  font-weight: 600;
+  padding: 0.1rem 0;
+}
+
+:global(.tiptap-mention-group-popover-item) {
+  padding: 0.1rem 0;
+}
+
+:global(.tiptap-mention-group-popover-item) > div {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:global(.tiptap-mention-group-popover-email) {
+  color: var(--ant-color-text-secondary);
+  font-size: var(--ant-font-size-sm, 12px);
+  line-height: 1.3;
+}
+
+:global(.tiptap-mention-group-popover-empty) {
+  color: var(--ant-color-text-secondary);
+  padding: 0.1rem 0;
+}

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/style.module.css
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/style.module.css
@@ -6,6 +6,11 @@
   color: var(--ant-color-link);
 }
 
+:global(.tiptap-mention-group) {
+  box-decoration-break: clone;
+  font-weight: 600;
+}
+
 :global(.tiptap-mention-items) {
   background: var(--ant-color-bg-container);
   border-radius: var(--ant-border-radius, 8px);

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/style.module.css
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/style.module.css
@@ -36,6 +36,15 @@
   background: var(--ant-control-item-bg-hover);
 }
 
+:global(.tiptap-mention-section) {
+  color: var(--ant-color-text-secondary);
+  font-size: var(--ant-font-size-sm, 12px);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  padding: 0.3rem 0.4rem 0.1rem;
+}
+
 :global(.tableWrapper),
 :global(.tiptap-table) {
   display: block;

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/suggestion.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/suggestion.js
@@ -19,8 +19,9 @@ import { type } from '@lowdefy/helpers';
 import tippy from 'tippy.js';
 
 import MentionList from './MentionList.js';
+import itemSection from './itemSection.js';
 
-function suggestion({ methods, char = '@', allowSpaces = true }) {
+function suggestion({ methods, char = '@', allowSpaces = true, limit = 5 }) {
   return {
     // `char` must be set explicitly: Mention.configure does a shallow merge
     // on its options.suggestion, replacing the extension's default `@`.
@@ -28,17 +29,27 @@ function suggestion({ methods, char = '@', allowSpaces = true }) {
     allowSpaces,
     items: ({ query, editor }) => {
       const itemsList = editor.options.editorProps.items ?? [];
-      return itemsList
-        .filter((item) => {
-          if (type.isString(item)) {
-            return item.toLowerCase().includes(query.toLowerCase());
-          }
-          if (type.isString(item?.label)) {
-            return item.label.toLowerCase().includes(query.toLowerCase());
-          }
-          return false;
-        })
-        .slice(0, 5);
+      const filtered = itemsList.filter((item) => {
+        if (type.isString(item)) {
+          return item.toLowerCase().includes(query.toLowerCase());
+        }
+        if (type.isString(item?.label)) {
+          return item.label.toLowerCase().includes(query.toLowerCase());
+        }
+        return false;
+      });
+      // no option declares a section → flat list capped at limit (today's behaviour)
+      if (!filtered.some((item) => !type.isNone(itemSection(item)))) {
+        return filtered.slice(0, limit);
+      }
+      const counts = new Map();
+      return filtered.filter((item) => {
+        const section = itemSection(item);
+        const n = counts.get(section) ?? 0;
+        if (n >= limit) return false;
+        counts.set(section, n + 1);
+        return true;
+      });
     },
 
     render: () => {

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests.yaml
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests.yaml
@@ -64,3 +64,28 @@
             _id: role_finance
           tag:
             section: Roles
+- id: properties.mentions.groupColors with group chips
+  type: TiptapMentionInput
+  properties:
+    mentions:
+      groupColors:
+        devs: '#13c2c2'
+      options:
+        - label: Alice
+          value:
+            _id: user_1
+          tag:
+            section: People
+        - label: Finance
+          value:
+            role: finance-admin
+          tag:
+            section: Roles
+            group: finance
+            color: '#722ed1'
+        - label: Developers
+          value:
+            role: developer
+          tag:
+            section: Roles
+            group: devs

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests.yaml
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests.yaml
@@ -43,3 +43,24 @@
         - label: bug
           value:
             _id: tag_bug
+- id: properties.mentions.limit with sections
+  type: TiptapMentionInput
+  properties:
+    mentions:
+      limit: 2
+      options:
+        - label: Alice
+          value:
+            _id: user_1
+          tag:
+            section: People
+        - label: Bob
+          value:
+            _id: user_2
+          tag:
+            section: People
+        - label: Finance
+          value:
+            _id: role_finance
+          tag:
+            section: Roles

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests.yaml
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests.yaml
@@ -64,12 +64,10 @@
             _id: role_finance
           tag:
             section: Roles
-- id: properties.mentions.groupColors with group chips
+- id: properties.mentions group chips with tag.color
   type: TiptapMentionInput
   properties:
     mentions:
-      groupColors:
-        devs: '#13c2c2'
       options:
         - label: Alice
           value:
@@ -89,3 +87,4 @@
           tag:
             section: Roles
             group: devs
+            color: '#13c2c2'

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests/TiptapMentionInput.e2e.spec.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests/TiptapMentionInput.e2e.spec.js
@@ -70,4 +70,107 @@ test.describe('TiptapMentionInput Block', () => {
     await expect(mention).toHaveText('@Bob');
     await expect(editor).not.toContainText('undefined');
   });
+
+  test.describe('group mentions', () => {
+    const groupsId = 'tiptap_mention_groups';
+
+    test('dropdown groups options under section headings', async ({ page }) => {
+      await editorLocator(page, groupsId).click();
+      await page.keyboard.type('@');
+      const dropdown = page.locator('.tiptap-mention-items');
+      await expect(dropdown).toBeVisible();
+      const sections = dropdown.locator('.tiptap-mention-section');
+      await expect(sections).toHaveText(['People', 'Roles']);
+    });
+
+    test('caps each section at mentions.limit (People trimmed to 3 of 4)', async ({ page }) => {
+      await editorLocator(page, groupsId).click();
+      await page.keyboard.type('@');
+      const dropdown = page.locator('.tiptap-mention-items');
+      await expect(dropdown).toBeVisible();
+      // People has 4 options (Alice, Amir, Anna, Aaron) but limit is 3.
+      await expect(dropdown.locator('.tiptap-mention-item', { hasText: 'Alice' })).toBeVisible();
+      await expect(dropdown.locator('.tiptap-mention-item', { hasText: 'Aaron' })).toHaveCount(0);
+      // Both Roles options fit under the cap.
+      await expect(dropdown.locator('.tiptap-mention-item', { hasText: 'Finance' })).toBeVisible();
+      await expect(
+        dropdown.locator('.tiptap-mention-item', { hasText: 'Developers' })
+      ).toBeVisible();
+    });
+
+    test('flat keyboard index crosses the section boundary', async ({ page }) => {
+      const editor = editorLocator(page, groupsId);
+      await editor.click();
+      await page.keyboard.type('@');
+      await expect(page.locator('.tiptap-mention-items')).toBeVisible();
+      // Flat order is [Alice, Amir, Anna | Finance, Developers]; selection starts at 0.
+      // Three ArrowDowns must land on Finance — the first Roles option — proving the
+      // index carries across the People→Roles heading.
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('Enter');
+      const chip = editor.locator('[data-mention-group="finance"]');
+      await expect(chip).toBeVisible();
+      await expect(chip).toHaveText('@Finance');
+    });
+
+    test('group option renders a coloured <span> chip with data-mention-group', async ({
+      page,
+    }) => {
+      const editor = editorLocator(page, groupsId);
+      await editor.click();
+      await page.keyboard.type('@Finance');
+      await page.locator('.tiptap-mention-items .tiptap-mention-item', { hasText: 'Finance' }).click();
+      const chip = editor.locator('.tiptap-mention-group');
+      await expect(chip).toHaveText('@Finance');
+      await expect(chip).toHaveClass(/tiptap-mention\b/);
+      await expect(chip).toHaveAttribute('data-mention-group', 'finance');
+      await expect(chip).toHaveAttribute('style', /color:\s*#722ed1/);
+      // getHref returns nothing for groups → plain span, never <a href="null">.
+      expect(await chip.evaluate((n) => n.tagName.toLowerCase())).toBe('span');
+    });
+
+    test('person option renders an <a> from getHref (no href="null")', async ({ page }) => {
+      const editor = editorLocator(page, groupsId);
+      await editor.click();
+      await page.keyboard.type('@Alice');
+      await page.locator('.tiptap-mention-items .tiptap-mention-item', { hasText: 'Alice' }).click();
+      const chip = editor.locator('a.tiptap-mention', { hasText: '@Alice' });
+      await expect(chip).toBeVisible();
+      await expect(chip).toHaveAttribute('href', '/contacts?_id=user_1');
+      await expect(chip).not.toHaveClass(/tiptap-mention-group/);
+    });
+
+    test('hovering a group chip shows its members, and typing tears it down', async ({ page }) => {
+      const editor = editorLocator(page, groupsId);
+      await editor.click();
+      await page.keyboard.type('@Finance');
+      await page.locator('.tiptap-mention-items .tiptap-mention-item', { hasText: 'Finance' }).click();
+      const chip = editor.locator('.tiptap-mention-group');
+      await chip.hover();
+      const popover = page.locator('.tiptap-mention-group-popover');
+      await expect(popover).toBeVisible();
+      await expect(popover.locator('.tiptap-mention-group-popover-header')).toContainText('Finance');
+      await expect(popover.locator('.tiptap-mention-group-popover-header')).toContainText('2');
+      await expect(popover).toContainText('Jane Doe');
+      await expect(popover).toContainText('jane@example.com');
+      // Editing the content must remove the popover.
+      await editor.click();
+      await page.keyboard.type(' hi');
+      await expect(popover).toHaveCount(0);
+    });
+
+    test('group chip keeps its inline colour in the saved html', async ({ page }) => {
+      const editor = editorLocator(page, groupsId);
+      await editor.click();
+      await page.keyboard.type('@Developers');
+      await page
+        .locator('.tiptap-mention-items .tiptap-mention-item', { hasText: 'Developers' })
+        .click();
+      const html = await editor.evaluate((n) => n.innerHTML);
+      expect(html).toContain('data-mention-group="devs"');
+      expect(html.toLowerCase()).toContain('#13c2c2');
+    });
+  });
 });

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests/TiptapMentionInput.e2e.yaml
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests/TiptapMentionInput.e2e.yaml
@@ -54,3 +54,65 @@ blocks:
           - label: Bob
             value:
               _id: user_2
+
+  - id: tiptap_mention_groups
+    type: TiptapMentionInput
+    properties:
+      title: Group mentions playground
+      placeholder: 'Type @ — People + Roles sections, group chips, hover members'
+      mentions:
+        limit: 3
+        groupMembers:
+          finance:
+            - name: Jane Doe
+              email: jane@example.com
+            - name: John Smith
+              email: john@example.com
+          devs:
+            - name: Ada Lovelace
+              email: ada@example.com
+            - name: Alan Turing
+              email: alan@example.com
+        # people carry value.href → <a>; groups omit it → nullish → <span>
+        getHref:
+          _function:
+            __args: 0.value.href
+        options:
+          - label: Alice
+            value:
+              name: Alice
+              href: '/contacts?_id=user_1'
+            tag:
+              section: People
+          - label: Amir
+            value:
+              name: Amir
+              href: '/contacts?_id=user_2'
+            tag:
+              section: People
+          - label: Anna
+            value:
+              name: Anna
+              href: '/contacts?_id=user_3'
+            tag:
+              section: People
+          - label: Aaron
+            value:
+              name: Aaron
+              href: '/contacts?_id=user_4'
+            tag:
+              section: People
+          - label: Finance
+            value:
+              role: finance-admin
+            tag:
+              section: Roles
+              group: finance
+              color: '#722ed1'
+          - label: Developers
+            value:
+              role: developer
+            tag:
+              section: Roles
+              group: devs
+              color: '#13c2c2'

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/useGroupMembersPopover.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/useGroupMembersPopover.js
@@ -1,0 +1,134 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { useEffect, useRef } from 'react';
+import { type } from '@lowdefy/helpers';
+import tippy from 'tippy.js';
+
+function buildPopoverContent({ chip, group, groupMembers, char }) {
+  const members = groupMembers[group] ?? [];
+
+  const root = document.createElement('div');
+  root.className = 'tiptap-mention-group-popover';
+
+  let title = chip.textContent ?? '';
+  if (title.startsWith(char)) {
+    title = title.slice(char.length);
+  }
+
+  const header = document.createElement('div');
+  header.className = 'tiptap-mention-group-popover-header';
+  header.textContent = `${title} — ${members.length}`;
+  root.appendChild(header);
+
+  if (members.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'tiptap-mention-group-popover-empty';
+    empty.textContent = 'No members';
+    root.appendChild(empty);
+    return root;
+  }
+
+  members.forEach((member) => {
+    const item = document.createElement('div');
+    item.className = 'tiptap-mention-group-popover-item';
+
+    const name = document.createElement('div');
+    name.textContent = member?.name ?? '';
+    item.appendChild(name);
+
+    if (!type.isNone(member?.email)) {
+      const email = document.createElement('div');
+      email.className = 'tiptap-mention-group-popover-email';
+      email.textContent = member.email;
+      item.appendChild(email);
+    }
+
+    root.appendChild(item);
+  });
+
+  return root;
+}
+
+function useGroupMembersPopover({ editor, properties }) {
+  // Updated every render so late-arriving groupMembers (typically from a
+  // request) is read at hover time, not captured at mount.
+  const mentionsRef = useRef(properties.mentions);
+  mentionsRef.current = properties.mentions;
+
+  const popoverRef = useRef(null);
+  const activeChipRef = useRef(null);
+
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) return undefined;
+    const dom = editor.view.dom;
+
+    const hide = () => {
+      if (popoverRef.current) {
+        popoverRef.current.destroy();
+        popoverRef.current = null;
+      }
+      activeChipRef.current = null;
+    };
+
+    const handleMouseOver = (event) => {
+      const chip = event.target?.closest?.('.tiptap-mention-group[data-mention-group]');
+      if (!chip) return;
+      if (!dom.contains(chip)) return;
+      if (chip === activeChipRef.current) return;
+
+      const groupMembers = mentionsRef.current?.groupMembers;
+      if (type.isNone(groupMembers)) return;
+
+      const group = chip.getAttribute('data-mention-group');
+      if (!Object.prototype.hasOwnProperty.call(groupMembers, group)) return;
+
+      hide();
+
+      const char = mentionsRef.current?.char ?? '@';
+      const content = buildPopoverContent({ chip, group, groupMembers, char });
+      const instance = tippy(chip, {
+        content,
+        trigger: 'manual',
+        appendTo: () => document.body,
+        placement: 'top-start',
+        interactive: false,
+      });
+      instance.show();
+      popoverRef.current = instance;
+      activeChipRef.current = chip;
+    };
+
+    const handleMouseOut = (event) => {
+      if (activeChipRef.current && !activeChipRef.current.contains(event.relatedTarget)) {
+        hide();
+      }
+    };
+
+    dom.addEventListener('mouseover', handleMouseOver);
+    dom.addEventListener('mouseout', handleMouseOut);
+    editor.on('update', hide);
+
+    return () => {
+      dom.removeEventListener('mouseover', handleMouseOver);
+      dom.removeEventListener('mouseout', handleMouseOut);
+      editor.off('update', hide);
+      hide();
+    };
+  }, [editor]);
+}
+
+export default useGroupMembersPopover;


### PR DESCRIPTION
## Summary

`TiptapMentionInput` renders every `@`-mention the same way today: a flat suggestion list and one link-coloured chip per option. This PR lets an app mark any mention option as belonging to an arbitrary, app-defined **group** (a role, a queue, a team, a segment). Group options render under menu-section headings, insert a distinctly coloured chip carrying a `data-mention-group` attribute, and show the group's current members in a hover popover. Which groups exist, their labels, colours, and members are all app data — the block hardcodes none. Also fixes a latent `getHref` bug so a nullish href renders `<span>` instead of `<a href="null">`.

Design: `designs/tiptap-group-mentions/design.md`.

## Changes

- **@lowdefy/blocks-tiptap**:
  - **Menu sections** — options with `tag.section` group under headings in the suggestion dropdown; a single flat keyboard index is kept so arrow/Enter navigation crosses section boundaries.
  - **Group chips** — an option with `tag.group` renders `class="tiptap-mention tiptap-mention-group"` + `data-mention-group="<group>"`, coloured inline from `tag.color` so the colour travels with saved HTML.
  - **Hover member popover** — a new `useGroupMembersPopover` hook shows `mentions.groupMembers` (a `{ group: [{ name, email }] }` map, which may load from a request) on chip hover in the live editor; it delegates listeners on the editor DOM and tears the popover down on edit/unmount.
  - **Configurable cap** — `mentions.limit` (default 5) caps suggestions, applied per section when sections are used, otherwise across the flat list.
  - **`getHref` fix** — the element is now chosen by the function's return value: non-nullish → `<a>`, nullish → `<span>` (no more `href="null"`).
  - Presentation stays on `tag` (`section`/`group`/`color`); `value` remains the app's opaque, emitted payload — the block never reads it for rendering.
- **docs** — the `TiptapMentionInput` reference page gains a group-mentions guide (`tag` fields, `mentions.limit`/`groupMembers`, the corrected `getHref`, emitted chip markup) with a worked example.

## Key Files

- `packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/TiptapMentionInput.js` — `renderHTML` group class/attr/inline colour + href-value element choice; wires the popover hook.
- `.../TiptapMentionInput/suggestion.js` — per-section cap with flat fallback.
- `.../TiptapMentionInput/MentionList.js` — group by section, headings, flat keyboard index.
- `.../TiptapMentionInput/useGroupMembersPopover.js` — new live-editor hover popover.
- `.../TiptapMentionInput/itemSection.js` — shared `tag.section` helper.

## Breaking Changes

- `getHref` returning `null`/`undefined` now renders `<span>` instead of `<a href="null">`. This only affects configs whose `getHref` returned a nullish value (previously a bug); configs returning real URLs are unaffected. Note the test is nullish-only — returning `''` still yields `<a href="">`.

## Notes

- Options with no `tag.section`, `tag.group`, or `tag.color` render exactly as before (flat menu, plain `tiptap-mention` chip) — fully backward compatible aside from the href fix.
- `mentions.groupColors` was considered and dropped in favour of the single `tag.color` source: a group is almost always one chip, and a central map would be captured at editor mount and silently fail for colours loaded from a request. `tag.color` rides on the selected option, so it is always current. `groupMembers` stays a map precisely because it is read live at hover time.
- e2e specs were added (`TiptapMentionInput.e2e.spec.js`) covering section headings, the per-section cap, cross-section keyboard nav, group chip attributes/colour, the `<span>`-vs-`<a>` href behaviour, and the hover popover lifecycle. They were not executed in the authoring sandbox (Playwright browser download is blocked there) and are expected to run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)