### PR TITLE
Fix AgentChat programmatic sendMessage dropping file attachments

### DIFF
--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
@@ -211,7 +211,7 @@ function AgentChat({ blockId, components: { Icon }, methods, pageId, properties 
       if (args?.text) {
         sendMessage({
           text: args.text,
-          ...(args.files ? { experimental_attachments: args.files } : {}),
+          ...(args.files ? { files: args.files } : {}),
           ...(args.metadata ? { metadata: args.metadata } : {}),
         });
       }


### PR DESCRIPTION
## Summary

The `AgentChat` block registers a programmatic `sendMessage` CallMethod so YAML actions can send messages with attachments. It passed files under the key `experimental_attachments`, which was the AI SDK v4/v5 API. AI SDK v6 (`ai@6.0.176`) no longer reads that field — its `sendMessage` only recognizes `text`, `files`, or `parts` — so any files passed via the method were silently dropped and only the text was sent.

## Changes

- **@lowdefy/blocks-antd-x**: In the `sendMessage` CallMethod, pass attachments as `files` instead of `experimental_attachments` so v6 builds file parts from the array.

## Notes

- Verified against the installed `ai@6.0.176`: `sendMessage` builds parts via `if ("text" in message || "files" in message)` and reads `message.files`; there is no `experimental_attachments` handling in either `ai` or `@ai-sdk/react@3.0.178`.
- `args.files` is expected to be an array of file UI parts (`{ type: 'file', url, mediaType, filename }`), which v6 uses directly. This matches the interactive composer path, which already builds file parts and calls `sendMessage({ parts })` correctly.
- No changeset added: `@lowdefy/blocks-antd-x` is already bumped by the `feat-file-storage-providers` changeset on this branch, and this is a fix to that same unreleased change.