### PR TITLE
Client event control flow: :if, :switch and :return in action lists

### DIFF
--- a/.changeset/feat-client-event-control-flow.md
+++ b/.changeset/feat-client-event-control-flow.md
@@ -12,3 +12,5 @@ Event action lists now support routine-style control flow, using the same gramma
 - `:return` ends the whole event successfully — replacing the early-`Throw` workaround — without running the event's `catch` actions.
 
 Controls can nest and work in both `try` and `catch` lists. Actions not executed for a control-flow reason (untaken branches, unmatched cases, actions after a `:return`) are reported as skipped, so `_actions` lookups and action indices are unchanged for existing configs. The build validates control shape and enforces action id uniqueness across all branches.
+
+Note: an event action carrying a stray `:if`, `:switch` or `:return` key (previously a schema warning at build and ignored at runtime) is now treated as a control and fails the build with a clear error.

--- a/.changeset/feat-client-event-control-flow.md
+++ b/.changeset/feat-client-event-control-flow.md
@@ -1,0 +1,14 @@
+---
+'@lowdefy/build': minor
+'@lowdefy/engine': minor
+---
+
+feat: Add `:if`, `:switch` and `:return` controls to client event action lists.
+
+Event action lists now support routine-style control flow, using the same grammar as API routines:
+
+- `:if` / `:then` / `:else` gates a group of actions on a single condition, instead of repeating the same `skip` expression on every action.
+- `:switch` runs the `:then` list of the first truthy `:case`; later cases are never evaluated, and an optional `:default` runs when no case matches.
+- `:return` ends the whole event successfully — replacing the early-`Throw` workaround — without running the event's `catch` actions.
+
+Controls can nest and work in both `try` and `catch` lists. Actions not executed for a control-flow reason (untaken branches, unmatched cases, actions after a `:return`) are reported as skipped, so `_actions` lookups and action indices are unchanged for existing configs. The build validates control shape and enforces action id uniqueness across all branches.

--- a/packages/build/src/build/buildPages/buildBlock/buildEvents.js
+++ b/packages/build/src/build/buildPages/buildBlock/buildEvents.js
@@ -27,6 +27,20 @@ const BROWSER_DEFAULT_SHORTCUTS = new Set([
   'mod+l',
 ]);
 
+const CONTROL_KEYS = [':if', ':switch', ':return'];
+const ACTION_KEYS_NOT_ALLOWED_ON_CONTROLS = ['id', 'skip', 'messages'];
+const CONTROL_META_KEYS = ['~ignoreBuildChecks', '~k', '~l', '~r'];
+const CONTROL_ALLOWED_KEYS = {
+  ':if': [':if', ':then', ':else'],
+  ':return': [':return'],
+  ':switch': [':switch', ':default'],
+};
+const CASE_ALLOWED_KEYS = [':case', ':then'];
+
+function isControl(item) {
+  return type.isObject(item) && CONTROL_KEYS.some((key) => key in item);
+}
+
 function checkAction(
   action,
   {
@@ -141,6 +155,115 @@ function checkAction(
   }
 }
 
+function checkBranchList({ list, listName, configKey }, ctx) {
+  const { blockId, eventId, pageId } = ctx;
+  if (!type.isArray(list)) {
+    throw new ConfigError(
+      `Control "${listName}" must be an array on event "${eventId}" on block "${blockId}" on page "${pageId}".`,
+      { received: list, configKey }
+    );
+  }
+  checkActionList(list, ctx);
+}
+
+function checkControl(control, ctx) {
+  const { blockId, eventId, pageId } = ctx;
+  const configKey = control['~k'];
+  const controlKeys = CONTROL_KEYS.filter((key) => key in control);
+  if (controlKeys.length > 1) {
+    const received = controlKeys.map((key) => `"${key}"`).join(', ');
+    throw new ConfigError(
+      `Control has more than one control key (${received}) on event "${eventId}" on block "${blockId}" on page "${pageId}".`,
+      { configKey }
+    );
+  }
+  const [controlKey] = controlKeys;
+  const actionKeys = ACTION_KEYS_NOT_ALLOWED_ON_CONTROLS.filter((key) => key in control);
+  if (actionKeys.length > 0) {
+    throw new ConfigError(
+      `Control "${controlKey}" can not have action property "${actionKeys[0]}" on event "${eventId}" on block "${blockId}" on page "${pageId}".`,
+      { configKey }
+    );
+  }
+  const invalidKeys = Object.keys(control).filter(
+    (key) => !CONTROL_ALLOWED_KEYS[controlKey].includes(key) && !CONTROL_META_KEYS.includes(key)
+  );
+  if (invalidKeys.length > 0) {
+    throw new ConfigError(
+      `Control "${controlKey}" has invalid key "${invalidKeys[0]}" on event "${eventId}" on block "${blockId}" on page "${pageId}".`,
+      { received: invalidKeys, configKey }
+    );
+  }
+  if (controlKey === ':if') {
+    if (type.isNone(control[':then'])) {
+      throw new ConfigError(
+        `Control ":if" requires a ":then" list on event "${eventId}" on block "${blockId}" on page "${pageId}".`,
+        { configKey }
+      );
+    }
+    checkBranchList({ list: control[':then'], listName: ':then', configKey }, ctx);
+    if (!type.isNone(control[':else'])) {
+      checkBranchList({ list: control[':else'], listName: ':else', configKey }, ctx);
+    }
+  }
+  if (controlKey === ':switch') {
+    if (!type.isArray(control[':switch'])) {
+      throw new ConfigError(
+        `Control ":switch" must be an array of case objects on event "${eventId}" on block "${blockId}" on page "${pageId}".`,
+        { received: control[':switch'], configKey }
+      );
+    }
+    control[':switch'].forEach((caseObject) => {
+      if (!type.isObject(caseObject)) {
+        throw new ConfigError(
+          `Control ":switch" case must be an object on event "${eventId}" on block "${blockId}" on page "${pageId}".`,
+          { received: caseObject, configKey }
+        );
+      }
+      const caseConfigKey = caseObject['~k'] ?? configKey;
+      if (!(':case' in caseObject)) {
+        throw new ConfigError(
+          `Control ":switch" case requires a ":case" condition on event "${eventId}" on block "${blockId}" on page "${pageId}".`,
+          { configKey: caseConfigKey }
+        );
+      }
+      if (type.isNone(caseObject[':then'])) {
+        throw new ConfigError(
+          `Control ":case" requires a ":then" list on event "${eventId}" on block "${blockId}" on page "${pageId}".`,
+          { configKey: caseConfigKey }
+        );
+      }
+      const invalidCaseKeys = Object.keys(caseObject).filter(
+        (key) => !CASE_ALLOWED_KEYS.includes(key) && !CONTROL_META_KEYS.includes(key)
+      );
+      if (invalidCaseKeys.length > 0) {
+        throw new ConfigError(
+          `Control ":switch" case has invalid key "${invalidCaseKeys[0]}" on event "${eventId}" on block "${blockId}" on page "${pageId}".`,
+          { received: invalidCaseKeys, configKey: caseConfigKey }
+        );
+      }
+      checkBranchList(
+        { list: caseObject[':then'], listName: ':then', configKey: caseConfigKey },
+        ctx
+      );
+    });
+    if (!type.isNone(control[':default'])) {
+      checkBranchList({ list: control[':default'], listName: ':default', configKey }, ctx);
+    }
+  }
+  // ':return' takes a value, not a list - nothing more to validate.
+}
+
+function checkActionList(list, ctx) {
+  list.forEach((item) => {
+    if (isControl(item)) {
+      checkControl(item, ctx);
+    } else {
+      checkAction(item, ctx);
+    }
+  });
+}
+
 function buildEvents(block, pageContext) {
   if (block.events) {
     Object.keys(block.events).map((key) => {
@@ -179,32 +302,19 @@ function buildEvents(block, pageContext) {
         message:
           'Duplicate actionId "{{ id }}" on event "{{ eventId }}" on block "{{ blockId }}" on page "{{ pageId }}".',
       });
-      block.events[key].try.map((action) =>
-        checkAction(action, {
-          eventId: key,
-          blockId: block.blockId,
-          callApiActionRefs: pageContext.callApiActionRefs,
-          typeCounters: pageContext.typeCounters,
-          pageId: pageContext.pageId,
-          linkActionRefs: pageContext.linkActionRefs,
-          requestActionRefs: pageContext.requestActionRefs,
-          websocketActionRefs: pageContext.websocketActionRefs,
-          checkDuplicateActionId,
-        })
-      );
-      block.events[key].catch.map((action) =>
-        checkAction(action, {
-          eventId: key,
-          blockId: block.blockId,
-          callApiActionRefs: pageContext.callApiActionRefs,
-          typeCounters: pageContext.typeCounters,
-          pageId: pageContext.pageId,
-          linkActionRefs: pageContext.linkActionRefs,
-          requestActionRefs: pageContext.requestActionRefs,
-          websocketActionRefs: pageContext.websocketActionRefs,
-          checkDuplicateActionId,
-        })
-      );
+      const actionContext = {
+        eventId: key,
+        blockId: block.blockId,
+        callApiActionRefs: pageContext.callApiActionRefs,
+        typeCounters: pageContext.typeCounters,
+        pageId: pageContext.pageId,
+        linkActionRefs: pageContext.linkActionRefs,
+        requestActionRefs: pageContext.requestActionRefs,
+        websocketActionRefs: pageContext.websocketActionRefs,
+        checkDuplicateActionId,
+      };
+      checkActionList(block.events[key].try, actionContext);
+      checkActionList(block.events[key].catch, actionContext);
 
       // Validate shortcut strings and collect refs for duplicate detection
       if (type.isObject(block.events[key]) && !type.isNone(block.events[key].shortcut)) {

--- a/packages/build/src/build/buildPages/buildBlock/buildEvents.js
+++ b/packages/build/src/build/buildPages/buildBlock/buildEvents.js
@@ -29,13 +29,18 @@ const BROWSER_DEFAULT_SHORTCUTS = new Set([
 
 const CONTROL_KEYS = [':if', ':switch', ':return'];
 const ACTION_KEYS_NOT_ALLOWED_ON_CONTROLS = ['id', 'skip', 'messages'];
-const CONTROL_META_KEYS = ['~ignoreBuildChecks', '~k', '~l', '~r'];
 const CONTROL_ALLOWED_KEYS = {
   ':if': [':if', ':then', ':else'],
   ':return': [':return'],
   ':switch': [':switch', ':default'],
 };
 const CASE_ALLOWED_KEYS = [':case', ':then'];
+
+// '~'-prefixed keys are build meta markers (~k, ~r, ~l, ~ignoreBuildChecks) and
+// never user config - tolerate them by prefix, as the rest of the build does.
+function isMetaKey(key) {
+  return key.startsWith('~');
+}
 
 function isControl(item) {
   return type.isObject(item) && CONTROL_KEYS.some((key) => key in item);
@@ -171,24 +176,24 @@ function checkControl(control, ctx) {
   const configKey = control['~k'];
   const controlKeys = CONTROL_KEYS.filter((key) => key in control);
   if (controlKeys.length > 1) {
-    const received = controlKeys.map((key) => `"${key}"`).join(', ');
+    const keyList = controlKeys.map((key) => `"${key}"`).join(', ');
     throw new ConfigError(
-      `Control has more than one control key (${received}) on event "${eventId}" on block "${blockId}" on page "${pageId}".`,
-      { configKey }
+      `Control has more than one control key (${keyList}) on event "${eventId}" on block "${blockId}" on page "${pageId}".`,
+      { received: controlKeys, configKey }
     );
   }
   const [controlKey] = controlKeys;
-  const actionKeys = ACTION_KEYS_NOT_ALLOWED_ON_CONTROLS.filter((key) => key in control);
-  if (actionKeys.length > 0) {
-    throw new ConfigError(
-      `Control "${controlKey}" can not have action property "${actionKeys[0]}" on event "${eventId}" on block "${blockId}" on page "${pageId}".`,
-      { configKey }
-    );
-  }
   const invalidKeys = Object.keys(control).filter(
-    (key) => !CONTROL_ALLOWED_KEYS[controlKey].includes(key) && !CONTROL_META_KEYS.includes(key)
+    (key) => !CONTROL_ALLOWED_KEYS[controlKey].includes(key) && !isMetaKey(key)
   );
   if (invalidKeys.length > 0) {
+    // Action keys do nothing on a control - call out the likely mistake directly.
+    if (ACTION_KEYS_NOT_ALLOWED_ON_CONTROLS.includes(invalidKeys[0])) {
+      throw new ConfigError(
+        `Control "${controlKey}" can not have action property "${invalidKeys[0]}" on event "${eventId}" on block "${blockId}" on page "${pageId}".`,
+        { received: invalidKeys, configKey }
+      );
+    }
     throw new ConfigError(
       `Control "${controlKey}" has invalid key "${invalidKeys[0]}" on event "${eventId}" on block "${blockId}" on page "${pageId}".`,
       { received: invalidKeys, configKey }
@@ -234,7 +239,7 @@ function checkControl(control, ctx) {
         );
       }
       const invalidCaseKeys = Object.keys(caseObject).filter(
-        (key) => !CASE_ALLOWED_KEYS.includes(key) && !CONTROL_META_KEYS.includes(key)
+        (key) => !CASE_ALLOWED_KEYS.includes(key) && !isMetaKey(key)
       );
       if (invalidCaseKeys.length > 0) {
         throw new ConfigError(

--- a/packages/build/src/build/buildPages/buildBlock/buildEvents.test.js
+++ b/packages/build/src/build/buildPages/buildBlock/buildEvents.test.js
@@ -457,3 +457,627 @@ test("don't throw on Duplicate separate block events action ids", () => {
     type: 'Input',
   });
 });
+
+test('block events with controls keep the nested structure', () => {
+  const components = {
+    pages: [
+      {
+        id: 'page_1',
+        type: 'Container',
+        auth,
+        blocks: [
+          {
+            id: 'block_1',
+            type: 'Input',
+            events: {
+              onClick: [
+                {
+                  id: 'action_1',
+                  type: 'Reset',
+                },
+                {
+                  ':if': { _state: 'flag' },
+                  ':then': [
+                    {
+                      id: 'action_2',
+                      type: 'Reset',
+                    },
+                    {
+                      ':switch': [
+                        {
+                          ':case': { _state: 'mode' },
+                          ':then': [
+                            {
+                              id: 'action_3',
+                              type: 'Reset',
+                            },
+                          ],
+                        },
+                      ],
+                      ':default': [
+                        {
+                          ':return': null,
+                        },
+                      ],
+                    },
+                  ],
+                  ':else': [
+                    {
+                      id: 'action_4',
+                      type: 'Reset',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  const res = buildPages({ components, context });
+  expect(get(res, 'pages.0.slots.content.blocks.0.events.onClick.try')).toEqual([
+    {
+      id: 'action_1',
+      type: 'Reset',
+    },
+    {
+      ':if': { _state: 'flag' },
+      ':then': [
+        {
+          id: 'action_2',
+          type: 'Reset',
+        },
+        {
+          ':switch': [
+            {
+              ':case': { _state: 'mode' },
+              ':then': [
+                {
+                  id: 'action_3',
+                  type: 'Reset',
+                },
+              ],
+            },
+          ],
+          ':default': [
+            {
+              ':return': null,
+            },
+          ],
+        },
+      ],
+      ':else': [
+        {
+          id: 'action_4',
+          type: 'Reset',
+        },
+      ],
+    },
+  ]);
+});
+
+test('throw on duplicate action ids across control branches', () => {
+  const components = {
+    pages: [
+      {
+        id: 'page_1',
+        type: 'Container',
+        auth,
+        blocks: [
+          {
+            id: 'block_1',
+            type: 'Input',
+            events: {
+              onClick: [
+                {
+                  ':if': true,
+                  ':then': [
+                    {
+                      id: 'action_1',
+                      type: 'Reset',
+                    },
+                  ],
+                  ':else': [
+                    {
+                      id: 'action_1',
+                      type: 'Reset',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  expect(() => buildPages({ components, context })).toThrow(
+    'Duplicate actionId "action_1" on event "onClick" on block "block_1" on page "page_1".'
+  );
+});
+
+test('throw on duplicate action id between try action and catch control branch', () => {
+  const components = {
+    pages: [
+      {
+        id: 'page_1',
+        type: 'Container',
+        auth,
+        blocks: [
+          {
+            id: 'block_1',
+            type: 'Input',
+            events: {
+              onClick: {
+                try: [
+                  {
+                    id: 'action_1',
+                    type: 'Reset',
+                  },
+                ],
+                catch: [
+                  {
+                    ':if': true,
+                    ':then': [
+                      {
+                        id: 'action_1',
+                        type: 'Reset',
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
+  expect(() => buildPages({ components, context })).toThrow(
+    'Duplicate actionId "action_1" on event "onClick" on block "block_1" on page "page_1".'
+  );
+});
+
+test('throw on control with more than one control key', () => {
+  const components = {
+    pages: [
+      {
+        id: 'page_1',
+        type: 'Container',
+        auth,
+        blocks: [
+          {
+            id: 'block_1',
+            type: 'Input',
+            events: {
+              onClick: [
+                {
+                  ':if': true,
+                  ':then': [],
+                  ':return': null,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  expect(() => buildPages({ components, context })).toThrow(
+    'Control has more than one control key (":if", ":return") on event "onClick" on block "block_1" on page "page_1".'
+  );
+});
+
+test('throw on control with action property id', () => {
+  const components = {
+    pages: [
+      {
+        id: 'page_1',
+        type: 'Container',
+        auth,
+        blocks: [
+          {
+            id: 'block_1',
+            type: 'Input',
+            events: {
+              onClick: [
+                {
+                  id: 'action_1',
+                  ':if': true,
+                  ':then': [],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  expect(() => buildPages({ components, context })).toThrow(
+    'Control ":if" can not have action property "id" on event "onClick" on block "block_1" on page "page_1".'
+  );
+});
+
+test('throw on control with action property skip', () => {
+  const components = {
+    pages: [
+      {
+        id: 'page_1',
+        type: 'Container',
+        auth,
+        blocks: [
+          {
+            id: 'block_1',
+            type: 'Input',
+            events: {
+              onClick: [
+                {
+                  ':return': null,
+                  skip: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  expect(() => buildPages({ components, context })).toThrow(
+    'Control ":return" can not have action property "skip" on event "onClick" on block "block_1" on page "page_1".'
+  );
+});
+
+test('throw on control with action property messages', () => {
+  const components = {
+    pages: [
+      {
+        id: 'page_1',
+        type: 'Container',
+        auth,
+        blocks: [
+          {
+            id: 'block_1',
+            type: 'Input',
+            events: {
+              onClick: [
+                {
+                  ':if': true,
+                  ':then': [],
+                  messages: { success: 'Done' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  expect(() => buildPages({ components, context })).toThrow(
+    'Control ":if" can not have action property "messages" on event "onClick" on block "block_1" on page "page_1".'
+  );
+});
+
+test('throw on :if control without :then', () => {
+  const components = {
+    pages: [
+      {
+        id: 'page_1',
+        type: 'Container',
+        auth,
+        blocks: [
+          {
+            id: 'block_1',
+            type: 'Input',
+            events: {
+              onClick: [
+                {
+                  ':if': true,
+                  ':else': [],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  expect(() => buildPages({ components, context })).toThrow(
+    'Control ":if" requires a ":then" list on event "onClick" on block "block_1" on page "page_1".'
+  );
+});
+
+test('throw on :switch case without :then', () => {
+  const components = {
+    pages: [
+      {
+        id: 'page_1',
+        type: 'Container',
+        auth,
+        blocks: [
+          {
+            id: 'block_1',
+            type: 'Input',
+            events: {
+              onClick: [
+                {
+                  ':switch': [
+                    {
+                      ':case': true,
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  expect(() => buildPages({ components, context })).toThrow(
+    'Control ":case" requires a ":then" list on event "onClick" on block "block_1" on page "page_1".'
+  );
+});
+
+test('throw on :switch that is not an array', () => {
+  const components = {
+    pages: [
+      {
+        id: 'page_1',
+        type: 'Container',
+        auth,
+        blocks: [
+          {
+            id: 'block_1',
+            type: 'Input',
+            events: {
+              onClick: [
+                {
+                  ':switch': { ':case': true, ':then': [] },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  expect(() => buildPages({ components, context })).toThrow(
+    'Control ":switch" must be an array of case objects on event "onClick" on block "block_1" on page "page_1".'
+  );
+});
+
+test('throw on :then that is not an array', () => {
+  const components = {
+    pages: [
+      {
+        id: 'page_1',
+        type: 'Container',
+        auth,
+        blocks: [
+          {
+            id: 'block_1',
+            type: 'Input',
+            events: {
+              onClick: [
+                {
+                  ':if': true,
+                  ':then': {
+                    id: 'action_1',
+                    type: 'Reset',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  expect(() => buildPages({ components, context })).toThrow(
+    'Control ":then" must be an array on event "onClick" on block "block_1" on page "page_1".'
+  );
+});
+
+test('nested controls inside branches are validated', () => {
+  const components = {
+    pages: [
+      {
+        id: 'page_1',
+        type: 'Container',
+        auth,
+        blocks: [
+          {
+            id: 'block_1',
+            type: 'Input',
+            events: {
+              onClick: [
+                {
+                  ':if': true,
+                  ':then': [
+                    {
+                      ':if': true,
+                      ':else': [],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  expect(() => buildPages({ components, context })).toThrow(
+    'Control ":if" requires a ":then" list on event "onClick" on block "block_1" on page "page_1".'
+  );
+});
+
+test('branch actions are validated like ordinary actions', () => {
+  const components = {
+    pages: [
+      {
+        id: 'page_1',
+        type: 'Container',
+        auth,
+        blocks: [
+          {
+            id: 'block_1',
+            type: 'Input',
+            events: {
+              onClick: [
+                {
+                  ':if': true,
+                  ':then': [
+                    {
+                      type: 'Reset',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  expect(() => buildPages({ components, context })).toThrow(
+    'Action id missing on event "onClick" on block "block_1" on page "page_1".'
+  );
+});
+
+test('throw on control with an unknown key', () => {
+  const components = {
+    pages: [
+      {
+        id: 'page_1',
+        type: 'Container',
+        auth,
+        blocks: [
+          {
+            id: 'block_1',
+            type: 'Input',
+            events: {
+              onClick: [
+                {
+                  ':if': true,
+                  ':then': [],
+                  ':esle': [
+                    {
+                      id: 'action_1',
+                      type: 'Reset',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  expect(() => buildPages({ components, context })).toThrow(
+    'Control ":if" has invalid key ":esle" on event "onClick" on block "block_1" on page "page_1".'
+  );
+});
+
+test('throw on control carrying an action type key', () => {
+  const components = {
+    pages: [
+      {
+        id: 'page_1',
+        type: 'Container',
+        auth,
+        blocks: [
+          {
+            id: 'block_1',
+            type: 'Input',
+            events: {
+              onClick: [
+                {
+                  type: 'Reset',
+                  ':if': true,
+                  ':then': [],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  expect(() => buildPages({ components, context })).toThrow(
+    'Control ":if" has invalid key "type" on event "onClick" on block "block_1" on page "page_1".'
+  );
+});
+
+test('throw on :switch case without :case', () => {
+  const components = {
+    pages: [
+      {
+        id: 'page_1',
+        type: 'Container',
+        auth,
+        blocks: [
+          {
+            id: 'block_1',
+            type: 'Input',
+            events: {
+              onClick: [
+                {
+                  ':switch': [
+                    {
+                      ':then': [
+                        {
+                          id: 'action_1',
+                          type: 'Reset',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  expect(() => buildPages({ components, context })).toThrow(
+    'Control ":switch" case requires a ":case" condition on event "onClick" on block "block_1" on page "page_1".'
+  );
+});
+
+test('throw on :switch case with an unknown key', () => {
+  const components = {
+    pages: [
+      {
+        id: 'page_1',
+        type: 'Container',
+        auth,
+        blocks: [
+          {
+            id: 'block_1',
+            type: 'Input',
+            events: {
+              onClick: [
+                {
+                  ':switch': [
+                    {
+                      ':case': true,
+                      ':then': [],
+                      ':default': [],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+  expect(() => buildPages({ components, context })).toThrow(
+    'Control ":switch" case has invalid key ":default" on event "onClick" on block "block_1" on page "page_1".'
+  );
+});

--- a/packages/build/src/lowdefySchema.js
+++ b/packages/build/src/lowdefySchema.js
@@ -1,3 +1,19 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 export default {
   $schema: 'http://json-schema.org/draft-07/schema#',
   $id: 'http://lowdefy.com/appSchema.json',
@@ -60,6 +76,114 @@ export default {
           id: 'Action should have required property "id".',
           type: 'Action should have required property "type".',
         },
+      },
+    },
+    actionOrControl: {
+      anyOf: [
+        { $ref: '#/definitions/action' },
+        { $ref: '#/definitions/controlIf' },
+        { $ref: '#/definitions/controlSwitch' },
+        { $ref: '#/definitions/controlReturn' },
+      ],
+    },
+    controlIf: {
+      type: 'object',
+      additionalProperties: false,
+      required: [':if', ':then'],
+      properties: {
+        '~r': {},
+        '~l': {},
+        ':if': {},
+        ':then': {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/actionOrControl',
+          },
+          errorMessage: {
+            type: 'Control ":then" should be an array of actions.',
+          },
+        },
+        ':else': {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/actionOrControl',
+          },
+          errorMessage: {
+            type: 'Control ":else" should be an array of actions.',
+          },
+        },
+      },
+      errorMessage: {
+        type: 'Control ":if" should be an object.',
+        required: {
+          ':then': 'Control ":if" should have required property ":then".',
+        },
+      },
+    },
+    controlReturn: {
+      type: 'object',
+      additionalProperties: false,
+      required: [':return'],
+      properties: {
+        '~r': {},
+        '~l': {},
+        ':return': {},
+      },
+      errorMessage: {
+        type: 'Control ":return" should be an object.',
+      },
+    },
+    controlSwitch: {
+      type: 'object',
+      additionalProperties: false,
+      required: [':switch'],
+      properties: {
+        '~r': {},
+        '~l': {},
+        ':switch': {
+          type: 'array',
+          items: {
+            type: 'object',
+            additionalProperties: false,
+            required: [':case', ':then'],
+            properties: {
+              '~r': {},
+              '~l': {},
+              ':case': {},
+              ':then': {
+                type: 'array',
+                items: {
+                  $ref: '#/definitions/actionOrControl',
+                },
+                errorMessage: {
+                  type: 'Control ":then" should be an array of actions.',
+                },
+              },
+            },
+            errorMessage: {
+              type: 'Control ":switch" cases should be objects.',
+              required: {
+                ':case': 'Control ":switch" case should have required property ":case".',
+                ':then': 'Control ":switch" case should have required property ":then".',
+              },
+            },
+          },
+          errorMessage: {
+            type: 'Control ":switch" should be an array of case objects.',
+          },
+        },
+        ':default': {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/actionOrControl',
+          },
+          errorMessage: {
+            type: 'Control ":default" should be an array of actions.',
+          },
+        },
+      },
+      errorMessage: {
+        type: 'Control ":switch" should be an object.',
       },
     },
     agent: {
@@ -909,7 +1033,7 @@ export default {
                 {
                   type: 'array',
                   items: {
-                    $ref: '#/definitions/action',
+                    $ref: '#/definitions/actionOrControl',
                   },
                 },
                 {
@@ -942,13 +1066,13 @@ export default {
                     try: {
                       type: 'array',
                       items: {
-                        $ref: '#/definitions/action',
+                        $ref: '#/definitions/actionOrControl',
                       },
                     },
                     catch: {
                       type: 'array',
                       items: {
-                        $ref: '#/definitions/action',
+                        $ref: '#/definitions/actionOrControl',
                       },
                     },
                     debounce: {

--- a/packages/docs/concepts/events-and-actions.yaml
+++ b/packages/docs/concepts/events-and-actions.yaml
@@ -88,15 +88,15 @@ _ref:
 
             The schema for passing actions to Lowdefy events is:
             ```
-              (eventName: action[])
+              (eventName: (action | control)[])
               (eventName: {
                 shortcut?: string | string[],
                 debounce?: {
                   ms?: number,
                   immediate?: boolean,
                 },
-                try: action[],
-                catch?: action[],
+                try: (action | control)[],
+                catch?: (action | control)[],
               })
             ```
 
@@ -125,6 +125,69 @@ _ref:
                       params:
                         # ...
             ```
+
+            ## Control flow in action lists
+
+            An item in an action list is either an action (`id` and `type`) or a control. Action lists support the routine controls [`:if`](/:if), [`:switch`](/:switch) and [`:return`](/:return):
+
+            - [`:if`](/:if): Evaluates a condition and executes the `:then` action list if the result is truthy, else the optional `:else` action list.
+            - [`:switch`](/:switch): Evaluates `:case` conditions in order and executes the `:then` action list of the first truthy case — later cases are never evaluated. If no case matches, the optional `:default` action list is executed.
+            - [`:return`](/:return): Ends the whole event successfully. No further actions execute — not even in enclosing lists — and the event's `catch` actions do not run. A `:return` inside a `catch` list ends the remaining catch actions the same way, but the event keeps its error result.
+
+            Branch lists are action lists themselves, so controls can nest, and controls can be used in both `try` and `catch` action lists.
+
+            ###### Control flow example:
+            ```yaml
+            events:
+              onClick:
+                - id: validate
+                  type: Validate
+                - :if:
+                    _not:
+                      _state: skip_reopen
+                  :then:
+                    - id: reopen_ticket
+                      type: Request
+                      params: reopen_ticket
+                    - id: redirect
+                      type: Link
+                      params:
+                        pageId: ticket-view
+                  :else:
+                    - id: show_blocked
+                      type: DisplayMessage
+                      params:
+                        content: Ticket cannot be reopened.
+                        status: warning
+            ```
+
+            Actions inside branches are ordinary actions — `skip`, `messages`, `async` and error behavior are unchanged. Actions the event does not execute for a control-flow reason — actions in an untaken branch, in an unmatched case, or after a `:return` — are recorded as skipped, so [`_actions`](/_actions) lookups like `_actions: my_action.skipped` keep working.
+
+            ### When to use which
+
+            - `skip` gates a single action.
+            - `:if` gates a group of consecutive actions with one condition.
+            - `:switch` replaces a chain of nested `:if`s over mutually exclusive alternatives.
+            - `:return` ends the event early — replacing the workaround of throwing an error in a `try` list.
+
+            Deep control nesting in an event is a sign the logic belongs in an [API routine](/lowdefy-api).
+
+            ### Routine controls in events
+
+            The control grammar is shared with [API routines](/lowdefy-api): where a control exists on both sides, the syntax and semantics match.
+
+            | Routine control | In events | Client answer |
+            | --- | --- | --- |
+            | `:if` | Yes | Same syntax and semantics as in routines. |
+            | `:switch` | Yes | First truthy `:case` wins; later cases are never evaluated; `:default` optional. |
+            | `:return` | Yes | Ends the event successfully — replaces the early-`Throw` workaround. |
+            | `:for`, `:parallel_for` | No | Loops belong in routines; move the iteration into an API endpoint. |
+            | `:parallel` | No | Parallelism belongs in routines; for fire-and-forget on the client, actions already take `async: true`. |
+            | `:try` / `:catch` / `:finally` | No | Events already scope errors with `try` / `catch` action lists. |
+            | `:set_state` | Already an action | [`SetState`](/SetState). Step-like controls exist server-side only because routines have no actions. |
+            | `:throw` | Already an action | [`Throw`](/Throw). |
+            | `:reject` | No client meaning | It maps a routine to a 4xx response; on the client, `Throw` covers aborts. |
+            | `:log` | No | Server logging concern; no client counterpart planned. |
 
             ## Debouncing events
 
@@ -224,6 +287,7 @@ _ref:
             - Operators used in action `params` are evaluated right before the action is executed.
             - The [`_actions`](/_actions) operator is available for sequential actions to use the values returned from preceding actions in the chain.
             - Actions have a `skip` field that can be used to skip action execution.
+            - Action lists also support the [`:if`](/:if), [`:switch`](/:switch) and [`:return`](/:return) controls — `skip` gates one action, `:if` gates a group, `:switch` picks between alternatives, and `:return` ends the event early.
             - Events support `shortcut` to bind keyboard shortcuts to the event. The shortcut fires the event when the key combination is pressed.
             - The `onInit` event is triggered the first time a page is mounted and keeps the page in loading until all actions have finished.
             - The `onInitAsync` event is triggered the first time a page is mounted and does not keep the page in loading.

--- a/packages/docs/controls/if.yaml
+++ b/packages/docs/controls/if.yaml
@@ -24,6 +24,10 @@ _ref:
       ```
     description: |
       The `:if` control executes different routines based on a boolean condition. It evaluates the condition and runs the `:then` branch if true, or the optional `:else` branch if false. Generally other operators are used to evaluate the test.
+
+      The `:if` control also works in client [event action lists](/events-and-actions) — there each branch is a list of actions, and the same syntax and semantics apply.
+
+      The condition uses JS truthiness — any truthy value takes the `:then` branch. This differs from an action's `skip` field, which only skips when it evaluates to exactly `true`.
     controlKeys: |
       - `:if: boolean`: __Required__ - The boolean result of a test or value.
       - `:then: routine`: __Required__ - The routine to execute if the test result is true.
@@ -91,4 +95,28 @@ _ref:
                 - amount: 2000
                   currency: eur
                   payment_method_types: ['card']
+      ```
+
+      ###### In a client event action list
+
+      ```yaml
+      events:
+        onClick:
+          - :if:
+              _not:
+                _state: skip_reopen
+            :then:
+              - id: reopen_ticket
+                type: Request
+                params: reopen_ticket
+              - id: redirect
+                type: Link
+                params:
+                  pageId: ticket-view
+            :else:
+              - id: show_blocked
+                type: DisplayMessage
+                params:
+                  content: Ticket cannot be reopened.
+                  status: warning
       ```

--- a/packages/docs/controls/return.yaml
+++ b/packages/docs/controls/return.yaml
@@ -26,6 +26,8 @@ _ref:
       The `:return` control immediately ends the execution of an API endpoint routine and returns a successful response with the specified data.
       Any routine steps after a `:return` are not executed. The control accepts any value type (objects, arrays, strings, numbers, null) and marks the API call as successful.
       When used within conditional controls like [`:if`](/:if) or [`:switch`](/:switch), it provides a way to exit early with a success status and return data to the client.
+
+      The `:return` control also works in client [event action lists](/events-and-actions) — it ends the whole event successfully, the event's `catch` actions do not run, and any actions after it are recorded as skipped. Inside a `catch` action list, `:return` ends the remaining catch actions the same way, but the event keeps its error result — `success` stays `false`.
     controlKeys: |
       - `:return: any`: __Required__ - The value that will be returned in the response object of the API call result.
     examples: |

--- a/packages/docs/controls/switch.yaml
+++ b/packages/docs/controls/switch.yaml
@@ -28,6 +28,8 @@ _ref:
       The control evaluates conditions from top to bottom, executing only the first matching case's `:then` block.
       If no cases match, the optional `:default` routine is executed.
       This control is ideal for handling multiple mutually exclusive conditions more elegantly than nested [`:if`](/:if) statements.
+
+      The `:switch` control also works in client [event action lists](/events-and-actions) — there each `:then` and `:default` is a list of actions, and the same syntax and semantics apply.
     controlKeys: |
       - `:switch: array`: __Required__
           - `:case: boolean`: __Required__ - The boolean result of a test.

--- a/packages/docs/operators/_actions.yaml
+++ b/packages/docs/operators/_actions.yaml
@@ -41,6 +41,8 @@ _ref:
       skipped: boolean,
       type: string,
       ```
+
+      Actions the event does not execute for a control-flow reason — actions in an untaken [`:if`](/:if) branch, in an unmatched [`:switch`](/:switch) case, or after a [`:return`](/:return) — are recorded as `skipped: true`, the same as actions skipped by their own `skip` field. Their operators are not evaluated, and `_actions` lookups on them return the skipped response object. A control records the skipped entries for its untaken branches once it completes, so an action inside the taken branch cannot yet read the skipped entries of a sibling branch — only actions after the control can.
     arguments: |
       ###### string
       If the `_actions` operator is called with a string equal to a preceding action id in the same event list, the action response object returned. If a string is passed which does not match preceding action id in the same event list, `null` is returned. Dot notation is supported.

--- a/packages/docs/operators/_actions.yaml
+++ b/packages/docs/operators/_actions.yaml
@@ -42,7 +42,7 @@ _ref:
       type: string,
       ```
 
-      Actions the event does not execute for a control-flow reason — actions in an untaken [`:if`](/:if) branch, in an unmatched [`:switch`](/:switch) case, or after a [`:return`](/:return) — are recorded as `skipped: true`, the same as actions skipped by their own `skip` field. Their operators are not evaluated, and `_actions` lookups on them return the skipped response object. A control records the skipped entries for its untaken branches once it completes, so an action inside the taken branch cannot yet read the skipped entries of a sibling branch — only actions after the control can.
+      Actions the event does not execute for a control-flow reason — actions in an untaken [`:if`](/:if) branch, in an unmatched [`:switch`](/:switch) case, or after a [`:return`](/:return) — are recorded as `skipped: true`, the same as actions skipped by their own `skip` field. Their operators are not evaluated, and `_actions` lookups on them return the skipped response object. Skipped entries are recorded in config order: when a branch executes, untaken branches written above it (an untaken `:then` when `:else` runs, or already-unmatched earlier cases) are recorded and readable, while branches below it are only recorded once the control completes. Actions after the control can read all of them.
     arguments: |
       ###### string
       If the `_actions` operator is called with a string equal to a preceding action id in the same event list, the action response object returned. If a string is passed which does not match preceding action id in the same event list, `null` is returned. Dot notation is supported.

--- a/packages/engine/src/Actions.js
+++ b/packages/engine/src/Actions.js
@@ -18,12 +18,19 @@ import { ActionError, ConfigError, UserError } from '@lowdefy/errors';
 import { type } from '@lowdefy/helpers';
 import getActionMethods from './actions/getActionMethods.js';
 
+const CONTROL_KEYS = [':if', ':switch', ':return'];
+
+function isControl(item) {
+  return type.isObject(item) && CONTROL_KEYS.some((key) => key in item);
+}
+
 class Actions {
   constructor(context) {
     this.context = context;
     this.callAction = this.callAction.bind(this);
     this.callActionLoop = this.callActionLoop.bind(this);
     this.callActions = this.callActions.bind(this);
+    this.callControl = this.callControl.bind(this);
     this.displayMessage = this.displayMessage.bind(this);
     this.logActionError = this.logActionError.bind(this);
     this.actions = context._internal.lowdefy._internal.actions;
@@ -71,8 +78,37 @@ class Actions {
     }
   }
 
-  async callActionLoop({ actions, arrayIndices, block, event, progress, responses }) {
-    for (const [index, action] of actions.entries()) {
+  // Returns true when a ':return' control ended the list, so callers can end the event.
+  async callActionLoop({
+    actions,
+    arrayIndices,
+    block,
+    controls,
+    counters,
+    event,
+    progress,
+    responses,
+  }) {
+    for (const [position, action] of actions.entries()) {
+      if (isControl(action)) {
+        const returned = await this.callControl({
+          arrayIndices,
+          block,
+          control: action,
+          controls,
+          counters,
+          event,
+          progress,
+          responses,
+        });
+        if (returned === true) {
+          this.recordSkippedActions({ actions: actions.slice(position + 1), counters, responses });
+          return true;
+        }
+        continue;
+      }
+      const index = counters.action;
+      counters.action += 1;
       try {
         if (action.async === true) {
           this.callAsyncAction({
@@ -102,20 +138,194 @@ class Actions {
         throw err;
       }
     }
+    return false;
+  }
+
+  async callControl({
+    arrayIndices,
+    block,
+    control,
+    controls,
+    counters,
+    event,
+    progress,
+    responses,
+  }) {
+    const index = counters.control;
+    counters.control += 1;
+    if (':return' in control) {
+      const value = this.evaluateControlValue({
+        arrayIndices,
+        block,
+        event,
+        input: control[':return'],
+        node: control,
+        responses,
+      });
+      controls.push({ index, type: ':return', taken: value });
+      return true;
+    }
+    if (':if' in control) {
+      const condition = this.evaluateControlValue({
+        arrayIndices,
+        block,
+        event,
+        input: control[':if'],
+        node: control,
+        responses,
+      });
+      // JS truthiness, matching the routine ':if' - not skip's strict === true.
+      if (condition) {
+        controls.push({ index, type: ':if', taken: 'then' });
+        const returned = await this.callActionLoop({
+          actions: control[':then'],
+          arrayIndices,
+          block,
+          controls,
+          counters,
+          event,
+          progress,
+          responses,
+        });
+        this.recordSkippedActions({ actions: control[':else'] ?? [], counters, responses });
+        return returned;
+      }
+      controls.push({ index, type: ':if', taken: 'else' });
+      this.recordSkippedActions({ actions: control[':then'], counters, responses });
+      return this.callActionLoop({
+        actions: control[':else'] ?? [],
+        arrayIndices,
+        block,
+        controls,
+        counters,
+        event,
+        progress,
+        responses,
+      });
+    }
+    // ':switch' - cases are evaluated in order and lazily: the first truthy ':case' wins,
+    // later cases are never evaluated, matching the routine ':switch'.
+    let matched = false;
+    let returned = false;
+    for (const [casePosition, caseObject] of control[':switch'].entries()) {
+      if (!matched) {
+        const condition = this.evaluateControlValue({
+          arrayIndices,
+          block,
+          event,
+          input: caseObject[':case'],
+          node: caseObject,
+          responses,
+        });
+        if (condition) {
+          matched = true;
+          controls.push({ index, type: ':switch', taken: casePosition });
+          returned = await this.callActionLoop({
+            actions: caseObject[':then'],
+            arrayIndices,
+            block,
+            controls,
+            counters,
+            event,
+            progress,
+            responses,
+          });
+          continue;
+        }
+      }
+      this.recordSkippedActions({ actions: caseObject[':then'], counters, responses });
+    }
+    if (matched) {
+      this.recordSkippedActions({ actions: control[':default'] ?? [], counters, responses });
+      return returned;
+    }
+    controls.push({ index, type: ':switch', taken: 'default' });
+    return this.callActionLoop({
+      actions: control[':default'] ?? [],
+      arrayIndices,
+      block,
+      controls,
+      counters,
+      event,
+      progress,
+      responses,
+    });
+  }
+
+  evaluateControlValue({ arrayIndices, block, event, input, node, responses }) {
+    const { output, errors: parserErrors } = this.context._internal.parser.parse({
+      actions: responses,
+      event,
+      arrayIndices,
+      input,
+      location: block.blockId,
+    });
+    if (parserErrors.length > 0) {
+      const error = parserErrors[0];
+      // Report against the nearest node's '~k' when the operator carries none.
+      if (!error.configKey) {
+        error.configKey = node['~k'];
+      }
+      // Controls are anonymous - no responses entry, so only {error} is thrown.
+      throw { error };
+    }
+    return output;
+  }
+
+  // Records actions the chain does not execute for a control-flow reason as skipped,
+  // without parsing their operators. Controls record no responses entry, but still
+  // consume a control index so reached controls keep their depth-first numbering.
+  recordSkippedActions({ actions, counters, responses }) {
+    for (const action of actions) {
+      if (isControl(action)) {
+        counters.control += 1;
+        if (':if' in action) {
+          this.recordSkippedActions({ actions: action[':then'], counters, responses });
+          this.recordSkippedActions({ actions: action[':else'] ?? [], counters, responses });
+        }
+        if (':switch' in action) {
+          action[':switch'].forEach((caseObject) => {
+            this.recordSkippedActions({ actions: caseObject[':then'], counters, responses });
+          });
+          this.recordSkippedActions({ actions: action[':default'] ?? [], counters, responses });
+        }
+        continue;
+      }
+      responses[action.id] = { type: action.type, skipped: true, index: counters.action };
+      counters.action += 1;
+    }
   }
 
   async callActions({ actions, arrayIndices, block, catchActions, event, eventName, progress }) {
     const startTimestamp = new Date();
     const responses = {};
+    // Only events with controls gain a 'controls' array - flat chains keep their result shape.
+    const hasControls = actions.some(isControl) || catchActions.some(isControl);
+    const controls = hasControls ? [] : undefined;
+    const counters = { action: 0, control: 0 };
     try {
-      await this.callActionLoop({ actions, arrayIndices, block, event, responses, progress });
+      await this.callActionLoop({
+        actions,
+        arrayIndices,
+        block,
+        controls,
+        counters,
+        event,
+        responses,
+        progress,
+      });
     } catch (error) {
       this.logActionError(error);
+      // Catch actions restart action numbering, matching flat-chain history; the control
+      // counter continues so every control entry keeps a unique index within the event.
+      counters.action = 0;
       try {
         await this.callActionLoop({
           actions: catchActions,
           arrayIndices,
           block,
+          controls,
+          counters,
           event,
           responses,
           progress,
@@ -125,6 +335,7 @@ class Actions {
         return {
           blockId: block.blockId,
           bounced: false,
+          ...(controls && { controls }),
           endTimestamp: new Date(),
           error,
           errorCatch,
@@ -138,6 +349,7 @@ class Actions {
       return {
         blockId: block.blockId,
         bounced: false,
+        ...(controls && { controls }),
         endTimestamp: new Date(),
         error,
         event,
@@ -150,6 +362,7 @@ class Actions {
     return {
       blockId: block.blockId,
       bounced: false,
+      ...(controls && { controls }),
       endTimestamp: new Date(),
       event,
       eventName,

--- a/packages/engine/src/Actions.js
+++ b/packages/engine/src/Actions.js
@@ -263,7 +263,7 @@ class Actions {
     if (parserErrors.length > 0) {
       const error = parserErrors[0];
       // Report against the nearest node's '~k' when the operator carries none.
-      if (!error.configKey) {
+      if (type.isNone(error.configKey)) {
         error.configKey = node['~k'];
       }
       // Controls are anonymous - no responses entry, so only {error} is thrown.

--- a/packages/engine/test/ActionsControls.test.js
+++ b/packages/engine/test/ActionsControls.test.js
@@ -1,0 +1,764 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+import { OperatorError } from '@lowdefy/errors';
+
+import testContext from './testContext.js';
+
+const timeout = (ms) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+const pageId = 'one';
+
+const RealDate = Date;
+const mockDate = jest.fn(() => ({ date: 0 }));
+mockDate.now = jest.fn(() => 0);
+
+const getActions = () => {
+  return {
+    ActionSync: jest.fn(({ params }) => params),
+    ActionAsync: jest.fn(async ({ params }) => {
+      await timeout(params.ms ?? 1);
+      return params;
+    }),
+    ActionError: jest.fn(() => {
+      throw new Error('Test error');
+    }),
+  };
+};
+
+const closeLoader = jest.fn();
+const displayMessage = jest.fn();
+const lowdefy = {
+  _internal: {
+    displayMessage,
+  },
+  pageId,
+};
+const arrayIndices = [];
+const eventName = 'eventName';
+
+// Comment out to use console.log
+console.log = () => {};
+console.error = () => {};
+
+beforeEach(() => {
+  global.Date = mockDate;
+  displayMessage.mockReset();
+  closeLoader.mockReset();
+  displayMessage.mockImplementation(() => closeLoader);
+});
+
+afterAll(() => {
+  global.Date = RealDate;
+});
+
+const setup = async (actions) => {
+  const pageConfig = {
+    id: 'root',
+    type: 'Box',
+  };
+  lowdefy._internal.actions = actions;
+  const context = await testContext({
+    lowdefy,
+    pageConfig,
+  });
+  return context._internal.Actions;
+};
+
+test(':if takes the :then branch when the condition is truthy and skips :else', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      {
+        ':if': true,
+        ':then': [{ id: 'then_action', type: 'ActionSync', params: 'then' }],
+        ':else': [{ id: 'else_action', type: 'ActionSync', params: 'else' }],
+      },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: {},
+    eventName,
+  });
+  expect(res).toEqual({
+    blockId: 'blockId',
+    bounced: false,
+    controls: [{ index: 0, type: ':if', taken: 'then' }],
+    event: {},
+    eventName: 'eventName',
+    responses: {
+      then_action: {
+        type: 'ActionSync',
+        index: 0,
+        response: 'then',
+      },
+      else_action: {
+        type: 'ActionSync',
+        skipped: true,
+        index: 1,
+      },
+    },
+    success: true,
+    startTimestamp: { date: 0 },
+    endTimestamp: { date: 0 },
+  });
+  expect(actions.ActionSync.mock.calls.length).toBe(1);
+});
+
+test(':if takes the :else branch when the condition is falsy and skips :then', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      {
+        ':if': { _event: 'missing' },
+        ':then': [{ id: 'then_action', type: 'ActionSync', params: 'then' }],
+        ':else': [{ id: 'else_action', type: 'ActionSync', params: 'else' }],
+      },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: {},
+    eventName,
+  });
+  expect(res).toEqual({
+    blockId: 'blockId',
+    bounced: false,
+    controls: [{ index: 0, type: ':if', taken: 'else' }],
+    event: {},
+    eventName: 'eventName',
+    responses: {
+      then_action: {
+        type: 'ActionSync',
+        skipped: true,
+        index: 0,
+      },
+      else_action: {
+        type: 'ActionSync',
+        index: 1,
+        response: 'else',
+      },
+    },
+    success: true,
+    startTimestamp: { date: 0 },
+    endTimestamp: { date: 0 },
+  });
+});
+
+test(':if without :else records taken "else" and the chain continues', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      {
+        ':if': false,
+        ':then': [{ id: 'then_action', type: 'ActionSync', params: 'then' }],
+      },
+      { id: 'after', type: 'ActionSync', params: 'after' },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: {},
+    eventName,
+  });
+  expect(res).toEqual({
+    blockId: 'blockId',
+    bounced: false,
+    controls: [{ index: 0, type: ':if', taken: 'else' }],
+    event: {},
+    eventName: 'eventName',
+    responses: {
+      then_action: {
+        type: 'ActionSync',
+        skipped: true,
+        index: 0,
+      },
+      after: {
+        type: 'ActionSync',
+        index: 1,
+        response: 'after',
+      },
+    },
+    success: true,
+    startTimestamp: { date: 0 },
+    endTimestamp: { date: 0 },
+  });
+});
+
+test(':if condition uses JS truthiness, not skip strict equality', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      // skip: 1 is not skipped - skip requires strict === true
+      { id: 'not_skipped', type: 'ActionSync', params: 'ran', skip: 1 },
+      {
+        // 1 is truthy - :then is taken
+        ':if': 1,
+        ':then': [{ id: 'then_action', type: 'ActionSync', params: 'then' }],
+      },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: {},
+    eventName,
+  });
+  expect(res.responses.not_skipped).toEqual({ type: 'ActionSync', index: 0, response: 'ran' });
+  expect(res.responses.then_action).toEqual({ type: 'ActionSync', index: 1, response: 'then' });
+  expect(res.controls).toEqual([{ index: 0, type: ':if', taken: 'then' }]);
+});
+
+test('wrapping actions in a control does not change action indices', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      { id: 'a0', type: 'ActionSync', params: 'r0' },
+      {
+        ':if': true,
+        ':then': [
+          { id: 'a1', type: 'ActionSync', params: 'r1' },
+          { id: 'a2', type: 'ActionSync', params: 'r2' },
+        ],
+        ':else': [{ id: 'a3', type: 'ActionSync', params: 'r3' }],
+      },
+      { id: 'a4', type: 'ActionSync', params: 'r4' },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: {},
+    eventName,
+  });
+  expect(res.responses).toEqual({
+    a0: { type: 'ActionSync', index: 0, response: 'r0' },
+    a1: { type: 'ActionSync', index: 1, response: 'r1' },
+    a2: { type: 'ActionSync', index: 2, response: 'r2' },
+    a3: { type: 'ActionSync', skipped: true, index: 3 },
+    a4: { type: 'ActionSync', index: 4, response: 'r4' },
+  });
+});
+
+test('nested :if controls assign depth-first action and control indices', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      {
+        ':if': true,
+        ':then': [
+          {
+            ':if': false,
+            ':then': [{ id: 'b1', type: 'ActionSync', params: 'b1' }],
+            ':else': [{ id: 'b2', type: 'ActionSync', params: 'b2' }],
+          },
+          { id: 'a1', type: 'ActionSync', params: 'a1' },
+        ],
+        ':else': [{ id: 'e1', type: 'ActionSync', params: 'e1' }],
+      },
+      { id: 'a2', type: 'ActionSync', params: 'a2' },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: {},
+    eventName,
+  });
+  expect(res.responses).toEqual({
+    b1: { type: 'ActionSync', skipped: true, index: 0 },
+    b2: { type: 'ActionSync', index: 1, response: 'b2' },
+    a1: { type: 'ActionSync', index: 2, response: 'a1' },
+    e1: { type: 'ActionSync', skipped: true, index: 3 },
+    a2: { type: 'ActionSync', index: 4, response: 'a2' },
+  });
+  expect(res.controls).toEqual([
+    { index: 0, type: ':if', taken: 'then' },
+    { index: 1, type: ':if', taken: 'else' },
+  ]);
+  expect(res.success).toBe(true);
+});
+
+test(':switch takes the first truthy :case and never evaluates later cases', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      {
+        ':switch': [
+          {
+            ':case': { _eq: [{ _event: 'mode' }, 'a'] },
+            ':then': [{ id: 'case_a', type: 'ActionSync', params: 'a' }],
+          },
+          {
+            ':case': { _event: 'truthy' },
+            ':then': [{ id: 'case_b', type: 'ActionSync', params: 'b' }],
+          },
+          {
+            // would throw an operator error if evaluated
+            ':case': { _divide: [1] },
+            ':then': [{ id: 'case_c', type: 'ActionSync', params: 'c' }],
+          },
+        ],
+        ':default': [{ id: 'default_action', type: 'ActionSync', params: 'd' }],
+      },
+      { id: 'after', type: 'ActionSync', params: 'after' },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: { mode: 'b', truthy: 1 },
+    eventName,
+  });
+  expect(res.responses).toEqual({
+    case_a: { type: 'ActionSync', skipped: true, index: 0 },
+    case_b: { type: 'ActionSync', index: 1, response: 'b' },
+    case_c: { type: 'ActionSync', skipped: true, index: 2 },
+    default_action: { type: 'ActionSync', skipped: true, index: 3 },
+    after: { type: 'ActionSync', index: 4, response: 'after' },
+  });
+  expect(res.controls).toEqual([{ index: 0, type: ':switch', taken: 1 }]);
+  expect(res.success).toBe(true);
+});
+
+test(':switch runs :default when no case matches', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      {
+        ':switch': [
+          {
+            ':case': false,
+            ':then': [{ id: 'case_a', type: 'ActionSync', params: 'a' }],
+          },
+        ],
+        ':default': [{ id: 'default_action', type: 'ActionSync', params: 'd' }],
+      },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: {},
+    eventName,
+  });
+  expect(res.responses).toEqual({
+    case_a: { type: 'ActionSync', skipped: true, index: 0 },
+    default_action: { type: 'ActionSync', index: 1, response: 'd' },
+  });
+  expect(res.controls).toEqual([{ index: 0, type: ':switch', taken: 'default' }]);
+});
+
+test(':switch with no match and no :default skips all case bodies and continues', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      {
+        ':switch': [
+          {
+            ':case': false,
+            ':then': [{ id: 'case_a', type: 'ActionSync', params: 'a' }],
+          },
+        ],
+      },
+      { id: 'after', type: 'ActionSync', params: 'after' },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: {},
+    eventName,
+  });
+  expect(res.responses).toEqual({
+    case_a: { type: 'ActionSync', skipped: true, index: 0 },
+    after: { type: 'ActionSync', index: 1, response: 'after' },
+  });
+  expect(res.controls).toEqual([{ index: 0, type: ':switch', taken: 'default' }]);
+  expect(res.success).toBe(true);
+});
+
+test(':return ends the event successfully and skips all remaining actions', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      { id: 'a0', type: 'ActionSync', params: 'r0' },
+      { ':return': { _event: 'value' } },
+      { id: 'a1', type: 'ActionSync', params: 'r1' },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [{ id: 'catch_action', type: 'ActionSync', params: 'c' }],
+    event: { value: 'done' },
+    eventName,
+  });
+  expect(res).toEqual({
+    blockId: 'blockId',
+    bounced: false,
+    controls: [{ index: 0, type: ':return', taken: 'done' }],
+    event: { value: 'done' },
+    eventName: 'eventName',
+    responses: {
+      a0: { type: 'ActionSync', index: 0, response: 'r0' },
+      a1: { type: 'ActionSync', skipped: true, index: 1 },
+    },
+    success: true,
+    startTimestamp: { date: 0 },
+    endTimestamp: { date: 0 },
+  });
+  // the event catch does not run
+  expect(res.responses.catch_action).toBe(undefined);
+});
+
+test(':return propagates up through nested controls to end the event', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      { id: 'a0', type: 'ActionSync', params: 'r0' },
+      {
+        ':if': true,
+        ':then': [{ ':return': null }, { id: 'a1', type: 'ActionSync', params: 'r1' }],
+        ':else': [{ id: 'a2', type: 'ActionSync', params: 'r2' }],
+      },
+      { id: 'a3', type: 'ActionSync', params: 'r3' },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: {},
+    eventName,
+  });
+  expect(res.responses).toEqual({
+    a0: { type: 'ActionSync', index: 0, response: 'r0' },
+    a1: { type: 'ActionSync', skipped: true, index: 1 },
+    a2: { type: 'ActionSync', skipped: true, index: 2 },
+    a3: { type: 'ActionSync', skipped: true, index: 3 },
+  });
+  expect(res.controls).toEqual([
+    { index: 0, type: ':if', taken: 'then' },
+    { index: 1, type: ':return', taken: null },
+  ]);
+  expect(res.success).toBe(true);
+});
+
+test(':return from a matched :switch case skips later case bodies and :default', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      {
+        ':switch': [
+          {
+            ':case': true,
+            ':then': [{ ':return': null }],
+          },
+          {
+            ':case': true,
+            ':then': [{ id: 'case_b', type: 'ActionSync', params: 'b' }],
+          },
+        ],
+        ':default': [{ id: 'default_action', type: 'ActionSync', params: 'd' }],
+      },
+      { id: 'after', type: 'ActionSync', params: 'after' },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: {},
+    eventName,
+  });
+  expect(res.responses).toEqual({
+    case_b: { type: 'ActionSync', skipped: true, index: 0 },
+    default_action: { type: 'ActionSync', skipped: true, index: 1 },
+    after: { type: 'ActionSync', skipped: true, index: 2 },
+  });
+  expect(res.controls).toEqual([
+    { index: 0, type: ':switch', taken: 0 },
+    { index: 1, type: ':return', taken: null },
+  ]);
+  expect(res.success).toBe(true);
+});
+
+test(':return inside a catch list ends the catch list the same way', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [{ id: 'try_error', type: 'ActionError', messages: { error: false } }],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [
+      { id: 'catch_first', type: 'ActionSync', params: 'c0' },
+      { ':return': null },
+      { id: 'catch_after', type: 'ActionSync', params: 'c1' },
+    ],
+    event: {},
+    eventName,
+  });
+  expect(res.success).toBe(false);
+  expect(res.error).toEqual({
+    action: { id: 'try_error', messages: { error: false }, type: 'ActionError' },
+    error: expect.any(Error),
+    index: 0,
+  });
+  expect(res.responses.catch_first).toEqual({ type: 'ActionSync', index: 0, response: 'c0' });
+  expect(res.responses.catch_after).toEqual({ type: 'ActionSync', skipped: true, index: 1 });
+  expect(res.controls).toEqual([{ index: 0, type: ':return', taken: null }]);
+});
+
+test('operator error in an :if condition aborts to the event catch', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      { id: 'a0', type: 'ActionSync', params: 'r0' },
+      {
+        ':if': { _divide: [1] },
+        ':then': [{ id: 'then_action', type: 'ActionSync', params: 'then' }],
+        '~k': 'if-key',
+      },
+      { id: 'a1', type: 'ActionSync', params: 'r1' },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [{ id: 'catch_action', type: 'ActionSync', params: 'c' }],
+    event: {},
+    eventName,
+  });
+  expect(res.success).toBe(false);
+  expect(res.error.error).toBeInstanceOf(OperatorError);
+  expect(res.error.error._message).toBe('_divide takes an array of length 2 as input.');
+  expect(res.error.error.configKey).toBe('if-key');
+  // an aborted chain records nothing for unreached actions
+  expect(res.responses.then_action).toBe(undefined);
+  expect(res.responses.a1).toBe(undefined);
+  expect(res.responses.a0).toEqual({ type: 'ActionSync', index: 0, response: 'r0' });
+  expect(res.responses.catch_action).toEqual({ type: 'ActionSync', index: 0, response: 'c' });
+  expect(res.controls).toEqual([]);
+});
+
+test('operator error in a :case is reported against the case object', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      {
+        ':switch': [
+          {
+            ':case': { _divide: [1] },
+            ':then': [{ id: 'case_a', type: 'ActionSync', params: 'a' }],
+            '~k': 'case-key',
+          },
+        ],
+        '~k': 'switch-key',
+      },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: {},
+    eventName,
+  });
+  expect(res.success).toBe(false);
+  expect(res.error.error).toBeInstanceOf(OperatorError);
+  expect(res.error.error.configKey).toBe('case-key');
+});
+
+test('operator error in a :return value aborts to the event catch', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [{ ':return': { _divide: [1] }, '~k': 'return-key' }],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: {},
+    eventName,
+  });
+  expect(res.success).toBe(false);
+  expect(res.error.error).toBeInstanceOf(OperatorError);
+  expect(res.error.error.configKey).toBe('return-key');
+  expect(res.controls).toEqual([]);
+});
+
+test('sync error in a branch action aborts the chain and falls to the event catch', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      {
+        ':if': true,
+        ':then': [
+          { id: 'branch_error', type: 'ActionError', messages: { error: false } },
+          { id: 'branch_after', type: 'ActionSync', params: 'r1' },
+        ],
+      },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [{ id: 'catch_action', type: 'ActionSync', params: 'c' }],
+    event: {},
+    eventName,
+  });
+  expect(res.success).toBe(false);
+  expect(res.error.action.id).toBe('branch_error');
+  expect(res.error.index).toBe(0);
+  expect(res.responses.branch_error.error).toBeDefined();
+  // unreached actions record nothing on the error path
+  expect(res.responses.branch_after).toBe(undefined);
+  expect(res.responses.catch_action).toEqual({ type: 'ActionSync', index: 0, response: 'c' });
+  expect(res.controls).toEqual([{ index: 0, type: ':if', taken: 'then' }]);
+});
+
+test('async: true actions inside a taken branch keep running after the chain returns', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      {
+        ':if': true,
+        ':then': [
+          { id: 'slow', type: 'ActionAsync', async: true, params: { ms: 100 } },
+          { id: 'fast', type: 'ActionSync', params: 'fast' },
+        ],
+      },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: {},
+    eventName,
+  });
+  expect(res.responses).toEqual({
+    fast: { type: 'ActionSync', index: 1, response: 'fast' },
+  });
+  expect(res.success).toBe(true);
+  await timeout(110);
+  expect(res.responses.slow).toEqual({ type: 'ActionAsync', index: 0, response: { ms: 100 } });
+});
+
+test('condition operators read _actions responses of earlier actions', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      { id: 'a0', type: 'ActionSync', params: 'val' },
+      {
+        ':if': { _eq: [{ _actions: 'a0.response' }, 'val'] },
+        ':then': [{ id: 'then_action', type: 'ActionSync', params: 'then' }],
+      },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: {},
+    eventName,
+  });
+  expect(res.responses.then_action).toEqual({ type: 'ActionSync', index: 1, response: 'then' });
+  expect(res.controls).toEqual([{ index: 0, type: ':if', taken: 'then' }]);
+});
+
+test('_actions lookups on unexecuted branch actions see skipped: true', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      {
+        ':if': false,
+        ':then': [{ id: 'then_action', type: 'ActionSync', params: 'then' }],
+      },
+      { id: 'reads_skipped', type: 'ActionSync', params: { _actions: 'then_action.skipped' } },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: {},
+    eventName,
+  });
+  expect(res.responses.reads_skipped).toEqual({ type: 'ActionSync', index: 1, response: true });
+});
+
+test('a condition referencing an action inside its own branches sees undefined', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      {
+        ':if': { _eq: [{ _actions: 'then_action.response' }, undefined] },
+        ':then': [{ id: 'then_action', type: 'ActionSync', params: 'then' }],
+      },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: {},
+    eventName,
+  });
+  expect(res.controls).toEqual([{ index: 0, type: ':if', taken: 'then' }]);
+  expect(res.responses.then_action).toEqual({ type: 'ActionSync', index: 0, response: 'then' });
+});
+
+test('flat chains without controls gain no controls key', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [{ id: 'test', type: 'ActionSync', params: 'params' }],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [],
+    event: {},
+    eventName,
+  });
+  expect('controls' in res).toBe(false);
+});
+
+test('control indices continue across try and catch lists', async () => {
+  const actions = getActions();
+  const Actions = await setup(actions);
+  const res = await Actions.callActions({
+    actions: [
+      {
+        ':if': true,
+        ':then': [{ id: 'try_error', type: 'ActionError', messages: { error: false } }],
+      },
+    ],
+    arrayIndices,
+    block: { blockId: 'blockId' },
+    catchActions: [
+      {
+        ':if': true,
+        ':then': [{ id: 'catch_action', type: 'ActionSync', params: 'c' }],
+      },
+    ],
+    event: {},
+    eventName,
+  });
+  expect(res.success).toBe(false);
+  expect(res.controls).toEqual([
+    { index: 0, type: ':if', taken: 'then' },
+    { index: 1, type: ':if', taken: 'then' },
+  ]);
+  // action indices still restart per list, matching flat-chain history
+  expect(res.responses.catch_action).toEqual({ type: 'ActionSync', index: 0, response: 'c' });
+});

--- a/scripts/lib/createWorkspace.mjs
+++ b/scripts/lib/createWorkspace.mjs
@@ -28,8 +28,10 @@ function createWorkspace({ targetDir }) {
   // are mirrored into pnpm-workspace.yaml — without them a fresh install
   // resolves @lowdefy/* plugins from the npm registry instead of the monorepo.
   const pkg = JSON.parse(fs.readFileSync(path.join(targetDir, 'package.json'), 'utf8'));
+  // YAML single-quoted scalars escape embedded quotes by doubling them.
+  const quote = (value) => `'${String(value).replace(/'/g, "''")}'`;
   const overrides = Object.entries(pkg.pnpm?.overrides ?? {}).map(
-    ([name, target]) => `  '${name}': '${target}'`
+    ([name, target]) => `  ${quote(name)}: ${quote(target)}`
   );
   fs.writeFileSync(
     path.join(targetDir, 'pnpm-workspace.yaml'),

--- a/scripts/lib/createWorkspace.mjs
+++ b/scripts/lib/createWorkspace.mjs
@@ -23,6 +23,14 @@ function createWorkspace({ targetDir }) {
   // better-sqlite3, esbuild) unless they are approved in the workspace file.
   // pnpm 10 reads onlyBuiltDependencies; pnpm 11 reads allowBuilds and fails
   // the install without it.
+  // pnpm 11 also stopped reading pnpm.overrides from package.json, so the
+  // link: overrides written by rewriteDeps/addPlugins (this runs after both)
+  // are mirrored into pnpm-workspace.yaml — without them a fresh install
+  // resolves @lowdefy/* plugins from the npm registry instead of the monorepo.
+  const pkg = JSON.parse(fs.readFileSync(path.join(targetDir, 'package.json'), 'utf8'));
+  const overrides = Object.entries(pkg.pnpm?.overrides ?? {}).map(
+    ([name, target]) => `  '${name}': '${target}'`
+  );
   fs.writeFileSync(
     path.join(targetDir, 'pnpm-workspace.yaml'),
     [
@@ -39,6 +47,7 @@ function createWorkspace({ targetDir }) {
       '  better-sqlite3: true',
       '  esbuild: true',
       '  sharp: true',
+      ...(overrides.length > 0 ? ['overrides:', ...overrides] : []),
       '',
     ].join('\n')
   );


### PR DESCRIPTION
## Summary

Event action chains are flat — a condition gating several consecutive actions must be repeated as `skip` on every one, and the only early exit is an intentional `Throw` in a `try` list. This PR adds routine-style control flow to client event action lists — `:if` / `:then` / `:else`, `:switch` with lazy first-truthy-case matching, and `:return` to end the event successfully — mirroring the API routine grammar so one syntax serves both sides. Implements `lowdefy-design/designs/client-event-control-flow/design.md`.

## Changes

- **@lowdefy/build**: Event action list items become `action | control` in the schema, with `controlIf` / `controlSwitch` / `controlReturn` definitions. `buildEvents` validates controls recursively — exactly one control key, `:then` required per `:if` and per `:case`, `:case` required per case, branch lists must be arrays, action keys and unknown keys rejected (matching the routine build's static strictness) — and enforces action id uniqueness across the whole event tree. The structure stays nested; build does not flatten.
- **@lowdefy/engine**: `callActionLoop` gains a control case. A control's own operator values (condition, `:case`s, `:return` value) evaluate with the standard web parser at the moment the chain reaches it; the taken branch recurses; `:return` propagates up through nesting to end the event with `success: true` (the event `catch` does not run). Unexecuted actions record `{ type, skipped: true, index }` without parsing their operators, with depth-first action indices that are identical before and after wrapping actions in a control. Each reached control records `{ index, type, taken }` in a new `controls` array on the event result — present only when the chain contains controls, so flat-chain results are byte-identical.
- **docs**: The events-and-actions concept page documents the three controls, the routine-control equivalence table, and the `skip`-for-one-action / `:if`-for-a-group / `:switch`-for-alternatives convention. The `:if` / `:switch` / `:return` reference pages note client-event support (the truthiness-vs-`skip` difference lives on `:if` only). `_actions` documents skipped reporting for control-flow-unexecuted actions.

## Key Files

- `packages/engine/src/Actions.js` — control execution: `callControl`, `evaluateControlValue`, `recordSkippedActions`
- `packages/build/src/build/buildPages/buildBlock/buildEvents.js` — recursive control-shape validation and tree-wide id uniqueness
- `packages/build/src/lowdefySchema.js` — `actionOrControl` and control schema definitions
- `packages/engine/test/ActionsControls.test.js` — engine semantics coverage (23 tests)

## Notes

- Purely additive: existing flat chains keep byte-identical responses and indices; `skip` is unchanged and not deprecated. One edge qualifies this (also noted in the changeset): an event action carrying a stray `:if` / `:switch` / `:return` key — previously a schema warning, ignored at runtime — is now treated as a control and fails the build with a clear error.
- Never-diverge contract: grammar and semantics match the server routine controls (`controlIf.js` / `controlSwitch.js` / `controlReturn.js`) — JS truthiness (not `skip`'s strict `=== true`), cases evaluated lazily in order, `:return` value evaluated with operators. Implementations stay separate; nothing under `packages/api/src/routes/endpoints/control/` changed.
- One deliberate deviation from the design text: the design assumed the server validates controls "only at runtime", but `buildApi/buildRoutine/controlTypes.js` validates statically — so event validation was tightened to routine-build parity (`:case` required, unknown keys rejected) to honor the one-grammar contract.
- `:return` inside a `catch` list ends the remaining catch actions but keeps `success: false` (the try did fail); documented on the `:return` page.
- Rider commits unrelated to the feature: two `fix(scripts)` commits write the dev-workspace link overrides to `pnpm-workspace.yaml` (pnpm 11 ignores `pnpm.overrides` in package.json — without this, fresh `_server/dev` / `_server/prod` installs resolve `@lowdefy/*` plugins from the npm registry) and escape quotes in the emitted YAML. Found while verifying this PR against the dev server.
- Verified beyond unit tests: driven in a real browser against the dev server — branch taken/skipped reporting, `_actions` lookups on skipped actions, switch laziness (a later `:case` holding a throwing operator is never evaluated), `:return` short-circuit, condition-error-to-catch — plus live invalid-config probes against the dev rebuild surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

