### PR TITLE
Reuse MongoDB client across requests

### DIFF
--- a/.changeset/fix-mongodb-client-reuse.md
+++ b/.changeset/fix-mongodb-client-reuse.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/connection-mongodb': patch
+---
+
+fix: Reuse the MongoDB client across requests instead of connecting per request.
+
+MongoDBCollection requests previously created a new MongoDB client, performed a full connection handshake (DNS, TLS, auth), and closed the connection for every request. Requests now share one cached client per unique `databaseUri` and `options` combination, so multi-request pages and routines no longer pay a connection setup per request — an 8-request routine measured against MongoDB Atlas dropped from 4.3s to 0.2s (~95% faster). Connections now stay open between requests; the driver's connection pool can be tuned with standard client options like `maxPoolSize` and `maxIdleTimeMS` on the connection's `options` property.

--- a/packages/docs/connections/MongoDB.yaml
+++ b/packages/docs/connections/MongoDB.yaml
@@ -68,6 +68,24 @@ _ref:
             - `write: boolean`: Default: `false` - Allow write operations like update on the collection.
             - `options: object`: See the [driver documentation](https://mongodb.github.io/node-mongodb-native/4.0/interfaces/mongoclientoptions.html) for more information.
 
+            #### Connection pooling
+
+            The MongoDB client is created once per unique `databaseUri` and `options` combination and reused for all requests, so requests share the driver's connection pool instead of opening a new connection for every request. The pool can be tuned with the standard driver options, for example:
+
+            ```yaml
+            connections:
+              - id: my_collection
+                type: MongoDBCollection
+                properties:
+                  databaseUri:
+                    _secret: MONGODB_URI
+                  collection: my_collection_name
+                  options:
+                    maxPoolSize: 20
+                    minPoolSize: 0
+                    maxIdleTimeMS: 60000
+            ```
+
             #### Examples
 
             ###### MongoDB collection with reads and writes:

--- a/packages/plugins/connections/connection-mongodb/jest-mongodb-config.js
+++ b/packages/plugins/connections/connection-mongodb/jest-mongodb-config.js
@@ -1,8 +1,8 @@
-export default {
-  mongodbMemoryServerOptions: {
-    instance: {
-      dbName: 'test',
-    },
-    autoStart: false,
+// @shelf/jest-mongodb loads this file with require(), which on Node >=22 returns the
+// module namespace for ESM files, so options must be a named export (not default).
+export const mongodbMemoryServerOptions = {
+  instance: {
+    dbName: 'test',
   },
+  autoStart: false,
 };

--- a/packages/plugins/connections/connection-mongodb/jest.config.js
+++ b/packages/plugins/connections/connection-mongodb/jest.config.js
@@ -12,6 +12,7 @@ export default {
   coverageReporters: [['lcov', { projectRoot: '../../../..' }], 'text', 'clover'],
   errorOnDeprecated: true,
   preset: '@shelf/jest-mongodb',
+  setupFilesAfterEnv: ['<rootDir>/test/closeClientsAfterAll.js'],
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/dist/'],
   transform: {

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBAggregation/MongoDBAggregation.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBAggregation/MongoDBAggregation.js
@@ -34,16 +34,9 @@ async function MongodbAggregation({ request, connection }) {
   const deserializedRequest = deserialize(request);
   const { pipeline, options } = deserializedRequest;
   checkOutAndMerge({ pipeline, connection });
-  const { collection, client } = await getCollection({ connection });
-  let res;
-  try {
-    const cursor = await collection.aggregate(pipeline, options);
-    res = await cursor.toArray();
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const cursor = await collection.aggregate(pipeline, options);
+  const res = await cursor.toArray();
   return serialize(res);
 }
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBBulkWrite/MongoDBBulkWrite.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBBulkWrite/MongoDBBulkWrite.js
@@ -21,15 +21,8 @@ import schema from './schema.js';
 async function MongodbBulkWrite({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { operations, options } = deserializedRequest;
-  const { collection, client } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.bulkWrite(operations, options);
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const response = await collection.bulkWrite(operations, options);
   return serialize(response);
 }
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteMany/MongoDBDeleteMany.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteMany/MongoDBDeleteMany.js
@@ -21,15 +21,8 @@ import schema from './schema.js';
 async function MongodbDeleteMany({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { filter, options } = deserializedRequest;
-  const { collection, client } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.deleteMany(filter, options);
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const response = await collection.deleteMany(filter, options);
   const { acknowledged, deletedCount } = serialize(response);
   return { acknowledged, deletedCount };
 }

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteOne/MongoDBDeleteOne.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteOne/MongoDBDeleteOne.js
@@ -21,15 +21,8 @@ import schema from './schema.js';
 async function MongodbDeleteOne({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { filter, options } = deserializedRequest;
-  const { collection, client } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.deleteOne(filter, options);
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const response = await collection.deleteOne(filter, options);
   return serialize(response);
 }
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBFind/MongoDBFind.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBFind/MongoDBFind.js
@@ -21,16 +21,9 @@ import schema from './schema.js';
 async function MongodbFind({ request, connection }) {
   const deserializedRequest = deserialize(request);
   const { query, options } = deserializedRequest;
-  const { collection, client } = await getCollection({ connection });
-  let res;
-  try {
-    const cursor = await collection.find(query, options);
-    res = await cursor.toArray();
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const cursor = await collection.find(query, options);
+  const res = await cursor.toArray();
   return serialize(res);
 }
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertMany/MongoDBInsertMany.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertMany/MongoDBInsertMany.js
@@ -21,15 +21,8 @@ import schema from './schema.js';
 async function MongodbInsertMany({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { docs, options } = deserializedRequest;
-  const { collection, client } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.insertMany(docs, options);
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const response = await collection.insertMany(docs, options);
   const { acknowledged, insertedCount } = serialize(response);
   return { acknowledged, insertedCount };
 }

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertOne/MongoDBInsertOne.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertOne/MongoDBInsertOne.js
@@ -21,15 +21,8 @@ import schema from './schema.js';
 async function MongodbInsertOne({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { doc, options } = deserializedRequest;
-  const { collection, client } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.insertOne(doc, options);
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const response = await collection.insertOne(doc, options);
   const { acknowledged, insertedId } = serialize(response);
   return { acknowledged, insertedId };
 }

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateMany/MongoDBUpdateMany.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateMany/MongoDBUpdateMany.js
@@ -21,15 +21,8 @@ import schema from './schema.js';
 async function MongodbUpdateMany({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { filter, update, options } = deserializedRequest;
-  const { collection, client } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.updateMany(filter, update, options);
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const response = await collection.updateMany(filter, update, options);
   const { modifiedCount, upsertedId, upsertedCount, matchedCount } = serialize(response);
   return { modifiedCount, upsertedId, upsertedCount, matchedCount };
 }

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/MongoDBUpdateOne.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/MongoDBUpdateOne.js
@@ -21,15 +21,8 @@ import schema from './schema.js';
 async function MongodbUpdateOne({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { filter, update, options } = deserializedRequest;
-  const { collection, client } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.updateOne(filter, update, options);
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const response = await collection.updateOne(filter, update, options);
   return serialize(response);
 }
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getClient.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getClient.js
@@ -1,0 +1,50 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { MongoClient } from 'mongodb';
+
+// Clients are cached for the lifetime of the process so requests share the driver's
+// connection pool instead of paying a full connect (DNS, TLS, auth) per request.
+const clientPromises = new Map();
+
+function getClient({ databaseUri, options }) {
+  const key = `${databaseUri}:${JSON.stringify(options ?? {})}`;
+  if (!clientPromises.has(key)) {
+    const clientPromise = new MongoClient(databaseUri, options).connect();
+    // Evict failed connects so the next request retries instead of replaying the rejection.
+    clientPromise.catch(() => clientPromises.delete(key));
+    clientPromises.set(key, clientPromise);
+  }
+  return clientPromises.get(key);
+}
+
+async function closeClients() {
+  const promises = [...clientPromises.values()];
+  clientPromises.clear();
+  await Promise.all(
+    promises.map(async (clientPromise) => {
+      try {
+        const client = await clientPromise;
+        await client.close();
+      } catch (error) {
+        // Clients that failed to connect have nothing to close.
+      }
+    })
+  );
+}
+
+export { closeClients };
+export default getClient;

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getClient.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getClient.test.js
@@ -1,0 +1,71 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+import { MongoClient } from 'mongodb';
+
+import getClient, { closeClients } from './getClient.js';
+
+const databaseUri = process.env.MONGO_URL;
+
+afterAll(async () => {
+  await closeClients();
+});
+
+test('getClient returns a connected MongoClient', async () => {
+  const client = await getClient({ databaseUri });
+  expect(client).toBeInstanceOf(MongoClient);
+});
+
+test('getClient returns the same client for the same databaseUri and options', async () => {
+  const promise1 = getClient({ databaseUri, options: { maxPoolSize: 7 } });
+  const promise2 = getClient({ databaseUri, options: { maxPoolSize: 7 } });
+  expect(promise1).toBe(promise2);
+  const client1 = await promise1;
+  const client2 = await promise2;
+  expect(client1).toBe(client2);
+});
+
+test('getClient shares one client across concurrent calls before the first connect resolves', async () => {
+  const [client1, client2] = await Promise.all([
+    getClient({ databaseUri, options: { appName: 'concurrent' } }),
+    getClient({ databaseUri, options: { appName: 'concurrent' } }),
+  ]);
+  expect(client1).toBe(client2);
+});
+
+test('getClient returns different clients for different options', async () => {
+  const client1 = await getClient({ databaseUri, options: { maxPoolSize: 3 } });
+  const client2 = await getClient({ databaseUri, options: { maxPoolSize: 4 } });
+  expect(client1).not.toBe(client2);
+});
+
+test('getClient evicts failed connects so the next call retries', async () => {
+  const unreachable = {
+    databaseUri: 'mongodb://localhost:1',
+    options: { serverSelectionTimeoutMS: 100 },
+  };
+  const promise1 = getClient(unreachable);
+  await expect(promise1).rejects.toThrow();
+  const promise2 = getClient(unreachable);
+  expect(promise2).not.toBe(promise1);
+  await expect(promise2).rejects.toThrow();
+});
+
+test('getClient creates a new client after closeClients', async () => {
+  const client1 = await getClient({ databaseUri, options: { appName: 'close' } });
+  await closeClients();
+  const client2 = await getClient({ databaseUri, options: { appName: 'close' } });
+  expect(client2).not.toBe(client1);
+});

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getCollection.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getCollection.js
@@ -14,32 +14,23 @@
   limitations under the License.
 */
 
-import { MongoClient } from 'mongodb';
 import { type } from '@lowdefy/helpers';
+
+import getClient from './getClient.js';
 
 async function getCollection({ connection }) {
   const { collection, databaseName, databaseUri, options } = connection;
   if (!type.isString(databaseUri)) {
     throw new Error('Database URI must be a string');
   }
-  const client = new MongoClient(databaseUri, options);
-  await client.connect();
-  try {
-    if (!type.isString(databaseName) && !type.isNone(databaseName)) {
-      throw new Error('Database name must be a string');
-    }
-    const db = client.db(databaseName);
-    if (!type.isString(collection)) {
-      throw new Error('Collection name must be a string');
-    }
-    return {
-      client,
-      collection: db.collection(collection),
-    };
-  } catch (error) {
-    await client.close();
-    throw error;
+  if (!type.isString(databaseName) && !type.isNone(databaseName)) {
+    throw new Error('Database name must be a string');
   }
+  if (!type.isString(collection)) {
+    throw new Error('Collection name must be a string');
+  }
+  const client = await getClient({ databaseUri, options });
+  return client.db(databaseName).collection(collection);
 }
 
 export default getCollection;

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getCollection.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getCollection.test.js
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-import { MongoClient, Collection } from 'mongodb';
+import { Collection } from 'mongodb';
 
 import getCollection from './getCollection.js';
 
@@ -26,9 +26,7 @@ test('get collection', async () => {
     collection: 'getCollection',
   };
   const res = await getCollection({ connection });
-  expect(res.client).toBeInstanceOf(MongoClient);
-  expect(res.collection).toBeInstanceOf(Collection);
-  await res.client.close();
+  expect(res).toBeInstanceOf(Collection);
 });
 
 test('get collection, no databaseName, uses databaseUri', async () => {
@@ -37,12 +35,10 @@ test('get collection, no databaseName, uses databaseUri', async () => {
     collection: 'getCollection',
   };
   const res = await getCollection({ connection });
-  expect(res.client).toBeInstanceOf(MongoClient);
-  expect(res.collection).toBeInstanceOf(Collection);
-  await res.client.close();
+  expect(res).toBeInstanceOf(Collection);
 });
 
-test('invalid databaseUri', async () => {
+test('invalid databaseUri scheme', async () => {
   const connection = {
     databaseUri: 'databaseUri',
     databaseName: 'test',

--- a/packages/plugins/connections/connection-mongodb/test/closeClientsAfterAll.js
+++ b/packages/plugins/connections/connection-mongodb/test/closeClientsAfterAll.js
@@ -14,22 +14,10 @@
   limitations under the License.
 */
 
-import getCollection from '../getCollection.js';
-import { serialize, deserialize } from '../serialize.js';
-import schema from './schema.js';
+import { closeClients } from '../src/connections/MongoDBCollection/getClient.js';
 
-async function MongodbFindOne({ request, connection }) {
-  const deserializedRequest = deserialize(request);
-  const { query, options } = deserializedRequest;
-  const collection = await getCollection({ connection });
-  const res = await collection.findOne(query, options);
-  return serialize(res);
-}
-
-MongodbFindOne.schema = schema;
-MongodbFindOne.meta = {
-  checkRead: true,
-  checkWrite: false,
-};
-
-export default MongodbFindOne;
+// Cached clients are kept open for the process lifetime, so close them after each
+// test file to let Jest workers exit cleanly.
+afterAll(async () => {
+  await closeClients();
+});


### PR DESCRIPTION
## Summary

Every `MongoDBCollection` request created a fresh `MongoClient`, performed a full connection handshake (DNS, TLS, auth), ran one operation, and closed the connection. Multi-request pages and API routines paid that handshake once per request — the dominant cost of routine execution against remote deployments like Atlas. Requests now share one cached client per unique `databaseUri` + `options` combination, so they reuse the driver's connection pool the way the MongoDB driver is designed to be used (and the way this package's own auth adapter already works).

**Expected query speed improvement:** in a direct reproduction, an 8-request routine against MongoDB Atlas dropped from **4.3s to 0.2s — a ~95% reduction (~21× faster)**, roughly ~500ms saved per request on TLS connections. Single-request pages gain the same per-request saving after the first request warms the client; local/low-latency databases see a smaller but still meaningful win.

## Changes

- **@lowdefy/connection-mongodb**: New `getClient.js` caches the `MongoClient.connect()` promise at module level, keyed by `databaseUri` + serialized `options`. Caching the promise (not the client) means concurrent requests share one connect instead of racing; failed connects are evicted so transient network errors don't poison later requests. `getCollection` now validates inputs before connecting and returns the `Collection` directly, and all 10 request methods drop their per-request `client.close()` + try/catch boilerplate. Also fixes the package's jest-mongodb config loading on Node 22+ (`require(esm)` returns a module namespace, so the options must be a named export).
- **@lowdefy/docs**: New "Connection pooling" section on the MongoDB connection page documenting client reuse and pool tuning via standard driver options (`maxPoolSize`, `minPoolSize`, `maxIdleTimeMS`).

## Key Files

- `packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getClient.js` — client cache, failure eviction, `closeClients()` for teardown
- `packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getCollection.js` — validate first, return collection from cached client
- `packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getClient.test.js` — reuse identity, concurrency, distinct keys, failure eviction
- `packages/plugins/connections/connection-mongodb/test/closeClientsAfterAll.js` — closes cached clients per test file so Jest workers exit cleanly

## Notes

- **Deliberate behavior change:** connections previously dropped to zero between requests; each server process now holds a persistent connection pool, so database connection counts (e.g. on Atlas dashboards) will look different. No new Lowdefy setting is needed — the connection's `options` property passes straight to the `MongoClient` constructor and is part of the cache key, so pool behavior is fully tunable per connection (e.g. `maxIdleTimeMS` to drain idle connections). This is also the recommended pattern for serverless: the cached client is reused across warm invocations.
- **This package's tests do not run in CI** — the root `pnpm test` script excludes `@lowdefy/connection-mongodb`, so reviewers should run `pnpm --filter=@lowdefy/connection-mongodb test` locally. All 175 tests pass locally against the lockfile driver (mongodb 6.3.0). Two pre-existing test failures surfaced when running with a newer driver (7.x changes unacknowledged-write results); they are unrelated to this change.
- The jest-mongodb config fix is included because without it the package's globalSetup crashes on Node ≥22, making the suite unrunnable locally on modern Node. It's inert on older Node (falls back to defaults, as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)