### PR TITLE
Reuse MongoDB client across requests (vite-hono)

### DIFF
--- a/.changeset/fix-mongodb-client-reuse.md
+++ b/.changeset/fix-mongodb-client-reuse.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/connection-mongodb': patch
+---
+
+fix: Reuse the MongoDB client across requests instead of connecting per request.
+
+MongoDBCollection requests previously created a new MongoDB client, performed a full connection handshake (DNS, TLS, auth), and closed the connection for every request. Requests now share one cached client per unique `databaseUri` and `options` combination, so multi-request pages and routines no longer pay a connection setup per request — an 8-request routine measured against MongoDB Atlas dropped from 4.3s to 0.2s (~95% faster). Connections now stay open between requests; the driver's connection pool can be tuned with standard client options like `maxPoolSize` and `maxIdleTimeMS` on the connection's `options` property.

--- a/packages/docs/connections/MongoDB.yaml
+++ b/packages/docs/connections/MongoDB.yaml
@@ -68,6 +68,24 @@ _ref:
             - `write: boolean`: Default: `false` - Allow write operations like update on the collection.
             - `options: object`: See the [driver documentation](https://mongodb.github.io/node-mongodb-native/4.0/interfaces/mongoclientoptions.html) for more information.
 
+            #### Connection pooling
+
+            The MongoDB client is created once per unique `databaseUri` and `options` combination and reused for all requests, so requests share the driver's connection pool instead of opening a new connection for every request. The pool can be tuned with the standard driver options, for example:
+
+            ```yaml
+            connections:
+              - id: my_collection
+                type: MongoDBCollection
+                properties:
+                  databaseUri:
+                    _secret: MONGODB_URI
+                  collection: my_collection_name
+                  options:
+                    maxPoolSize: 20
+                    minPoolSize: 0
+                    maxIdleTimeMS: 60000
+            ```
+
             #### Examples
 
             ###### MongoDB collection with reads and writes:

--- a/packages/plugins/connections/connection-mongodb/jest-mongodb-config.js
+++ b/packages/plugins/connections/connection-mongodb/jest-mongodb-config.js
@@ -1,8 +1,8 @@
-export default {
-  mongodbMemoryServerOptions: {
-    instance: {
-      dbName: 'test',
-    },
-    autoStart: false,
+// @shelf/jest-mongodb loads this file with require(), which on Node >=22 returns the
+// module namespace for ESM files, so options must be a named export (not default).
+export const mongodbMemoryServerOptions = {
+  instance: {
+    dbName: 'test',
   },
+  autoStart: false,
 };

--- a/packages/plugins/connections/connection-mongodb/jest.config.js
+++ b/packages/plugins/connections/connection-mongodb/jest.config.js
@@ -12,6 +12,7 @@ export default {
   coverageReporters: [['lcov', { projectRoot: '../../../..' }], 'text', 'clover'],
   errorOnDeprecated: true,
   preset: '@shelf/jest-mongodb',
+  setupFilesAfterEnv: ['<rootDir>/test/closeClientsAfterAll.js'],
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/dist/'],
   transform: {

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBAggregation/MongoDBAggregation.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBAggregation/MongoDBAggregation.js
@@ -34,16 +34,9 @@ async function MongodbAggregation({ request, connection }) {
   const deserializedRequest = deserialize(request);
   const { pipeline, options } = deserializedRequest;
   checkOutAndMerge({ pipeline, connection });
-  const { collection, client } = await getCollection({ connection });
-  let res;
-  try {
-    const cursor = await collection.aggregate(pipeline, options);
-    res = await cursor.toArray();
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const cursor = await collection.aggregate(pipeline, options);
+  const res = await cursor.toArray();
   return serialize(res);
 }
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBBulkWrite/MongoDBBulkWrite.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBBulkWrite/MongoDBBulkWrite.js
@@ -21,15 +21,8 @@ import schema from './schema.js';
 async function MongodbBulkWrite({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { operations, options } = deserializedRequest;
-  const { collection, client } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.bulkWrite(operations, options);
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const response = await collection.bulkWrite(operations, options);
   return serialize(response);
 }
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBChangeStream/MongoDBChangeStream.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBChangeStream/MongoDBChangeStream.js
@@ -25,35 +25,37 @@ import schema from './schema.js';
 // deployments).
 async function MongoDBChangeStream({ connection, properties, publish, signal }) {
   const { fullDocument, pipeline } = deserialize(properties ?? {});
-  const { collection, client } = await getCollection({ connection });
+  // The client is cached and shared with all other requests on this connection,
+  // so only the stream may be closed here, never the client.
+  const collection = await getCollection({ connection });
+  if (signal.aborted) {
+    return;
+  }
+  const stream = collection.watch(pipeline ?? [], {
+    fullDocument: fullDocument ?? 'updateLookup',
+  });
+  signal.addEventListener(
+    'abort',
+    () => {
+      stream.close().catch(() => {
+        // Already closed — nothing to clean up.
+      });
+    },
+    { once: true }
+  );
   try {
-    if (signal.aborted) {
-      return;
+    for await (const change of stream) {
+      publish({ data: serialize(change) });
     }
-    const stream = collection.watch(pipeline ?? [], {
-      fullDocument: fullDocument ?? 'updateLookup',
-    });
-    signal.addEventListener(
-      'abort',
-      () => {
-        stream.close().catch(() => {
-          // Already closed — nothing to clean up.
-        });
-      },
-      { once: true }
-    );
-    try {
-      for await (const change of stream) {
-        publish({ data: serialize(change) });
-      }
-    } catch (error) {
-      // Closing the stream on abort surfaces as an error on the iterator.
-      if (!signal.aborted) {
-        throw error;
-      }
+  } catch (error) {
+    // Closing the stream on abort surfaces as an error on the iterator.
+    if (!signal.aborted) {
+      throw error;
     }
   } finally {
-    await client.close();
+    await stream.close().catch(() => {
+      // Already closed — nothing to clean up.
+    });
   }
 }
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBChangeStream/MongoDBChangeStream.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBChangeStream/MongoDBChangeStream.test.js
@@ -53,12 +53,11 @@ function createFakeStream({ changes = [], failWith = null } = {}) {
 
 function createHarness({ changes, failWith } = {}) {
   const stream = createFakeStream({ changes, failWith });
-  const client = { close: jest.fn() };
   const collection = { watch: jest.fn(() => stream) };
-  mockGetCollection.mockResolvedValue({ client, collection });
+  mockGetCollection.mockResolvedValue(collection);
   const publish = jest.fn();
   const abortController = new AbortController();
-  return { abortController, client, collection, publish, stream };
+  return { abortController, collection, publish, stream };
 }
 
 beforeEach(() => {
@@ -68,7 +67,7 @@ beforeEach(() => {
 test('MongoDBChangeStream publishes serialized change events', async () => {
   const { default: MongoDBChangeStream } = await import('./MongoDBChangeStream.js');
   const createdAt = new Date('2026-01-15T00:00:00.000Z');
-  const { abortController, client, publish } = createHarness({
+  const { abortController, collection, publish } = createHarness({
     changes: [
       { operationType: 'insert', fullDocument: { name: 'one', createdAt } },
       { operationType: 'update', fullDocument: { name: 'two' } },
@@ -84,13 +83,13 @@ test('MongoDBChangeStream publishes serialized change events', async () => {
   });
   await run;
   expect(publish).toHaveBeenCalledTimes(0); // aborted before start — resolver returns early
-  expect(client.close).toHaveBeenCalled();
+  expect(collection.watch).not.toHaveBeenCalled();
 });
 
 test('MongoDBChangeStream publishes events until aborted', async () => {
   const { default: MongoDBChangeStream } = await import('./MongoDBChangeStream.js');
   const createdAt = new Date('2026-01-15T00:00:00.000Z');
-  const { abortController, client, collection, publish, stream } = createHarness({
+  const { abortController, collection, publish, stream } = createHarness({
     changes: [
       { operationType: 'insert', fullDocument: { name: 'one', createdAt } },
       { operationType: 'update', fullDocument: { name: 'two' } },
@@ -117,7 +116,6 @@ test('MongoDBChangeStream publishes events until aborted', async () => {
   expect(publish.mock.calls[0][0].data.fullDocument.createdAt).toEqual(createdAt);
   expect(publish.mock.calls[1][0].data.fullDocument.name).toEqual('two');
   expect(stream.close).toHaveBeenCalled();
-  expect(client.close).toHaveBeenCalled();
 });
 
 test('MongoDBChangeStream passes fullDocument option through', async () => {
@@ -137,7 +135,7 @@ test('MongoDBChangeStream passes fullDocument option through', async () => {
 
 test('MongoDBChangeStream rethrows stream errors when not aborted', async () => {
   const { default: MongoDBChangeStream } = await import('./MongoDBChangeStream.js');
-  const { abortController, client, publish } = createHarness({
+  const { abortController, publish, stream } = createHarness({
     changes: [],
     failWith: new Error('stream broke'),
   });
@@ -149,5 +147,5 @@ test('MongoDBChangeStream rethrows stream errors when not aborted', async () => 
       signal: abortController.signal,
     })
   ).rejects.toThrow('stream broke');
-  expect(client.close).toHaveBeenCalled();
+  expect(stream.close).toHaveBeenCalled();
 });

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteMany/MongoDBDeleteMany.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteMany/MongoDBDeleteMany.js
@@ -21,15 +21,8 @@ import schema from './schema.js';
 async function MongodbDeleteMany({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { filter, options } = deserializedRequest;
-  const { collection, client } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.deleteMany(filter, options);
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const response = await collection.deleteMany(filter, options);
   const { acknowledged, deletedCount } = serialize(response);
   return { acknowledged, deletedCount };
 }

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteOne/MongoDBDeleteOne.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteOne/MongoDBDeleteOne.js
@@ -21,15 +21,8 @@ import schema from './schema.js';
 async function MongodbDeleteOne({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { filter, options } = deserializedRequest;
-  const { collection, client } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.deleteOne(filter, options);
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const response = await collection.deleteOne(filter, options);
   return serialize(response);
 }
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBFind/MongoDBFind.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBFind/MongoDBFind.js
@@ -21,16 +21,9 @@ import schema from './schema.js';
 async function MongodbFind({ request, connection }) {
   const deserializedRequest = deserialize(request);
   const { query, options } = deserializedRequest;
-  const { collection, client } = await getCollection({ connection });
-  let res;
-  try {
-    const cursor = await collection.find(query, options);
-    res = await cursor.toArray();
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const cursor = await collection.find(query, options);
+  const res = await cursor.toArray();
   return serialize(res);
 }
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertMany/MongoDBInsertMany.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertMany/MongoDBInsertMany.js
@@ -21,15 +21,8 @@ import schema from './schema.js';
 async function MongodbInsertMany({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { docs, options } = deserializedRequest;
-  const { collection, client } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.insertMany(docs, options);
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const response = await collection.insertMany(docs, options);
   const { acknowledged, insertedCount } = serialize(response);
   return { acknowledged, insertedCount };
 }

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertOne/MongoDBInsertOne.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertOne/MongoDBInsertOne.js
@@ -21,15 +21,8 @@ import schema from './schema.js';
 async function MongodbInsertOne({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { doc, options } = deserializedRequest;
-  const { collection, client } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.insertOne(doc, options);
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const response = await collection.insertOne(doc, options);
   const { acknowledged, insertedId } = serialize(response);
   return { acknowledged, insertedId };
 }

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateMany/MongoDBUpdateMany.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateMany/MongoDBUpdateMany.js
@@ -21,15 +21,8 @@ import schema from './schema.js';
 async function MongodbUpdateMany({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { filter, update, options } = deserializedRequest;
-  const { collection, client } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.updateMany(filter, update, options);
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const response = await collection.updateMany(filter, update, options);
   const { modifiedCount, upsertedId, upsertedCount, matchedCount } = serialize(response);
   return { modifiedCount, upsertedId, upsertedCount, matchedCount };
 }

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/MongoDBUpdateOne.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/MongoDBUpdateOne.js
@@ -21,15 +21,8 @@ import schema from './schema.js';
 async function MongodbUpdateOne({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { filter, update, options } = deserializedRequest;
-  const { collection, client } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.updateOne(filter, update, options);
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
-  await client.close();
+  const collection = await getCollection({ connection });
+  const response = await collection.updateOne(filter, update, options);
   return serialize(response);
 }
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getClient.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getClient.js
@@ -1,0 +1,50 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { MongoClient } from 'mongodb';
+
+// Clients are cached for the lifetime of the process so requests share the driver's
+// connection pool instead of paying a full connect (DNS, TLS, auth) per request.
+const clientPromises = new Map();
+
+function getClient({ databaseUri, options }) {
+  const key = `${databaseUri}:${JSON.stringify(options ?? {})}`;
+  if (!clientPromises.has(key)) {
+    const clientPromise = new MongoClient(databaseUri, options).connect();
+    // Evict failed connects so the next request retries instead of replaying the rejection.
+    clientPromise.catch(() => clientPromises.delete(key));
+    clientPromises.set(key, clientPromise);
+  }
+  return clientPromises.get(key);
+}
+
+async function closeClients() {
+  const promises = [...clientPromises.values()];
+  clientPromises.clear();
+  await Promise.all(
+    promises.map(async (clientPromise) => {
+      try {
+        const client = await clientPromise;
+        await client.close();
+      } catch (error) {
+        // Clients that failed to connect have nothing to close.
+      }
+    })
+  );
+}
+
+export { closeClients };
+export default getClient;

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getClient.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getClient.test.js
@@ -1,0 +1,71 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+import { MongoClient } from 'mongodb';
+
+import getClient, { closeClients } from './getClient.js';
+
+const databaseUri = process.env.MONGO_URL;
+
+afterAll(async () => {
+  await closeClients();
+});
+
+test('getClient returns a connected MongoClient', async () => {
+  const client = await getClient({ databaseUri });
+  expect(client).toBeInstanceOf(MongoClient);
+});
+
+test('getClient returns the same client for the same databaseUri and options', async () => {
+  const promise1 = getClient({ databaseUri, options: { maxPoolSize: 7 } });
+  const promise2 = getClient({ databaseUri, options: { maxPoolSize: 7 } });
+  expect(promise1).toBe(promise2);
+  const client1 = await promise1;
+  const client2 = await promise2;
+  expect(client1).toBe(client2);
+});
+
+test('getClient shares one client across concurrent calls before the first connect resolves', async () => {
+  const [client1, client2] = await Promise.all([
+    getClient({ databaseUri, options: { appName: 'concurrent' } }),
+    getClient({ databaseUri, options: { appName: 'concurrent' } }),
+  ]);
+  expect(client1).toBe(client2);
+});
+
+test('getClient returns different clients for different options', async () => {
+  const client1 = await getClient({ databaseUri, options: { maxPoolSize: 3 } });
+  const client2 = await getClient({ databaseUri, options: { maxPoolSize: 4 } });
+  expect(client1).not.toBe(client2);
+});
+
+test('getClient evicts failed connects so the next call retries', async () => {
+  const unreachable = {
+    databaseUri: 'mongodb://localhost:1',
+    options: { serverSelectionTimeoutMS: 100 },
+  };
+  const promise1 = getClient(unreachable);
+  await expect(promise1).rejects.toThrow();
+  const promise2 = getClient(unreachable);
+  expect(promise2).not.toBe(promise1);
+  await expect(promise2).rejects.toThrow();
+});
+
+test('getClient creates a new client after closeClients', async () => {
+  const client1 = await getClient({ databaseUri, options: { appName: 'close' } });
+  await closeClients();
+  const client2 = await getClient({ databaseUri, options: { appName: 'close' } });
+  expect(client2).not.toBe(client1);
+});

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getCollection.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getCollection.js
@@ -14,32 +14,23 @@
   limitations under the License.
 */
 
-import { MongoClient } from 'mongodb';
 import { type } from '@lowdefy/helpers';
+
+import getClient from './getClient.js';
 
 async function getCollection({ connection }) {
   const { collection, databaseName, databaseUri, options } = connection;
   if (!type.isString(databaseUri)) {
     throw new Error('Database URI must be a string');
   }
-  const client = new MongoClient(databaseUri, options);
-  await client.connect();
-  try {
-    if (!type.isString(databaseName) && !type.isNone(databaseName)) {
-      throw new Error('Database name must be a string');
-    }
-    const db = client.db(databaseName);
-    if (!type.isString(collection)) {
-      throw new Error('Collection name must be a string');
-    }
-    return {
-      client,
-      collection: db.collection(collection),
-    };
-  } catch (error) {
-    await client.close();
-    throw error;
+  if (!type.isString(databaseName) && !type.isNone(databaseName)) {
+    throw new Error('Database name must be a string');
   }
+  if (!type.isString(collection)) {
+    throw new Error('Collection name must be a string');
+  }
+  const client = await getClient({ databaseUri, options });
+  return client.db(databaseName).collection(collection);
 }
 
 export default getCollection;

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getCollection.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getCollection.test.js
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-import { MongoClient, Collection } from 'mongodb';
+import { Collection } from 'mongodb';
 
 import getCollection from './getCollection.js';
 
@@ -26,9 +26,7 @@ test('get collection', async () => {
     collection: 'getCollection',
   };
   const res = await getCollection({ connection });
-  expect(res.client).toBeInstanceOf(MongoClient);
-  expect(res.collection).toBeInstanceOf(Collection);
-  await res.client.close();
+  expect(res).toBeInstanceOf(Collection);
 });
 
 test('get collection, no databaseName, uses databaseUri', async () => {
@@ -37,12 +35,10 @@ test('get collection, no databaseName, uses databaseUri', async () => {
     collection: 'getCollection',
   };
   const res = await getCollection({ connection });
-  expect(res.client).toBeInstanceOf(MongoClient);
-  expect(res.collection).toBeInstanceOf(Collection);
-  await res.client.close();
+  expect(res).toBeInstanceOf(Collection);
 });
 
-test('invalid databaseUri', async () => {
+test('invalid databaseUri scheme', async () => {
   const connection = {
     databaseUri: 'databaseUri',
     databaseName: 'test',

--- a/packages/plugins/connections/connection-mongodb/test/closeClientsAfterAll.js
+++ b/packages/plugins/connections/connection-mongodb/test/closeClientsAfterAll.js
@@ -14,22 +14,10 @@
   limitations under the License.
 */
 
-import getCollection from '../getCollection.js';
-import { serialize, deserialize } from '../serialize.js';
-import schema from './schema.js';
+import { closeClients } from '../src/connections/MongoDBCollection/getClient.js';
 
-async function MongodbFindOne({ request, connection }) {
-  const deserializedRequest = deserialize(request);
-  const { query, options } = deserializedRequest;
-  const collection = await getCollection({ connection });
-  const res = await collection.findOne(query, options);
-  return serialize(res);
-}
-
-MongodbFindOne.schema = schema;
-MongodbFindOne.meta = {
-  checkRead: true,
-  checkWrite: false,
-};
-
-export default MongodbFindOne;
+// Cached clients are kept open for the process lifetime, so close them after each
+// test file to let Jest workers exit cleanly.
+afterAll(async () => {
+  await closeClients();
+});


### PR DESCRIPTION
## Summary

Port of #2261 to `vite-hono`: `MongoDBCollection` requests share one cached MongoDB client per unique `databaseUri` + `options` combination instead of creating, connecting, and closing a fresh client per request. Measured on an 8-request routine against Atlas: **4.3s → 0.2s, a ~95% reduction (~21× faster)**.

This branch carries the exact same commits as #2261 (merged in, so the eventual vite-hono ↔ develop merge resolves cleanly) plus one vite-hono-specific commit adapting `MongoDBChangeStream` to the new contract.

## Changes

- **@lowdefy/connection-mongodb**: Same as #2261 — `getClient.js` client cache (connect-promise caching, failure eviction, `closeClients()` for teardown), `getCollection` returns the `Collection` directly, all request methods drop per-request `client.close()` boilerplate.
- **MongoDBChangeStream (vite-hono only)**: Adapted to the shared client. It previously did `await client.close()` in a `finally` when the stream ended — against the shared cached client that would have killed the connection pool for every other request on that connection. It now closes only the change stream, with a `finally` `stream.close()` replacing the old client teardown as the safety net for non-abort exits.
- **@lowdefy/docs**: Connection pooling section on the MongoDB connection page (`maxPoolSize`, `minPoolSize`, `maxIdleTimeMS` via connection `options`).

## Notes

- The `jest-mongodb-config.js` Node 22+ fix in #2261 conflicted trivially with vite-hono's existing identical fix; resolved keeping vite-hono's version.
- All 179 tests pass locally against this branch's mongodb 7.2.0 driver (`pnpm --filter=@lowdefy/connection-mongodb test` — this package is excluded from the root CI test script).
- Behavior change to be aware of: server processes now hold a persistent connection pool instead of dropping to zero connections between requests. Pool behavior is tunable per connection via standard driver options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)