### PR TITLE
Accept null cc/bcc/replyTo in SMTPMailSend

### DIFF
--- a/packages/plugins/connections/connection-smtp/src/connections/SMTP/SMTPMailSend/SMTPMailSend.test.js
+++ b/packages/plugins/connections/connection-smtp/src/connections/SMTP/SMTPMailSend/SMTPMailSend.test.js
@@ -162,6 +162,22 @@ test('SMTPMailSend schema validates a valid request', async () => {
   expect(validate({ schema, data: request })).toEqual({ valid: true });
 });
 
+test('SMTPMailSend schema accepts null cc, bcc and replyTo', async () => {
+  const SMTPMailSend = (await import('./SMTPMailSend.js')).default;
+  const schema = SMTPMailSend.schema;
+  // Operator-driven configs (e.g. `_if_none: [item.cc, null]`) resolve
+  // absent optional address fields to null; the schema must treat that as omitted.
+  const request = {
+    to: 'someone@example.com',
+    cc: null,
+    bcc: null,
+    replyTo: null,
+    subject: 'A',
+    text: 'B',
+  };
+  expect(validate({ schema, data: request })).toEqual({ valid: true });
+});
+
 test('SMTPMailSend schema validates an array request', async () => {
   const SMTPMailSend = (await import('./SMTPMailSend.js')).default;
   const schema = SMTPMailSend.schema;

--- a/packages/plugins/connections/connection-smtp/src/connections/SMTP/SMTPMailSend/schema.js
+++ b/packages/plugins/connections/connection-smtp/src/connections/SMTP/SMTPMailSend/schema.js
@@ -86,15 +86,17 @@ export default {
           description: 'Email address to send to.',
         },
         cc: {
-          $ref: '#/definitions/emails',
+          // Optional address fields accept null so operator-driven configs
+          // (e.g. `_if_none: [item.cc, null]`) resolve to an omitted cc.
+          anyOf: [{ $ref: '#/definitions/emails' }, { type: 'null' }],
           description: 'Email address to cc in communication.',
         },
         bcc: {
-          $ref: '#/definitions/emails',
+          anyOf: [{ $ref: '#/definitions/emails' }, { type: 'null' }],
           description: 'Email address to bcc in communication.',
         },
         replyTo: {
-          $ref: '#/definitions/emails',
+          anyOf: [{ $ref: '#/definitions/emails' }, { type: 'null' }],
           description: 'Email address to reply to.',
         },
         subject: {


### PR DESCRIPTION
## Summary

`SMTPMailSend`'s schema accepted an email address or list, but not `null`, for the optional `cc`, `bcc`, and `replyTo` fields. Operator-driven configs routinely resolve an absent optional field to `null` (e.g. `_if_none: [item.cc, null]`), so a request without cc/bcc failed schema validation. The notifications dispatch pipeline hit this in a real integration test: every notification item without cc/bcc failed the send step and persisted `sent: false` with `send_attempts` bumped — looking like "notifications silently don't send." Found during a spike on an app (encircle-mvp).

## Changes

- **@lowdefy/connection-smtp**: `cc`, `bcc`, and `replyTo` on `SMTPMailSend` now accept `null` (treated as omitted) in addition to an address or address list. `to` remains required and non-null. The send path already tolerated null/empty (the delivery filter maps empty recipients to `undefined`), so only schema validation needed to change. Added a schema test for null cc/bcc/replyTo.

## Notes

- No changeset: `@lowdefy/connection-smtp`'s next release is already covered by the email-notifications minor bump on `vite-hono`, and this is a fix to that same unreleased package.
- The companion module fix (nesting 3-item `_if_none`, and defaulting the dispatch send step's cc/bcc to `[]`) is on lowdefy/modules-mongodb#92. That module fix means notifications work even on a framework release predating this one; this change is the general framework-side fix so any caller passing null cc/bcc is tolerated.
- `@lowdefy/connection-sendgrid`'s `SendGridMailSend` has the same shape and could get the same treatment for parity, but the notifications module only uses `SMTPMailSend`, so it's not required here.