### PR TITLE
Prevent Tiptap editor teardown crashes when navigating away mid-edit

### DIFF
--- a/.changeset/fix-tiptap-teardown-crashes.md
+++ b/.changeset/fix-tiptap-teardown-crashes.md
@@ -1,0 +1,12 @@
+---
+'@lowdefy/blocks-tiptap': patch
+---
+
+fix: Prevent rich-text editor crash when navigating away mid-edit.
+
+Fixed a "removeChild" crash in the Tiptap editor blocks that could occur when the
+editor was unmounted while the formatting menu or an `@`-mention popup was open, or
+while an image upload was still in progress — for example when a user submitted or
+started editing content and immediately navigated away. The editor now tears these
+down safely, so navigating away no longer throws or leaves the editor in a broken
+state.

--- a/packages/plugins/blocks/blocks-tiptap/package.json
+++ b/packages/plugins/blocks/blocks-tiptap/package.json
@@ -58,6 +58,7 @@
     "@lowdefy/blocks-antd": "5.3.0",
     "@lowdefy/helpers": "5.3.0",
     "@tiptap/core": "2.27.2",
+    "@tiptap/extension-bubble-menu": "2.27.2",
     "@tiptap/extension-file-handler": "2.27.2",
     "@tiptap/extension-highlight": "2.27.2",
     "@tiptap/extension-image": "2.27.2",

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/useTiptapState.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapInput/useTiptapState.js
@@ -54,6 +54,10 @@ function useTiptapState({ value, methods }) {
 
   const insertImage = async (editor, file, pos) => {
     const url = await s3FileUpload({ file, methods });
+    // The upload is async: bail if the editor was torn down meanwhile (e.g. the
+    // surrounding page navigated away before the upload resolved), otherwise the
+    // chained commands run against a destroyed editor and throw.
+    if (editor.isDestroyed) return;
     editor
       .chain()
       .insertContentAt(pos, [

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/suggestion.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/suggestion.js
@@ -66,22 +66,39 @@ function suggestion({ methods, char = '@', allowSpaces = true }) {
         },
 
         onUpdate(props) {
-          component.updateProps(props);
+          component?.updateProps(props);
           if (!props.clientRect) return;
-          popup[0].setProps({ getReferenceClientRect: props.clientRect });
+          popup?.[0]?.setProps({ getReferenceClientRect: props.clientRect });
         },
 
         onKeyDown(props) {
           if (props.event.key === 'Escape') {
-            popup[0].hide();
+            popup?.[0]?.hide();
             return true;
           }
-          return component.ref?.onKeyDown(props);
+          return component?.ref?.onKeyDown(props) ?? false;
         },
 
         onExit() {
-          popup[0].destroy();
-          component.destroy();
+          // Tear down in this order — React portal first, tippy popup after —
+          // to avoid "NotFoundError: Failed to execute 'removeChild'" when the
+          // user navigates away (e.g. clicks another item) while the mention
+          // popup is open. MentionList is rendered as a React portal into
+          // component.element, which tippy relocates into document.body.
+          // Destroying tippy first detaches that container out from under
+          // React's portal teardown; destroying the component first lets React
+          // remove the MentionList DOM cleanly while the container is still
+          // attached. The tippy teardown is then deferred to a microtask so it
+          // never runs synchronously inside React's own unmount commit.
+          component?.destroy();
+          component = undefined;
+          const instance = popup?.[0];
+          popup = undefined;
+          if (instance && !instance.state.isDestroyed) {
+            queueMicrotask(() => {
+              if (!instance.state.isDestroyed) instance.destroy();
+            });
+          }
         },
       };
     },

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/useTiptapMentionState.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/useTiptapMentionState.js
@@ -61,6 +61,10 @@ function useTiptapMentionState({ value, methods }) {
 
   const insertImage = async (editor, file, pos) => {
     const url = await s3FileUpload({ file, methods });
+    // The upload is async: bail if the editor was torn down meanwhile (e.g. the
+    // surrounding page navigated away before the upload resolved), otherwise the
+    // chained commands run against a destroyed editor and throw.
+    if (editor.isDestroyed) return;
     editor
       .chain()
       .insertContentAt(pos, [

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/PopoverMenu.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/utils/PopoverMenu.js
@@ -14,8 +14,9 @@
   limitations under the License.
 */
 
-import React from 'react';
-import { BubbleMenu } from '@tiptap/react';
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { BubbleMenuPlugin } from '@tiptap/extension-bubble-menu';
 import {
   AiOutlineBold,
   AiOutlineItalic,
@@ -35,33 +36,68 @@ function hasExt(editor, name) {
   return editor.extensionManager.extensions.some((ext) => ext.name === name);
 }
 
+// Custom bubble menu built on tiptap's BubbleMenuPlugin instead of the
+// `<BubbleMenu>` React wrapper. The wrapper renders its menu element with
+// React and then the plugin calls `element.remove()` on it (bubble-menu-plugin
+// detaches the menu from the DOM on construction). When the editor block later
+// unmounts — e.g. the surrounding page navigates away, or `disabled` flips and
+// unmounts this menu — React tries to removeChild an element that is no longer
+// where it rendered it, throwing "NotFoundError: Failed to execute
+// 'removeChild' on 'Node'".
+//
+// Here we own the container element ourselves and render the buttons into it
+// with a portal. React only ever removes the buttons from our container (always
+// their parent), never the plugin-detached element, so the teardown race is
+// gone.
 const PopoverMenu = ({ editor }) => {
+  const [container] = useState(() =>
+    typeof document === 'undefined' ? null : document.createElement('div')
+  );
+
   const showBold = hasExt(editor, 'bold');
   const showItalic = hasExt(editor, 'italic');
   const showStrike = hasExt(editor, 'strike');
   const showHighlight = hasExt(editor, 'highlight');
+  const hasTools = showBold || showItalic || showStrike || showHighlight;
 
-  if (!showBold && !showItalic && !showStrike && !showHighlight) {
-    return null;
-  }
+  useEffect(() => {
+    if (!container || !editor || editor.isDestroyed || !hasTools) return undefined;
 
-  return (
-    <BubbleMenu
-      className="tiptap-popover"
-      editor={editor}
-      shouldShow={({ editor, view, state, from, to }) => {
-        if (editor.isActive('image')) return false;
-        const { doc, selection } = state;
+    container.className = 'tiptap-popover';
+
+    const plugin = BubbleMenuPlugin({
+      pluginKey: 'bubbleMenu',
+      editor,
+      element: container,
+      shouldShow: ({ editor: menuEditor, view, state, from, to }) => {
+        if (menuEditor.isActive('image')) return false;
+        const { selection } = state;
         const { empty } = selection;
         const isEmptyTextBlock =
-          !doc.textBetween(from, to).length && isTextSelection(state.selection);
+          !state.doc.textBetween(from, to).length && isTextSelection(state.selection);
         const hasEditorFocus = view.hasFocus();
-        if (!hasEditorFocus || empty || isEmptyTextBlock || !editor.isEditable) {
+        if (!hasEditorFocus || empty || isEmptyTextBlock || !menuEditor.isEditable) {
           return false;
         }
         return true;
-      }}
-    >
+      },
+    });
+
+    editor.registerPlugin(plugin);
+    return () => {
+      // Tear the plugin (and its tippy instance) down first. React then
+      // unmounts the portal, removing the buttons from our still-intact
+      // container.
+      if (!editor.isDestroyed) {
+        editor.unregisterPlugin('bubbleMenu');
+      }
+    };
+  }, [editor, container, hasTools]);
+
+  if (!container || !hasTools) return null;
+
+  return createPortal(
+    <>
       {showBold && (
         <AiOutlineBold
           className="tiptap-icon"
@@ -89,7 +125,8 @@ const PopoverMenu = ({ editor }) => {
             onClick={() => editor.chain().focus().toggleHighlight({ color: fill }).run()}
           />
         ))}
-    </BubbleMenu>
+    </>,
+    container
   );
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1129,6 +1129,9 @@ importers:
       '@tiptap/core':
         specifier: 2.27.2
         version: 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/extension-bubble-menu':
+        specifier: 2.27.2
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
       '@tiptap/extension-file-handler':
         specifier: 2.27.2
         version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/extension-text-style@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2)))


### PR DESCRIPTION
## Summary

The `@lowdefy/blocks-tiptap` blocks contained three "act then immediately unmount/navigate" teardown races that all surface as `NotFoundError: Failed to execute 'removeChild' on 'Node'`. These were found and fixed in a downstream fork (`@mrmtech/plugin-tiptap`) and are ported back here since the source is identical.

The crash reproduces when the editor unmounts while something it owns is still torn down asynchronously — e.g. a user submits or starts editing content and immediately clicks away.

### Fixes

1. **Bubble/formatting menu** (`utils/PopoverMenu.js`) — replaced tiptap's `<BubbleMenu>` React wrapper with a manual `BubbleMenuPlugin` that renders the buttons into a self-owned container via a portal. The wrapper let its React-rendered menu element be `element.remove()`'d by the plugin on construction, so on unmount React tried to `removeChild` a node that had moved. Owning the container means React only ever removes the buttons from their real parent.

2. **`@`-mention popup** (`TiptapMentionInput/suggestion.js`) — `onExit` now destroys the React portal first and defers the tippy teardown to a microtask so it never runs synchronously inside React's unmount commit. Added optional-chaining guards to `onUpdate`/`onKeyDown`.

3. **Async image insert** (`TiptapInput/useTiptapState.js`, `TiptapMentionInput/useTiptapMentionState.js`) — bail if `editor.isDestroyed` after the async S3 upload resolves, instead of chaining commands onto a destroyed editor.

Also adds `@tiptap/extension-bubble-menu` as a direct dependency (previously only transitive via `@tiptap/react`), now that `PopoverMenu` imports it directly.

## Test plan

- Open a Tiptap editor, select text to show the formatting menu, then navigate away / unmount the block → no `removeChild` crash.
- Open the `@`-mention popup, then navigate away while it's open → no crash.
- Start an image upload, navigate away before it resolves → no crash against a destroyed editor.

## Notes

Verified downstream in production (the identical fork). Syntax-verified locally with swc; a full workspace build was not run in this worktree.

## PR Checklist
- [ ] Documentation updated if needed
- [ ] Self-review completed