### PR TITLE
Build notifications and validate CallAgent steps in the dev build

### DIFF
--- a/packages/build/src/build/jit/buildPageJitCallApi.integration.test.js
+++ b/packages/build/src/build/jit/buildPageJitCallApi.integration.test.js
@@ -81,6 +81,10 @@ const typesMap = {
     ...snapshotTypesMap.actions,
     CallAPI: { package: '@lowdefy/actions-core' },
   },
+  notifications: {
+    ...snapshotTypesMap.notifications,
+    NotificationEmail: { package: '@lowdefy/email-templates' },
+  },
 };
 
 // Packages that would be installed in a real dev server using these blocks/actions.
@@ -143,8 +147,16 @@ modules:
   - id: inviter
     source: 'file:modules/inviter'
 
+notifications:
+  - id: hello
+    type: NotificationEmail
+    properties:
+      subject: Hello
+      message: Hi there
+
 api:
   - _ref: api/top-endpoint.yaml
+  - _ref: api/render-endpoint.yaml
 
 pages:
   - _ref: pages/home.yaml
@@ -153,6 +165,20 @@ pages:
   );
 
   write('api/top-endpoint.yaml', returnEndpoint('top_endpoint'));
+  write(
+    'api/render-endpoint.yaml',
+    `id: render-test
+type: Api
+routine:
+  - id: render
+    type: RenderNotification
+    properties:
+      notificationId: hello
+      data:
+        contact:
+          email: test@example.com
+`
+  );
   write('pages/home.yaml', callApiPage('home', 'top_endpoint'));
   write('pages/missing.yaml', callApiPage('missing', 'does_not_exist'));
 
@@ -279,7 +305,17 @@ async function buildAndCollectWarnings(pageId) {
 test('shallowBuild writes scoped api endpoint artifacts to build/api', () => {
   const endpointIds = apiArtifacts.map((c) => c.endpointId).sort();
   // Top-level keeps its id; module endpoint is scoped with the module entry id.
-  expect(endpointIds).toEqual(['inviter/send-invite', 'top_endpoint']);
+  expect(endpointIds).toEqual(['inviter/send-invite', 'render-test', 'top_endpoint']);
+});
+
+test('shallowBuild writes the notifications config artifact to build/notifications', () => {
+  // Regression: the dev shallow build previously dropped the notifications: section,
+  // so RenderNotification threw "Notification does not exist" under lowdefy dev.
+  const notification = readArtifact(buildDir, 'notifications/hello.json');
+  expect(notification).not.toBeNull();
+  expect(notification.notificationId).toBe('hello');
+  expect(notification.type).toBe('NotificationEmail');
+  expect(notification.properties.subject).toBe('Hello');
 });
 
 test('JIT build of a page calling a top-level endpoint emits no false non-existent warning', async () => {

--- a/packages/build/src/build/jit/shallowBuild.js
+++ b/packages/build/src/build/jit/shallowBuild.js
@@ -36,9 +36,11 @@ import buildImports from '../buildImports/buildImports.js';
 import buildMenu from '../buildMenu.js';
 import buildModuleDefs from '../buildModuleDefs.js';
 import buildModules from '../buildModules.js';
+import buildNotifications from '../buildNotifications.js';
 import buildRefs from '../buildRefs/buildRefs.js';
 import buildTypes from '../buildTypes.js';
 import buildWebsockets from '../buildWebsockets.js';
+import validateRenderNotificationSteps from '../validateRenderNotificationSteps.js';
 import cleanBuildDirectory from '../cleanBuildDirectory.js';
 import copyAgentFileSystems from '../copyAgentFileSystems.js';
 import copyPublicFolder from '../copyPublicFolder.js';
@@ -51,6 +53,7 @@ import writeConfig from '../writeConfig.js';
 import writeConnections from '../writeConnections.js';
 import writeAgents from '../writeAgents.js';
 import writeApi from '../writeApi.js';
+import writeNotifications from '../writeNotifications.js';
 import writeGlobal from '../writeGlobal.js';
 import writeJs from '../buildJs/writeJs.js';
 import writeWebsockets from '../writeWebsockets.js';
@@ -138,6 +141,12 @@ async function shallowBuild(options) {
     tryBuildStep(buildApi, 'buildApi', { components, context });
     tryBuildStep(buildAgents, 'buildAgents', { components, context });
     tryBuildStep(buildWebsockets, 'buildWebsockets', { components, context });
+    tryBuildStep(buildNotifications, 'buildNotifications', { components, context });
+    // Cross-config validation — needs buildApi (stepIds) and buildNotifications (id set)
+    tryBuildStep(validateRenderNotificationSteps, 'validateRenderNotificationSteps', {
+      components,
+      context,
+    });
 
     const { pageRegistry, sourcelessPageArtifacts } = buildShallowPages({ components, context });
 
@@ -168,6 +177,7 @@ async function shallowBuild(options) {
     await writeApi({ components, context });
     await writeAgents({ components, context });
     await writeWebsockets({ components, context });
+    await writeNotifications({ components, context });
     await writeConfig({ components, context });
     await writeGlobal({ components, context });
     await writeTheme({ components, context });

--- a/packages/build/src/build/jit/shallowBuild.js
+++ b/packages/build/src/build/jit/shallowBuild.js
@@ -40,6 +40,7 @@ import buildNotifications from '../buildNotifications.js';
 import buildRefs from '../buildRefs/buildRefs.js';
 import buildTypes from '../buildTypes.js';
 import buildWebsockets from '../buildWebsockets.js';
+import validateCallAgentSteps from '../validateCallAgentSteps.js';
 import validateRenderNotificationSteps from '../validateRenderNotificationSteps.js';
 import cleanBuildDirectory from '../cleanBuildDirectory.js';
 import copyAgentFileSystems from '../copyAgentFileSystems.js';
@@ -142,7 +143,9 @@ async function shallowBuild(options) {
     tryBuildStep(buildAgents, 'buildAgents', { components, context });
     tryBuildStep(buildWebsockets, 'buildWebsockets', { components, context });
     tryBuildStep(buildNotifications, 'buildNotifications', { components, context });
-    // Cross-config validation — needs buildApi (stepIds) and buildNotifications (id set)
+    // Cross-config validations — need buildApi (stepIds) and the buildAgents/
+    // buildNotifications id sets. Match the full build (index.js).
+    tryBuildStep(validateCallAgentSteps, 'validateCallAgentSteps', { components, context });
     tryBuildStep(validateRenderNotificationSteps, 'validateRenderNotificationSteps', {
       components,
       context,


### PR DESCRIPTION
## Summary

A `RenderNotification` step works under `lowdefy build` + `lowdefy start` but throws `Notification "<id>" does not exist` under `lowdefy dev`. The dev server builds via a separate shallow-build sequence (`shallowBuild.js`) that never processed the `notifications:` config section, so `.lowdefy/dev/build/` had no `notifications/` artifacts and `getNotificationConfig` read `null`. This brings the dev shallow build to parity with the full build (`index.js`). Found during a real integration smoke test on an app (build + start worked; dev threw).

## Changes

- **@lowdefy/build**: the dev shallow build now runs `buildNotifications`, `validateRenderNotificationSteps`, and `writeNotifications` (matching the full build's order — after `buildWebsockets`, and `writeNotifications` after `writeWebsockets`), so `lowdefy dev` emits `notifications/<id>.json` and hot-reloads changes to the section. Also adds `validateCallAgentSteps` to the shallow build — the same parity gap meant dev did not catch `CallAgent` steps referencing a non-existent agent. A regression test in `buildPageJitCallApi.integration.test.js` drives the real `shallowBuild` and asserts the notification artifact is written.

## Notes

- No changeset: `@lowdefy/build`'s next release is already covered by the email-notifications minor bump on `vite-hono`, and this is a fix to that same unreleased feature.
- The `validateCallAgentSteps` addition means `lowdefy dev` will now surface a build error for a `CallAgent` step that references a missing agent, where before it was silent — this matches `lowdefy build` behavior, but is a change for dev specifically.
- Consumers on a published experimental release will need a new experimental release cut to pick up this dev fix.