### PR TITLE
feat(build): module-level agents — scoped ids, LLM-safe tool names, _module.agentId

### DIFF
--- a/packages/build/src/build/buildAgents.js
+++ b/packages/build/src/build/buildAgents.js
@@ -24,6 +24,9 @@ import { RESERVED_PLATFORM_TOOL_NAMES } from '@lowdefy/ai-utils';
 import countOperators from '../utils/countOperators.js';
 import createCheckDuplicateId from '../utils/createCheckDuplicateId.js';
 
+// Provider tool-name rule (Anthropic and OpenAI both).
+const TOOL_NAME_REGEX = /^[a-zA-Z0-9_-]{1,64}$/;
+
 function detectCycles(agents) {
   const graph = {};
   for (const agent of agents) {
@@ -113,14 +116,36 @@ function buildAgents({ components, context }) {
       return tool;
     });
 
-    // Validate tools reference existing API endpoints with required tool metadata
+    // Assign LLM-safe tool names. Providers require ^[a-zA-Z0-9_-]{1,64}$ —
+    // module-scoped endpoint ids contain '/', so the default name replaces
+    // '/' with '__'; config may override with an explicit "name".
+    const toolNames = new Set();
     agent.tools.forEach((toolConfig) => {
-      if (RESERVED_PLATFORM_TOOL_NAMES.includes(toolConfig.endpointId)) {
+      if (type.isNone(toolConfig.name)) {
+        toolConfig.name = toolConfig.endpointId.replaceAll('/', '__');
+      }
+      if (!TOOL_NAME_REGEX.test(toolConfig.name)) {
         throw new ConfigError(
-          `Agent "${agent.id}" tool "${toolConfig.endpointId}" uses a reserved platform tool name. Reserved: ${RESERVED_PLATFORM_TOOL_NAMES.join(', ')}.`,
+          `Agent "${agent.id}" tool name "${toolConfig.name}" is invalid. Tool names must match ^[a-zA-Z0-9_-]{1,64}$ — set "name" on the tool to override the default derived from the endpoint id.`,
           { configKey }
         );
       }
+      if (RESERVED_PLATFORM_TOOL_NAMES.includes(toolConfig.name)) {
+        throw new ConfigError(
+          `Agent "${agent.id}" tool "${toolConfig.name}" uses a reserved platform tool name. Reserved: ${RESERVED_PLATFORM_TOOL_NAMES.join(', ')}.`,
+          { configKey }
+        );
+      }
+      if (toolNames.has(toolConfig.name)) {
+        throw new ConfigError(`Agent "${agent.id}" has duplicate tool name "${toolConfig.name}".`, {
+          configKey,
+        });
+      }
+      toolNames.add(toolConfig.name);
+    });
+
+    // Validate tools reference existing API endpoints with required tool metadata
+    agent.tools.forEach((toolConfig) => {
       const endpoint = (components.api ?? []).find(
         (e) => e.id === toolConfig.endpointId || e.endpointId === toolConfig.endpointId
       );
@@ -213,6 +238,32 @@ function buildAgents({ components, context }) {
       return ref;
     });
 
+    // Sub-agents surface to the model as tools too — same naming rule.
+    agent.agents.forEach((ref) => {
+      if (type.isNone(ref.name)) {
+        ref.name = ref.agentId.replaceAll('/', '__');
+      }
+      if (!TOOL_NAME_REGEX.test(ref.name)) {
+        throw new ConfigError(
+          `Agent "${agent.id}" sub-agent tool name "${ref.name}" is invalid. Tool names must match ^[a-zA-Z0-9_-]{1,64}$ — set "name" on the sub-agent reference to override the default derived from the agent id.`,
+          { configKey }
+        );
+      }
+      if (RESERVED_PLATFORM_TOOL_NAMES.includes(ref.name)) {
+        throw new ConfigError(
+          `Agent "${agent.id}" sub-agent "${ref.agentId}" uses a reserved platform tool name. Reserved: ${RESERVED_PLATFORM_TOOL_NAMES.join(', ')}.`,
+          { configKey }
+        );
+      }
+      if (toolNames.has(ref.name)) {
+        throw new ConfigError(
+          `Agent "${agent.id}" sub-agent "${ref.agentId}" conflicts with an endpoint tool of the same name.`,
+          { configKey }
+        );
+      }
+      toolNames.add(ref.name);
+    });
+
     // Validate fileSystem basePath if present
     if (agent.properties?.fileSystem) {
       const basePath = agent.properties.fileSystem.basePath;
@@ -251,25 +302,6 @@ function buildAgents({ components, context }) {
       if (!context.agentIds.has(subAgentRef.agentId)) {
         throw new ConfigError(
           `Agent "${agent.agentId}" references sub-agent "${subAgentRef.agentId}" which does not exist.`,
-          { configKey }
-        );
-      }
-
-      // Reserved platform tool name guard for sub-agents
-      if (RESERVED_PLATFORM_TOOL_NAMES.includes(subAgentRef.agentId)) {
-        throw new ConfigError(
-          `Agent "${agent.agentId}" sub-agent "${subAgentRef.agentId}" uses a reserved platform tool name. Reserved: ${RESERVED_PLATFORM_TOOL_NAMES.join(', ')}.`,
-          { configKey }
-        );
-      }
-
-      // Check for name collision with endpoint tools
-      const hasToolCollision = agent.tools.some(
-        (toolConfig) => toolConfig.endpointId === subAgentRef.agentId
-      );
-      if (hasToolCollision) {
-        throw new ConfigError(
-          `Agent "${agent.agentId}" sub-agent "${subAgentRef.agentId}" conflicts with an endpoint tool of the same name.`,
           { configKey }
         );
       }

--- a/packages/build/src/build/buildAgents.test.js
+++ b/packages/build/src/build/buildAgents.test.js
@@ -84,7 +84,7 @@ test('buildAgents valid agent renames id and adds to agentIds', () => {
       agentId: 'agent1',
       type: 'AnthropicAgent',
       connectionId: 'conn1',
-      tools: [{ endpointId: 'tool1' }],
+      tools: [{ endpointId: 'tool1', name: 'tool1' }],
       mcp: [],
       agents: [],
       properties: {
@@ -519,7 +519,10 @@ test('buildAgents validates multiple tools all referencing existing endpoints', 
     ],
   };
   const res = buildAgents({ components, context });
-  expect(res.agents[0].tools).toEqual([{ endpointId: 'tool1' }, { endpointId: 'tool2' }]);
+  expect(res.agents[0].tools).toEqual([
+    { endpointId: 'tool1', name: 'tool1' },
+    { endpointId: 'tool2', name: 'tool2' },
+  ]);
 });
 
 test('buildAgents throws when model is not defined', () => {
@@ -746,7 +749,7 @@ test('buildAgents normalizes string tools to objects', () => {
     ],
   };
   const res = buildAgents({ components, context });
-  expect(res.agents[0].tools).toEqual([{ endpointId: 'tool1' }]);
+  expect(res.agents[0].tools).toEqual([{ endpointId: 'tool1', name: 'tool1' }]);
 });
 
 test('buildAgents passes through object tools with confirm', () => {
@@ -780,7 +783,7 @@ test('buildAgents passes through object tools with confirm', () => {
     ],
   };
   const res = buildAgents({ components, context });
-  expect(res.agents[0].tools).toEqual([{ endpointId: 'tool1', confirm: true }]);
+  expect(res.agents[0].tools).toEqual([{ endpointId: 'tool1', name: 'tool1', confirm: true }]);
 });
 
 test('buildAgents normalizes mixed tool array', () => {
@@ -823,8 +826,8 @@ test('buildAgents normalizes mixed tool array', () => {
   };
   const res = buildAgents({ components, context });
   expect(res.agents[0].tools).toEqual([
-    { endpointId: 'tool1' },
-    { endpointId: 'tool2', confirm: true },
+    { endpointId: 'tool1', name: 'tool1' },
+    { endpointId: 'tool2', name: 'tool2', confirm: true },
   ]);
 });
 
@@ -1082,7 +1085,7 @@ test('buildAgents normalizes string agents to objects with agentId', () => {
     ],
   };
   const res = buildAgents({ components, context });
-  expect(res.agents[1].agents).toEqual([{ agentId: 'researcher' }]);
+  expect(res.agents[1].agents).toEqual([{ agentId: 'researcher', name: 'researcher' }]);
 });
 
 test('buildAgents passes through object agents with agentId', () => {
@@ -1109,7 +1112,7 @@ test('buildAgents passes through object agents with agentId', () => {
   };
   const res = buildAgents({ components, context });
   expect(res.agents[1].agents).toEqual([
-    { agentId: 'researcher', description: 'Research topics' },
+    { agentId: 'researcher', name: 'researcher', description: 'Research topics' },
   ]);
 });
 
@@ -1143,8 +1146,8 @@ test('buildAgents normalizes mixed agents array', () => {
   };
   const res = buildAgents({ components, context });
   expect(res.agents[2].agents).toEqual([
-    { agentId: 'researcher' },
-    { agentId: 'analyzer', description: 'Analyze data' },
+    { agentId: 'researcher', name: 'researcher' },
+    { agentId: 'analyzer', name: 'analyzer', description: 'Analyze data' },
   ]);
 });
 
@@ -1598,5 +1601,226 @@ test('buildAgents throws when sub-agent agentId uses a reserved platform tool na
   };
   expect(() => buildAgents({ components, context })).toThrow(
     /sub-agent "read-file" uses a reserved platform tool name/
+  );
+});
+
+test('buildAgents defaults tool name from module-scoped endpoint id', () => {
+  const context = testContext();
+  const components = {
+    connections: [{ id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' }],
+    api: [
+      {
+        id: 'endpoint:reporting/query-data',
+        endpointId: 'reporting/query-data',
+        type: 'Api',
+        description: 'Query data',
+        payloadSchema: { type: 'object' },
+        routine: [],
+      },
+    ],
+    agents: [
+      {
+        id: 'reporting/assistant',
+        type: 'AnthropicAgent',
+        connectionId: 'conn1',
+        tools: ['reporting/query-data'],
+        properties: { model: 'test-model' },
+      },
+    ],
+  };
+  const res = buildAgents({ components, context });
+  expect(res.agents[0].tools).toEqual([
+    { endpointId: 'reporting/query-data', name: 'reporting__query-data' },
+  ]);
+  expect(context.agentIds).toEqual(new Set(['reporting/assistant']));
+});
+
+test('buildAgents keeps explicit tool name', () => {
+  const context = testContext();
+  const components = {
+    connections: [{ id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' }],
+    api: [
+      {
+        id: 'endpoint:reporting/query-data',
+        endpointId: 'reporting/query-data',
+        type: 'Api',
+        description: 'Query data',
+        payloadSchema: { type: 'object' },
+        routine: [],
+      },
+    ],
+    agents: [
+      {
+        id: 'agent1',
+        type: 'AnthropicAgent',
+        connectionId: 'conn1',
+        tools: [{ endpointId: 'reporting/query-data', name: 'query_data' }],
+        properties: { model: 'test-model' },
+      },
+    ],
+  };
+  const res = buildAgents({ components, context });
+  expect(res.agents[0].tools).toEqual([
+    { endpointId: 'reporting/query-data', name: 'query_data' },
+  ]);
+});
+
+test('buildAgents throws on invalid explicit tool name', () => {
+  const context = testContext();
+  const components = {
+    connections: [{ id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' }],
+    api: [
+      {
+        id: 'endpoint:tool1',
+        endpointId: 'tool1',
+        type: 'Api',
+        description: 'A tool',
+        payloadSchema: { type: 'object' },
+        routine: [],
+      },
+    ],
+    agents: [
+      {
+        id: 'agent1',
+        type: 'AnthropicAgent',
+        connectionId: 'conn1',
+        tools: [{ endpointId: 'tool1', name: 'has space' }],
+        properties: { model: 'test-model' },
+      },
+    ],
+  };
+  expect(() => buildAgents({ components, context })).toThrow(
+    /tool name "has space" is invalid/
+  );
+});
+
+test('buildAgents throws when explicit tool name is reserved', () => {
+  const context = testContext();
+  const components = {
+    connections: [{ id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' }],
+    api: [
+      {
+        id: 'endpoint:tool1',
+        endpointId: 'tool1',
+        type: 'Api',
+        description: 'A tool',
+        payloadSchema: { type: 'object' },
+        routine: [],
+      },
+    ],
+    agents: [
+      {
+        id: 'agent1',
+        type: 'AnthropicAgent',
+        connectionId: 'conn1',
+        tools: [{ endpointId: 'tool1', name: 'update-page-state' }],
+        properties: { model: 'test-model' },
+      },
+    ],
+  };
+  expect(() => buildAgents({ components, context })).toThrow(
+    /tool "update-page-state" uses a reserved platform tool name/
+  );
+});
+
+test('buildAgents throws on duplicate tool names', () => {
+  const context = testContext();
+  const components = {
+    connections: [{ id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' }],
+    api: [
+      {
+        id: 'endpoint:tool1',
+        endpointId: 'tool1',
+        type: 'Api',
+        description: 'Tool 1',
+        payloadSchema: { type: 'object' },
+        routine: [],
+      },
+      {
+        id: 'endpoint:tool2',
+        endpointId: 'tool2',
+        type: 'Api',
+        description: 'Tool 2',
+        payloadSchema: { type: 'object' },
+        routine: [],
+      },
+    ],
+    agents: [
+      {
+        id: 'agent1',
+        type: 'AnthropicAgent',
+        connectionId: 'conn1',
+        tools: [
+          { endpointId: 'tool1', name: 'the_tool' },
+          { endpointId: 'tool2', name: 'the_tool' },
+        ],
+        properties: { model: 'test-model' },
+      },
+    ],
+  };
+  expect(() => buildAgents({ components, context })).toThrow(
+    /duplicate tool name "the_tool"/
+  );
+});
+
+test('buildAgents defaults sub-agent tool name from scoped agent id', () => {
+  const context = testContext();
+  const components = {
+    connections: [{ id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' }],
+    agents: [
+      {
+        id: 'reporting/researcher',
+        type: 'AnthropicAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+      },
+      {
+        id: 'reporting/orchestrator',
+        type: 'AnthropicAgent',
+        connectionId: 'conn1',
+        agents: ['reporting/researcher'],
+        properties: { model: 'test-model' },
+      },
+    ],
+  };
+  const res = buildAgents({ components, context });
+  expect(res.agents[1].agents).toEqual([
+    { agentId: 'reporting/researcher', name: 'reporting__researcher' },
+  ]);
+});
+
+test('buildAgents throws when sub-agent name collides with a tool name', () => {
+  const context = testContext();
+  const components = {
+    connections: [{ id: 'connection:conn1', connectionId: 'conn1', type: 'Anthropic' }],
+    api: [
+      {
+        id: 'endpoint:helper',
+        endpointId: 'helper',
+        type: 'Api',
+        description: 'A tool',
+        payloadSchema: { type: 'object' },
+        routine: [],
+      },
+    ],
+    agents: [
+      {
+        id: 'helper-agent',
+        type: 'AnthropicAgent',
+        connectionId: 'conn1',
+        properties: { model: 'test-model' },
+      },
+      {
+        id: 'parent',
+        type: 'AnthropicAgent',
+        connectionId: 'conn1',
+        tools: ['helper'],
+        agents: [{ agentId: 'helper-agent', name: 'helper' }],
+        properties: { model: 'test-model' },
+      },
+    ],
+  };
+  expect(() => buildAgents({ components, context })).toThrow(
+    /sub-agent "helper-agent" conflicts with an endpoint tool of the same name/
   );
 });

--- a/packages/build/src/build/buildModules.js
+++ b/packages/build/src/build/buildModules.js
@@ -90,6 +90,9 @@ function buildModules({ components, context }) {
     for (const endpoint of manifest.api ?? []) {
       validateModuleSecrets({ content: endpoint, manifest, entryId: entry.id });
     }
+    for (const agent of manifest.agents ?? []) {
+      validateModuleSecrets({ content: agent, manifest, entryId: entry.id });
+    }
 
     // Process pages
     for (const page of manifest.pages ?? []) {
@@ -111,6 +114,13 @@ function buildModules({ components, context }) {
       endpoint.id = `${entry.id}/${endpoint.id}`;
       components.api = components.api ?? [];
       components.api.push(endpoint);
+    }
+
+    // Process agents
+    for (const agent of manifest.agents ?? []) {
+      agent.id = `${entry.id}/${agent.id}`;
+      components.agents = components.agents ?? [];
+      components.agents.push(agent);
     }
   }
 

--- a/packages/build/src/build/buildRefs/deferredRegions.js
+++ b/packages/build/src/build/buildRefs/deferredRegions.js
@@ -37,8 +37,8 @@
 // preserve and is not a manifest phase).
 
 const VAR_DEFAULT = /^vars(\.[^.]+\.properties)*\.[^.]+\.default(\..*)?$/;
-const CONTENT_SECTIONS = /^(pages|api|connections|menus|components)(\..*)?$/;
-const NON_EXPORTABLE_SECTIONS = /^(pages|api|connections|vars|dependencies|plugins|secrets)(\..*)?$/;
+const CONTENT_SECTIONS = /^(pages|api|connections|agents|menus|components)(\..*)?$/;
+const NON_EXPORTABLE_SECTIONS = /^(pages|api|connections|agents|vars|dependencies|plugins|secrets)(\..*)?$/;
 
 const DEFERRED_REGIONS = [
   { phase: 'header', match: VAR_DEFAULT, action: 'record:varDefault' },

--- a/packages/build/src/build/buildRefs/walker.js
+++ b/packages/build/src/build/buildRefs/walker.js
@@ -386,6 +386,7 @@ const MODULE_ID_OPERATOR_KEYS = [
   '_module.pageId',
   '_module.connectionId',
   '_module.endpointId',
+  '_module.agentId',
   '_module.id',
 ];
 
@@ -499,6 +500,34 @@ function resolveModuleEndpointId(arg, moduleEntry, context, configKey) {
   });
 }
 
+// Resolve _module.agentId
+function resolveModuleAgentId(arg, moduleEntry, context, configKey) {
+  if (type.isString(arg)) {
+    if (!moduleEntry) {
+      throw new ConfigError(
+        '_module.agentId string form is ambiguous at the app level — no module to scope against. Use { id, module } to specify the target module.',
+        { configKey }
+      );
+    }
+    return `${moduleEntry.id}/${arg}`;
+  }
+
+  if (type.isObject(arg) && type.isString(arg.id) && type.isString(arg.module)) {
+    const targetEntry = resolveDepTarget({
+      moduleEntry,
+      depName: arg.module,
+      context,
+      configKey,
+      usage: `_module.agentId { id: "${arg.id}", module: "${arg.module}" }`,
+    });
+    return `${targetEntry.id}/${arg.id}`;
+  }
+
+  throw new ConfigError('_module.agentId requires a string or object { id, module }.', {
+    configKey,
+  });
+}
+
 // Resolve _module.id
 function resolveModuleId(arg, moduleEntry, context, configKey) {
   if (!type.isObject(arg)) {
@@ -571,6 +600,9 @@ async function resolveModuleIdOperator(node, ctx) {
   }
   if (!type.isUndefined(node['_module.endpointId'])) {
     return resolveModuleEndpointId(node['_module.endpointId'], moduleEntry, context, configKey);
+  }
+  if (!type.isUndefined(node['_module.agentId'])) {
+    return resolveModuleAgentId(node['_module.agentId'], moduleEntry, context, configKey);
   }
   if (!type.isUndefined(node['_module.id'])) {
     return resolveModuleId(node['_module.id'], moduleEntry, context, configKey);

--- a/packages/build/src/build/registerModules.js
+++ b/packages/build/src/build/registerModules.js
@@ -370,7 +370,7 @@ async function resolveFullManifest({ entryId, context }) {
   const resolved = await resolve(manifest, ctx);
 
   // Filter null entries produced by _ref resolution failures
-  for (const key of ['pages', 'connections', 'api']) {
+  for (const key of ['pages', 'connections', 'api', 'agents']) {
     if (type.isArray(resolved[key])) {
       resolved[key] = resolved[key].filter((item) => !type.isNone(item));
     }

--- a/packages/build/src/lowdefySchema.js
+++ b/packages/build/src/lowdefySchema.js
@@ -248,6 +248,7 @@ export default {
                 required: ['endpointId'],
                 properties: {
                   endpointId: { type: 'string' },
+                  name: { type: 'string' },
                   confirm: {
                     const: true,
                   },
@@ -313,6 +314,7 @@ export default {
                 required: ['agentId'],
                 properties: {
                   agentId: { type: 'string' },
+                  name: { type: 'string' },
                   description: { type: 'string' },
                   inputSchema: { type: 'object' },
                 },

--- a/packages/build/src/tests/success/95-module-agents/lowdefy.yaml
+++ b/packages/build/src/tests/success/95-module-agents/lowdefy.yaml
@@ -1,0 +1,18 @@
+# 95: Module-level agents — a module ships its agent; the agent id scopes per
+# entry, tools get LLM-safe names, and _module.agentId resolves in pages and
+# CallAgent steps.
+lowdefy: local
+name: Module Agents Test
+
+modules:
+  - id: helper
+    source: 'file:modules/assistant'
+
+pages:
+  - id: home
+    type: Box
+    blocks:
+      - id: title
+        type: Title
+        properties:
+          content: Home

--- a/packages/build/src/tests/success/95-module-agents/modules/assistant/agents/assistant.yaml
+++ b/packages/build/src/tests/success/95-module-agents/modules/assistant/agents/assistant.yaml
@@ -1,0 +1,19 @@
+id: assistant
+type: ClaudeAgent
+connectionId:
+  _module.connectionId: ai
+properties:
+  model: claude-haiku-4-5
+  instructions: You answer questions about signups.
+  maxSteps: 5
+tools:
+  # Explicit LLM-safe name over a module-scoped endpoint id.
+  - name: lookup_signups
+    endpointId:
+      _module.endpointId: lookup-signups
+  # No name — defaults to the scoped endpoint id with '/' replaced by '__'.
+  - endpointId:
+      _module.endpointId: count-users
+hooks:
+  onFinish:
+    - _module.endpointId: save-log

--- a/packages/build/src/tests/success/95-module-agents/modules/assistant/api/count-users.yaml
+++ b/packages/build/src/tests/success/95-module-agents/modules/assistant/api/count-users.yaml
@@ -1,0 +1,9 @@
+id: count-users
+type: InternalApi
+description: Count registered users.
+payloadSchema:
+  type: object
+  properties: {}
+routine:
+  - ':return':
+      users: 7

--- a/packages/build/src/tests/success/95-module-agents/modules/assistant/api/lookup-signups.yaml
+++ b/packages/build/src/tests/success/95-module-agents/modules/assistant/api/lookup-signups.yaml
@@ -1,0 +1,11 @@
+id: lookup-signups
+type: InternalApi
+description: Look up signup counts for a date range.
+payloadSchema:
+  type: object
+  properties:
+    days:
+      type: number
+routine:
+  - ':return':
+      signups: 42

--- a/packages/build/src/tests/success/95-module-agents/modules/assistant/api/run-assistant.yaml
+++ b/packages/build/src/tests/success/95-module-agents/modules/assistant/api/run-assistant.yaml
@@ -1,0 +1,13 @@
+id: run-assistant
+type: Api
+routine:
+  - id: run
+    type: CallAgent
+    properties:
+      agentId:
+        _module.agentId: assistant
+      prompt:
+        _payload: instruction
+  - ':return':
+      summary:
+        _step: run.text

--- a/packages/build/src/tests/success/95-module-agents/modules/assistant/api/save-log.yaml
+++ b/packages/build/src/tests/success/95-module-agents/modules/assistant/api/save-log.yaml
@@ -1,0 +1,5 @@
+id: save-log
+type: InternalApi
+routine:
+  - ':return':
+      ok: true

--- a/packages/build/src/tests/success/95-module-agents/modules/assistant/connections/ai.yaml
+++ b/packages/build/src/tests/success/95-module-agents/modules/assistant/connections/ai.yaml
@@ -1,0 +1,5 @@
+id: ai
+type: Anthropic
+properties:
+  apiKey:
+    _secret: ANTHROPIC_API_KEY

--- a/packages/build/src/tests/success/95-module-agents/modules/assistant/module.lowdefy.yaml
+++ b/packages/build/src/tests/success/95-module-agents/modules/assistant/module.lowdefy.yaml
@@ -1,0 +1,21 @@
+name: Assistant
+description: Module that ships its own agent
+
+secrets:
+  - name: ANTHROPIC_API_KEY
+    description: Anthropic API key
+
+connections:
+  - _ref: connections/ai.yaml
+
+api:
+  - _ref: api/lookup-signups.yaml
+  - _ref: api/count-users.yaml
+  - _ref: api/save-log.yaml
+  - _ref: api/run-assistant.yaml
+
+agents:
+  - _ref: agents/assistant.yaml
+
+pages:
+  - _ref: pages/chat.yaml

--- a/packages/build/src/tests/success/95-module-agents/modules/assistant/pages/chat.yaml
+++ b/packages/build/src/tests/success/95-module-agents/modules/assistant/pages/chat.yaml
@@ -1,0 +1,11 @@
+id: chat
+type: Box
+properties:
+  # Mimics AgentChat.agentId — the block property must carry the scoped id.
+  agentId:
+    _module.agentId: assistant
+blocks:
+  - id: title
+    type: Title
+    properties:
+      content: Assistant Chat

--- a/packages/build/src/tests/success/95-module-agents/snapshot.json
+++ b/packages/build/src/tests/success/95-module-agents/snapshot.json
@@ -1,98 +1,68 @@
 {
   "agentFileSystems.json": [],
-  "agents/research_agent.json": {
-    "id": "agent:research_agent",
+  "agents/helper/assistant.json": {
+    "id": "agent:helper/assistant",
     "type": "ClaudeAgent",
-    "connectionId": "claude",
+    "connectionId": "helper/ai",
     "properties": {
       "model": "claude-haiku-4-5",
-      "instructions": "You research signup data and summarize findings.",
+      "instructions": "You answer questions about signups.",
       "maxSteps": 5,
-      "~k": "b"
+      "~k": "1c"
     },
     "tools": {
       "~arr": [
         {
-          "endpointId": "lookup-signups",
-          "name": "lookup-signups",
-          "~k": "1r"
+          "name": "lookup_signups",
+          "endpointId": "helper/lookup-signups",
+          "~k": "1e"
+        },
+        {
+          "endpointId": "helper/count-users",
+          "name": "helper__count-users",
+          "~k": "1f"
         }
       ],
-      "~k": "1q"
+      "~k": "2t"
+    },
+    "hooks": {
+      "onFinish": {
+        "~arr": [
+          "helper/save-log"
+        ],
+        "~k": "1h"
+      },
+      "~k": "1g"
     },
     "mcp": {
       "~arr": [],
-      "~k": "1s"
+      "~k": "2u"
     },
     "agents": {
       "~arr": [],
-      "~k": "1t"
+      "~k": "2v"
     },
-    "agentId": "research_agent",
-    "~k": "a"
+    "agentId": "helper/assistant",
+    "~k": "1b"
   },
-  "api/daily-research.json": {
-    "id": "endpoint:daily-research",
-    "type": "Api",
+  "api/helper/count-users.json": {
+    "id": "endpoint:helper/count-users",
+    "type": "InternalApi",
+    "description": "Count registered users.",
+    "payloadSchema": {
+      "type": "object",
+      "properties": {
+        "~k": "u"
+      },
+      "~k": "t"
+    },
     "routine": {
       "~arr": [
-        {
-          "id": "agent:daily-research:research",
-          "type": "CallAgent",
-          "properties": {
-            "agentId": "research_agent",
-            "prompt": {
-              "_payload": "instruction",
-              "~k": "p"
-            },
-            "~k": "o"
-          },
-          "stepId": "research",
-          "endpointId": "daily-research",
-          "~k": "n"
-        },
         {
           ":return": {
-            "summary": {
-              "_step": "research.text",
-              "~k": "s"
-            },
-            "usage": {
-              "_step": "research.usage",
-              "~k": "t"
-            },
-            "~k": "r"
-          },
-          "~k": "q"
-        }
-      ],
-      "~k": "m"
-    },
-    "auth": {
-      "public": true,
-      "~k": "1v"
-    },
-    "endpointId": "daily-research",
-    "~k": "l"
-  },
-  "api/dynamic-agent.json": {
-    "id": "endpoint:dynamic-agent",
-    "type": "Api",
-    "routine": {
-      "~arr": [
-        {
-          "id": "agent:dynamic-agent:run_agent",
-          "type": "CallAgent",
-          "properties": {
-            "agentId": {
-              "_payload": "agent_id",
-              "~k": "y"
-            },
-            "prompt": "Run the standard analysis.",
+            "users": 7,
             "~k": "x"
           },
-          "stepId": "run_agent",
-          "endpointId": "dynamic-agent",
           "~k": "w"
         }
       ],
@@ -100,13 +70,13 @@
     },
     "auth": {
       "public": true,
-      "~k": "1w"
+      "~k": "2q"
     },
-    "endpointId": "dynamic-agent",
-    "~k": "u"
+    "endpointId": "helper/count-users",
+    "~k": "s"
   },
-  "api/lookup-signups.json": {
-    "id": "endpoint:lookup-signups",
+  "api/helper/lookup-signups.json": {
+    "id": "endpoint:helper/lookup-signups",
     "type": "InternalApi",
     "description": "Look up signup counts for a date range.",
     "payloadSchema": {
@@ -114,95 +84,157 @@
       "properties": {
         "days": {
           "type": "number",
-          "~k": "h"
+          "~k": "o"
         },
-        "~k": "g"
+        "~k": "n"
       },
-      "~k": "f"
+      "~k": "m"
     },
     "routine": {
       "~arr": [
         {
           ":return": {
             "signups": 42,
-            "~k": "k"
+            "~k": "r"
           },
-          "~k": "j"
+          "~k": "q"
         }
       ],
-      "~k": "i"
+      "~k": "p"
     },
     "auth": {
       "public": true,
-      "~k": "1u"
+      "~k": "2p"
     },
-    "endpointId": "lookup-signups",
-    "~k": "e"
+    "endpointId": "helper/lookup-signups",
+    "~k": "l"
+  },
+  "api/helper/run-assistant.json": {
+    "id": "endpoint:helper/run-assistant",
+    "type": "Api",
+    "routine": {
+      "~arr": [
+        {
+          "id": "agent:helper/run-assistant:run",
+          "type": "CallAgent",
+          "properties": {
+            "agentId": "helper/assistant",
+            "prompt": {
+              "_payload": "instruction",
+              "~k": "16"
+            },
+            "~k": "15"
+          },
+          "stepId": "run",
+          "endpointId": "helper/run-assistant",
+          "~k": "14"
+        },
+        {
+          ":return": {
+            "summary": {
+              "_step": "run.text",
+              "~k": "19"
+            },
+            "~k": "18"
+          },
+          "~k": "17"
+        }
+      ],
+      "~k": "13"
+    },
+    "auth": {
+      "public": true,
+      "~k": "2s"
+    },
+    "endpointId": "helper/run-assistant",
+    "~k": "12"
+  },
+  "api/helper/save-log.json": {
+    "id": "endpoint:helper/save-log",
+    "type": "InternalApi",
+    "routine": {
+      "~arr": [
+        {
+          ":return": {
+            "ok": true,
+            "~k": "11"
+          },
+          "~k": "10"
+        }
+      ],
+      "~k": "z"
+    },
+    "auth": {
+      "public": true,
+      "~k": "2r"
+    },
+    "endpointId": "helper/save-log",
+    "~k": "y"
   },
   "app.json": {
     "html": {
       "appendBody": "",
       "appendHead": "",
-      "~k": "1k"
+      "~k": "1y"
     },
     "email": {
-      "companyName": "API CallAgent Test",
-      "~k": "1l"
+      "companyName": "Module Agents Test",
+      "~k": "1z"
     },
-    "~k": "1j"
+    "~k": "1x"
   },
   "appMeta.json": {
     "slug": null,
-    "name": "API CallAgent Test",
+    "name": "Module Agents Test",
     "version": null,
     "description": null,
     "license": null,
     "lowdefyVersion": "local",
     "gitSha": "test-git-sha-for-snapshots",
-    "~k": "1m"
+    "~k": "20"
   },
   "auth.json": {
     "api": {
       "roles": {
-        "~k": "2e"
+        "~k": "2y"
       },
-      "~k": "2d"
+      "~k": "2x"
     },
     "websockets": {
       "roles": {
-        "~k": "2g"
+        "~k": "30"
       },
-      "~k": "2f"
+      "~k": "2z"
     },
     "authPages": {
-      "~k": "2h"
+      "~k": "31"
     },
     "pages": {
       "roles": {
-        "~k": "2j"
+        "~k": "33"
       },
-      "~k": "2i"
+      "~k": "32"
     },
     "callbacks": {
       "~arr": [],
-      "~k": "2k"
+      "~k": "34"
     },
     "events": {
       "~arr": [],
-      "~k": "2l"
+      "~k": "35"
     },
     "providers": {
       "~arr": [],
-      "~k": "2m"
+      "~k": "36"
     },
     "session": {
-      "~k": "2n"
+      "~k": "37"
     },
     "theme": {
-      "~k": "2o"
+      "~k": "38"
     },
     "configured": false,
-    "~k": "2c"
+    "~k": "2w"
   },
   "blockPackages.json": [
     "@lowdefy/blocks-basic",
@@ -210,20 +242,20 @@
     "@lowdefy/blocks-loaders"
   ],
   "config.json": {
-    "~k": "1o"
+    "~k": "22"
   },
-  "connections/claude.json": {
-    "id": "connection:claude",
+  "connections/helper/ai.json": {
+    "id": "connection:helper/ai",
     "type": "Anthropic",
     "properties": {
       "apiKey": {
         "_secret": "ANTHROPIC_API_KEY",
-        "~k": "8"
+        "~k": "j"
       },
-      "~k": "7"
+      "~k": "i"
     },
-    "connectionId": "claude",
-    "~k": "6"
+    "connectionId": "helper/ai",
+    "~k": "h"
   },
   "global.json": {},
   "globals.css": "/* Generated by Lowdefy build */\n\n/* Layer order — locks cascade priority before Tailwind declares its own layers */\n@layer theme, base, antd, components, utilities;\n\n/* source(none) disables Tailwind's automatic source detection — without it the\n   oxide scanner walks the entire server directory tree (node_modules and all,\n   ~50s cold) on the first CSS compile. The explicit @source globs below are\n   the only scan inputs Lowdefy needs. */\n@import \"tailwindcss\" source(none);\n@import \"@lowdefy/layout/grid.css\";\n\n/* Imported CSS file — when this changes, PostCSS re-runs and Tailwind re-scans @source.\n   This import is the ONLY recompile trigger in dev: the @source .html files below are\n   deliberately excluded from Vite's watcher (server.watch.ignored in the dev server's\n   vite.config.js) because watched .html changes force full browser reloads. The JIT\n   page builder touches this file whenever tailwind content changes. */\n@import \"./tailwind-candidates.css\";\n\n/* Content sources for Tailwind JIT — block JS content collected at build time */\n@source \"../lowdefy-build/tailwind/*.html\";\n\n/* Themed scrollbars — opts out of the browser default that clashes on dark surfaces,\n   especially on Windows/Linux where scrollbars are always visible and native-chrome.\n   Colors use antd CSS custom properties so they auto-swap with dark/light mode. */\n@layer base {\n  * {\n    scrollbar-width: thin;\n    scrollbar-color: var(--ant-color-border-secondary, rgba(0, 0, 0, 0.15)) transparent;\n  }\n  *::-webkit-scrollbar {\n    width: 10px;\n    height: 10px;\n  }\n  *::-webkit-scrollbar-track {\n    background: transparent;\n  }\n  *::-webkit-scrollbar-thumb {\n    background-color: var(--ant-color-border-secondary, rgba(0, 0, 0, 0.15));\n    background-clip: padding-box;\n    border: 2px solid transparent;\n    border-radius: 10px;\n  }\n  *::-webkit-scrollbar-thumb:hover {\n    background-color: var(--ant-color-text-tertiary, rgba(0, 0, 0, 0.45));\n  }\n  *::-webkit-scrollbar-corner {\n    background: transparent;\n  }\n}\n\n/* Antd-to-Tailwind theme bridge — extends default Tailwind theme with antd design tokens */\n@theme inline {\n  --color-primary: var(--ant-color-primary);\n  --color-primary-hover: var(--ant-color-primary-hover);\n  --color-primary-active: var(--ant-color-primary-active);\n  --color-primary-bg: var(--ant-color-primary-bg);\n  --color-success: var(--ant-color-success);\n  --color-warning: var(--ant-color-warning);\n  --color-error: var(--ant-color-error);\n  --color-info: var(--ant-color-info);\n  --color-text-primary: var(--ant-color-text);\n  --color-text-secondary: var(--ant-color-text-secondary);\n  --color-bg-container: var(--ant-color-bg-container);\n  --color-bg-layout: var(--ant-color-bg-layout);\n  --color-border: var(--ant-color-border);\n  --radius-DEFAULT: var(--ant-border-radius);\n  --radius-sm: var(--ant-border-radius-sm);\n  --radius-lg: var(--ant-border-radius-lg);\n  --font-size-DEFAULT: var(--ant-font-size);\n  --font-size-sm: var(--ant-font-size-sm);\n  --font-size-lg: var(--ant-font-size-lg);\n  --font-family-sans: var(--ant-font-family);\n}\n",
@@ -232,1030 +264,1164 @@
   "i18n/antdXLocales.js": "// Generated by @lowdefy/build. Do not edit.\nconst loaders = {\n\n};\nexport default loaders;\n",
   "i18n/dayjsLocales.js": "// Generated by @lowdefy/build. Do not edit.\n\nconst localeMap = {\n\n};\nexport default localeMap;\n",
   "keyMap.json": {
-    "4": {
-      "key": "root",
-      "~k_parent": "3",
-      "~l": 2
-    },
     "5": {
-      "key": "root.connections",
+      "key": "root",
       "~k_parent": "4",
-      "~l": 5
+      "~l": 4
     },
     "6": {
-      "key": "root.connections[0:claude:Anthropic]",
+      "key": "root.pages",
       "~k_parent": "5",
-      "~l": 6
+      "~l": 11
     },
     "7": {
-      "key": "root.connections[0:claude:Anthropic].properties",
+      "key": "root.pages[0:home:Box]",
       "~k_parent": "6",
-      "~l": 8
-    },
-    "8": {
-      "key": "root.connections[0:claude:Anthropic].properties.apiKey",
-      "~k_parent": "7",
-      "~l": 9
-    },
-    "9": {
-      "key": "root.agents",
-      "~k_parent": "4",
       "~l": 12
     },
+    "8": {
+      "key": "root.pages[0:home:Box].blocks",
+      "~k_parent": "7",
+      "~l": 14
+    },
+    "9": {
+      "key": "root.pages[0:home:Box].blocks[0:title:Title]",
+      "~k_parent": "8",
+      "~l": 15
+    },
     "10": {
-      "key": "root.pages[0:home:Box]",
+      "key": "root.api[2:helper/save-log:InternalApi].routine[0]",
       "~k_parent": "z",
-      "~l": 62
+      "~r": "api.2",
+      "~l": 4
     },
     "11": {
-      "key": "root.pages[0:home:Box].blocks",
+      "key": "root.api[2:helper/save-log:InternalApi].routine[0].:return",
       "~k_parent": "10",
-      "~l": 64
+      "~r": "api.2",
+      "~l": 4
     },
     "12": {
-      "key": "root.pages[0:home:Box].blocks[0:title:Title]",
-      "~k_parent": "11",
-      "~l": 65
+      "key": "root.api[3:helper/run-assistant:Api]",
+      "~k_parent": "k",
+      "~r": "api.3",
+      "~l": 1
     },
     "13": {
-      "key": "root.pages[0:home:Box].blocks[0:title:Title].properties",
+      "key": "root.api[3:helper/run-assistant:Api].routine",
       "~k_parent": "12",
-      "~l": 67
+      "~r": "api.3",
+      "~l": 3
+    },
+    "14": {
+      "key": "root.api[3:helper/run-assistant:Api].routine[0:run:CallAgent]",
+      "~k_parent": "13",
+      "~r": "api.3",
+      "~l": 4
     },
     "15": {
-      "key": "root.pages",
-      "~k_parent": "4"
+      "key": "root.api[3:helper/run-assistant:Api].routine[0:run:CallAgent].properties",
+      "~k_parent": "14",
+      "~r": "api.3",
+      "~l": 6
     },
     "16": {
-      "key": "root.pages[1:404:Result]",
-      "~k_parent": "15"
+      "key": "root.api[3:helper/run-assistant:Api].routine[0:run:CallAgent].properties.prompt",
+      "~k_parent": "15",
+      "~r": "api.3",
+      "~l": 9
     },
     "17": {
-      "key": "root.pages[1:404:Result].style",
-      "~k_parent": "16"
+      "key": "root.api[3:helper/run-assistant:Api].routine[1]",
+      "~k_parent": "13",
+      "~r": "api.3",
+      "~l": 11
     },
     "18": {
-      "key": "root.pages[1:404:Result].properties",
-      "~k_parent": "16"
+      "key": "root.api[3:helper/run-assistant:Api].routine[1].:return",
+      "~k_parent": "17",
+      "~r": "api.3",
+      "~l": 11
     },
     "19": {
-      "key": "root.pages[1:404:Result].properties.icon",
-      "~k_parent": "18"
+      "key": "root.api[3:helper/run-assistant:Api].routine[1].:return.summary",
+      "~k_parent": "18",
+      "~r": "api.3",
+      "~l": 12
     },
     "20": {
-      "key": "root.pages[0:home:Box].slots",
-      "~k_parent": "1y"
+      "key": "root.appMeta",
+      "~k_parent": "5"
     },
     "21": {
-      "key": "root.pages[0:home:Box].slots.content",
-      "~k_parent": "20"
+      "key": "root.logger",
+      "~k_parent": "5"
     },
     "22": {
-      "key": "root.pages[0:home:Box].subscriptions",
-      "~k_parent": "1y"
-    },
-    "23": {
-      "key": "root.pages[0:home:Box].requests",
-      "~k_parent": "1y"
+      "key": "root.config",
+      "~k_parent": "5"
     },
     "24": {
-      "key": "root.pages[1:404:Result]",
-      "~k_parent": "1x"
+      "key": "root.pages",
+      "~k_parent": "5"
     },
     "25": {
-      "key": "root.pages[1:404:Result].style",
+      "key": "root.pages[0:home:Box]",
       "~k_parent": "24"
     },
     "26": {
-      "key": "root.pages[1:404:Result].style.block",
+      "key": "root.pages[0:home:Box].auth",
       "~k_parent": "25"
     },
     "27": {
-      "key": "root.pages[1:404:Result].slots.extra.blocks[0:home:Button].events.onClick",
-      "~k_parent": "1f"
+      "key": "root.pages[0:home:Box].slots",
+      "~k_parent": "25"
     },
     "28": {
-      "key": "root.pages[1:404:Result].slots.extra.blocks[0:home:Button].events.onClick.catch",
+      "key": "root.pages[0:home:Box].slots.content",
       "~k_parent": "27"
     },
     "29": {
-      "key": "root.pages[1:404:Result].auth",
-      "~k_parent": "24"
+      "key": "root.pages[0:home:Box].subscriptions",
+      "~k_parent": "25"
     },
     "30": {
-      "key": "root.types.auth",
-      "~k_parent": "2u"
+      "key": "root.auth.websockets.roles",
+      "~k_parent": "2z"
     },
     "31": {
-      "key": "root.types.auth.adapters",
-      "~k_parent": "30"
+      "key": "root.auth.authPages",
+      "~k_parent": "2w"
     },
     "32": {
-      "key": "root.types.auth.callbacks",
-      "~k_parent": "30"
+      "key": "root.auth.pages",
+      "~k_parent": "2w"
     },
     "33": {
-      "key": "root.types.auth.events",
-      "~k_parent": "30"
+      "key": "root.auth.pages.roles",
+      "~k_parent": "32"
     },
     "34": {
-      "key": "root.types.auth.providers",
-      "~k_parent": "30"
+      "key": "root.auth.callbacks",
+      "~k_parent": "2w"
     },
     "35": {
-      "key": "root.types.blocks",
-      "~k_parent": "2u"
+      "key": "root.auth.events",
+      "~k_parent": "2w"
     },
     "36": {
-      "key": "root.types.blocks.Box",
-      "~k_parent": "35"
+      "key": "root.auth.providers",
+      "~k_parent": "2w"
     },
     "37": {
-      "key": "root.types.blocks.Title",
-      "~k_parent": "35"
+      "key": "root.auth.session",
+      "~k_parent": "2w"
     },
     "38": {
-      "key": "root.types.blocks.Result",
-      "~k_parent": "35"
+      "key": "root.auth.theme",
+      "~k_parent": "2w"
     },
     "39": {
-      "key": "root.types.blocks.Button",
-      "~k_parent": "35"
+      "key": "root.menus",
+      "~k_parent": "5"
     },
     "40": {
-      "key": "root.types.operators.client._type",
-      "~k_parent": "3y"
+      "key": "root.types.blocks.Icon",
+      "~k_parent": "3r"
     },
     "41": {
-      "key": "root.types.operators.server",
-      "~k_parent": "3x"
+      "key": "root.types.blocks.Img",
+      "~k_parent": "3r"
     },
     "42": {
-      "key": "root.types.operators.server._secret",
-      "~k_parent": "41"
+      "key": "root.types.blocks.List",
+      "~k_parent": "3r"
     },
     "43": {
-      "key": "root.types.operators.server._payload",
-      "~k_parent": "41"
+      "key": "root.types.blocks.Span",
+      "~k_parent": "3r"
     },
     "44": {
-      "key": "root.types.operators.server._step",
-      "~k_parent": "41"
+      "key": "root.types.blocks.Throw",
+      "~k_parent": "3r"
     },
     "45": {
-      "key": "root.imports",
-      "~k_parent": "4"
+      "key": "root.types.blocks.ProgressBar",
+      "~k_parent": "3r"
     },
     "46": {
-      "key": "root.imports.actions",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Skeleton",
+      "~k_parent": "3r"
     },
     "47": {
-      "key": "root.imports.actions[0]",
-      "~k_parent": "46"
+      "key": "root.types.blocks.SkeletonAvatar",
+      "~k_parent": "3r"
     },
     "48": {
-      "key": "root.imports.actions[1]",
-      "~k_parent": "46"
+      "key": "root.types.blocks.SkeletonButton",
+      "~k_parent": "3r"
     },
     "49": {
-      "key": "root.imports.agents",
-      "~k_parent": "45"
+      "key": "root.types.blocks.SkeletonInput",
+      "~k_parent": "3r"
     },
     "50": {
-      "key": "root.imports.blocks[19]",
-      "~k_parent": "4g"
+      "key": "root.imports.auth.events",
+      "~k_parent": "4x"
     },
     "51": {
-      "key": "root.imports.blocks[20]",
-      "~k_parent": "4g"
+      "key": "root.imports.auth.providers",
+      "~k_parent": "4x"
     },
     "52": {
-      "key": "root.imports.connections",
-      "~k_parent": "45"
+      "key": "root.imports.blocks",
+      "~k_parent": "4r"
     },
     "53": {
-      "key": "root.imports.connections[0]",
+      "key": "root.imports.blocks[0]",
       "~k_parent": "52"
     },
     "54": {
-      "key": "root.imports.icons",
-      "~k_parent": "45"
+      "key": "root.imports.blocks[1]",
+      "~k_parent": "52"
     },
     "55": {
-      "key": "root.imports.icons[0]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[2]",
+      "~k_parent": "52"
     },
     "56": {
-      "key": "root.imports.icons[0].icons",
-      "~k_parent": "55"
+      "key": "root.imports.blocks[3]",
+      "~k_parent": "52"
     },
     "57": {
-      "key": "root.imports.icons[1]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[4]",
+      "~k_parent": "52"
     },
     "58": {
-      "key": "root.imports.icons[1].icons",
-      "~k_parent": "57"
+      "key": "root.imports.blocks[5]",
+      "~k_parent": "52"
     },
     "59": {
-      "key": "root.imports.icons[2]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[6]",
+      "~k_parent": "52"
     },
     "60": {
-      "key": "root.imports.icons[15].icons",
+      "key": "root.imports.icons[4].icons",
       "~k_parent": "5z"
     },
     "61": {
-      "key": "root.imports.icons[16]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[5]",
+      "~k_parent": "5q"
     },
     "62": {
-      "key": "root.imports.icons[16].icons",
+      "key": "root.imports.icons[5].icons",
       "~k_parent": "61"
     },
     "63": {
-      "key": "root.imports.icons[17]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[6]",
+      "~k_parent": "5q"
     },
     "64": {
-      "key": "root.imports.icons[17].icons",
+      "key": "root.imports.icons[6].icons",
       "~k_parent": "63"
     },
     "65": {
-      "key": "root.imports.icons[18]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[7]",
+      "~k_parent": "5q"
     },
     "66": {
-      "key": "root.imports.icons[18].icons",
+      "key": "root.imports.icons[7].icons",
       "~k_parent": "65"
     },
     "67": {
-      "key": "root.imports.icons[19]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[8]",
+      "~k_parent": "5q"
     },
     "68": {
-      "key": "root.imports.icons[19].icons",
+      "key": "root.imports.icons[8].icons",
       "~k_parent": "67"
     },
     "69": {
-      "key": "root.imports.icons[20]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[9]",
+      "~k_parent": "5q"
+    },
+    "70": {
+      "key": "root.imports.icons[22].icons",
+      "~k_parent": "6z"
+    },
+    "71": {
+      "key": "root.imports.icons[23]",
+      "~k_parent": "5q"
+    },
+    "72": {
+      "key": "root.imports.icons[23].icons",
+      "~k_parent": "71"
+    },
+    "73": {
+      "key": "root.imports.icons[24]",
+      "~k_parent": "5q"
+    },
+    "74": {
+      "key": "root.imports.icons[24].icons",
+      "~k_parent": "73"
+    },
+    "75": {
+      "key": "root.imports.icons[25]",
+      "~k_parent": "5q"
+    },
+    "76": {
+      "key": "root.imports.icons[25].icons",
+      "~k_parent": "75"
+    },
+    "77": {
+      "key": "root.imports.icons[26]",
+      "~k_parent": "5q"
+    },
+    "78": {
+      "key": "root.imports.icons[26].icons",
+      "~k_parent": "77"
+    },
+    "79": {
+      "key": "root.imports.icons[27]",
+      "~k_parent": "5q"
     },
     "a": {
-      "key": "root.agents[0:claude:ClaudeAgent]",
+      "key": "root.pages[0:home:Box].blocks[0:title:Title].properties",
       "~k_parent": "9",
-      "~l": 13
+      "~l": 17
     },
     "b": {
-      "key": "root.agents[0:claude:ClaudeAgent].properties",
-      "~k_parent": "a",
-      "~l": 16
+      "key": "root.pages[1:helper/chat:Box]",
+      "~k_parent": "6",
+      "~r": "pages.0",
+      "~l": 1
     },
     "c": {
-      "key": "root.agents[0:claude:ClaudeAgent].tools",
-      "~k_parent": "a",
-      "~l": 20
+      "key": "root.pages[1:helper/chat:Box].properties",
+      "~k_parent": "b",
+      "~r": "pages.0",
+      "~l": 3
     },
     "d": {
-      "key": "root.api",
-      "~k_parent": "4",
-      "~l": 23
+      "key": "root.pages[1:helper/chat:Box].blocks",
+      "~k_parent": "b",
+      "~r": "pages.0",
+      "~l": 7
     },
     "e": {
-      "key": "root.api[0:lookup-signups:InternalApi]",
+      "key": "root.pages[1:helper/chat:Box].blocks[0:title:Title]",
       "~k_parent": "d",
-      "~l": 24
+      "~r": "pages.0",
+      "~l": 8
     },
     "f": {
-      "key": "root.api[0:lookup-signups:InternalApi].payloadSchema",
+      "key": "root.pages[1:helper/chat:Box].blocks[0:title:Title].properties",
       "~k_parent": "e",
-      "~l": 27
+      "~r": "pages.0",
+      "~l": 10
     },
     "g": {
-      "key": "root.api[0:lookup-signups:InternalApi].payloadSchema.properties",
-      "~k_parent": "f",
-      "~l": 29
+      "key": "root.connections",
+      "~k_parent": "5"
     },
     "h": {
-      "key": "root.api[0:lookup-signups:InternalApi].payloadSchema.properties.days",
+      "key": "root.connections[0:helper/ai:Anthropic]",
       "~k_parent": "g",
-      "~l": 30
+      "~r": "connections.0",
+      "~l": 1
     },
     "i": {
-      "key": "root.api[0:lookup-signups:InternalApi].routine",
-      "~k_parent": "e",
-      "~l": 32
+      "key": "root.connections[0:helper/ai:Anthropic].properties",
+      "~k_parent": "h",
+      "~r": "connections.0",
+      "~l": 3
     },
     "j": {
-      "key": "root.api[0:lookup-signups:InternalApi].routine[0]",
+      "key": "root.connections[0:helper/ai:Anthropic].properties.apiKey",
       "~k_parent": "i",
-      "~l": 33
+      "~r": "connections.0",
+      "~l": 4
     },
     "k": {
-      "key": "root.api[0:lookup-signups:InternalApi].routine[0].:return",
-      "~k_parent": "j",
-      "~l": 33
+      "key": "root.api",
+      "~k_parent": "5"
     },
     "l": {
-      "key": "root.api[1:daily-research:Api]",
-      "~k_parent": "d",
-      "~l": 36
+      "key": "root.api[0:helper/lookup-signups:InternalApi]",
+      "~k_parent": "k",
+      "~r": "api.0",
+      "~l": 1
     },
     "m": {
-      "key": "root.api[1:daily-research:Api].routine",
+      "key": "root.api[0:helper/lookup-signups:InternalApi].payloadSchema",
       "~k_parent": "l",
-      "~l": 38
+      "~r": "api.0",
+      "~l": 4
     },
     "n": {
-      "key": "root.api[1:daily-research:Api].routine[0:research:CallAgent]",
+      "key": "root.api[0:helper/lookup-signups:InternalApi].payloadSchema.properties",
       "~k_parent": "m",
-      "~l": 39
+      "~r": "api.0",
+      "~l": 6
     },
     "o": {
-      "key": "root.api[1:daily-research:Api].routine[0:research:CallAgent].properties",
+      "key": "root.api[0:helper/lookup-signups:InternalApi].payloadSchema.properties.days",
       "~k_parent": "n",
-      "~l": 41
+      "~r": "api.0",
+      "~l": 7
     },
     "p": {
-      "key": "root.api[1:daily-research:Api].routine[0:research:CallAgent].properties.prompt",
-      "~k_parent": "o",
-      "~l": 43
+      "key": "root.api[0:helper/lookup-signups:InternalApi].routine",
+      "~k_parent": "l",
+      "~r": "api.0",
+      "~l": 9
     },
     "q": {
-      "key": "root.api[1:daily-research:Api].routine[1]",
-      "~k_parent": "m",
-      "~l": 45
+      "key": "root.api[0:helper/lookup-signups:InternalApi].routine[0]",
+      "~k_parent": "p",
+      "~r": "api.0",
+      "~l": 10
     },
     "r": {
-      "key": "root.api[1:daily-research:Api].routine[1].:return",
+      "key": "root.api[0:helper/lookup-signups:InternalApi].routine[0].:return",
       "~k_parent": "q",
-      "~l": 45
+      "~r": "api.0",
+      "~l": 10
     },
     "s": {
-      "key": "root.api[1:daily-research:Api].routine[1].:return.summary",
-      "~k_parent": "r",
-      "~l": 46
+      "key": "root.api[1:helper/count-users:InternalApi]",
+      "~k_parent": "k",
+      "~r": "api.1",
+      "~l": 1
     },
     "t": {
-      "key": "root.api[1:daily-research:Api].routine[1].:return.usage",
-      "~k_parent": "r",
-      "~l": 48
+      "key": "root.api[1:helper/count-users:InternalApi].payloadSchema",
+      "~k_parent": "s",
+      "~r": "api.1",
+      "~l": 4
     },
     "u": {
-      "key": "root.api[2:dynamic-agent:Api]",
-      "~k_parent": "d",
-      "~l": 51
+      "key": "root.api[1:helper/count-users:InternalApi].payloadSchema.properties",
+      "~k_parent": "t",
+      "~r": "api.1",
+      "~l": 6
     },
     "v": {
-      "key": "root.api[2:dynamic-agent:Api].routine",
-      "~k_parent": "u",
-      "~l": 53
+      "key": "root.api[1:helper/count-users:InternalApi].routine",
+      "~k_parent": "s",
+      "~r": "api.1",
+      "~l": 7
     },
     "w": {
-      "key": "root.api[2:dynamic-agent:Api].routine[0:run_agent:CallAgent]",
+      "key": "root.api[1:helper/count-users:InternalApi].routine[0]",
       "~k_parent": "v",
-      "~l": 54
+      "~r": "api.1",
+      "~l": 8
     },
     "x": {
-      "key": "root.api[2:dynamic-agent:Api].routine[0:run_agent:CallAgent].properties",
+      "key": "root.api[1:helper/count-users:InternalApi].routine[0].:return",
       "~k_parent": "w",
-      "~l": 56
+      "~r": "api.1",
+      "~l": 8
     },
     "y": {
-      "key": "root.api[2:dynamic-agent:Api].routine[0:run_agent:CallAgent].properties.agentId",
-      "~k_parent": "x",
-      "~l": 57
+      "key": "root.api[2:helper/save-log:InternalApi]",
+      "~k_parent": "k",
+      "~r": "api.2",
+      "~l": 1
     },
     "z": {
-      "key": "root.pages",
-      "~k_parent": "4",
-      "~l": 61
+      "key": "root.api[2:helper/save-log:InternalApi].routine",
+      "~k_parent": "y",
+      "~r": "api.2",
+      "~l": 3
     },
     "1a": {
-      "key": "root.pages[1:404:Result].slots",
-      "~k_parent": "16"
+      "key": "root.agents",
+      "~k_parent": "5"
     },
     "1b": {
-      "key": "root.pages[1:404:Result].slots.extra",
-      "~k_parent": "1a"
+      "key": "root.agents[0:helper/ai:ClaudeAgent]",
+      "~k_parent": "1a",
+      "~r": "agents.0",
+      "~l": 1
     },
     "1c": {
-      "key": "root.pages[1:404:Result].slots.extra.blocks",
-      "~k_parent": "1b"
+      "key": "root.agents[0:helper/ai:ClaudeAgent].properties",
+      "~k_parent": "1b",
+      "~r": "agents.0",
+      "~l": 5
     },
     "1d": {
-      "key": "root.pages[1:404:Result].slots.extra.blocks[0:home:Button]",
-      "~k_parent": "1c"
+      "key": "root.agents[0:helper/ai:ClaudeAgent].tools",
+      "~k_parent": "1b",
+      "~r": "agents.0",
+      "~l": 9
     },
     "1e": {
-      "key": "root.pages[1:404:Result].slots.extra.blocks[0:home:Button].properties",
-      "~k_parent": "1d"
+      "key": "root.agents[0:helper/ai:ClaudeAgent].tools[0]",
+      "~k_parent": "1d",
+      "~r": "agents.0",
+      "~l": 11
     },
     "1f": {
-      "key": "root.pages[1:404:Result].slots.extra.blocks[0:home:Button].events",
-      "~k_parent": "1d"
+      "key": "root.agents[0:helper/ai:ClaudeAgent].tools[1]",
+      "~k_parent": "1d",
+      "~r": "agents.0",
+      "~l": 15
     },
     "1g": {
-      "key": "root.pages[1:404:Result].slots.extra.blocks[0:home:Button].events.onClick",
-      "~k_parent": "1f"
+      "key": "root.agents[0:helper/ai:ClaudeAgent].hooks",
+      "~k_parent": "1b",
+      "~r": "agents.0",
+      "~l": 17
     },
     "1h": {
-      "key": "root.pages[1:404:Result].slots.extra.blocks[0:home:Button].events.onClick[0:home:Link]",
-      "~k_parent": "1g"
-    },
-    "1i": {
-      "key": "root.pages[1:404:Result].slots.extra.blocks[0:home:Button].events.onClick[0:home:Link].params",
-      "~k_parent": "1h"
+      "key": "root.agents[0:helper/ai:ClaudeAgent].hooks.onFinish",
+      "~k_parent": "1g",
+      "~r": "agents.0",
+      "~l": 18
     },
     "1j": {
-      "key": "root.app",
-      "~k_parent": "4"
+      "key": "root.pages",
+      "~k_parent": "5"
     },
     "1k": {
-      "key": "root.app.html",
+      "key": "root.pages[2:404:Result]",
       "~k_parent": "1j"
     },
     "1l": {
-      "key": "root.app.email",
-      "~k_parent": "1j"
+      "key": "root.pages[2:404:Result].style",
+      "~k_parent": "1k"
     },
     "1m": {
-      "key": "root.appMeta",
-      "~k_parent": "4"
+      "key": "root.pages[2:404:Result].properties",
+      "~k_parent": "1k"
     },
     "1n": {
-      "key": "root.logger",
-      "~k_parent": "4"
+      "key": "root.pages[2:404:Result].properties.icon",
+      "~k_parent": "1m"
     },
     "1o": {
-      "key": "root.config",
-      "~k_parent": "4"
+      "key": "root.pages[2:404:Result].slots",
+      "~k_parent": "1k"
+    },
+    "1p": {
+      "key": "root.pages[2:404:Result].slots.extra",
+      "~k_parent": "1o"
     },
     "1q": {
-      "key": "root.agents[0:claude:ClaudeAgent].tools",
-      "~k_parent": "a"
+      "key": "root.pages[2:404:Result].slots.extra.blocks",
+      "~k_parent": "1p"
     },
     "1r": {
-      "key": "root.agents[0:claude:ClaudeAgent].tools[0]",
+      "key": "root.pages[2:404:Result].slots.extra.blocks[0:home:Button]",
       "~k_parent": "1q"
     },
     "1s": {
-      "key": "root.agents[0:claude:ClaudeAgent].mcp",
-      "~k_parent": "a"
+      "key": "root.pages[2:404:Result].slots.extra.blocks[0:home:Button].properties",
+      "~k_parent": "1r"
     },
     "1t": {
-      "key": "root.agents[0:claude:ClaudeAgent].agents",
-      "~k_parent": "a"
+      "key": "root.pages[2:404:Result].slots.extra.blocks[0:home:Button].events",
+      "~k_parent": "1r"
     },
     "1u": {
-      "key": "root.api[0:lookup-signups:InternalApi].auth",
-      "~k_parent": "e"
+      "key": "root.pages[2:404:Result].slots.extra.blocks[0:home:Button].events.onClick",
+      "~k_parent": "1t"
     },
     "1v": {
-      "key": "root.api[1:daily-research:Api].auth",
-      "~k_parent": "l"
+      "key": "root.pages[2:404:Result].slots.extra.blocks[0:home:Button].events.onClick[0:home:Link]",
+      "~k_parent": "1u"
     },
     "1w": {
-      "key": "root.api[2:dynamic-agent:Api].auth",
-      "~k_parent": "u"
+      "key": "root.pages[2:404:Result].slots.extra.blocks[0:home:Button].events.onClick[0:home:Link].params",
+      "~k_parent": "1v"
     },
     "1x": {
-      "key": "root.pages",
-      "~k_parent": "4"
+      "key": "root.app",
+      "~k_parent": "5"
     },
     "1y": {
-      "key": "root.pages[0:home:Box]",
+      "key": "root.app.html",
       "~k_parent": "1x"
     },
     "1z": {
-      "key": "root.pages[0:home:Box].auth",
-      "~k_parent": "1y"
+      "key": "root.app.email",
+      "~k_parent": "1x"
     },
     "2a": {
-      "key": "root.pages[1:404:Result].subscriptions",
-      "~k_parent": "24"
+      "key": "root.pages[0:home:Box].requests",
+      "~k_parent": "25"
     },
     "2b": {
-      "key": "root.pages[1:404:Result].requests",
+      "key": "root.pages[1:helper/chat:Box]",
       "~k_parent": "24"
     },
     "2c": {
-      "key": "root.auth",
-      "~k_parent": "4"
+      "key": "root.pages[1:helper/chat:Box].auth",
+      "~k_parent": "2b"
     },
     "2d": {
-      "key": "root.auth.api",
-      "~k_parent": "2c"
+      "key": "root.pages[1:helper/chat:Box].slots",
+      "~k_parent": "2b"
     },
     "2e": {
-      "key": "root.auth.api.roles",
+      "key": "root.pages[1:helper/chat:Box].slots.content",
       "~k_parent": "2d"
     },
     "2f": {
-      "key": "root.auth.websockets",
-      "~k_parent": "2c"
+      "key": "root.pages[1:helper/chat:Box].subscriptions",
+      "~k_parent": "2b"
     },
     "2g": {
-      "key": "root.auth.websockets.roles",
-      "~k_parent": "2f"
+      "key": "root.pages[1:helper/chat:Box].requests",
+      "~k_parent": "2b"
     },
     "2h": {
-      "key": "root.auth.authPages",
-      "~k_parent": "2c"
+      "key": "root.pages[2:404:Result]",
+      "~k_parent": "24"
     },
     "2i": {
-      "key": "root.auth.pages",
-      "~k_parent": "2c"
+      "key": "root.pages[2:404:Result].style",
+      "~k_parent": "2h"
     },
     "2j": {
-      "key": "root.auth.pages.roles",
+      "key": "root.pages[2:404:Result].style.block",
       "~k_parent": "2i"
     },
     "2k": {
-      "key": "root.auth.callbacks",
-      "~k_parent": "2c"
+      "key": "root.pages[2:404:Result].slots.extra.blocks[0:home:Button].events.onClick",
+      "~k_parent": "1t"
     },
     "2l": {
-      "key": "root.auth.events",
-      "~k_parent": "2c"
+      "key": "root.pages[2:404:Result].slots.extra.blocks[0:home:Button].events.onClick.catch",
+      "~k_parent": "2k"
     },
     "2m": {
-      "key": "root.auth.providers",
-      "~k_parent": "2c"
+      "key": "root.pages[2:404:Result].auth",
+      "~k_parent": "2h"
     },
     "2n": {
-      "key": "root.auth.session",
-      "~k_parent": "2c"
+      "key": "root.pages[2:404:Result].subscriptions",
+      "~k_parent": "2h"
     },
     "2o": {
-      "key": "root.auth.theme",
-      "~k_parent": "2c"
+      "key": "root.pages[2:404:Result].requests",
+      "~k_parent": "2h"
     },
     "2p": {
-      "key": "root.menus",
-      "~k_parent": "4"
+      "key": "root.api[0:helper/lookup-signups:InternalApi].auth",
+      "~k_parent": "l"
     },
     "2q": {
-      "key": "root.menus[0:default]",
-      "~k_parent": "2p"
+      "key": "root.api[1:helper/count-users:InternalApi].auth",
+      "~k_parent": "s"
     },
     "2r": {
-      "key": "root.menus[0:default].links",
-      "~k_parent": "2q"
+      "key": "root.api[2:helper/save-log:InternalApi].auth",
+      "~k_parent": "y"
     },
     "2s": {
-      "key": "root.menus[0:default].links[0:0:MenuLink]",
-      "~k_parent": "2r"
+      "key": "root.api[3:helper/run-assistant:Api].auth",
+      "~k_parent": "12"
     },
     "2t": {
-      "key": "root.menus[0:default].links[0:0:MenuLink].auth",
-      "~k_parent": "2s"
+      "key": "root.agents[0:helper/ai:ClaudeAgent].tools",
+      "~k_parent": "1b"
     },
     "2u": {
-      "key": "root.types",
-      "~k_parent": "4"
+      "key": "root.agents[0:helper/ai:ClaudeAgent].mcp",
+      "~k_parent": "1b"
     },
     "2v": {
-      "key": "root.types.actions",
-      "~k_parent": "2u"
+      "key": "root.agents[0:helper/ai:ClaudeAgent].agents",
+      "~k_parent": "1b"
     },
     "2w": {
-      "key": "root.types.actions.Link",
-      "~k_parent": "2v"
+      "key": "root.auth",
+      "~k_parent": "5"
     },
     "2x": {
-      "key": "root.types.actions.SetDarkMode",
-      "~k_parent": "2v"
+      "key": "root.auth.api",
+      "~k_parent": "2w"
     },
     "2y": {
-      "key": "root.types.agents",
-      "~k_parent": "2u"
+      "key": "root.auth.api.roles",
+      "~k_parent": "2x"
     },
     "2z": {
-      "key": "root.types.agents.ClaudeAgent",
-      "~k_parent": "2y"
+      "key": "root.auth.websockets",
+      "~k_parent": "2w"
     },
     "3a": {
-      "key": "root.types.blocks.Anchor",
-      "~k_parent": "35"
+      "key": "root.menus[0:default]",
+      "~k_parent": "39"
     },
     "3b": {
-      "key": "root.types.blocks.DangerousHtml",
-      "~k_parent": "35"
+      "key": "root.menus[0:default].links",
+      "~k_parent": "3a"
     },
     "3c": {
-      "key": "root.types.blocks.Dynamic",
-      "~k_parent": "35"
+      "key": "root.menus[0:default].links[0:0:MenuLink]",
+      "~k_parent": "3b"
     },
     "3d": {
-      "key": "root.types.blocks.Html",
-      "~k_parent": "35"
+      "key": "root.menus[0:default].links[0:0:MenuLink].auth",
+      "~k_parent": "3c"
     },
     "3e": {
-      "key": "root.types.blocks.Icon",
-      "~k_parent": "35"
+      "key": "root.menus[0:default].links[1:1:MenuLink]",
+      "~k_parent": "3b"
     },
     "3f": {
-      "key": "root.types.blocks.Img",
-      "~k_parent": "35"
+      "key": "root.menus[0:default].links[1:1:MenuLink].auth",
+      "~k_parent": "3e"
     },
     "3g": {
-      "key": "root.types.blocks.List",
-      "~k_parent": "35"
+      "key": "root.types",
+      "~k_parent": "5"
     },
     "3h": {
-      "key": "root.types.blocks.Span",
-      "~k_parent": "35"
+      "key": "root.types.actions",
+      "~k_parent": "3g"
     },
     "3i": {
-      "key": "root.types.blocks.Throw",
-      "~k_parent": "35"
+      "key": "root.types.actions.Link",
+      "~k_parent": "3h"
     },
     "3j": {
-      "key": "root.types.blocks.ProgressBar",
-      "~k_parent": "35"
+      "key": "root.types.actions.SetDarkMode",
+      "~k_parent": "3h"
     },
     "3k": {
-      "key": "root.types.blocks.Skeleton",
-      "~k_parent": "35"
+      "key": "root.types.agents",
+      "~k_parent": "3g"
     },
     "3l": {
-      "key": "root.types.blocks.SkeletonAvatar",
-      "~k_parent": "35"
+      "key": "root.types.agents.ClaudeAgent",
+      "~k_parent": "3k"
     },
     "3m": {
-      "key": "root.types.blocks.SkeletonButton",
-      "~k_parent": "35"
+      "key": "root.types.auth",
+      "~k_parent": "3g"
     },
     "3n": {
-      "key": "root.types.blocks.SkeletonInput",
-      "~k_parent": "35"
+      "key": "root.types.auth.adapters",
+      "~k_parent": "3m"
     },
     "3o": {
-      "key": "root.types.blocks.SkeletonParagraph",
-      "~k_parent": "35"
+      "key": "root.types.auth.callbacks",
+      "~k_parent": "3m"
     },
     "3p": {
-      "key": "root.types.blocks.Spinner",
-      "~k_parent": "35"
+      "key": "root.types.auth.events",
+      "~k_parent": "3m"
     },
     "3q": {
-      "key": "root.types.blocks.Message",
-      "~k_parent": "35"
+      "key": "root.types.auth.providers",
+      "~k_parent": "3m"
     },
     "3r": {
-      "key": "root.types.connections",
-      "~k_parent": "2u"
+      "key": "root.types.blocks",
+      "~k_parent": "3g"
     },
     "3s": {
-      "key": "root.types.connections.Anthropic",
+      "key": "root.types.blocks.Box",
       "~k_parent": "3r"
     },
     "3t": {
-      "key": "root.types.notifications",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Title",
+      "~k_parent": "3r"
     },
     "3u": {
-      "key": "root.types.requests",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Result",
+      "~k_parent": "3r"
     },
     "3v": {
-      "key": "root.types.websockets",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Button",
+      "~k_parent": "3r"
     },
     "3w": {
-      "key": "root.types.api",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.Anchor",
+      "~k_parent": "3r"
     },
     "3x": {
-      "key": "root.types.operators",
-      "~k_parent": "2u"
+      "key": "root.types.blocks.DangerousHtml",
+      "~k_parent": "3r"
     },
     "3y": {
-      "key": "root.types.operators.client",
-      "~k_parent": "3x"
+      "key": "root.types.blocks.Dynamic",
+      "~k_parent": "3r"
     },
     "3z": {
-      "key": "root.types.operators.client._not",
-      "~k_parent": "3y"
+      "key": "root.types.blocks.Html",
+      "~k_parent": "3r"
     },
     "4a": {
-      "key": "root.imports.agents[0]",
-      "~k_parent": "49"
+      "key": "root.types.blocks.SkeletonParagraph",
+      "~k_parent": "3r"
     },
     "4b": {
-      "key": "root.imports.auth",
-      "~k_parent": "45"
+      "key": "root.types.blocks.Spinner",
+      "~k_parent": "3r"
     },
     "4c": {
-      "key": "root.imports.auth.adapters",
-      "~k_parent": "4b"
+      "key": "root.types.blocks.Message",
+      "~k_parent": "3r"
     },
     "4d": {
-      "key": "root.imports.auth.callbacks",
-      "~k_parent": "4b"
+      "key": "root.types.connections",
+      "~k_parent": "3g"
     },
     "4e": {
-      "key": "root.imports.auth.events",
-      "~k_parent": "4b"
+      "key": "root.types.connections.Anthropic",
+      "~k_parent": "4d"
     },
     "4f": {
-      "key": "root.imports.auth.providers",
-      "~k_parent": "4b"
+      "key": "root.types.notifications",
+      "~k_parent": "3g"
     },
     "4g": {
-      "key": "root.imports.blocks",
-      "~k_parent": "45"
+      "key": "root.types.requests",
+      "~k_parent": "3g"
     },
     "4h": {
-      "key": "root.imports.blocks[0]",
-      "~k_parent": "4g"
+      "key": "root.types.websockets",
+      "~k_parent": "3g"
     },
     "4i": {
-      "key": "root.imports.blocks[1]",
-      "~k_parent": "4g"
+      "key": "root.types.api",
+      "~k_parent": "3g"
     },
     "4j": {
-      "key": "root.imports.blocks[2]",
-      "~k_parent": "4g"
+      "key": "root.types.operators",
+      "~k_parent": "3g"
     },
     "4k": {
-      "key": "root.imports.blocks[3]",
-      "~k_parent": "4g"
+      "key": "root.types.operators.client",
+      "~k_parent": "4j"
     },
     "4l": {
-      "key": "root.imports.blocks[4]",
-      "~k_parent": "4g"
+      "key": "root.types.operators.client._not",
+      "~k_parent": "4k"
     },
     "4m": {
-      "key": "root.imports.blocks[5]",
-      "~k_parent": "4g"
+      "key": "root.types.operators.client._type",
+      "~k_parent": "4k"
     },
     "4n": {
-      "key": "root.imports.blocks[6]",
-      "~k_parent": "4g"
+      "key": "root.types.operators.server",
+      "~k_parent": "4j"
     },
     "4o": {
-      "key": "root.imports.blocks[7]",
-      "~k_parent": "4g"
+      "key": "root.types.operators.server._secret",
+      "~k_parent": "4n"
     },
     "4p": {
-      "key": "root.imports.blocks[8]",
-      "~k_parent": "4g"
+      "key": "root.types.operators.server._payload",
+      "~k_parent": "4n"
     },
     "4q": {
-      "key": "root.imports.blocks[9]",
-      "~k_parent": "4g"
+      "key": "root.types.operators.server._step",
+      "~k_parent": "4n"
     },
     "4r": {
-      "key": "root.imports.blocks[10]",
-      "~k_parent": "4g"
+      "key": "root.imports",
+      "~k_parent": "5"
     },
     "4s": {
-      "key": "root.imports.blocks[11]",
-      "~k_parent": "4g"
+      "key": "root.imports.actions",
+      "~k_parent": "4r"
     },
     "4t": {
-      "key": "root.imports.blocks[12]",
-      "~k_parent": "4g"
+      "key": "root.imports.actions[0]",
+      "~k_parent": "4s"
     },
     "4u": {
-      "key": "root.imports.blocks[13]",
-      "~k_parent": "4g"
+      "key": "root.imports.actions[1]",
+      "~k_parent": "4s"
     },
     "4v": {
-      "key": "root.imports.blocks[14]",
-      "~k_parent": "4g"
+      "key": "root.imports.agents",
+      "~k_parent": "4r"
     },
     "4w": {
-      "key": "root.imports.blocks[15]",
-      "~k_parent": "4g"
+      "key": "root.imports.agents[0]",
+      "~k_parent": "4v"
     },
     "4x": {
-      "key": "root.imports.blocks[16]",
-      "~k_parent": "4g"
+      "key": "root.imports.auth",
+      "~k_parent": "4r"
     },
     "4y": {
-      "key": "root.imports.blocks[17]",
-      "~k_parent": "4g"
+      "key": "root.imports.auth.adapters",
+      "~k_parent": "4x"
     },
     "4z": {
-      "key": "root.imports.blocks[18]",
-      "~k_parent": "4g"
+      "key": "root.imports.auth.callbacks",
+      "~k_parent": "4x"
     },
     "5a": {
-      "key": "root.imports.icons[2].icons",
-      "~k_parent": "59"
+      "key": "root.imports.blocks[7]",
+      "~k_parent": "52"
     },
     "5b": {
-      "key": "root.imports.icons[3]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[8]",
+      "~k_parent": "52"
     },
     "5c": {
-      "key": "root.imports.icons[3].icons",
-      "~k_parent": "5b"
+      "key": "root.imports.blocks[9]",
+      "~k_parent": "52"
     },
     "5d": {
-      "key": "root.imports.icons[4]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[10]",
+      "~k_parent": "52"
     },
     "5e": {
-      "key": "root.imports.icons[4].icons",
-      "~k_parent": "5d"
+      "key": "root.imports.blocks[11]",
+      "~k_parent": "52"
     },
     "5f": {
-      "key": "root.imports.icons[5]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[12]",
+      "~k_parent": "52"
     },
     "5g": {
-      "key": "root.imports.icons[5].icons",
-      "~k_parent": "5f"
+      "key": "root.imports.blocks[13]",
+      "~k_parent": "52"
     },
     "5h": {
-      "key": "root.imports.icons[6]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[14]",
+      "~k_parent": "52"
     },
     "5i": {
-      "key": "root.imports.icons[6].icons",
-      "~k_parent": "5h"
+      "key": "root.imports.blocks[15]",
+      "~k_parent": "52"
     },
     "5j": {
-      "key": "root.imports.icons[7]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[16]",
+      "~k_parent": "52"
     },
     "5k": {
-      "key": "root.imports.icons[7].icons",
-      "~k_parent": "5j"
+      "key": "root.imports.blocks[17]",
+      "~k_parent": "52"
     },
     "5l": {
-      "key": "root.imports.icons[8]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[18]",
+      "~k_parent": "52"
     },
     "5m": {
-      "key": "root.imports.icons[8].icons",
-      "~k_parent": "5l"
+      "key": "root.imports.blocks[19]",
+      "~k_parent": "52"
     },
     "5n": {
-      "key": "root.imports.icons[9]",
-      "~k_parent": "54"
+      "key": "root.imports.blocks[20]",
+      "~k_parent": "52"
     },
     "5o": {
-      "key": "root.imports.icons[9].icons",
-      "~k_parent": "5n"
+      "key": "root.imports.connections",
+      "~k_parent": "4r"
     },
     "5p": {
-      "key": "root.imports.icons[10]",
-      "~k_parent": "54"
+      "key": "root.imports.connections[0]",
+      "~k_parent": "5o"
     },
     "5q": {
-      "key": "root.imports.icons[10].icons",
-      "~k_parent": "5p"
+      "key": "root.imports.icons",
+      "~k_parent": "4r"
     },
     "5r": {
-      "key": "root.imports.icons[11]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[0]",
+      "~k_parent": "5q"
     },
     "5s": {
-      "key": "root.imports.icons[11].icons",
+      "key": "root.imports.icons[0].icons",
       "~k_parent": "5r"
     },
     "5t": {
-      "key": "root.imports.icons[12]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[1]",
+      "~k_parent": "5q"
     },
     "5u": {
-      "key": "root.imports.icons[12].icons",
+      "key": "root.imports.icons[1].icons",
       "~k_parent": "5t"
     },
     "5v": {
-      "key": "root.imports.icons[13]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[2]",
+      "~k_parent": "5q"
     },
     "5w": {
-      "key": "root.imports.icons[13].icons",
+      "key": "root.imports.icons[2].icons",
       "~k_parent": "5v"
     },
     "5x": {
-      "key": "root.imports.icons[14]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[3]",
+      "~k_parent": "5q"
     },
     "5y": {
-      "key": "root.imports.icons[14].icons",
+      "key": "root.imports.icons[3].icons",
       "~k_parent": "5x"
     },
     "5z": {
-      "key": "root.imports.icons[15]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[4]",
+      "~k_parent": "5q"
     },
     "6a": {
-      "key": "root.imports.icons[20].icons",
+      "key": "root.imports.icons[9].icons",
       "~k_parent": "69"
     },
     "6b": {
-      "key": "root.imports.icons[21]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[10]",
+      "~k_parent": "5q"
     },
     "6c": {
-      "key": "root.imports.icons[21].icons",
+      "key": "root.imports.icons[10].icons",
       "~k_parent": "6b"
     },
     "6d": {
-      "key": "root.imports.icons[22]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[11]",
+      "~k_parent": "5q"
     },
     "6e": {
-      "key": "root.imports.icons[22].icons",
+      "key": "root.imports.icons[11].icons",
       "~k_parent": "6d"
     },
     "6f": {
-      "key": "root.imports.icons[23]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[12]",
+      "~k_parent": "5q"
     },
     "6g": {
-      "key": "root.imports.icons[23].icons",
+      "key": "root.imports.icons[12].icons",
       "~k_parent": "6f"
     },
     "6h": {
-      "key": "root.imports.icons[24]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[13]",
+      "~k_parent": "5q"
     },
     "6i": {
-      "key": "root.imports.icons[24].icons",
+      "key": "root.imports.icons[13].icons",
       "~k_parent": "6h"
     },
     "6j": {
-      "key": "root.imports.icons[25]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[14]",
+      "~k_parent": "5q"
     },
     "6k": {
-      "key": "root.imports.icons[25].icons",
+      "key": "root.imports.icons[14].icons",
       "~k_parent": "6j"
     },
     "6l": {
-      "key": "root.imports.icons[26]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[15]",
+      "~k_parent": "5q"
     },
     "6m": {
-      "key": "root.imports.icons[26].icons",
+      "key": "root.imports.icons[15].icons",
       "~k_parent": "6l"
     },
     "6n": {
-      "key": "root.imports.icons[27]",
-      "~k_parent": "54"
+      "key": "root.imports.icons[16]",
+      "~k_parent": "5q"
     },
     "6o": {
-      "key": "root.imports.icons[27].icons",
+      "key": "root.imports.icons[16].icons",
       "~k_parent": "6n"
     },
     "6p": {
-      "key": "root.imports.notifications",
-      "~k_parent": "45"
+      "key": "root.imports.icons[17]",
+      "~k_parent": "5q"
     },
     "6q": {
-      "key": "root.imports.requests",
-      "~k_parent": "45"
+      "key": "root.imports.icons[17].icons",
+      "~k_parent": "6p"
     },
     "6r": {
-      "key": "root.imports.websockets",
-      "~k_parent": "45"
+      "key": "root.imports.icons[18]",
+      "~k_parent": "5q"
     },
     "6s": {
-      "key": "root.imports.operators",
-      "~k_parent": "45"
+      "key": "root.imports.icons[18].icons",
+      "~k_parent": "6r"
     },
     "6t": {
-      "key": "root.imports.operators.client",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[19]",
+      "~k_parent": "5q"
     },
     "6u": {
-      "key": "root.imports.operators.client[0]",
+      "key": "root.imports.icons[19].icons",
       "~k_parent": "6t"
     },
     "6v": {
-      "key": "root.imports.operators.client[1]",
-      "~k_parent": "6t"
+      "key": "root.imports.icons[20]",
+      "~k_parent": "5q"
     },
     "6w": {
-      "key": "root.imports.operators.server",
-      "~k_parent": "6s"
+      "key": "root.imports.icons[20].icons",
+      "~k_parent": "6v"
     },
     "6x": {
-      "key": "root.imports.operators.server[0]",
-      "~k_parent": "6w"
+      "key": "root.imports.icons[21]",
+      "~k_parent": "5q"
     },
     "6y": {
-      "key": "root.imports.operators.server[1]",
-      "~k_parent": "6w"
+      "key": "root.imports.icons[21].icons",
+      "~k_parent": "6x"
     },
     "6z": {
+      "key": "root.imports.icons[22]",
+      "~k_parent": "5q"
+    },
+    "7a": {
+      "key": "root.imports.icons[27].icons",
+      "~k_parent": "79"
+    },
+    "7b": {
+      "key": "root.imports.notifications",
+      "~k_parent": "4r"
+    },
+    "7c": {
+      "key": "root.imports.requests",
+      "~k_parent": "4r"
+    },
+    "7d": {
+      "key": "root.imports.websockets",
+      "~k_parent": "4r"
+    },
+    "7e": {
+      "key": "root.imports.operators",
+      "~k_parent": "4r"
+    },
+    "7f": {
+      "key": "root.imports.operators.client",
+      "~k_parent": "7e"
+    },
+    "7g": {
+      "key": "root.imports.operators.client[0]",
+      "~k_parent": "7f"
+    },
+    "7h": {
+      "key": "root.imports.operators.client[1]",
+      "~k_parent": "7f"
+    },
+    "7i": {
+      "key": "root.imports.operators.server",
+      "~k_parent": "7e"
+    },
+    "7j": {
+      "key": "root.imports.operators.server[0]",
+      "~k_parent": "7i"
+    },
+    "7k": {
+      "key": "root.imports.operators.server[1]",
+      "~k_parent": "7i"
+    },
+    "7l": {
       "key": "root.imports.operators.server[2]",
-      "~k_parent": "6w"
+      "~k_parent": "7i"
     }
   },
   "layer-order.css": "/* Generated by Lowdefy build */\n@layer theme, base, antd, components, utilities;\n",
   "logger.json": {
-    "~k": "1n"
+    "~k": "21"
   },
   "menus.json": {
     "~arr": [
@@ -1269,19 +1435,30 @@
               "pageId": "home",
               "auth": {
                 "public": true,
-                "~k": "2t"
+                "~k": "3d"
               },
               "menuItemId": "0",
-              "~k": "2s"
+              "~k": "3c"
+            },
+            {
+              "id": "menuitem:default:1",
+              "type": "MenuLink",
+              "pageId": "helper/chat",
+              "auth": {
+                "public": true,
+                "~k": "3f"
+              },
+              "menuItemId": "1",
+              "~k": "3e"
             }
           ],
-          "~k": "2r"
+          "~k": "3b"
         },
         "menuId": "default",
-        "~k": "2q"
+        "~k": "3a"
       }
     ],
-    "~k": "2p"
+    "~k": "39"
   },
   "pages/404.json": {
     "id": "page:404",
@@ -1290,9 +1467,9 @@
       "block": {
         "minHeight": "100vh",
         "background": "var(--ant-color-bg-layout)",
-        "~k": "26"
+        "~k": "2j"
       },
-      "~k": "25"
+      "~k": "2i"
     },
     "properties": {
       "status": "info",
@@ -1300,11 +1477,11 @@
         "name": "AiOutlineFileSearch",
         "size": 80,
         "color": "var(--ant-color-primary)",
-        "~k": "19"
+        "~k": "1n"
       },
       "title": "404",
       "subTitle": "Sorry, the page you are visiting does not exist.",
-      "~k": "18"
+      "~k": "1m"
     },
     "slots": {
       "extra": {
@@ -1315,7 +1492,7 @@
               "type": "Button",
               "properties": {
                 "title": "Go to home page",
-                "~k": "1e"
+                "~k": "1s"
               },
               "events": {
                 "onClick": {
@@ -1326,53 +1503,97 @@
                         "type": "Link",
                         "params": {
                           "home": true,
-                          "~k": "1i"
+                          "~k": "1w"
                         },
-                        "~k": "1h"
+                        "~k": "1v"
                       }
                     ],
-                    "~k": "1g"
+                    "~k": "1u"
                   },
                   "catch": {
                     "~arr": [],
-                    "~k": "28"
+                    "~k": "2l"
                   },
-                  "~k": "27"
+                  "~k": "2k"
                 },
-                "~k": "1f"
+                "~k": "1t"
               },
               "blockId": "home",
-              "~k": "1d"
+              "~k": "1r"
             }
           ],
-          "~k": "1c"
+          "~k": "1q"
         },
-        "~k": "1b"
+        "~k": "1p"
       },
-      "~k": "1a"
+      "~k": "1o"
     },
     "auth": {
       "public": true,
-      "~k": "29"
+      "~k": "2m"
     },
     "pageId": "404",
     "blockId": "404",
     "subscriptions": {
       "~arr": [],
-      "~k": "2a"
+      "~k": "2n"
     },
     "requests": {
       "~arr": [],
-      "~k": "2b"
+      "~k": "2o"
     },
-    "~k": "24"
+    "~k": "2h"
+  },
+  "pages/helper/chat.json": {
+    "id": "page:helper/chat",
+    "type": "Box",
+    "properties": {
+      "agentId": "helper/assistant",
+      "~k": "c"
+    },
+    "auth": {
+      "public": true,
+      "~k": "2c"
+    },
+    "pageId": "helper/chat",
+    "blockId": "helper/chat",
+    "slots": {
+      "content": {
+        "blocks": {
+          "~arr": [
+            {
+              "id": "block:helper/chat:title:0",
+              "type": "Title",
+              "properties": {
+                "content": "Assistant Chat",
+                "~k": "f"
+              },
+              "blockId": "title",
+              "~k": "e"
+            }
+          ],
+          "~k": "d"
+        },
+        "~k": "2e"
+      },
+      "~k": "2d"
+    },
+    "subscriptions": {
+      "~arr": [],
+      "~k": "2f"
+    },
+    "requests": {
+      "~arr": [],
+      "~k": "2g"
+    },
+    "~k": "2b"
   },
   "pages/home.json": {
     "id": "page:home",
     "type": "Box",
     "auth": {
       "public": true,
-      "~k": "1z"
+      "~k": "26"
     },
     "pageId": "home",
     "blockId": "home",
@@ -1384,28 +1605,28 @@
               "id": "block:home:title:0",
               "type": "Title",
               "properties": {
-                "content": "CallAgent Test",
-                "~k": "13"
+                "content": "Home",
+                "~k": "a"
               },
               "blockId": "title",
-              "~k": "12"
+              "~k": "9"
             }
           ],
-          "~k": "11"
+          "~k": "8"
         },
-        "~k": "21"
+        "~k": "28"
       },
-      "~k": "20"
+      "~k": "27"
     },
     "subscriptions": {
       "~arr": [],
-      "~k": "22"
+      "~k": "29"
     },
     "requests": {
       "~arr": [],
-      "~k": "23"
+      "~k": "2a"
     },
-    "~k": "1y"
+    "~k": "25"
   },
   "plugins/actionSchemas.json": {
     "Link": {
@@ -6331,6 +6552,44 @@
     },
     "2": {
       "parent": null
+    },
+    "3": {
+      "parent": null
+    },
+    "connections.0": {
+      "parent": "2",
+      "lineNumber": 9,
+      "path": "<CONFIG_DIR>/modules/assistant/connections/ai.yaml"
+    },
+    "api.0": {
+      "parent": "2",
+      "lineNumber": 12,
+      "path": "<CONFIG_DIR>/modules/assistant/api/lookup-signups.yaml"
+    },
+    "api.1": {
+      "parent": "2",
+      "lineNumber": 13,
+      "path": "<CONFIG_DIR>/modules/assistant/api/count-users.yaml"
+    },
+    "api.2": {
+      "parent": "2",
+      "lineNumber": 14,
+      "path": "<CONFIG_DIR>/modules/assistant/api/save-log.yaml"
+    },
+    "api.3": {
+      "parent": "2",
+      "lineNumber": 15,
+      "path": "<CONFIG_DIR>/modules/assistant/api/run-assistant.yaml"
+    },
+    "agents.0": {
+      "parent": "2",
+      "lineNumber": 18,
+      "path": "<CONFIG_DIR>/modules/assistant/agents/assistant.yaml"
+    },
+    "pages.0": {
+      "parent": "2",
+      "lineNumber": 21,
+      "path": "<CONFIG_DIR>/modules/assistant/pages/chat.yaml"
     }
   },
   "tailwind-candidates.css": "/* Generated by Lowdefy build — rewritten on page changes to trigger CSS recompilation */\n",
@@ -6343,189 +6602,189 @@
         "originalTypeName": "Link",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "2w"
+        "~k": "3i"
       },
       "SetDarkMode": {
         "originalTypeName": "SetDarkMode",
         "package": "@lowdefy/actions-core",
         "count": 1,
-        "~k": "2x"
+        "~k": "3j"
       },
-      "~k": "2v"
+      "~k": "3h"
     },
     "agents": {
       "ClaudeAgent": {
         "originalTypeName": "ClaudeAgent",
         "package": "@lowdefy/connection-anthropic",
         "count": 1,
-        "~k": "2z"
+        "~k": "3l"
       },
-      "~k": "2y"
+      "~k": "3k"
     },
     "auth": {
       "adapters": {
-        "~k": "31"
+        "~k": "3n"
       },
       "callbacks": {
-        "~k": "32"
+        "~k": "3o"
       },
       "events": {
-        "~k": "33"
+        "~k": "3p"
       },
       "providers": {
-        "~k": "34"
+        "~k": "3q"
       },
-      "~k": "30"
+      "~k": "3m"
     },
     "blocks": {
       "Box": {
         "originalTypeName": "Box",
         "package": "@lowdefy/blocks-basic",
-        "count": 2,
-        "~k": "36"
+        "count": 3,
+        "~k": "3s"
       },
       "Title": {
         "originalTypeName": "Title",
         "package": "@lowdefy/blocks-basic",
-        "count": 1,
-        "~k": "37"
+        "count": 2,
+        "~k": "3t"
       },
       "Result": {
         "originalTypeName": "Result",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "38"
+        "~k": "3u"
       },
       "Button": {
         "originalTypeName": "Button",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "39"
+        "~k": "3v"
       },
       "Anchor": {
         "originalTypeName": "Anchor",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3a"
+        "~k": "3w"
       },
       "DangerousHtml": {
         "originalTypeName": "DangerousHtml",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3b"
+        "~k": "3x"
       },
       "Dynamic": {
         "originalTypeName": "Dynamic",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3c"
+        "~k": "3y"
       },
       "Html": {
         "originalTypeName": "Html",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3d"
+        "~k": "3z"
       },
       "Icon": {
         "originalTypeName": "Icon",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3e"
+        "~k": "40"
       },
       "Img": {
         "originalTypeName": "Img",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3f"
+        "~k": "41"
       },
       "List": {
         "originalTypeName": "List",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3g"
+        "~k": "42"
       },
       "Span": {
         "originalTypeName": "Span",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3h"
+        "~k": "43"
       },
       "Throw": {
         "originalTypeName": "Throw",
         "package": "@lowdefy/blocks-basic",
         "count": 1,
-        "~k": "3i"
+        "~k": "44"
       },
       "ProgressBar": {
         "originalTypeName": "ProgressBar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3j"
+        "~k": "45"
       },
       "Skeleton": {
         "originalTypeName": "Skeleton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3k"
+        "~k": "46"
       },
       "SkeletonAvatar": {
         "originalTypeName": "SkeletonAvatar",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3l"
+        "~k": "47"
       },
       "SkeletonButton": {
         "originalTypeName": "SkeletonButton",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3m"
+        "~k": "48"
       },
       "SkeletonInput": {
         "originalTypeName": "SkeletonInput",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3n"
+        "~k": "49"
       },
       "SkeletonParagraph": {
         "originalTypeName": "SkeletonParagraph",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3o"
+        "~k": "4a"
       },
       "Spinner": {
         "originalTypeName": "Spinner",
         "package": "@lowdefy/blocks-loaders",
         "count": 1,
-        "~k": "3p"
+        "~k": "4b"
       },
       "Message": {
         "originalTypeName": "Message",
         "package": "@lowdefy/blocks-antd",
         "count": 1,
-        "~k": "3q"
+        "~k": "4c"
       },
-      "~k": "35"
+      "~k": "3r"
     },
     "connections": {
       "Anthropic": {
         "originalTypeName": "Anthropic",
         "package": "@lowdefy/connection-anthropic",
         "count": 1,
-        "~k": "3s"
+        "~k": "4e"
       },
-      "~k": "3r"
+      "~k": "4d"
     },
     "notifications": {
-      "~k": "3t"
+      "~k": "4f"
     },
     "requests": {
-      "~k": "3u"
+      "~k": "4g"
     },
     "websockets": {
-      "~k": "3v"
+      "~k": "4h"
     },
     "api": {
-      "~k": "3w"
+      "~k": "4i"
     },
     "operators": {
       "client": {
@@ -6533,39 +6792,39 @@
           "originalTypeName": "_not",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "3z"
+          "~k": "4l"
         },
         "_type": {
           "originalTypeName": "_type",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "40"
+          "~k": "4m"
         },
-        "~k": "3y"
+        "~k": "4k"
       },
       "server": {
         "_secret": {
           "originalTypeName": "_secret",
           "package": "@lowdefy/operators-js",
           "count": 1,
-          "~k": "42"
+          "~k": "4o"
         },
         "_payload": {
           "originalTypeName": "_payload",
           "package": "@lowdefy/operators-js",
-          "count": 2,
-          "~k": "43"
+          "count": 1,
+          "~k": "4p"
         },
         "_step": {
           "originalTypeName": "_step",
           "package": "@lowdefy/operators-js",
-          "count": 2,
-          "~k": "44"
+          "count": 1,
+          "~k": "4q"
         },
-        "~k": "41"
+        "~k": "4n"
       },
-      "~k": "3x"
+      "~k": "4j"
     },
-    "~k": "2u"
+    "~k": "3g"
   }
 }

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/LowdefyChatTransport.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/LowdefyChatTransport.js
@@ -17,7 +17,9 @@
 import { DefaultChatTransport } from 'ai';
 
 function createLowdefyChatTransport({ pageId, agentId, conversationId, urlQuery, sharedStateRef }) {
-  const base = `/api/agent/${pageId}/${agentId}`;
+  // The server route takes the last path segment as the agentId — module-scoped
+  // agent ids contain '/', so encode the agentId into a single segment.
+  const base = `/api/agent/${pageId}/${encodeURIComponent(agentId)}`;
   const api = conversationId
     ? `${base}?conversationId=${encodeURIComponent(conversationId)}`
     : base;

--- a/packages/utils/ai-utils/src/buildAgentTools.js
+++ b/packages/utils/ai-utils/src/buildAgentTools.js
@@ -64,13 +64,16 @@ async function buildAgentTools({ agent, context, depth = 0, autoApprove = false 
   const tools = {};
   const mcpClients = [];
 
-  // Build endpoint tools
+  // Build endpoint tools. The model-facing tool name is toolConfig.name
+  // (assigned by buildAgents — endpoint id with '/' → '__' unless overridden);
+  // execution still targets the endpointId.
   for (const toolConfig of agent.tools ?? []) {
     const { endpointId, confirm } = toolConfig;
-    assertNotReserved(endpointId, 'Endpoint tool', context.i18n);
+    const toolName = toolConfig.name ?? endpointId;
+    assertNotReserved(toolName, 'Endpoint tool', context.i18n);
     const endpointConfig = await context.getEndpointConfig({ endpointId });
 
-    tools[endpointId] = tool({
+    tools[toolName] = tool({
       description: endpointConfig.description,
       inputSchema: jsonSchema(cleanBuildArtifact(endpointConfig.payloadSchema)),
       ...(confirm && !autoApprove ? { needsApproval: true } : {}),
@@ -150,9 +153,11 @@ async function buildAgentTools({ agent, context, depth = 0, autoApprove = false 
     }
   }
 
-  // Build sub-agent tools
+  // Build sub-agent tools — keyed by name for the same provider-rule reason
+  // as endpoint tools (scoped agent ids contain '/').
   for (const subAgentRef of agent.agents ?? []) {
-    assertNotReserved(subAgentRef.agentId, 'Sub-agent', context.i18n);
+    const subAgentToolName = subAgentRef.name ?? subAgentRef.agentId;
+    assertNotReserved(subAgentToolName, 'Sub-agent', context.i18n);
     const subAgentConfig = await context.getAgentConfig({ agentId: subAgentRef.agentId });
     const subConnection = await context.getConnectionForAgent({ agentConfig: subAgentConfig });
     subAgentConfig.mcp = await context.resolveMcpSources({ agentConfig: subAgentConfig });
@@ -189,7 +194,7 @@ async function buildAgentTools({ agent, context, depth = 0, autoApprove = false 
           required: ['task'],
         });
 
-    tools[subAgentRef.agentId] = tool({
+    tools[subAgentToolName] = tool({
       description,
       inputSchema,
       execute: async (input, { abortSignal }) => {

--- a/packages/utils/ai-utils/src/buildAgentTools.test.js
+++ b/packages/utils/ai-utils/src/buildAgentTools.test.js
@@ -291,6 +291,66 @@ test('buildAgentTools with no agents property returns only endpoint tools', asyn
   expect(Object.keys(tools)).toEqual([]);
 });
 
+test('buildAgentTools keys endpoint tools by name and executes by endpointId', async () => {
+  const { default: buildAgentTools } = await import('./buildAgentTools.js');
+
+  const agent = {
+    tools: [{ endpointId: 'reporting/query-data', name: 'query_data' }],
+    mcp: [],
+  };
+  const context = {
+    getEndpointConfig: jest.fn().mockResolvedValue({
+      description: 'Query data',
+      payloadSchema: { type: 'object' },
+    }),
+    callEndpoint: jest.fn().mockResolvedValue({ success: true, response: { rows: [] } }),
+    evaluateOperators: jest.fn((x) => x),
+  };
+
+  const { tools } = await buildAgentTools({ agent, context });
+
+  expect(Object.keys(tools)).toEqual(['query_data']);
+  await tools['query_data'].execute({ dataset: 'orders' }, {});
+  expect(context.callEndpoint).toHaveBeenCalledWith('reporting/query-data', {
+    payload: { dataset: 'orders' },
+    abortSignal: undefined,
+  });
+});
+
+test('buildAgentTools keys sub-agent tools by name', async () => {
+  const { default: buildAgentTools } = await import('./buildAgentTools.js');
+
+  const subAgentConfig = {
+    agentId: 'reporting/researcher',
+    connectionId: 'anthropic',
+    tools: [],
+    mcp: [],
+    properties: {
+      model: 'claude-haiku-4-5-20251001',
+      instructions: 'You research topics.',
+    },
+  };
+  const agent = {
+    tools: [],
+    mcp: [],
+    agents: [{ agentId: 'reporting/researcher', name: 'reporting__researcher' }],
+  };
+  const context = {
+    getEndpointConfig: jest.fn(),
+    callEndpoint: jest.fn(),
+    evaluateOperators: jest.fn((x) => x),
+    getAgentConfig: jest.fn().mockResolvedValue(subAgentConfig),
+    getConnectionForAgent: jest
+      .fn()
+      .mockResolvedValue({ provider: jest.fn().mockReturnValue('sub-model') }),
+    resolveMcpSources: jest.fn().mockResolvedValue([]),
+  };
+
+  const { tools } = await buildAgentTools({ agent, context });
+
+  expect(Object.keys(tools)).toEqual(['reporting__researcher']);
+});
+
 test('buildAgentTools throws ConfigError when endpoint tool name collides with reserved platform tool', async () => {
   const { default: buildAgentTools } = await import('./buildAgentTools.js');
 


### PR DESCRIPTION
## Summary

Modules can now ship agents. `module.lowdefy.yaml` gains an `agents:` section, processed like `connections`/`api` — agent ids scope to `{entryId}/{agentId}` and merge into `components.agents` before `buildAgents` runs. This is the framework prerequisite for the AI chat reporting module (design: `lowdefy-design/designs/ai-chat-reporting`); without it a module whose entire purpose is an agent cannot ship its agent.

## Changes

- **`buildModules`**: iterate `agents` alongside `connections`/`api` — validate module secret references, scope ids per entry, merge into `components.agents`. Multi-instance installs get distinct agents per entry.
- **`deferredRegions`**: `agents` joins the content-section regexes, so the header walk leaves the section raw and the full manifest walk resolves it with the module entry in scope (`_module.*` operators work anywhere in the agent config).
- **`registerModules`**: null-filter `agents` entries like the other sections.
- **Walker**: new `_module.agentId` operator (string and `{ id, module }` forms), mirroring `resolveModuleEndpointId`. Needed by `AgentChat.agentId` in module pages and `CallAgent` steps in module endpoints — no existing `_module.*` operator produces a scoped agent id.
- **Tool names** (`buildAgents` + `buildAgentTools`): endpoint tools and sub-agent references gain a model-facing `name`. Providers require `^[a-zA-Z0-9_-]{1,64}$` and scoped ids contain `/`, so the default name replaces `/` with `__`; an explicit `name` overrides (better LLM ergonomics: `query_data` instead of `reporting__query-data`). Validated for pattern, reserved platform names, and per-agent uniqueness across tools and sub-agents. `buildAgentTools` keys tools by name; execution still targets the `endpointId`.
- **Schema**: `name` allowed on tool and sub-agent objects.
- **AgentChat transport**: URL-encode the agentId path segment — the agent route takes the last segment as the agentId (`getPathSegments` decodes per segment), and scoped ids contain `/`.

## Tests

- New fixture `95-module-agents`: a module ships its agent — the snapshot pins scoped agent/connection/hook ids, an explicit tool name, the `helper__count-users` default, and `_module.agentId` resolution in both a page property and a `CallAgent` step.
- New unit tests for name defaulting, explicit names, invalid/reserved/duplicate names, and sub-agent name collisions; runtime tests for name-keyed tools.
- Fixture 94's snapshot picks up the defaulted tool name (`name: lookup-signups` — identical to the endpoint id for unscoped ids, so no behavior change for existing apps).
- Full suites green: 1,681 build tests, 166 ai-utils tests.

## Notes

- Verified end-to-end by building a test app that installs the reporting module from `lowdefy/modules-mongodb` (companion PR there): agent ids, tool endpoints, hooks, `CallAgent` agentId, Dynamic `endpointId` and client `_api` keys all resolve to entry-scoped ids.
- Targets `vite-hono` — the change builds on the module system and agent system on that line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jGT2SkTpc2JSkKAeT3vYJ
