### PR TITLE
fix(api): Log routine errors under pino's err key so the serializer runs

### DIFF
--- a/.changeset/fix-api-error-log-serializer.md
+++ b/.changeset/fix-api-error-log-serializer.md
@@ -1,0 +1,14 @@
+---
+'@lowdefy/api': patch
+---
+
+fix(api): Log routine errors under pino's `err` key so the error serializer runs.
+
+`controlThrow`, `controlReject`, and `handleValidateSchema` logged the thrown
+`Error` under the key `error`, but the logger built by `createNodeLogger`
+registers its error serializer for the `err` key only. Since `Error.message`
+and `stack` are non-enumerable, the un-serialized dump lost the message
+entirely — every `:throw`/`:reject` printed as
+`{"name":"UserError","isLowdefyError":true,"isReject":false}` with no way to
+tell which error occurred. Logging under `err` runs the registered serializer
+and lands the full serialized error (message, stack, cause) in the log line.

--- a/packages/api/src/routes/endpoints/control/controlReject.js
+++ b/packages/api/src/routes/endpoints/control/controlReject.js
@@ -39,9 +39,11 @@ async function controlReject(context, routineContext, { control }) {
   });
   const error = new UserError(message, { cause, isReject: true });
 
+  // Log under `err` — see controlThrow: only the `err` key runs the pino error
+  // serializer, so `error` would drop the message from the log line.
   context.logger.warn({
     event: 'warn_control_reject',
-    error,
+    err: error,
   });
   return {
     status: 'reject',

--- a/packages/api/src/routes/endpoints/control/controlReject.test.js
+++ b/packages/api/src/routes/endpoints/control/controlReject.test.js
@@ -25,7 +25,7 @@ test('single reject', async () => {
   const { res, context } = await runTest({ routine });
   expect(res.status).toEqual('reject');
   expect(context.logger.warn.mock.calls).toEqual([
-    [{ event: 'warn_control_reject', error: new UserError('Rejected', { isReject: true }) }],
+    [{ event: 'warn_control_reject', err: new UserError('Rejected', { isReject: true }) }],
   ]);
   expect(res.error).toEqual(new UserError('Rejected', { isReject: true }));
   expect(res.error).toBeInstanceOf(UserError);

--- a/packages/api/src/routes/endpoints/control/controlThrow.js
+++ b/packages/api/src/routes/endpoints/control/controlThrow.js
@@ -39,9 +39,12 @@ async function controlThrow(context, routineContext, { control }) {
   });
   const error = new UserError(message, { cause });
 
+  // Log under `err` — the pino error serializer (createNodeLogger) is registered
+  // for the `err` key only; an Error passed as `error` is JSON-dumped without its
+  // non-enumerable `message`/`stack`, producing a log line with no message.
   context.logger.error({
     event: 'error_control_throw',
-    error,
+    err: error,
   });
 
   return {

--- a/packages/api/src/routes/endpoints/control/controlThrow.test.js
+++ b/packages/api/src/routes/endpoints/control/controlThrow.test.js
@@ -99,7 +99,7 @@ test('throw at end of routine', async () => {
       },
     ],
   ]);
-  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', error }]]);
+  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', err: error }]]);
 });
 
 test('throw in the middle of routine', async () => {
@@ -151,7 +151,7 @@ test('throw in the middle of routine', async () => {
       },
     ],
   ]);
-  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', error }]]);
+  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', err: error }]]);
   expect(res.error).toEqual(error);
 });
 
@@ -205,7 +205,7 @@ test('multiple throws in routine', async () => {
       },
     ],
   ]);
-  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', error }]]);
+  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', err: error }]]);
   expect(res.error).toEqual(error);
 });
 
@@ -266,7 +266,7 @@ test('truthy guard statement throw', async () => {
       },
     ],
   ]);
-  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', error }]]);
+  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', err: error }]]);
 });
 
 test('throw in a try block with catch return', async () => {
@@ -363,7 +363,7 @@ test('throw in a try block with missing catch', async () => {
       },
     ],
   ]);
-  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', error }]]);
+  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', err: error }]]);
 });
 
 test('throw in a try block with error in finally', async () => {
@@ -416,9 +416,9 @@ test('throw in a try block with error in finally', async () => {
     [{ event: 'debug_control_finally' }],
   ]);
   expect(context.logger.error.mock.calls).toEqual([
-    [{ event: 'error_control_throw', error: new UserError('Error occurred at the end') }],
-    [{ event: 'error_control_throw', error: new UserError('Error in catch') }],
-    [{ event: 'error_control_throw', error }],
+    [{ event: 'error_control_throw', err: new UserError('Error occurred at the end') }],
+    [{ event: 'error_control_throw', err: new UserError('Error in catch') }],
+    [{ event: 'error_control_throw', err: error }],
   ]);
 });
 
@@ -467,7 +467,7 @@ test('throw in try block with cause', async () => {
       },
     ],
   ]);
-  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', error }]]);
+  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', err: error }]]);
 });
 
 test('throw in try block with empty catch', async () => {
@@ -517,7 +517,7 @@ test('throw in try block with empty catch', async () => {
     ],
     [{ event: 'debug_control_catch' }],
   ]);
-  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', error }]]);
+  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', err: error }]]);
 });
 
 test('throw in try block with return in finally block', async () => {
@@ -568,7 +568,7 @@ test('throw in try block with return in finally block', async () => {
     [{ event: 'debug_control_finally' }],
     [{ event: 'debug_control_return', response: { message: 'Error ignored' } }],
   ]);
-  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', error }]]);
+  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', err: error }]]);
 });
 
 test('throw in try block with request in finally block', async () => {
@@ -649,5 +649,5 @@ test('throw in try block with request in finally block', async () => {
       },
     ],
   ]);
-  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', error }]]);
+  expect(context.logger.error.mock.calls).toEqual([[{ event: 'error_control_throw', err: error }]]);
 });

--- a/packages/api/src/routes/endpoints/handleValidateSchema.js
+++ b/packages/api/src/routes/endpoints/handleValidateSchema.js
@@ -54,10 +54,12 @@ async function handleValidateSchema(context, routineContext, { step }) {
     const error = new Error(buildErrorMessage(result.errors, step.stepId), {
       cause: result.errors,
     });
+    // Log under `err` — see controlThrow: only the `err` key runs the pino error
+    // serializer, so `error` would drop the message from the log line.
     logger.error({
       event: 'error_validate_schema',
       stepId: step.stepId,
-      error,
+      err: error,
     });
     return { status: 'error', error };
   }


### PR DESCRIPTION
## Problem

`controlThrow`, `controlReject`, and `handleValidateSchema` log the thrown `Error` under the key `error`, but the pino logger built by `createNodeLogger` registers its error serializer for the `err` key only:

```js
serializers: {
  err: (error) => serializer.serialize(error)?.['~e'] ?? error,
}
```

Since `Error.message` and `Error.stack` are non-enumerable, pino's plain JSON dump of the `error` property drops them — every `:throw` / `:reject` in every API routine logs as:

```
error: {"name":"UserError","isLowdefyError":true,"isReject":false}
```

with no way to tell which error occurred. (Observed live driving a ~90-endpoint app under load: thousands of business rejections logged with the message amputated.)

## Fix

Log under `err` at the three call sites so the registered serializer runs and the full serialized error (`~e` shape: message, stack, cause) lands in the log line. Severity levels are untouched — `:throw` at `error` / `:reject` at `warn` per the documented system-error vs user-facing-rejection semantics.

## Before / after (standalone pino repro with the createNodeLogger serializer config)

```
BEFORE (error key): {"name":"UserError","isLowdefyError":true,"isReject":false}
AFTER  (err key)  : {"name":"UserError","message":"Credit limit exceeded"}
```

## Changes

- `packages/api/src/routes/endpoints/control/controlThrow.js` — `error` → `err: error`
- `packages/api/src/routes/endpoints/control/controlReject.js` — same
- `packages/api/src/routes/endpoints/handleValidateSchema.js` — same
- Matching test-assertion updates (13 assertions across the two control test files)
- Changeset: `@lowdefy/api` patch

## Repo-wide audit (post-PR sweep)

Audited every logger call site in the monorepo (~180 across `packages/api`, `packages/servers/*`, `packages/build`, `packages/cli`, `packages/client`, `packages/engine`) plus every logger factory:

- **These three call sites were the only offenders.** The rest of the codebase already follows the `err:` convention (20+ sites verified: `callEndpoint.js`, `scheduleBackground.js`, `websocket/createChannelRegistry.js`, all `get*Config`/`get*Resolver` handlers, `callRequestResolver.js`, …) or passes the Error as pino's native first argument (which pino v8 remaps to `errorKey: 'err'` before serialization — `lib/proto.js` `write()`).
- The CLI logger (`createCliLogger`) and browser logger (`createBrowserLogger`) are architecturally unaffected (no per-key JSON serialization step).
- Related observation, no change needed: `createStdOutLineHandler` (the CLI bridge for spawned-server JSON logs) special-cases `parsed.err` only — consistent with the `err:` convention this PR restores, and a second reason the `error` key was a dead end (it would be double-amputated through the bridge).

So this PR aligns the three stragglers with the codebase's own existing convention rather than introducing a new one.