### PR TITLE
Authorize nested CallApi in system-context endpoint runs

### DIFF
--- a/.changeset/fix-api-system-context-nested-callapi.md
+++ b/.changeset/fix-api-system-context-nested-callapi.md
@@ -1,0 +1,14 @@
+---
+'@lowdefy/api': patch
+---
+
+fix(api): CallApi steps inside scheduled, webhook, and detached endpoint routines no longer fail authorization; the system context now authorizes nested endpoint calls.
+
+Scheduled (cron), webhook, and detached endpoint runs execute as a system context with no
+user session. Nested CallApi steps in those routines were re-authorized against that
+session-less context, so any call to a protected (`auth.public: false`) endpoint threw
+`API Endpoint "<id>" does not exist.` — silently breaking cron endpoints that compose other
+endpoints via CallApi. A routine that is already executing was authorized at its entry point
+(CRON_SECRET or webhook token), so the system context now authorizes nested endpoint calls
+unconditionally. User-session behavior is unchanged: a user-initiated CallApi chain still
+re-authorizes each target against the user's roles.

--- a/packages/api/src/context/createAuthorize.js
+++ b/packages/api/src/context/createAuthorize.js
@@ -16,7 +16,7 @@
 
 import { ConfigError } from '@lowdefy/errors';
 
-function createAuthorize({ session }) {
+function createAuthorize({ session, system = false }) {
   // Next-auth getSession provides a session object if the user is authenticated
   // else session will be null
 
@@ -29,6 +29,9 @@ function createAuthorize({ session }) {
   }
 
   function authorize(config) {
+    // A system context (scheduled, webhook, detached runs) was authorized at the
+    // transport layer, so nested endpoint calls are never gated on a user session.
+    if (system === true) return true;
     const { auth } = config;
     if (auth.public === true) return true;
     if (auth.public === false) {

--- a/packages/api/src/context/createAuthorize.test.js
+++ b/packages/api/src/context/createAuthorize.test.js
@@ -125,6 +125,17 @@ test('throws ConfigError when session.user.roles is an object', () => {
   throw new Error('Expected ConfigError to be thrown');
 });
 
+test('system: true authorizes protected config without a session', () => {
+  const authorize = createAuthorize({ session: undefined, system: true });
+  expect(authorize({ auth: { public: false } })).toBe(true);
+  expect(authorize({ auth: { public: true } })).toBe(true);
+});
+
+test('system: true authorizes roles-protected config without a session', () => {
+  const authorize = createAuthorize({ session: undefined, system: true });
+  expect(authorize({ auth: { public: false, roles: ['admin'] } })).toBe(true);
+});
+
 test('throws ConfigError with configKey for location tracing', () => {
   const authorize = createAuthorize({});
   try {

--- a/packages/api/src/routes/endpoints/backgroundEndpoints.test.js
+++ b/packages/api/src/routes/endpoints/backgroundEndpoints.test.js
@@ -16,8 +16,12 @@
 
 import { jest } from '@jest/globals';
 import { ConfigError } from '@lowdefy/errors';
+import { operatorsServer } from '@lowdefy/operators-js';
 
 import callEndpoint from './callEndpoint.js';
+import runDetachedEndpoint from './runDetachedEndpoint.js';
+import runScheduledEndpoint from './runScheduledEndpoint.js';
+import runWebhookEndpoint from './runWebhookEndpoint.js';
 import scheduleBackground from './scheduleBackground.js';
 import testContext from '../../test/testContext.js';
 
@@ -200,4 +204,113 @@ test('webhook endpoints: gated on webhook: true, payload is { body, query, heade
   await expect(
     runWebhookEndpoint(context2, { endpointId: 'plain_ep', body: {}, query: {}, headers: {} })
   ).rejects.toThrow('does not exist');
+});
+
+// Nested CallApi authorization in system contexts — a routine already running was
+// authorized at its entry point (CRON_SECRET / webhook token), so CallApi steps to
+// protected endpoints must not be re-gated on a (missing) user session.
+
+function createNestedCallReadConfigFile({ parent, childType = 'Api' }) {
+  return jest.fn((path) => {
+    if (path === `api/${parent.endpointId}.json`) {
+      return parent;
+    }
+    if (path === 'api/child_ep.json') {
+      return {
+        endpointId: 'child_ep',
+        type: childType,
+        auth: { public: false },
+        routine: { ':return': 'child_ran' },
+      };
+    }
+    return null;
+  });
+}
+
+const nestedCallRoutine = (parentId) => [
+  {
+    id: `endpoint:${parentId}:call_child`,
+    stepId: 'call_child',
+    type: 'CallApi',
+    properties: { endpointId: 'child_ep', payload: {} },
+  },
+  { ':return': { child: { _step: 'call_child' } } },
+];
+
+test('scheduled endpoint CallApi to a protected Api endpoint runs the child routine', async () => {
+  const readConfigFile = createNestedCallReadConfigFile({
+    parent: {
+      endpointId: 'parent_cron',
+      type: 'Api',
+      auth: { public: false },
+      schedules: [{ cron: '0 6 * * *' }],
+      routine: nestedCallRoutine('parent_cron'),
+    },
+  });
+  const context = testContext({ logger, operators: operatorsServer, readConfigFile });
+  const result = await runScheduledEndpoint(context, {
+    endpointId: 'parent_cron',
+    cron: '0 6 * * *',
+  });
+  expect(result.success).toBe(true);
+  expect(result.response).toEqual({ child: 'child_ran' });
+});
+
+test('scheduled endpoint CallApi to a protected InternalApi endpoint runs the child routine', async () => {
+  const readConfigFile = createNestedCallReadConfigFile({
+    parent: {
+      endpointId: 'parent_cron',
+      type: 'Api',
+      auth: { public: false },
+      schedules: [{ cron: '0 6 * * *' }],
+      routine: nestedCallRoutine('parent_cron'),
+    },
+    childType: 'InternalApi',
+  });
+  const context = testContext({ logger, operators: operatorsServer, readConfigFile });
+  const result = await runScheduledEndpoint(context, {
+    endpointId: 'parent_cron',
+    cron: '0 6 * * *',
+  });
+  expect(result.success).toBe(true);
+  expect(result.response).toEqual({ child: 'child_ran' });
+});
+
+test('webhook endpoint CallApi to a protected Api endpoint runs the child routine', async () => {
+  const readConfigFile = createNestedCallReadConfigFile({
+    parent: {
+      endpointId: 'parent_hook',
+      type: 'Api',
+      auth: { public: false },
+      webhook: true,
+      routine: nestedCallRoutine('parent_hook'),
+    },
+  });
+  const context = testContext({ logger, operators: operatorsServer, readConfigFile });
+  const result = await runWebhookEndpoint(context, {
+    endpointId: 'parent_hook',
+    body: {},
+    query: {},
+    headers: {},
+  });
+  expect(result.success).toBe(true);
+  expect(result.response).toEqual({ child: 'child_ran' });
+});
+
+test('detached endpoint CallApi to a protected Api endpoint runs the child routine', async () => {
+  const readConfigFile = createNestedCallReadConfigFile({
+    parent: {
+      endpointId: 'parent_detached',
+      type: 'Api',
+      auth: { public: false },
+      routine: nestedCallRoutine('parent_detached'),
+    },
+  });
+  const context = testContext({ logger, operators: operatorsServer, readConfigFile });
+  const result = await runDetachedEndpoint(context, {
+    endpointId: 'parent_detached',
+    payload: {},
+  });
+  expect(result.success).toBe(true);
+  expect(result.response).toEqual({ child: 'child_ran' });
 });

--- a/packages/api/src/routes/endpoints/callEndpoint.test.js
+++ b/packages/api/src/routes/endpoints/callEndpoint.test.js
@@ -93,6 +93,29 @@ test('Api endpoint proceeds normally', async () => {
   expect(result.status).toBe('success');
 });
 
+test('unauthenticated call to a protected endpoint throws masked does-not-exist error', async () => {
+  const mockReadConfigFile = jest.fn((path) => {
+    if (path === 'api/protected_ep.json') {
+      return {
+        endpointId: 'protected_ep',
+        type: 'Api',
+        auth: { public: false },
+        routine: { ':return': 'secret' },
+      };
+    }
+    return null;
+  });
+  const context = testContext({ logger, readConfigFile: mockReadConfigFile });
+  await expect(
+    callEndpoint(context, {
+      blockId: 'blockId',
+      endpointId: 'protected_ep',
+      pageId: 'pageId',
+      payload: {},
+    })
+  ).rejects.toThrow('API Endpoint "protected_ep" does not exist.');
+});
+
 test('InternalApi error matches missing endpoint error message', async () => {
   const mockReadConfigFile = jest.fn((path) => {
     if (path === 'api/internal_ep.json') {

--- a/packages/api/src/routes/endpoints/invokeEndpoint.test.js
+++ b/packages/api/src/routes/endpoints/invokeEndpoint.test.js
@@ -18,6 +18,7 @@ import { jest } from '@jest/globals';
 import { operatorsServer } from '@lowdefy/operators-js';
 import { ConfigError } from '@lowdefy/errors';
 
+import createAuthorize from '../../context/createAuthorize.js';
 import createEvaluateOperators from '../../context/createEvaluateOperators.js';
 import invokeEndpoint from './invokeEndpoint.js';
 import testContext from '../../test/testContext.js';
@@ -145,6 +146,46 @@ test('throws ConfigError on authorization failure', async () => {
   await expect(
     invokeEndpoint(context, { endpointId: 'target', payload: {}, endpointDepth: 0 })
   ).rejects.toBeInstanceOf(ConfigError);
+});
+
+test('system context authorizes nested call to a protected endpoint', async () => {
+  const context = createTestContext({
+    endpointConfigs: {
+      target: {
+        endpointId: 'target',
+        type: 'Api',
+        routine: { ':return': 'ran' },
+        auth: { public: false, roles: ['admin'] },
+      },
+    },
+  });
+  context.session = undefined;
+  context.user = undefined;
+  context.authorize = createAuthorize({ session: undefined, system: true });
+  const result = await invokeEndpoint(context, {
+    endpointId: 'target',
+    payload: {},
+    endpointDepth: 0,
+  });
+  expect(result.status).toBe('return');
+  expect(result.response).toBe('ran');
+});
+
+test('user session with insufficient roles gets masked does-not-exist error on nested call', async () => {
+  const context = createTestContext({
+    endpointConfigs: {
+      target: {
+        endpointId: 'target',
+        type: 'Api',
+        routine: { ':return': true },
+        auth: { public: false, roles: ['admin'] },
+      },
+    },
+    session: { user: { id: 'user_1', roles: ['viewer'] } },
+  });
+  await expect(
+    invokeEndpoint(context, { endpointId: 'target', payload: {}, endpointDepth: 0 })
+  ).rejects.toThrow('API Endpoint "target" does not exist.');
 });
 
 test('propagates :throw status envelope from runRoutine', async () => {

--- a/packages/api/src/routes/endpoints/runDetachedEndpoint.js
+++ b/packages/api/src/routes/endpoints/runDetachedEndpoint.js
@@ -38,9 +38,11 @@ async function runDetachedEndpoint(context, { endpointId, payload }) {
   const endpointConfig = await getEndpointConfig(context, { endpointId });
 
   // Force a system context regardless of any session cookie sent with the request.
+  // system: true — nested CallApi steps are authorized like function calls (the run
+  // was already authorized at the transport layer), not re-gated on a user session.
   context.session = undefined;
   context.user = undefined;
-  context.authorize = createAuthorize({ session: undefined });
+  context.authorize = createAuthorize({ session: undefined, system: true });
 
   const routineContext = {
     steps: {},

--- a/packages/api/src/routes/endpoints/runScheduledEndpoint.js
+++ b/packages/api/src/routes/endpoints/runScheduledEndpoint.js
@@ -56,9 +56,11 @@ async function runScheduledEndpoint(context, { endpointId, cron }) {
   }
 
   // Force a system context regardless of any session cookie sent with the request.
+  // system: true — nested CallApi steps are authorized like function calls (the run
+  // was already authorized at the transport layer), not re-gated on a user session.
   context.session = undefined;
   context.user = undefined;
-  context.authorize = createAuthorize({ session: undefined });
+  context.authorize = createAuthorize({ session: undefined, system: true });
 
   const routineContext = {
     steps: {},

--- a/packages/api/src/routes/endpoints/runWebhookEndpoint.js
+++ b/packages/api/src/routes/endpoints/runWebhookEndpoint.js
@@ -48,9 +48,11 @@ async function runWebhookEndpoint(context, { endpointId, body, query, headers })
   }
 
   // Force a system context regardless of any session cookie sent with the request.
+  // system: true — nested CallApi steps are authorized like function calls (the run
+  // was already authorized at the transport layer), not re-gated on a user session.
   context.session = undefined;
   context.user = undefined;
-  context.authorize = createAuthorize({ session: undefined });
+  context.authorize = createAuthorize({ session: undefined, system: true });
 
   const routineContext = {
     steps: {},


### PR DESCRIPTION
## Summary

Scheduled (cron), webhook, and detached endpoint runs execute as a system context: no user session, with `authorize` built from `createAuthorize({ session: undefined })`. When such a routine contained a CallApi step, `invokeEndpoint` re-authorized the target endpoint against that session-less context, so any nested call to a protected (`auth.public: false`) endpoint threw the masked `API Endpoint "<id>" does not exist.` error. With `api.protected: true` (the common default) this made every cron endpoint that composes other endpoints via CallApi fail — silently, if the caller wrapped the steps in `:try`/`:catch`.

This PR implements option B: a routine that is already executing was authorized at its entry point (HTTP `callEndpoint` checks the endpoint's auth config; scheduled/webhook/detached runs are authorized at the transport layer via CRON_SECRET or the webhook's own token check), so the system context now authorizes nested endpoint calls unconditionally. Option A (skipping `authorizeApiEndpoint` for all nested calls) was deliberately not taken: it would change security semantics for user-initiated chains, where a low-privilege endpoint could compose into an admin-roles endpoint. User-session behavior is unchanged — a user-initiated CallApi chain still re-authorizes each target against the user's roles, and unauthorized targets still surface as the masked "does not exist" error.

## Changes

- **@lowdefy/api**: `createAuthorize` accepts a `system` flag that makes `authorize()` return true unconditionally. The three system-context runners (`runScheduledEndpoint`, `runWebhookEndpoint`, `runDetachedEndpoint`) create their context with `system: true`. Entry-point behavior is untouched: scheduled runs still skip the entry endpoint's auth config and still allow InternalApi targets, and HTTP `callEndpoint` still blocks InternalApi and enforces entry auth.

## Notes

- Tests cover nested CallApi to protected `Api` and `InternalApi` children through all three system runners (real `runRoutine`, no mocks), plus regressions: a user session with insufficient roles still gets the masked error on nested calls, and HTTP entry auth / InternalApi blocking are unchanged.
- Includes a patch changeset for `@lowdefy/api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)