### PR TITLE
Port MongoDB community plugin features into connection-mongodb

### DIFF
--- a/.changeset/feat-mongodb-community-plugin-port.md
+++ b/.changeset/feat-mongodb-community-plugin-port.md
@@ -1,0 +1,27 @@
+---
+'@lowdefy/connection-mongodb': minor
+'@lowdefy/codemods': minor
+---
+
+feat: Port MongoDB community plugin features into @lowdefy/connection-mongodb.
+
+All features of `@lowdefy/community-plugin-mongodb` are now part of the core MongoDB connection, so apps can drop the community plugin.
+
+**Change log auditing**
+
+- New `changeLog` connection property (`collection`, `meta`). All write requests log a change record — request arguments, request context, timestamp, and either the driver response or before/after document snapshots (`MongoDBUpdateOne`, `MongoDBVersionedUpdateOne`, `MongoDBDeleteOne`) — to the log collection. Response shapes are the same with or without a log collection.
+
+**MongoDBUpdateOne no-match error (behavior change)**
+
+- `MongoDBUpdateOne` now throws `No matching record to update.` when no document matches the filter and `upsert` is not set. Set `disableNoMatchError: true` on the request to keep the previous silent behavior. Running `lowdefy upgrade` applies a codemod that adds the flag to existing requests, so upgraded apps behave exactly as before. Apps already using the community plugin are unaffected.
+
+**New requests**
+
+- `MongoDBVersionedUpdateOne`: updates a document while preserving the previous version as a copy under a new `_id`.
+- `MongoDBInsertConsecutiveId` and `MongoDBInsertManyConsecutiveIds`: insert documents with sequential human-readable ids (for example `INV0001`), assigned inside a transaction (requires a replica set). Also fixes a community plugin bug where the id lookup ran outside the transaction.
+
+**New auth adapter**
+
+- `MultiAppMongoDBAdapter`: next-auth adapter for multiple apps sharing one `user-contacts` collection, with per-app membership, roles, and an invite-required sign up flow.
+
+`MongoDBInsertMany` now also returns `insertedIds`, matching the community plugin response.

--- a/packages/codemods/registry.json
+++ b/packages/codemods/registry.json
@@ -1,6 +1,18 @@
 {
   "versions": [
     {
+      "version": "5.5.0",
+      "from": ">=5.1.0 <5.5.0",
+      "description": "MongoDBUpdateOne throws a no-match error by default; opt out per request with disableNoMatchError",
+      "codemods": [
+        {
+          "id": "add-disable-no-match-error",
+          "description": "Add disableNoMatchError: true to existing MongoDBUpdateOne requests to preserve pre-5.5.0 behavior, with a per-request report for author review. No-op for apps using @lowdefy/community-plugin-mongodb.",
+          "path": "v5-5-0/01-add-disable-no-match-error.md"
+        }
+      ]
+    },
+    {
       "version": "5.1.0",
       "from": ">=5.0.0 <5.1.0",
       "description": "AgGrid built-in cell renderer types (tag, avatar, link, date, boolean, progress, number) + ellipsis + align",

--- a/packages/codemods/v5-5-0/01-add-disable-no-match-error.md
+++ b/packages/codemods/v5-5-0/01-add-disable-no-match-error.md
@@ -1,0 +1,128 @@
+# Migration: Preserve `MongoDBUpdateOne` no-match behavior with `disableNoMatchError`
+
+## Context
+
+From Lowdefy v5.5.0, the `MongoDBUpdateOne` and `MongoDBVersionedUpdateOne` requests throw `No matching record to update.` when the filter matches no document (and `upsert` is not set). Before v5.5.0, `MongoDBUpdateOne` silently returned `matchedCount: 0`. The new default fails loudly because a no-match update usually indicates a bug — a wrong filter or a missing document.
+
+Requests can opt out of the error with the request property `disableNoMatchError: true`.
+
+Apps already using `@lowdefy/community-plugin-mongodb` have always had this throwing behavior and need **no changes** — for those apps this codemod is a no-op.
+
+## What to Do
+
+### Step 1: Check whether the app uses the community plugin
+
+```bash
+grep -rn 'community-plugin-mongodb' lowdefy.yaml lowdefy.yml package.json 2>/dev/null
+grep -rn 'community-plugin-mongodb' --include='*.yaml' --include='*.yml' . | grep -i 'plugin'
+```
+
+If the app lists `@lowdefy/community-plugin-mongodb` as a plugin, **stop — no changes needed**. The app already has the throwing behavior and the same `disableNoMatchError` flag.
+
+### Step 2: Find all MongoDBUpdateOne requests
+
+```bash
+grep -rn 'type:\s*MongoDBUpdateOne' --include='*.yaml' --include='*.yml' --include='*.njk' .
+```
+
+### Step 3: Add `disableNoMatchError: true` to each request
+
+For every request found, add `disableNoMatchError: true` to the request `properties`, so the app behaves exactly as before the upgrade. Skip requests that:
+
+- already set `disableNoMatchError` (either value), or
+- set `upsert: true` in `options` (upserts never throw the no-match error).
+
+### Step 4: Report
+
+Produce a report with one entry per modified request:
+
+- File path + line number of the request definition.
+- The request `id`.
+- Whether the flag was added, or why it was skipped (`upsert`, already set).
+
+Share the report with the app author. For each request, the author should decide whether to **remove** the flag and adopt the new fail-loudly default — for most update requests the throw is the better behavior, since a silent no-op update hides bugs. The flag should only stay on requests where "update if exists" is the intended logic.
+
+### Step 5: Verify
+
+```bash
+grep -rn -A 10 'type:\s*MongoDBUpdateOne' --include='*.yaml' --include='*.yml' --include='*.njk' . | grep -c 'disableNoMatchError\|upsert'
+```
+
+Every `MongoDBUpdateOne` request should now either set `disableNoMatchError`, set `upsert: true`, or have been deliberately left to throw by the author.
+
+## Scope
+
+`app` — all YAML config files including Nunjucks templates (`.yaml.njk`), shared components, module files, and API endpoint definitions. Also check directories referenced by `_ref` paths outside the main app directory (e.g., `modules/`, `shared/`). Requests can be defined on pages and in `api:` endpoints — both count.
+
+## Files to Check
+
+Glob: `**/*.{yaml,yml,njk}`
+Grep: `type:\s*MongoDBUpdateOne`
+
+**Do not forget `.yaml.njk` files** — Nunjucks templates contain the same request structures.
+
+## Examples
+
+### Before
+
+```yaml
+requests:
+  - id: update_status
+    type: MongoDBUpdateOne
+    connectionId: orders
+    properties:
+      filter:
+        _id:
+          _state: order_id
+      update:
+        $set:
+          status: shipped
+```
+
+### After
+
+```yaml
+requests:
+  - id: update_status
+    type: MongoDBUpdateOne
+    connectionId: orders
+    properties:
+      disableNoMatchError: true
+      filter:
+        _id:
+          _state: order_id
+      update:
+        $set:
+          status: shipped
+```
+
+### Skipped — upsert request (never throws)
+
+```yaml
+requests:
+  - id: upsert_setting
+    type: MongoDBUpdateOne
+    connectionId: settings
+    properties:
+      filter:
+        key: theme
+      update:
+        $set:
+          value: dark
+      options:
+        upsert: true
+```
+
+## Edge Cases
+
+- Requests whose `properties` are built with operators (e.g., a `_ref` to a shared request file): follow the `_ref` and add the flag in the referenced file. If the referenced file is shared by multiple requests, adding the flag there changes all of them — list this in the report for author review instead of editing blindly.
+- Requests with `options` set via an operator (e.g., `options: { _if: ... }`) where `upsert` cannot be determined statically: add the flag and note it in the report.
+- `MongoDBVersionedUpdateOne` is new in v5.5.0, so no existing configs reference it — only `MongoDBUpdateOne` needs migration.
+
+## Verification
+
+```bash
+grep -rn 'type:\s*MongoDBUpdateOne' --include='*.yaml' --include='*.yml' --include='*.njk' .
+```
+
+Cross-check the report against this list — every request is either modified, skipped for `upsert`, or explicitly signed off by the author to adopt the throwing default.

--- a/packages/docs/connections/MongoDB.yaml
+++ b/packages/docs/connections/MongoDB.yaml
@@ -58,12 +58,15 @@ _ref:
 
             >Since the connection URI contains authentication secrets, it should be stored using the [`_secret`](operators/secret.md) operator.
 
-            When using MongoDBUpdateOne and MongoDBDeleteOne requests, take note that the responses differ if the connection has a log collection.
+            When the connection has a `changeLog` collection, all write requests log a change record to that collection. The record contains the request arguments, the request context (`blockId`, `pageId`, `requestId`, `connectionId`, `payload`), a `timestamp`, the request `type`, the connection's `changeLog.meta` value, and either the driver response or `before`/`after` document snapshots (for `MongoDBUpdateOne`, `MongoDBVersionedUpdateOne` and `MongoDBDeleteOne`). The response shape of every request stays the same whether or not a log collection is configured.
 
             #### Properties
             - `databaseUri: string`: __Required__ - Connection uri string for the MongoDb deployment. Should be stored using the [_secret](operators/secret.md) operator.
             - `databaseName: string`: Default: Database specified in connection string - The name of the database in the MongoDB deployment.
             - `collection: string`: __Required__ - The name of the MongoDB collection.
+            - `changeLog: object`: Log all changes made by write requests to a log collection.
+              - `collection: string`: __Required__ - The name of the collection change log records are written to.
+              - `meta: object`: Additional data to include in every change log record, for example the user making the change.
             - `read: boolean`: Default: `true` - Allow read operations like find on the collection.
             - `write: boolean`: Default: `false` - Allow write operations like update on the collection.
             - `options: object`: See the [driver documentation](https://mongodb.github.io/node-mongodb-native/4.0/interfaces/mongoclientoptions.html) for more information.
@@ -129,10 +132,13 @@ _ref:
               - MongoDBDeleteOne
               - MongoDBFind
               - MongoDBFindOne
+              - MongoDBInsertConsecutiveId
               - MongoDBInsertMany
+              - MongoDBInsertManyConsecutiveIds
               - MongoDBInsertOne
               - MongoDBUpdateMany
               - MongoDBUpdateOne
+              - MongoDBVersionedUpdateOne
 
 
             ### MongoDBAggregation
@@ -315,7 +321,7 @@ _ref:
             ### MongoDBDeleteOne
 
             The `MongoDBDeleteOne` request deletes a single document in the collection specified in the connectionId. It requires a filter, which is written in the query syntax, to select a document to delete. It will delete the first document that matches the filter.
-            > MongoDBDeleteOne response differs when the connection has a log collection. When a log collection is set on the connection, a findOneAndDelete operation is performed compared to the standard deleteOne operation.
+            > When the connection has a log collection, a findOneAndDelete operation is performed instead of the standard deleteOne operation so the deleted document can be captured in the change log. The response shape is the same in both cases.
 
             #### Properties
             - `filter: object`: __Required__ - The filter used to select the document to update.
@@ -489,6 +495,34 @@ _ref:
                       _payload: _id
             ```
 
+            ### MongoDBInsertConsecutiveId
+
+            The `MongoDBInsertConsecutiveId` request inserts a single document into the collection specified in the connectionId, assigning a sequential, human-readable `_id` like `INV0001`. The id is built from a prefix and the next consecutive number for that prefix, zero-padded to `length` digits. The id read and the insert run inside a transaction so concurrent requests cannot claim the same id.
+
+            > Transactions require MongoDB to run as a replica set. Standalone deployments are not supported by this request.
+
+            #### Properties
+            - `doc: object`: __Required__ - The document to be inserted. The `_id` is assigned by the request.
+            - `prefix: string`: __Required__ - Prefix to add to the id, for example `INV`.
+            - `length: number`: The numeric part of the id is zero-padded to this number of digits. If omitted, the number is not padded.
+            - `options: object`: Optional settings passed to the insert. See the [driver documentation](https://mongodb.github.io/node-mongodb-native/4.0/classes/collection.html#insertone) for more information.
+
+            #### Examples
+
+            ###### Insert an invoice with a sequential id (INV0001, INV0002, ...):
+            ```yaml
+            requests:
+              - id: insert_invoice
+                type: MongoDBInsertConsecutiveId
+                connectionId: my_mongodb_collection_id
+                properties:
+                  prefix: INV
+                  length: 4
+                  doc:
+                    amount:
+                      _state: amount
+            ```
+
             ### MongoDBInsertMany
 
             The `MongoDBInsertMany` request inserts an array of documents into the collection specified in the connectionId. If a `_id` field is not specified on a document, a MongoDB `ObjectID` will be generated.
@@ -534,6 +568,33 @@ _ref:
                     - _id: 3
                       value: 7
 
+            ```
+
+            ### MongoDBInsertManyConsecutiveIds
+
+            The `MongoDBInsertManyConsecutiveIds` request inserts an array of documents into the collection specified in the connectionId, assigning each document a sequential, human-readable `_id` like `INV0001`. Ids continue from the highest existing id for the prefix. The id read and the insert run inside a transaction so concurrent requests cannot claim the same ids.
+
+            > Transactions require MongoDB to run as a replica set. Standalone deployments are not supported by this request.
+
+            #### Properties
+            - `docs: object[]`: __Required__ - The documents to be inserted. The `_id` values are assigned by the request.
+            - `prefix: string`: __Required__ - Prefix to add to the ids, for example `INV`.
+            - `length: number`: The numeric part of each id is zero-padded to this number of digits. If omitted, the numbers are not padded.
+            - `options: object`: Optional settings passed to the insert. See the [driver documentation](https://mongodb.github.io/node-mongodb-native/4.0/classes/collection.html#insertmany) for more information.
+
+            #### Examples
+
+            ###### Insert order lines with sequential ids:
+            ```yaml
+            requests:
+              - id: insert_order_lines
+                type: MongoDBInsertManyConsecutiveIds
+                connectionId: my_mongodb_collection_id
+                properties:
+                  prefix: LINE
+                  length: 6
+                  docs:
+                    _state: order_lines
             ```
 
             ### MongoDBInsertOne
@@ -643,11 +704,15 @@ _ref:
             ### MongoDBUpdateOne
 
             The `MongoDBUpdateOne` request updates a single document in the collection specified in the connectionId. It requires a filter, which is written in the query syntax, to select a document to update. It will update the first document that matches the filter. If the `upsert` option is set to true, it will insert a new document if no document is found to update.
-            > MongoDBUpdateOne response differs when the connection has a log collection. When a log collection is set on the connection, a findOneAndUpdate operation is performed compared to the standard updateOne operation.
+
+            If no document matches the filter, the request throws `No matching record to update.` — a silent no-op update usually indicates a bug. Set `disableNoMatchError: true` on the request to restore the pre-5.5.0 behavior of returning `matchedCount: 0`. Requests with the `upsert` option never throw this error. Running `lowdefy upgrade` adds `disableNoMatchError: true` to existing requests so upgraded apps keep their behavior.
+
+            > When the connection has a log collection, a findOneAndUpdate operation is performed instead of the standard updateOne operation so before and after document snapshots can be captured in the change log. The response shape is the same in both cases.
 
             #### Properties
             - `filter: object`: __Required__ - The filter used to select the document to update.
             - `update: object | object[]`: __Required__ - The update operations to be applied to the document.
+            - `disableNoMatchError: boolean`: Default: `false` - Do not throw an error when no document matches the filter.
             - `options: object`: Optional settings. See the [driver documentation](https://mongodb.github.io/node-mongodb-native/4.0/classes/collection.html#updateone) for more information. Supported settings are:
               - `arrayFilters: object[]`: _Array_ - Array filters for the [`$[<identifier>]`](https://docs.mongodb.com/manual/reference/operator/update/positional-filtered/) array update operator.
               - `authdb: string`: Specifies the authentication information to be used.
@@ -714,4 +779,45 @@ _ref:
                     $set:
                       last_liked:
                         _date: now
+            ```
+
+            ### MongoDBVersionedUpdateOne
+
+            The `MongoDBVersionedUpdateOne` request updates a single document while preserving the previous version. The matched document is re-inserted under a new `_id`, and the update is applied to the new copy — so the collection keeps a full version history of the document.
+
+            If no document matches the filter, the request throws `No matching record to update.`. Set `disableNoMatchError: true` on the request to suppress the error. Requests with the `upsert` update option never throw this error.
+
+            > The version insert and the update are separate operations, not a transaction. If the update fails, the inserted version copy remains in the collection.
+
+            > When the connection has a log collection, a findOneAndUpdate operation is performed instead of the standard updateOne operation so before and after document snapshots can be captured in the change log. The response shape is the same in both cases.
+
+            #### Properties
+            - `filter: object`: __Required__ - The filter used to select the document to version and update.
+            - `update: object | object[]`: __Required__ - The update operations to be applied to the new copy of the document.
+            - `disableNoMatchError: boolean`: Default: `false` - Do not throw an error when no document matches the filter.
+            - `options: object`: Optional settings for each underlying operation:
+              - `find: object`: Options for the find one operation. See the [driver documentation](https://mongodb.github.io/node-mongodb-native/4.0/classes/collection.html#findone).
+              - `insert: object`: Options for the insert one operation that creates the version copy. See the [driver documentation](https://mongodb.github.io/node-mongodb-native/4.0/classes/collection.html#insertone).
+              - `update: object`: Options for the update operation. See the [driver documentation](https://mongodb.github.io/node-mongodb-native/4.0/classes/collection.html#updateone).
+
+            #### Examples
+
+            ###### Update a document, keeping the previous version:
+            ```yaml
+            requests:
+              - id: versioned_update
+                type: MongoDBVersionedUpdateOne
+                connectionId: my_mongodb_collection_id
+                payload:
+                  doc_id:
+                    _state: doc_id
+                properties:
+                  filter:
+                    doc_id:
+                      _payload: doc_id
+                    current: true
+                  update:
+                    $set:
+                      status:
+                        _state: status
             ```

--- a/packages/docs/menus.yaml
+++ b/packages/docs/menus.yaml
@@ -347,6 +347,9 @@
             - id: MongoDBAdapter
               type: MenuLink
               pageId: MongoDBAdapter
+            - id: MultiAppMongoDBAdapter
+              type: MenuLink
+              pageId: MultiAppMongoDBAdapter
         - id: auth_callback_reference
           type: MenuGroup
           properties:

--- a/packages/docs/pages.yaml
+++ b/packages/docs/pages.yaml
@@ -63,6 +63,7 @@
 - _ref: users/reference/next-auth-providers.yaml
 - _ref: users/reference/OpenIDConnectProvider.yaml
 - _ref: users/reference/MongoDBAdapter.yaml
+- _ref: users/reference/MultiAppMongoDBAdapter.yaml
 - _ref: users/reference/Auth0LogoutCallback.yaml
 
 - _ref: testing/e2e-introduction.yaml

--- a/packages/docs/users/reference/MultiAppMongoDBAdapter.yaml
+++ b/packages/docs/users/reference/MultiAppMongoDBAdapter.yaml
@@ -1,0 +1,91 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_ref:
+  path: templates/general.yaml.njk
+  vars:
+    pageId: MultiAppMongoDBAdapter
+    pageTitle: MultiAppMongoDBAdapter
+    section: User Authentication
+    filePath: users/reference/MultiAppMongoDBAdapter.yaml
+    content:
+      - id: content
+        type: MarkdownWithCode
+        properties:
+          content:
+            _nunjucks:
+              on:
+                version:
+                  _ref: version.yaml
+              template: |
+                The MultiAppMongoDBAdapter connects Next-Auth to a MongoDB database where multiple apps share a single collection of people. Each person is stored as a contact document with a sub-document per app, so one person can be a user of some apps and not others, with roles and attributes per app.
+
+                Contacts are looked up by lowercase email. When a person signs in for the first time, a contact is created (or the existing contact is updated) with an app membership sub-document for the current app. A contact only counts as a user of an app if the app sub-document has `is_user: true` and neither the contact nor the app membership is disabled.
+
+                When `invite.required` is `true`, sign up is refused with an `Access denied.` error unless the contact has an open invite for the app (`apps.<appName>.invite.open: true`). Signing up consumes the invite.
+
+                The default collection names are `user-contacts`, `user-accounts`, `user-sessions` and `user-verification-tokens`.
+
+                #### Properties
+
+                ###### object
+                  - `appName: string`: Required - The key of this app in the contact's `apps` sub-document.
+                  - `databaseUri: string`: Required - Connection uri string for the MongoDb deployment. Should be stored using the _secret operator.
+                  - `mongoDBClientOptions: object`: See the [driver documentation](https://mongodb.github.io/node-mongodb-native/4.0/interfaces/mongoclientoptions.html) for more information.
+                  - `collections: object`: Set names of MongoDB collections used.
+                    - `accounts: string`: Default: `user-accounts`.
+                    - `contacts: string`: Default: `user-contacts`.
+                    - `sessions: string`: Default: `user-sessions`.
+                    - `verificationTokens: string`: Default: `user-verification-tokens`.
+                  - `invite: object`:
+                    - `required: boolean`: Default: `false` - Only allow sign up for contacts with an open invite for this app.
+                  - `verificationTokens: object`:
+                    - `uses: number`: Default: `1` - The number of times a verification token can be used.
+
+                #### Examples
+
+                ###### Minimum configuration.
+
+                ```yaml
+                lowdefy: {{ version }}
+                auth:
+                  adapter:
+                    id: multi_app_adapter
+                    type: MultiAppMongoDBAdapter
+                    properties:
+                      appName: my-app
+                      databaseUri:
+                        _secret: MONGODB_URI
+                ```
+
+                ###### Invite-only sign up with custom collections.
+
+                ```yaml
+                lowdefy: {{ version }}
+                auth:
+                  adapter:
+                    id: multi_app_adapter
+                    type: MultiAppMongoDBAdapter
+                    properties:
+                      appName: my-app
+                      databaseUri:
+                        _secret: MONGODB_URI
+                      invite:
+                        required: true
+                      collections:
+                        contacts: people
+                        accounts: people-accounts
+                        sessions: people-sessions
+                        verificationTokens: people-verification-tokens
+                ```

--- a/packages/plugins/connections/connection-mongodb/jest-mongodb-config.js
+++ b/packages/plugins/connections/connection-mongodb/jest-mongodb-config.js
@@ -1,8 +1,17 @@
 // @shelf/jest-mongodb loads this file with require(), which on Node >=22 returns the
 // module namespace for ESM files, so options must be a named export (not default).
+// A single-node replica set is used instead of a standalone server because the
+// consecutive id requests use transactions, which require a replica set. The
+// instance block is still required — the preset reads instance.dbName even in
+// replica set mode.
 export const mongodbMemoryServerOptions = {
   instance: {
     dbName: 'test',
+  },
+  replSet: {
+    count: 1,
+    dbName: 'test',
+    storageEngine: 'wiredTiger',
   },
   autoStart: false,
 };

--- a/packages/plugins/connections/connection-mongodb/package.json
+++ b/packages/plugins/connections/connection-mongodb/package.json
@@ -49,7 +49,8 @@
     "@lowdefy/helpers": "5.4.0",
     "@next-auth/mongodb-adapter": "1.1.3",
     "mongodb": "6.3.0",
-    "saslprep": "1.0.3"
+    "saslprep": "1.0.3",
+    "uuid": "13.0.0"
   },
   "devDependencies": {
     "@lowdefy/ajv": "5.4.0",

--- a/packages/plugins/connections/connection-mongodb/src/auth/adapters.js
+++ b/packages/plugins/connections/connection-mongodb/src/auth/adapters.js
@@ -1,3 +1,4 @@
 import MongoDBAdapter from './adapters/MongoDBAdapter/MongoDBAdapter.js';
+import MultiAppMongoDBAdapter from './adapters/MultiAppMongoDBAdapter/MultiAppMongoDBAdapter.js';
 
-export { MongoDBAdapter };
+export { MongoDBAdapter, MultiAppMongoDBAdapter };

--- a/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/MultiAppMongoDBAdapter.js
+++ b/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/MultiAppMongoDBAdapter.js
@@ -1,0 +1,167 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { MongoClient } from 'mongodb';
+
+import createDatabaseUser from './createDatabaseUser.js';
+import getUserFromDbByEmail from './getUserFromDbByEmail.js';
+import getUserFromDbById from './getUserFromDbById.js';
+import updateDatabaseUser from './updateDatabaseUser.js';
+
+function from({ _id, ...data }) {
+  return { id: _id, ...data };
+}
+
+function to({ id, ...data }) {
+  return { _id: id, ...data };
+}
+
+function MultiAppMongoDBAdapter({ properties }) {
+  const { appName, collections, databaseUri, mongoDBClientOptions } = properties;
+  const mongoClient = new MongoClient(databaseUri, mongoDBClientOptions);
+  const collectionNames = {
+    accounts: collections?.accounts ?? 'user-accounts',
+    contacts: collections?.contacts ?? 'user-contacts',
+    sessions: collections?.sessions ?? 'user-sessions',
+    verificationTokens: collections?.verificationTokens ?? 'user-verification-tokens',
+  };
+
+  return {
+    async createUser(adapterUserData) {
+      return createDatabaseUser({
+        adapterUserData,
+        appName,
+        collectionNames,
+        inviteRequired: properties.invite?.required,
+        mongoClient,
+      });
+    },
+
+    async getUser(userId) {
+      return getUserFromDbById({ appName, collectionNames, mongoClient, userId });
+    },
+
+    async getUserByEmail(email) {
+      return getUserFromDbByEmail({ appName, collectionNames, mongoClient, email });
+    },
+
+    async getUserByAccount(provider_providerAccountId) {
+      const account = await mongoClient
+        .db()
+        .collection(collectionNames.accounts)
+        .findOne(provider_providerAccountId);
+      if (!account) return null;
+
+      return getUserFromDbById({ appName, collectionNames, mongoClient, userId: account.userId });
+    },
+
+    async updateUser(adapterUserData) {
+      await updateDatabaseUser({ adapterUserData, collectionNames, mongoClient });
+      return adapterUserData;
+    },
+
+    // This is not yet implemented by Auth.js
+    // and we want to set a disabled flag, not delete users
+    // async deleteUser(userId) {
+    //   await Promise.all([
+    //     db.accounts.deleteMany({ userId }),
+    //     db.sessions.deleteMany({ userId }),
+    //     deleteDatabaseUser({ userId }),
+    //   ]);
+    // },
+
+    async linkAccount(account) {
+      await mongoClient.db().collection(collectionNames.accounts).insertOne(to(account));
+      return from(account);
+    },
+
+    async unlinkAccount(provider_providerAccountId) {
+      const account = await mongoClient
+        .db()
+        .collection(collectionNames.accounts)
+        .findOneAndDelete(provider_providerAccountId);
+      return from(account);
+    },
+
+    async getSessionAndUser(sessionToken) {
+      // eslint-disable-next-line no-unused-vars
+      const session = await mongoClient
+        .db()
+        .collection(collectionNames.sessions)
+        .findOne({ sessionToken });
+      if (!session) return null;
+
+      const user = await getUserFromDbById({
+        appName,
+        collectionNames,
+        mongoClient,
+        userId: session.userId,
+      });
+
+      return {
+        user,
+        session: from(session),
+      };
+    },
+
+    async createSession(session) {
+      await mongoClient.db().collection(collectionNames.sessions).insertOne(to(session));
+      return session;
+    },
+
+    async updateSession(data) {
+      // eslint-disable-next-line no-unused-vars
+      const { _id, ...session } = to(data);
+
+      const result = await mongoClient
+        .db()
+        .collection(collectionNames.sessions)
+        .findOneAndUpdate(
+          { sessionToken: session.sessionToken },
+          { $set: session },
+          { returnDocument: 'after' }
+        );
+      return from(result);
+    },
+
+    async deleteSession(sessionToken) {
+      const session = await mongoClient.db().collection(collectionNames.sessions).findOneAndDelete({
+        sessionToken,
+      });
+      return from(session);
+    },
+
+    async createVerificationToken(data) {
+      const tokens = Array.from({ length: properties?.verificationTokens?.uses ?? 1 }, () =>
+        to(data)
+      );
+      await mongoClient.db().collection(collectionNames.verificationTokens).insertMany(tokens);
+      return data;
+    },
+
+    async useVerificationToken(identifier_token) {
+      const verificationToken = await mongoClient
+        .db()
+        .collection(collectionNames.verificationTokens)
+        .findOneAndDelete(identifier_token);
+
+      if (!verificationToken) return null;
+      return from(verificationToken);
+    },
+  };
+}
+
+export default MultiAppMongoDBAdapter;

--- a/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/MultiAppMongoDBAdapter.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/MultiAppMongoDBAdapter.test.js
@@ -1,0 +1,294 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { MongoClient } from 'mongodb';
+
+import MultiAppMongoDBAdapter from './MultiAppMongoDBAdapter.js';
+import createDatabaseUser from './createDatabaseUser.js';
+import getUserFromDbByEmail from './getUserFromDbByEmail.js';
+import getUserFromDbById from './getUserFromDbById.js';
+import transformContactToAdapterUser from './transformContactToAdapterUser.js';
+
+const appName = 'test-app';
+const collectionNames = {
+  accounts: 'user-accounts',
+  contacts: 'user-contacts',
+  sessions: 'user-sessions',
+  verificationTokens: 'user-verification-tokens',
+};
+
+let mongoClient;
+
+beforeAll(async () => {
+  mongoClient = new MongoClient(process.env.MONGO_URL);
+  await mongoClient.connect();
+});
+
+beforeEach(async () => {
+  await mongoClient.db().collection(collectionNames.contacts).deleteMany({});
+});
+
+afterAll(async () => {
+  await mongoClient.close();
+});
+
+test('adapter factory returns the next-auth adapter methods', () => {
+  const adapter = MultiAppMongoDBAdapter({
+    properties: { appName, databaseUri: process.env.MONGO_URL },
+  });
+  expect(Object.keys(adapter).sort()).toEqual([
+    'createSession',
+    'createUser',
+    'createVerificationToken',
+    'deleteSession',
+    'getSessionAndUser',
+    'getUser',
+    'getUserByAccount',
+    'getUserByEmail',
+    'linkAccount',
+    'unlinkAccount',
+    'updateSession',
+    'updateUser',
+    'useVerificationToken',
+  ]);
+});
+
+test('createDatabaseUser creates a new contact when none exists', async () => {
+  const user = await createDatabaseUser({
+    adapterUserData: { email: 'New.User@Example.com', emailVerified: null, image: null },
+    appName,
+    collectionNames,
+    inviteRequired: false,
+    mongoClient,
+  });
+  expect(user).toEqual({
+    id: expect.any(String),
+    app_attributes: {},
+    email: 'New.User@Example.com',
+    emailVerified: null,
+    image: null,
+    profile: {},
+    roles: [],
+    global_attributes: {},
+  });
+  const contact = await mongoClient
+    .db()
+    .collection(collectionNames.contacts)
+    .findOne({ lowercase_email: 'new.user@example.com' });
+  expect(contact).toMatchObject({
+    email: 'New.User@Example.com',
+    lowercase_email: 'new.user@example.com',
+    disabled: false,
+    apps: {
+      [appName]: {
+        app_attributes: {},
+        disabled: false,
+        is_user: true,
+        roles: [],
+      },
+    },
+  });
+});
+
+test('createDatabaseUser throws Access denied when invite required and no contact exists', async () => {
+  await expect(
+    createDatabaseUser({
+      adapterUserData: { email: 'uninvited@example.com', emailVerified: null },
+      appName,
+      collectionNames,
+      inviteRequired: true,
+      mongoClient,
+    })
+  ).rejects.toThrow('Access denied.');
+});
+
+test('createDatabaseUser consumes an open invite when invite required', async () => {
+  await mongoClient
+    .db()
+    .collection(collectionNames.contacts)
+    .insertOne({
+      _id: 'invited-contact',
+      email: 'invited@example.com',
+      lowercase_email: 'invited@example.com',
+      disabled: false,
+      apps: {
+        [appName]: {
+          app_attributes: {},
+          disabled: false,
+          is_user: false,
+          roles: ['admin'],
+          invite: { open: true },
+        },
+      },
+    });
+  const user = await createDatabaseUser({
+    adapterUserData: { email: 'invited@example.com', emailVerified: new Date(), image: null },
+    appName,
+    collectionNames,
+    inviteRequired: true,
+    mongoClient,
+  });
+  expect(user).toMatchObject({
+    id: 'invited-contact',
+    email: 'invited@example.com',
+    roles: ['admin'],
+  });
+  const contact = await mongoClient
+    .db()
+    .collection(collectionNames.contacts)
+    .findOne({ _id: 'invited-contact' });
+  expect(contact.apps[appName].invite.open).toBe(false);
+  expect(contact.apps[appName].is_user).toBe(true);
+});
+
+test('createDatabaseUser throws Access denied for a contact without an open invite', async () => {
+  await mongoClient
+    .db()
+    .collection(collectionNames.contacts)
+    .insertOne({
+      _id: 'no-invite-contact',
+      email: 'noinvite@example.com',
+      lowercase_email: 'noinvite@example.com',
+      disabled: false,
+      apps: {
+        [appName]: {
+          app_attributes: {},
+          disabled: false,
+          is_user: false,
+          roles: [],
+          invite: { open: false },
+        },
+      },
+    });
+  await expect(
+    createDatabaseUser({
+      adapterUserData: { email: 'noinvite@example.com', emailVerified: null },
+      appName,
+      collectionNames,
+      inviteRequired: true,
+      mongoClient,
+    })
+  ).rejects.toThrow('Access denied.');
+});
+
+test('createDatabaseUser throws Access denied for a disabled contact', async () => {
+  await mongoClient.db().collection(collectionNames.contacts).insertOne({
+    _id: 'disabled-contact',
+    email: 'disabled@example.com',
+    lowercase_email: 'disabled@example.com',
+    disabled: true,
+    apps: {},
+  });
+  await expect(
+    createDatabaseUser({
+      adapterUserData: { email: 'disabled@example.com', emailVerified: null },
+      appName,
+      collectionNames,
+      inviteRequired: false,
+      mongoClient,
+    })
+  ).rejects.toThrow('Access denied.');
+});
+
+test('getUserFromDbByEmail looks up by lowercase email and requires app membership', async () => {
+  await mongoClient
+    .db()
+    .collection(collectionNames.contacts)
+    .insertMany([
+      {
+        _id: 'app-user',
+        email: 'App.User@Example.com',
+        lowercase_email: 'app.user@example.com',
+        disabled: false,
+        apps: { [appName]: { app_attributes: {}, disabled: false, is_user: true, roles: [] } },
+      },
+      {
+        _id: 'other-app-user',
+        email: 'other@example.com',
+        lowercase_email: 'other@example.com',
+        disabled: false,
+        apps: { 'other-app': { app_attributes: {}, disabled: false, is_user: true, roles: [] } },
+      },
+    ]);
+  const user = await getUserFromDbByEmail({
+    appName,
+    collectionNames,
+    mongoClient,
+    email: 'APP.USER@example.com',
+  });
+  expect(user).toMatchObject({ id: 'app-user', email: 'App.User@Example.com' });
+  const notAppUser = await getUserFromDbByEmail({
+    appName,
+    collectionNames,
+    mongoClient,
+    email: 'other@example.com',
+  });
+  expect(notAppUser).toBe(null);
+});
+
+test('getUserFromDbById returns null for disabled or removed contacts', async () => {
+  await mongoClient
+    .db()
+    .collection(collectionNames.contacts)
+    .insertMany([
+      {
+        _id: 'disabled-app-user',
+        email: 'a@example.com',
+        lowercase_email: 'a@example.com',
+        disabled: false,
+        apps: { [appName]: { app_attributes: {}, disabled: true, is_user: true, roles: [] } },
+      },
+      {
+        _id: 'removed-user',
+        email: 'b@example.com',
+        lowercase_email: 'b@example.com',
+        disabled: false,
+        removed: true,
+        apps: { [appName]: { app_attributes: {}, disabled: false, is_user: true, roles: [] } },
+      },
+    ]);
+  expect(
+    await getUserFromDbById({ appName, collectionNames, mongoClient, userId: 'disabled-app-user' })
+  ).toBe(null);
+  expect(
+    await getUserFromDbById({ appName, collectionNames, mongoClient, userId: 'removed-user' })
+  ).toBe(null);
+});
+
+test('transformContactToAdapterUser maps contact fields to the adapter user shape', async () => {
+  const user = await transformContactToAdapterUser({
+    appName,
+    contact: {
+      _id: 'contact-id',
+      email: 'shape@example.com',
+      email_verified: null,
+      image: 'image-url',
+      profile: { name: 'Shape' },
+      global_attributes: { theme: 'dark' },
+      apps: { [appName]: { app_attributes: { plan: 'pro' }, roles: ['user'] } },
+    },
+  });
+  expect(user).toEqual({
+    id: 'contact-id',
+    app_attributes: { plan: 'pro' },
+    email: 'shape@example.com',
+    emailVerified: null,
+    image: 'image-url',
+    profile: { name: 'Shape' },
+    roles: ['user'],
+    global_attributes: { theme: 'dark' },
+  });
+});

--- a/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/createDatabaseUser.js
+++ b/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/createDatabaseUser.js
@@ -1,0 +1,51 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import createDatabaseUserFromContact from './createDatabaseUserFromContact.js';
+import createDatabaseUserWithoutContact from './createDatabaseUserWithoutContact.js';
+
+async function createDatabaseUser({
+  adapterUserData,
+  appName,
+  collectionNames,
+  inviteRequired,
+  mongoClient,
+}) {
+  const contact = await mongoClient.db().collection(collectionNames.contacts).findOne({
+    lowercase_email: adapterUserData.email.toLowerCase(),
+  });
+
+  if (contact) {
+    return createDatabaseUserFromContact({
+      adapterUserData,
+      appName,
+      collectionNames,
+      contact,
+      inviteRequired,
+      mongoClient,
+    });
+  }
+
+  return createDatabaseUserWithoutContact({
+    adapterUserData,
+    appName,
+    collectionNames,
+    inviteRequired,
+    mongoClient,
+  });
+}
+
+export default createDatabaseUser;

--- a/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/createDatabaseUserFromContact.js
+++ b/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/createDatabaseUserFromContact.js
@@ -1,0 +1,69 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import transformContactToAdapterUser from './transformContactToAdapterUser.js';
+
+async function createDatabaseUserFromContact({
+  adapterUserData,
+  appName,
+  collectionNames,
+  contact,
+  inviteRequired,
+  mongoClient,
+}) {
+  const invite = contact.apps?.[appName]?.invite;
+  if (inviteRequired && (!invite || !invite.open)) {
+    throw new Error('Access denied.');
+  }
+
+  if (contact.disabled || contact.removed || contact.apps?.[appName]?.disabled) {
+    throw new Error('Access denied.');
+  }
+
+  const { emailVerified: email_verified, image } = adapterUserData;
+
+  const update = {
+    email_verified,
+    image,
+    updated: { timestamp: new Date(), user: { id: contact._id } },
+  };
+
+  if (contact.apps?.[appName]) {
+    update[`apps.${appName}.disabled`] = false;
+    update[`apps.${appName}.is_user`] = true;
+    update[`apps.${appName}.sign_up`] = new Date();
+
+    if (invite) {
+      update[`apps.${appName}.invite.open`] = false;
+    }
+  } else {
+    update[`apps.${appName}`] = {
+      app_attributes: {},
+      disabled: false,
+      is_user: true,
+      roles: [],
+      sign_up: new Date(),
+    };
+  }
+
+  const updatedContact = await mongoClient
+    .db()
+    .collection(collectionNames.contacts)
+    .findOneAndUpdate({ _id: contact._id }, { $set: update }, { returnDocument: 'after' });
+  return transformContactToAdapterUser({ appName, contact: updatedContact });
+}
+
+export default createDatabaseUserFromContact;

--- a/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/createDatabaseUserWithoutContact.js
+++ b/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/createDatabaseUserWithoutContact.js
@@ -1,0 +1,58 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { v4 as uuid } from 'uuid';
+
+import transformContactToAdapterUser from './transformContactToAdapterUser.js';
+
+async function createDatabaseUserWithoutContact({
+  adapterUserData,
+  appName,
+  collectionNames,
+  inviteRequired,
+  mongoClient,
+}) {
+  if (inviteRequired) {
+    throw new Error('Access denied.');
+  }
+  const { email, emailVerified: email_verified, image = null } = adapterUserData;
+  const contact = {
+    _id: uuid(),
+    email,
+    email_verified,
+    global_attributes: {},
+    image,
+    lowercase_email: email.toLowerCase(),
+    profile: {},
+    disabled: false,
+    apps: {
+      [appName]: {
+        app_attributes: {},
+        disabled: false,
+        is_user: true,
+        roles: [],
+        sign_up: new Date(),
+      },
+    },
+  };
+  contact.created = { timestamp: new Date(), user: { id: contact._id } };
+  contact.updated = { timestamp: new Date(), user: { id: contact._id } };
+
+  await mongoClient.db().collection(collectionNames.contacts).insertOne(contact);
+  return transformContactToAdapterUser({ appName, contact });
+}
+
+export default createDatabaseUserWithoutContact;

--- a/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/getUserFromDbByEmail.js
+++ b/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/getUserFromDbByEmail.js
@@ -1,0 +1,37 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import transformContactToAdapterUser from './transformContactToAdapterUser.js';
+
+async function getUserFromDbByEmail({ appName, collectionNames, email, mongoClient }) {
+  const contact = await mongoClient
+    .db()
+    .collection(collectionNames.contacts)
+    .findOne({ lowercase_email: email.toLowerCase() });
+  if (
+    !contact ||
+    contact.disabled ||
+    contact.removed ||
+    !contact.apps?.[appName]?.is_user ||
+    contact.apps?.[appName]?.disabled
+  ) {
+    return null;
+  }
+
+  return transformContactToAdapterUser({ appName, contact });
+}
+
+export default getUserFromDbByEmail;

--- a/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/getUserFromDbById.js
+++ b/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/getUserFromDbById.js
@@ -14,24 +14,24 @@
   limitations under the License.
 */
 
-export default {
-  connections: ['MongoDBCollection'],
-  requests: [
-    'MongoDBAggregation',
-    'MongoDBBulkWrite',
-    'MongoDBDeleteMany',
-    'MongoDBDeleteOne',
-    'MongoDBFind',
-    'MongoDBFindOne',
-    'MongoDBInsertConsecutiveId',
-    'MongoDBInsertMany',
-    'MongoDBInsertManyConsecutiveIds',
-    'MongoDBInsertOne',
-    'MongoDBUpdateMany',
-    'MongoDBUpdateOne',
-    'MongoDBVersionedUpdateOne',
-  ],
-  auth: {
-    adapters: ['MongoDBAdapter', 'MultiAppMongoDBAdapter'],
-  },
-};
+import transformContactToAdapterUser from './transformContactToAdapterUser.js';
+
+async function getUserFromDbById({ appName, collectionNames, mongoClient, userId }) {
+  const contact = await mongoClient
+    .db()
+    .collection(collectionNames.contacts)
+    .findOne({ _id: userId });
+  if (
+    !contact ||
+    contact.disabled ||
+    contact.removed ||
+    !contact.apps?.[appName]?.is_user ||
+    contact.apps?.[appName]?.disabled
+  ) {
+    return null;
+  }
+
+  return transformContactToAdapterUser({ appName, contact });
+}
+
+export default getUserFromDbById;

--- a/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/transformContactToAdapterUser.js
+++ b/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/transformContactToAdapterUser.js
@@ -14,24 +14,28 @@
   limitations under the License.
 */
 
-export default {
-  connections: ['MongoDBCollection'],
-  requests: [
-    'MongoDBAggregation',
-    'MongoDBBulkWrite',
-    'MongoDBDeleteMany',
-    'MongoDBDeleteOne',
-    'MongoDBFind',
-    'MongoDBFindOne',
-    'MongoDBInsertConsecutiveId',
-    'MongoDBInsertMany',
-    'MongoDBInsertManyConsecutiveIds',
-    'MongoDBInsertOne',
-    'MongoDBUpdateMany',
-    'MongoDBUpdateOne',
-    'MongoDBVersionedUpdateOne',
-  ],
-  auth: {
-    adapters: ['MongoDBAdapter', 'MultiAppMongoDBAdapter'],
-  },
-};
+async function transformContactToAdapterUser({ appName, contact }) {
+  const {
+    _id: id,
+    email,
+    email_verified: emailVerified = null,
+    global_attributes = {},
+    image = null,
+    profile = {},
+  } = contact;
+
+  const { app_attributes, roles } = contact.apps[appName];
+
+  return {
+    id,
+    app_attributes,
+    email,
+    emailVerified,
+    image,
+    profile,
+    roles,
+    global_attributes,
+  };
+}
+
+export default transformContactToAdapterUser;

--- a/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/updateDatabaseUser.js
+++ b/packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/updateDatabaseUser.js
@@ -14,24 +14,12 @@
   limitations under the License.
 */
 
-export default {
-  connections: ['MongoDBCollection'],
-  requests: [
-    'MongoDBAggregation',
-    'MongoDBBulkWrite',
-    'MongoDBDeleteMany',
-    'MongoDBDeleteOne',
-    'MongoDBFind',
-    'MongoDBFindOne',
-    'MongoDBInsertConsecutiveId',
-    'MongoDBInsertMany',
-    'MongoDBInsertManyConsecutiveIds',
-    'MongoDBInsertOne',
-    'MongoDBUpdateMany',
-    'MongoDBUpdateOne',
-    'MongoDBVersionedUpdateOne',
-  ],
-  auth: {
-    adapters: ['MongoDBAdapter', 'MultiAppMongoDBAdapter'],
-  },
-};
+async function updateDatabaseUser({ adapterUserData, collectionNames, mongoClient }) {
+  const { emailVerified: email_verified, id, image } = adapterUserData;
+  await mongoClient
+    .db()
+    .collection(collectionNames.contacts)
+    .updateOne({ _id: id }, { $set: { email_verified, image } });
+}
+
+export default updateDatabaseUser;

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBAggregation/MongoDBAggregation.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBAggregation/MongoDBAggregation.js
@@ -34,7 +34,7 @@ async function MongodbAggregation({ request, connection }) {
   const deserializedRequest = deserialize(request);
   const { pipeline, options } = deserializedRequest;
   checkOutAndMerge({ pipeline, connection });
-  const collection = await getCollection({ connection });
+  const { collection } = await getCollection({ connection });
   const cursor = await collection.aggregate(pipeline, options);
   const res = await cursor.toArray();
   return serialize(res);

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBBulkWrite/MongoDBBulkWrite.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBBulkWrite/MongoDBBulkWrite.js
@@ -21,7 +21,7 @@ import schema from './schema.js';
 async function MongodbBulkWrite({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { operations, options } = deserializedRequest;
-  const collection = await getCollection({ connection });
+  const { collection } = await getCollection({ connection });
   const response = await collection.bulkWrite(operations, options);
   return serialize(response);
 }

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBCollection.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBCollection.js
@@ -20,7 +20,9 @@ import MongoDBDeleteMany from './MongoDBDeleteMany/MongoDBDeleteMany.js';
 import MongoDBDeleteOne from './MongoDBDeleteOne/MongoDBDeleteOne.js';
 import MongoDBFind from './MongoDBFind/MongoDBFind.js';
 import MongoDBFindOne from './MongoDBFindOne/MongoDBFindOne.js';
+import MongoDBInsertConsecutiveId from './MongoDBInsertConsecutiveId/MongoDBInsertConsecutiveId.js';
 import MongoDBInsertMany from './MongoDBInsertMany/MongoDBInsertMany.js';
+import MongoDBInsertManyConsecutiveIds from './MongoDBInsertManyConsecutiveIds/MongoDBInsertManyConsecutiveIds.js';
 import MongoDBInsertOne from './MongoDBInsertOne/MongoDBInsertOne.js';
 import MongoDBUpdateMany from './MongoDBUpdateMany/MongoDBUpdateMany.js';
 import MongoDBUpdateOne from './MongoDBUpdateOne/MongoDBUpdateOne.js';
@@ -36,7 +38,9 @@ export default {
     MongoDBDeleteOne,
     MongoDBFind,
     MongoDBFindOne,
+    MongoDBInsertConsecutiveId,
     MongoDBInsertMany,
+    MongoDBInsertManyConsecutiveIds,
     MongoDBInsertOne,
     MongoDBUpdateMany,
     MongoDBUpdateOne,

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBCollection.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBCollection.js
@@ -24,6 +24,7 @@ import MongoDBInsertMany from './MongoDBInsertMany/MongoDBInsertMany.js';
 import MongoDBInsertOne from './MongoDBInsertOne/MongoDBInsertOne.js';
 import MongoDBUpdateMany from './MongoDBUpdateMany/MongoDBUpdateMany.js';
 import MongoDBUpdateOne from './MongoDBUpdateOne/MongoDBUpdateOne.js';
+import MongoDBVersionedUpdateOne from './MongoDBVersionedUpdateOne/MongoDBVersionedUpdateOne.js';
 import schema from './schema.js';
 
 export default {
@@ -39,5 +40,6 @@ export default {
     MongoDBInsertOne,
     MongoDBUpdateMany,
     MongoDBUpdateOne,
+    MongoDBVersionedUpdateOne,
   },
 };

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteMany/MongoDBDeleteMany.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteMany/MongoDBDeleteMany.js
@@ -18,11 +18,33 @@ import getCollection from '../getCollection.js';
 import { serialize, deserialize } from '../serialize.js';
 import schema from './schema.js';
 
-async function MongodbDeleteMany({ connection, request }) {
+async function MongodbDeleteMany({
+  blockId,
+  connection,
+  connectionId,
+  pageId,
+  payload,
+  request,
+  requestId,
+}) {
   const deserializedRequest = deserialize(request);
   const { filter, options } = deserializedRequest;
-  const { collection } = await getCollection({ connection });
+  const { collection, logCollection } = await getCollection({ connection });
   const response = await collection.deleteMany(filter, options);
+  if (logCollection) {
+    await logCollection.insertOne({
+      args: { filter, options },
+      blockId,
+      connectionId,
+      pageId,
+      payload,
+      requestId,
+      response,
+      timestamp: new Date(),
+      type: 'MongoDBDeleteMany',
+      meta: connection.changeLog?.meta,
+    });
+  }
   const { acknowledged, deletedCount } = serialize(response);
   return { acknowledged, deletedCount };
 }

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteMany/MongoDBDeleteMany.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteMany/MongoDBDeleteMany.js
@@ -21,7 +21,7 @@ import schema from './schema.js';
 async function MongodbDeleteMany({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { filter, options } = deserializedRequest;
-  const collection = await getCollection({ connection });
+  const { collection } = await getCollection({ connection });
   const response = await collection.deleteMany(filter, options);
   const { acknowledged, deletedCount } = serialize(response);
   return { acknowledged, deletedCount };

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteMany/MongoDBDeleteMany.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteMany/MongoDBDeleteMany.test.js
@@ -16,6 +16,7 @@
 
 import { validate } from '@lowdefy/ajv';
 import MongoDBDeleteMany from './MongoDBDeleteMany.js';
+import findLogCollectionRecordTestMongoDb from '../../../../test/findLogCollectionRecordTestMongoDb.js';
 import populateTestMongoDb from '../../../../test/populateTestMongoDb.js';
 
 const { checkRead, checkWrite } = MongoDBDeleteMany.meta;
@@ -24,6 +25,7 @@ const schema = MongoDBDeleteMany.schema;
 const databaseUri = process.env.MONGO_URL;
 const databaseName = 'test';
 const collection = 'deleteMany';
+const logCollection = 'logCollection';
 const documents = [
   { _id: 'deleteMany' },
   { _id: 'deleteMany_1' },
@@ -32,6 +34,13 @@ const documents = [
   { _id: 'deleteMany_4', f: 'deleteMany' },
   { _id: 'deleteMany_5', f: 'deleteMany' },
   { _id: 'deleteMany_6', f: 'deleteMany' },
+  { _id: 'deleteMany_log' },
+  { _id: 'deleteMany_1_log' },
+  { _id: 'deleteMany_2_log' },
+  { _id: 'deleteMany_3_log' },
+  { _id: 'deleteMany_4_log', f: 'deleteMany_log' },
+  { _id: 'deleteMany_5_log', f: 'deleteMany_log' },
+  { _id: 'deleteMany_6_log', f: 'deleteMany_log' },
 ];
 
 beforeAll(() => {
@@ -55,6 +64,45 @@ test('deleteMany - Single Document', async () => {
   });
 });
 
+test('deleteMany logCollection - Single Document', async () => {
+  const request = {
+    filter: { _id: 'deleteMany_log' },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBDeleteMany({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'deleteMany_log',
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    deletedCount: 1,
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'deleteMany_log',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'deleteMany_log',
+    type: 'MongoDBDeleteMany',
+    meta: { meta: true },
+  });
+});
+
 test('deleteMany - Multiple Documents', async () => {
   const request = {
     filter: { _id: { $in: ['deleteMany_1', 'deleteMany_2', 'deleteMany_3'] } },
@@ -72,6 +120,45 @@ test('deleteMany - Multiple Documents', async () => {
   });
 });
 
+test('deleteMany logCollection - Multiple Documents', async () => {
+  const request = {
+    filter: { _id: { $in: ['deleteMany_1_log', 'deleteMany_2_log', 'deleteMany_3_log'] } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBDeleteMany({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'deleteMany_multiple',
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    deletedCount: 3,
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'deleteMany_multiple',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'deleteMany_multiple',
+    type: 'MongoDBDeleteMany',
+    meta: { meta: true },
+  });
+});
+
 test('deleteMany - Multiple Documents one field', async () => {
   const request = {
     filter: { f: 'deleteMany' },
@@ -86,6 +173,45 @@ test('deleteMany - Multiple Documents one field', async () => {
   expect(res).toEqual({
     acknowledged: true,
     deletedCount: 3,
+  });
+});
+
+test('deleteMany logCollection - Multiple Documents one field', async () => {
+  const request = {
+    filter: { f: 'deleteMany_log' },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBDeleteMany({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'deleteMany_multiple_one_field',
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    deletedCount: 3,
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'deleteMany_multiple_one_field',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'deleteMany_multiple_one_field',
+    type: 'MongoDBDeleteMany',
+    meta: { meta: true },
   });
 });
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteOne/MongoDBDeleteOne.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteOne/MongoDBDeleteOne.js
@@ -18,11 +18,46 @@ import getCollection from '../getCollection.js';
 import { serialize, deserialize } from '../serialize.js';
 import schema from './schema.js';
 
-async function MongodbDeleteOne({ connection, request }) {
+async function MongodbDeleteOne({
+  blockId,
+  connection,
+  connectionId,
+  pageId,
+  payload,
+  request,
+  requestId,
+}) {
   const deserializedRequest = deserialize(request);
   const { filter, options } = deserializedRequest;
-  const { collection } = await getCollection({ connection });
-  const response = await collection.deleteOne(filter, options);
+  const { collection, logCollection } = await getCollection({ connection });
+  let response;
+  if (logCollection) {
+    // findOneAndDelete instead of deleteOne to capture the deleted document
+    // for the change log. The response shape matches the deleteOne response.
+    const result = await collection.findOneAndDelete(filter, {
+      ...options,
+      includeResultMetadata: true,
+    });
+    const before = result.value ?? null;
+    response = {
+      acknowledged: true,
+      deletedCount: result.lastErrorObject?.n ?? 0,
+    };
+    await logCollection.insertOne({
+      args: { filter, options },
+      blockId,
+      connectionId,
+      pageId,
+      payload,
+      requestId,
+      before,
+      timestamp: new Date(),
+      type: 'MongoDBDeleteOne',
+      meta: connection.changeLog?.meta,
+    });
+  } else {
+    response = await collection.deleteOne(filter, options);
+  }
   return serialize(response);
 }
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteOne/MongoDBDeleteOne.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteOne/MongoDBDeleteOne.js
@@ -21,7 +21,7 @@ import schema from './schema.js';
 async function MongodbDeleteOne({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { filter, options } = deserializedRequest;
-  const collection = await getCollection({ connection });
+  const { collection } = await getCollection({ connection });
   const response = await collection.deleteOne(filter, options);
   return serialize(response);
 }

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteOne/MongoDBDeleteOne.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBDeleteOne/MongoDBDeleteOne.test.js
@@ -16,6 +16,7 @@
 
 import { validate } from '@lowdefy/ajv';
 import MongoDBDeleteOne from './MongoDBDeleteOne.js';
+import findLogCollectionRecordTestMongoDb from '../../../../test/findLogCollectionRecordTestMongoDb.js';
 import populateTestMongoDb from '../../../../test/populateTestMongoDb.js';
 
 const { checkRead, checkWrite } = MongoDBDeleteOne.meta;
@@ -24,6 +25,7 @@ const schema = MongoDBDeleteOne.schema;
 const databaseUri = process.env.MONGO_URL;
 const databaseName = 'test';
 const collection = 'deleteOne';
+const logCollection = 'logCollection';
 const documents = [{ _id: 'deleteOne' }, { _id: 'deleteOne_log' }];
 
 beforeAll(() => {
@@ -45,6 +47,101 @@ test('deleteOne', async () => {
     acknowledged: true,
     deletedCount: 1,
   });
+});
+
+test('deleteOne logCollection', async () => {
+  const request = {
+    filter: { _id: 'deleteOne_log' },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBDeleteOne({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'deleteOne_log',
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    deletedCount: 1,
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'deleteOne_log',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'deleteOne_log',
+    before: { _id: 'deleteOne_log' },
+    type: 'MongoDBDeleteOne',
+    meta: { meta: true },
+  });
+});
+
+test('deleteOne response shape is invariant to logCollection', async () => {
+  const invarianceCollection = 'deleteOneInvariance';
+  await populateTestMongoDb({
+    collection: invarianceCollection,
+    documents: [{ _id: 'inv_no_log' }, { _id: 'inv_with_log' }],
+  });
+  const baseConnection = {
+    databaseUri,
+    databaseName,
+    collection: invarianceCollection,
+    write: true,
+  };
+  const logConnection = {
+    ...baseConnection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+  };
+
+  const expectedKeys = ['acknowledged', 'deletedCount'];
+
+  const resNoLog = await MongoDBDeleteOne({
+    request: { filter: { _id: 'inv_no_log' } },
+    connection: baseConnection,
+  });
+  const resWithLog = await MongoDBDeleteOne({
+    request: { filter: { _id: 'inv_with_log' } },
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'deleteOne_invariance_log',
+    connection: logConnection,
+  });
+  expect(Object.keys(resNoLog).sort()).toEqual(expectedKeys);
+  expect(Object.keys(resWithLog).sort()).toEqual(expectedKeys);
+  expect(resWithLog).toEqual(resNoLog);
+
+  // No-match case
+  const resNoMatchNoLog = await MongoDBDeleteOne({
+    request: { filter: { _id: 'inv_missing' } },
+    connection: baseConnection,
+  });
+  const resNoMatchWithLog = await MongoDBDeleteOne({
+    request: { filter: { _id: 'inv_missing' } },
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'deleteOne_invariance_no_match_log',
+    connection: logConnection,
+  });
+  expect(Object.keys(resNoMatchNoLog).sort()).toEqual(expectedKeys);
+  expect(Object.keys(resNoMatchWithLog).sort()).toEqual(expectedKeys);
+  expect(resNoMatchWithLog).toEqual(resNoMatchNoLog);
 });
 
 test('deleteOne connection error', async () => {

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBFind/MongoDBFind.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBFind/MongoDBFind.js
@@ -21,7 +21,7 @@ import schema from './schema.js';
 async function MongodbFind({ request, connection }) {
   const deserializedRequest = deserialize(request);
   const { query, options } = deserializedRequest;
-  const collection = await getCollection({ connection });
+  const { collection } = await getCollection({ connection });
   const cursor = await collection.find(query, options);
   const res = await cursor.toArray();
   return serialize(res);

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBFindOne/MongoDBFindOne.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBFindOne/MongoDBFindOne.js
@@ -21,7 +21,7 @@ import schema from './schema.js';
 async function MongodbFindOne({ request, connection }) {
   const deserializedRequest = deserialize(request);
   const { query, options } = deserializedRequest;
-  const collection = await getCollection({ connection });
+  const { collection } = await getCollection({ connection });
   const res = await collection.findOne(query, options);
   return serialize(res);
 }

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertConsecutiveId/MongoDBInsertConsecutiveId.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertConsecutiveId/MongoDBInsertConsecutiveId.js
@@ -1,0 +1,80 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import getCollection from '../getCollection.js';
+import getConsecutiveIdIndex from '../getConsecutiveIdIndex.js';
+import { serialize, deserialize } from '../serialize.js';
+import schema from './schema.js';
+
+async function MongoDBInsertConsecutiveId({
+  blockId,
+  connection,
+  connectionId,
+  pageId,
+  payload,
+  request,
+  requestId,
+}) {
+  const deserializedRequest = deserialize(request);
+  const { doc, options, prefix, length } = deserializedRequest;
+  const { client, collection, logCollection } = await getCollection({ connection });
+
+  // The id read and insert run in a transaction so concurrent requests cannot
+  // claim the same id. Transactions require MongoDB to run as a replica set.
+  const session = client.startSession();
+  const transactionOptions = {
+    readPreference: 'primary',
+    readConcern: { level: 'local' },
+    writeConcern: { w: 'majority' },
+  };
+  let response = {};
+  try {
+    await session.withTransaction(async () => {
+      const index = await getConsecutiveIdIndex({ collection, prefix, session });
+      doc._id = `${prefix}${String(index).padStart(length, '0')}`;
+      response = await collection.insertOne(doc, { ...options, session });
+      if (logCollection) {
+        await logCollection.insertOne(
+          {
+            args: { doc, options },
+            blockId,
+            connectionId,
+            pageId,
+            payload,
+            requestId,
+            response,
+            timestamp: new Date(),
+            type: 'MongoDBInsertConsecutiveId',
+            meta: connection.changeLog?.meta,
+          },
+          { session }
+        );
+      }
+    }, transactionOptions);
+  } finally {
+    await session.endSession();
+  }
+  const { acknowledged, insertedId } = serialize(response);
+  return { acknowledged, insertedId };
+}
+
+MongoDBInsertConsecutiveId.schema = schema;
+MongoDBInsertConsecutiveId.meta = {
+  checkRead: false,
+  checkWrite: true,
+};
+
+export default MongoDBInsertConsecutiveId;

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertConsecutiveId/MongoDBInsertConsecutiveId.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertConsecutiveId/MongoDBInsertConsecutiveId.test.js
@@ -1,0 +1,186 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { validate } from '@lowdefy/ajv';
+import MongoDBInsertConsecutiveId from './MongoDBInsertConsecutiveId.js';
+import clearTestMongoDb from '../../../../test/clearTestMongoDb.js';
+import findLogCollectionRecordTestMongoDb from '../../../../test/findLogCollectionRecordTestMongoDb.js';
+import populateTestMongoDb from '../../../../test/populateTestMongoDb.js';
+
+const { checkRead, checkWrite } = MongoDBInsertConsecutiveId.meta;
+const schema = MongoDBInsertConsecutiveId.schema;
+
+const databaseUri = process.env.MONGO_URL;
+const databaseName = 'test';
+const collection = 'insertConsecutiveId';
+const logCollection = 'logCollection';
+
+const connection = {
+  databaseUri,
+  databaseName,
+  collection,
+  write: true,
+};
+
+beforeAll(() => {
+  return clearTestMongoDb({ collection });
+});
+
+test('insertConsecutiveId assigns sequential prefixed ids', async () => {
+  const first = await MongoDBInsertConsecutiveId({
+    request: { doc: { v: 'first' }, prefix: 'P', length: 4 },
+    connection,
+  });
+  expect(first).toEqual({
+    acknowledged: true,
+    insertedId: 'P0001',
+  });
+  const second = await MongoDBInsertConsecutiveId({
+    request: { doc: { v: 'second' }, prefix: 'P', length: 4 },
+    connection,
+  });
+  expect(second).toEqual({
+    acknowledged: true,
+    insertedId: 'P0002',
+  });
+});
+
+test('insertConsecutiveId isolates ids per prefix', async () => {
+  const res = await MongoDBInsertConsecutiveId({
+    request: { doc: { v: 'other prefix' }, prefix: 'Q', length: 4 },
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    insertedId: 'Q0001',
+  });
+});
+
+test('insertConsecutiveId without length does not pad the id', async () => {
+  const res = await MongoDBInsertConsecutiveId({
+    request: { doc: { v: 'no padding' }, prefix: 'NOPAD' },
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    insertedId: 'NOPAD1',
+  });
+});
+
+test('insertConsecutiveId ignores ids with non-numeric suffixes', async () => {
+  const regexCollection = 'insertConsecutiveIdRegex';
+  await populateTestMongoDb({
+    collection: regexCollection,
+    documents: [{ _id: 'PABC' }, { _id: 'P0005' }],
+  });
+  const res = await MongoDBInsertConsecutiveId({
+    request: { doc: { v: 'regex' }, prefix: 'P', length: 4 },
+    connection: { ...connection, collection: regexCollection },
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    insertedId: 'P0006',
+  });
+});
+
+test('insertConsecutiveId logCollection', async () => {
+  const res = await MongoDBInsertConsecutiveId({
+    request: { doc: { v: 'logged' }, prefix: 'LOG', length: 3 },
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'insertConsecutiveId_log',
+    connection: {
+      ...connection,
+      changeLog: { collection: logCollection, meta: { meta: true } },
+    },
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    insertedId: 'LOG001',
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'insertConsecutiveId_log',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'insertConsecutiveId_log',
+    type: 'MongoDBInsertConsecutiveId',
+    meta: { meta: true },
+  });
+});
+
+test('checkRead should be false', async () => {
+  expect(checkRead).toBe(false);
+});
+
+test('checkWrite should be true', async () => {
+  expect(checkWrite).toBe(true);
+});
+
+test('request not an object', async () => {
+  const request = 'request';
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBInsertConsecutiveId request properties should be an object.'
+  );
+});
+
+test('request no doc', async () => {
+  const request = { prefix: 'P' };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBInsertConsecutiveId request should have required property "doc".'
+  );
+});
+
+test('request no prefix', async () => {
+  const request = { doc: {} };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBInsertConsecutiveId request should have required property "prefix".'
+  );
+});
+
+test('request doc not an object', async () => {
+  const request = { doc: 'doc', prefix: 'P' };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBInsertConsecutiveId request property "doc" should be an object.'
+  );
+});
+
+test('request prefix not a string', async () => {
+  const request = { doc: {}, prefix: 1 };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBInsertConsecutiveId request property "prefix" should be a string.'
+  );
+});
+
+test('request length not a number', async () => {
+  const request = { doc: {}, prefix: 'P', length: '4' };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBInsertConsecutiveId request property "length" should be a number.'
+  );
+});
+
+test('request options not an object', async () => {
+  const request = { doc: {}, prefix: 'P', options: 'options' };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBInsertConsecutiveId request property "options" should be an object.'
+  );
+});

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertConsecutiveId/schema.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertConsecutiveId/schema.js
@@ -1,0 +1,59 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+export default {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'Lowdefy Request Schema - MongoDBInsertConsecutiveId',
+  type: 'object',
+  required: ['doc', 'prefix'],
+  properties: {
+    doc: {
+      type: 'object',
+      description: 'The document to be inserted.',
+      errorMessage: {
+        type: 'MongoDBInsertConsecutiveId request property "doc" should be an object.',
+      },
+    },
+    options: {
+      type: 'object',
+      description: 'Optional settings.',
+      errorMessage: {
+        type: 'MongoDBInsertConsecutiveId request property "options" should be an object.',
+      },
+    },
+    prefix: {
+      type: 'string',
+      description: 'Prefix to add to _id.',
+      errorMessage: {
+        type: 'MongoDBInsertConsecutiveId request property "prefix" should be a string.',
+      },
+    },
+    length: {
+      type: 'number',
+      description: 'The numeric ID will be padded to this number of digits.',
+      errorMessage: {
+        type: 'MongoDBInsertConsecutiveId request property "length" should be a number.',
+      },
+    },
+  },
+  errorMessage: {
+    type: 'MongoDBInsertConsecutiveId request properties should be an object.',
+    required: {
+      doc: 'MongoDBInsertConsecutiveId request should have required property "doc".',
+      prefix: 'MongoDBInsertConsecutiveId request should have required property "prefix".',
+    },
+  },
+};

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertMany/MongoDBInsertMany.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertMany/MongoDBInsertMany.js
@@ -18,13 +18,35 @@ import getCollection from '../getCollection.js';
 import { serialize, deserialize } from '../serialize.js';
 import schema from './schema.js';
 
-async function MongodbInsertMany({ connection, request }) {
+async function MongodbInsertMany({
+  blockId,
+  connection,
+  connectionId,
+  pageId,
+  payload,
+  request,
+  requestId,
+}) {
   const deserializedRequest = deserialize(request);
   const { docs, options } = deserializedRequest;
-  const { collection } = await getCollection({ connection });
+  const { collection, logCollection } = await getCollection({ connection });
   const response = await collection.insertMany(docs, options);
-  const { acknowledged, insertedCount } = serialize(response);
-  return { acknowledged, insertedCount };
+  if (logCollection) {
+    await logCollection.insertOne({
+      args: { docs, options },
+      blockId,
+      connectionId,
+      pageId,
+      payload,
+      requestId,
+      response,
+      timestamp: new Date(),
+      type: 'MongoDBInsertMany',
+      meta: connection.changeLog?.meta,
+    });
+  }
+  const { acknowledged, insertedCount, insertedIds } = serialize(response);
+  return { acknowledged, insertedCount, insertedIds };
 }
 
 MongodbInsertMany.schema = schema;

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertMany/MongoDBInsertMany.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertMany/MongoDBInsertMany.js
@@ -21,7 +21,7 @@ import schema from './schema.js';
 async function MongodbInsertMany({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { docs, options } = deserializedRequest;
-  const collection = await getCollection({ connection });
+  const { collection } = await getCollection({ connection });
   const response = await collection.insertMany(docs, options);
   const { acknowledged, insertedCount } = serialize(response);
   return { acknowledged, insertedCount };

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertMany/MongoDBInsertMany.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertMany/MongoDBInsertMany.test.js
@@ -17,6 +17,7 @@
 import { validate } from '@lowdefy/ajv';
 import MongoDBInsertMany from './MongoDBInsertMany.js';
 import clearTestMongoDb from '../../../../test/clearTestMongoDb.js';
+import findLogCollectionRecordTestMongoDb from '../../../../test/findLogCollectionRecordTestMongoDb.js';
 
 const { checkRead, checkWrite } = MongoDBInsertMany.meta;
 const schema = MongoDBInsertMany.schema;
@@ -24,6 +25,7 @@ const schema = MongoDBInsertMany.schema;
 const databaseUri = process.env.MONGO_URL;
 const databaseName = 'test';
 const collection = 'insertMany';
+const logCollection = 'logCollection';
 
 beforeAll(() => {
   return clearTestMongoDb({ collection });
@@ -43,6 +45,51 @@ test('insertMany', async () => {
   expect(res).toEqual({
     acknowledged: true,
     insertedCount: 3,
+    insertedIds: { 0: 'insertMany1-1', 1: 'insertMany1-2', 2: 'insertMany1-3' },
+  });
+});
+
+test('insertMany logCollection', async () => {
+  const request = {
+    docs: [
+      { _id: 'insertMany1-1_log' },
+      { _id: 'insertMany1-2_log' },
+      { _id: 'insertMany1-3_log' },
+    ],
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBInsertMany({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'insertMany_log',
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    insertedCount: 3,
+    insertedIds: { 0: 'insertMany1-1_log', 1: 'insertMany1-2_log', 2: 'insertMany1-3_log' },
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'insertMany_log',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'insertMany_log',
+    type: 'MongoDBInsertMany',
+    meta: { meta: true },
   });
 });
 
@@ -61,6 +108,48 @@ test('insertMany options', async () => {
   expect(res).toEqual({
     acknowledged: true,
     insertedCount: 2,
+    insertedIds: { 0: 'insertMany2-1', 1: 'insertMany2-2' },
+  });
+});
+
+test('insertMany logCollection options', async () => {
+  const request = {
+    docs: [{ _id: 'insertMany2-1_log' }, { _id: 'insertMany2-2_log' }],
+    options: { writeConcern: { w: 'majority' } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBInsertMany({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'insertMany_options_log',
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    insertedCount: 2,
+    insertedIds: { 0: 'insertMany2-1_log', 1: 'insertMany2-2_log' },
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'insertMany_options_log',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'insertMany_options_log',
+    type: 'MongoDBInsertMany',
+    meta: { meta: true },
   });
 });
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertManyConsecutiveIds/MongoDBInsertManyConsecutiveIds.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertManyConsecutiveIds/MongoDBInsertManyConsecutiveIds.js
@@ -1,0 +1,82 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import getCollection from '../getCollection.js';
+import getConsecutiveIdIndex from '../getConsecutiveIdIndex.js';
+import { serialize, deserialize } from '../serialize.js';
+import schema from './schema.js';
+
+async function MongoDBInsertManyConsecutiveIds({
+  blockId,
+  connection,
+  connectionId,
+  pageId,
+  payload,
+  request,
+  requestId,
+}) {
+  const deserializedRequest = deserialize(request);
+  const { docs, options, prefix, length } = deserializedRequest;
+  const { client, collection, logCollection } = await getCollection({ connection });
+
+  // The id read and insert run in a transaction so concurrent requests cannot
+  // claim the same ids. Transactions require MongoDB to run as a replica set.
+  const session = client.startSession();
+  const transactionOptions = {
+    readPreference: 'primary',
+    readConcern: { level: 'local' },
+    writeConcern: { w: 'majority' },
+  };
+  let response = {};
+  try {
+    await session.withTransaction(async () => {
+      const firstIndex = await getConsecutiveIdIndex({ collection, prefix, session });
+      docs.forEach((doc, index) => {
+        doc._id = `${prefix}${String(firstIndex + index).padStart(length, '0')}`;
+      });
+      response = await collection.insertMany(docs, { ...options, session });
+      if (logCollection) {
+        await logCollection.insertOne(
+          {
+            args: { docs, options },
+            blockId,
+            connectionId,
+            pageId,
+            payload,
+            requestId,
+            response,
+            timestamp: new Date(),
+            type: 'MongoDBInsertManyConsecutiveIds',
+            meta: connection.changeLog?.meta,
+          },
+          { session }
+        );
+      }
+    }, transactionOptions);
+  } finally {
+    await session.endSession();
+  }
+  const { acknowledged, insertedIds } = serialize(response);
+  return { acknowledged, insertedIds };
+}
+
+MongoDBInsertManyConsecutiveIds.schema = schema;
+MongoDBInsertManyConsecutiveIds.meta = {
+  checkRead: false,
+  checkWrite: true,
+};
+
+export default MongoDBInsertManyConsecutiveIds;

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertManyConsecutiveIds/MongoDBInsertManyConsecutiveIds.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertManyConsecutiveIds/MongoDBInsertManyConsecutiveIds.test.js
@@ -1,0 +1,162 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { validate } from '@lowdefy/ajv';
+import MongoDBInsertManyConsecutiveIds from './MongoDBInsertManyConsecutiveIds.js';
+import clearTestMongoDb from '../../../../test/clearTestMongoDb.js';
+import findLogCollectionRecordTestMongoDb from '../../../../test/findLogCollectionRecordTestMongoDb.js';
+
+const { checkRead, checkWrite } = MongoDBInsertManyConsecutiveIds.meta;
+const schema = MongoDBInsertManyConsecutiveIds.schema;
+
+const databaseUri = process.env.MONGO_URL;
+const databaseName = 'test';
+const collection = 'insertManyConsecutiveIds';
+const logCollection = 'logCollection';
+
+const connection = {
+  databaseUri,
+  databaseName,
+  collection,
+  write: true,
+};
+
+beforeAll(() => {
+  return clearTestMongoDb({ collection });
+});
+
+test('insertManyConsecutiveIds assigns sequential prefixed ids', async () => {
+  const res = await MongoDBInsertManyConsecutiveIds({
+    request: {
+      docs: [{ v: 'one' }, { v: 'two' }, { v: 'three' }],
+      prefix: 'M',
+      length: 4,
+    },
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    insertedIds: { 0: 'M0001', 1: 'M0002', 2: 'M0003' },
+  });
+});
+
+test('insertManyConsecutiveIds continues from the highest existing id', async () => {
+  const res = await MongoDBInsertManyConsecutiveIds({
+    request: {
+      docs: [{ v: 'four' }, { v: 'five' }],
+      prefix: 'M',
+      length: 4,
+    },
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    insertedIds: { 0: 'M0004', 1: 'M0005' },
+  });
+});
+
+test('insertManyConsecutiveIds logCollection', async () => {
+  const res = await MongoDBInsertManyConsecutiveIds({
+    request: {
+      docs: [{ v: 'logged' }],
+      prefix: 'MLOG',
+      length: 3,
+    },
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'insertManyConsecutiveIds_log',
+    connection: {
+      ...connection,
+      changeLog: { collection: logCollection, meta: { meta: true } },
+    },
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    insertedIds: { 0: 'MLOG001' },
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'insertManyConsecutiveIds_log',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'insertManyConsecutiveIds_log',
+    type: 'MongoDBInsertManyConsecutiveIds',
+    meta: { meta: true },
+  });
+});
+
+test('checkRead should be false', async () => {
+  expect(checkRead).toBe(false);
+});
+
+test('checkWrite should be true', async () => {
+  expect(checkWrite).toBe(true);
+});
+
+test('request not an object', async () => {
+  const request = 'request';
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBInsertManyConsecutiveIds request properties should be an object.'
+  );
+});
+
+test('request no docs', async () => {
+  const request = { prefix: 'M' };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBInsertManyConsecutiveIds request should have required property "docs".'
+  );
+});
+
+test('request no prefix', async () => {
+  const request = { docs: [] };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBInsertManyConsecutiveIds request should have required property "prefix".'
+  );
+});
+
+test('request docs not an array', async () => {
+  const request = { docs: 'docs', prefix: 'M' };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBInsertManyConsecutiveIds request property "docs" should be an array.'
+  );
+});
+
+test('request prefix not a string', async () => {
+  const request = { docs: [], prefix: 1 };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBInsertManyConsecutiveIds request property "prefix" should be a string.'
+  );
+});
+
+test('request length not a number', async () => {
+  const request = { docs: [], prefix: 'M', length: '4' };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBInsertManyConsecutiveIds request property "length" should be a number.'
+  );
+});
+
+test('request options not an object', async () => {
+  const request = { docs: [], prefix: 'M', options: 'options' };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBInsertManyConsecutiveIds request property "options" should be an object.'
+  );
+});

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertManyConsecutiveIds/schema.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertManyConsecutiveIds/schema.js
@@ -1,0 +1,65 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+export default {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'Lowdefy Request Schema - MongoDBInsertManyConsecutiveIds',
+  type: 'object',
+  required: ['docs', 'prefix'],
+  properties: {
+    docs: {
+      type: 'array',
+      description: 'The documents to be inserted.',
+      items: {
+        type: 'object',
+        errorMessage: {
+          type: 'MongoDBInsertManyConsecutiveIds request property "docs" should be an array of objects.',
+        },
+      },
+      errorMessage: {
+        type: 'MongoDBInsertManyConsecutiveIds request property "docs" should be an array.',
+      },
+    },
+    options: {
+      type: 'object',
+      description: 'Optional settings.',
+      errorMessage: {
+        type: 'MongoDBInsertManyConsecutiveIds request property "options" should be an object.',
+      },
+    },
+    prefix: {
+      type: 'string',
+      description: 'Prefix to add to _id.',
+      errorMessage: {
+        type: 'MongoDBInsertManyConsecutiveIds request property "prefix" should be a string.',
+      },
+    },
+    length: {
+      type: 'number',
+      description: 'The numeric ID will be padded to this number of digits.',
+      errorMessage: {
+        type: 'MongoDBInsertManyConsecutiveIds request property "length" should be a number.',
+      },
+    },
+  },
+  errorMessage: {
+    type: 'MongoDBInsertManyConsecutiveIds request properties should be an object.',
+    required: {
+      docs: 'MongoDBInsertManyConsecutiveIds request should have required property "docs".',
+      prefix: 'MongoDBInsertManyConsecutiveIds request should have required property "prefix".',
+    },
+  },
+};

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertOne/MongoDBInsertOne.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertOne/MongoDBInsertOne.js
@@ -21,7 +21,7 @@ import schema from './schema.js';
 async function MongodbInsertOne({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { doc, options } = deserializedRequest;
-  const collection = await getCollection({ connection });
+  const { collection } = await getCollection({ connection });
   const response = await collection.insertOne(doc, options);
   const { acknowledged, insertedId } = serialize(response);
   return { acknowledged, insertedId };

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertOne/MongoDBInsertOne.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertOne/MongoDBInsertOne.js
@@ -18,11 +18,33 @@ import getCollection from '../getCollection.js';
 import { serialize, deserialize } from '../serialize.js';
 import schema from './schema.js';
 
-async function MongodbInsertOne({ connection, request }) {
+async function MongodbInsertOne({
+  blockId,
+  connection,
+  connectionId,
+  pageId,
+  payload,
+  request,
+  requestId,
+}) {
   const deserializedRequest = deserialize(request);
   const { doc, options } = deserializedRequest;
-  const { collection } = await getCollection({ connection });
+  const { collection, logCollection } = await getCollection({ connection });
   const response = await collection.insertOne(doc, options);
+  if (logCollection) {
+    await logCollection.insertOne({
+      args: { doc, options },
+      blockId,
+      connectionId,
+      pageId,
+      payload,
+      requestId,
+      response,
+      timestamp: new Date(),
+      type: 'MongoDBInsertOne',
+      meta: connection.changeLog?.meta,
+    });
+  }
   const { acknowledged, insertedId } = serialize(response);
   return { acknowledged, insertedId };
 }

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertOne/MongoDBInsertOne.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBInsertOne/MongoDBInsertOne.test.js
@@ -18,6 +18,7 @@ import { validate } from '@lowdefy/ajv';
 import { MongoClient } from 'mongodb';
 import MongoDBInsertOne from './MongoDBInsertOne.js';
 import clearTestMongoDb from '../../../../test/clearTestMongoDb.js';
+import findLogCollectionRecordTestMongoDb from '../../../../test/findLogCollectionRecordTestMongoDb.js';
 
 const { checkRead, checkWrite } = MongoDBInsertOne.meta;
 const schema = MongoDBInsertOne.schema;
@@ -25,6 +26,7 @@ const schema = MongoDBInsertOne.schema;
 const databaseUri = process.env.MONGO_URL;
 const databaseName = 'test';
 const collection = 'insertOne';
+const logCollection = 'logCollection';
 
 beforeAll(() => {
   return clearTestMongoDb({ collection });
@@ -45,6 +47,43 @@ test('insertOne', async () => {
   });
 });
 
+test('insertOne logCollection', async () => {
+  const request = { doc: { _id: 'insertOne_log' } };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBInsertOne({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'insertOne_log',
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    insertedId: 'insertOne_log',
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'insertOne_log',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'insertOne_log',
+    type: 'MongoDBInsertOne',
+    meta: { meta: true },
+  });
+});
+
 test('insertOne options', async () => {
   const request = {
     doc: { _id: 'insertOne_options' },
@@ -60,6 +99,46 @@ test('insertOne options', async () => {
   expect(res).toEqual({
     acknowledged: true,
     insertedId: 'insertOne_options',
+  });
+});
+
+test('insertOne logCollection options', async () => {
+  const request = {
+    doc: { _id: 'insertOne_options_log' },
+    options: { writeConcern: { w: 'majority' } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBInsertOne({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'insertOne_options_log',
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    insertedId: 'insertOne_options_log',
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'insertOne_options_log',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'insertOne_options_log',
+    type: 'MongoDBInsertOne',
+    meta: { meta: true },
   });
 });
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateMany/MongoDBUpdateMany.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateMany/MongoDBUpdateMany.js
@@ -21,7 +21,7 @@ import schema from './schema.js';
 async function MongodbUpdateMany({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { filter, update, options } = deserializedRequest;
-  const collection = await getCollection({ connection });
+  const { collection } = await getCollection({ connection });
   const response = await collection.updateMany(filter, update, options);
   const { modifiedCount, upsertedId, upsertedCount, matchedCount } = serialize(response);
   return { modifiedCount, upsertedId, upsertedCount, matchedCount };

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateMany/MongoDBUpdateMany.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateMany/MongoDBUpdateMany.js
@@ -18,11 +18,33 @@ import getCollection from '../getCollection.js';
 import { serialize, deserialize } from '../serialize.js';
 import schema from './schema.js';
 
-async function MongodbUpdateMany({ connection, request }) {
+async function MongodbUpdateMany({
+  blockId,
+  connection,
+  connectionId,
+  pageId,
+  payload,
+  request,
+  requestId,
+}) {
   const deserializedRequest = deserialize(request);
   const { filter, update, options } = deserializedRequest;
-  const { collection } = await getCollection({ connection });
+  const { collection, logCollection } = await getCollection({ connection });
   const response = await collection.updateMany(filter, update, options);
+  if (logCollection) {
+    await logCollection.insertOne({
+      args: { filter, update, options },
+      blockId,
+      connectionId,
+      pageId,
+      payload,
+      requestId,
+      response,
+      timestamp: new Date(),
+      type: 'MongoDBUpdateMany',
+      meta: connection.changeLog?.meta,
+    });
+  }
   const { modifiedCount, upsertedId, upsertedCount, matchedCount } = serialize(response);
   return { modifiedCount, upsertedId, upsertedCount, matchedCount };
 }

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateMany/MongoDBUpdateMany.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateMany/MongoDBUpdateMany.test.js
@@ -16,6 +16,7 @@
 
 import { validate } from '@lowdefy/ajv';
 import MongoDBUpdateMany from './MongoDBUpdateMany.js';
+import findLogCollectionRecordTestMongoDb from '../../../../test/findLogCollectionRecordTestMongoDb.js';
 import populateTestMongoDb from '../../../../test/populateTestMongoDb.js';
 
 const { checkRead, checkWrite } = MongoDBUpdateMany.meta;
@@ -24,6 +25,7 @@ const schema = MongoDBUpdateMany.schema;
 const databaseUri = process.env.MONGO_URL;
 const databaseName = 'test';
 const collection = 'updateMany';
+const logCollection = 'logCollection';
 const documents = [
   { _id: 'updateMany', v: 'before' },
   { _id: 'updateMany_1', v: 'before' },
@@ -58,6 +60,48 @@ test('updateMany - Single Document', async () => {
   });
 });
 
+test('updateMany logCollection - Single Document', async () => {
+  const request = {
+    filter: { _id: 'updateMany' },
+    update: { $set: { v: 'afterLog' } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBUpdateMany({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateMany',
+    connection,
+  });
+  expect(res).toEqual({
+    modifiedCount: 1,
+    upsertedId: null,
+    upsertedCount: 0,
+    matchedCount: 1,
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateMany',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateMany',
+    type: 'MongoDBUpdateMany',
+    meta: { meta: true },
+  });
+});
+
 test('updateMany - Multiple Documents', async () => {
   const request = {
     filter: { _id: { $in: ['updateMany_1', 'updateMany_2', 'updateMany_3'] } },
@@ -78,6 +122,48 @@ test('updateMany - Multiple Documents', async () => {
   });
 });
 
+test('updateMany logCollection - Multiple Documents', async () => {
+  const request = {
+    filter: { _id: { $in: ['updateMany_1', 'updateMany_2', 'updateMany_3'] } },
+    update: { $set: { v: 'afterLog' } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBUpdateMany({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateMany_multiple',
+    connection,
+  });
+  expect(res).toEqual({
+    modifiedCount: 3,
+    upsertedId: null,
+    upsertedCount: 0,
+    matchedCount: 3,
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateMany_multiple',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateMany_multiple',
+    type: 'MongoDBUpdateMany',
+    meta: { meta: true },
+  });
+});
+
 test('updateMany - Multiple Documents one field', async () => {
   const request = {
     filter: { f: 'updateMany' },
@@ -95,6 +181,48 @@ test('updateMany - Multiple Documents one field', async () => {
     upsertedId: null,
     upsertedCount: 0,
     matchedCount: 3,
+  });
+});
+
+test('updateMany logCollection - Multiple Documents one field', async () => {
+  const request = {
+    filter: { f: 'updateMany' },
+    update: { $set: { v: 'afterLog' } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBUpdateMany({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateMany_multiple_one_field',
+    connection,
+  });
+  expect(res).toEqual({
+    modifiedCount: 3,
+    upsertedId: null,
+    upsertedCount: 0,
+    matchedCount: 3,
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateMany_multiple_one_field',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateMany_multiple_one_field',
+    type: 'MongoDBUpdateMany',
+    meta: { meta: true },
   });
 });
 
@@ -119,6 +247,49 @@ test('updateMany upsert', async () => {
   });
 });
 
+test('updateMany logCollection upsert', async () => {
+  const request = {
+    filter: { _id: 'updateMany_upsert_log' },
+    update: { $set: { v: 'after' } },
+    options: { upsert: true },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBUpdateMany({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateMany_upsert_log',
+    connection,
+  });
+  expect(res).toEqual({
+    modifiedCount: 0,
+    upsertedId: 'updateMany_upsert_log',
+    upsertedCount: 1,
+    matchedCount: 0,
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateMany_upsert_log',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateMany_upsert_log',
+    type: 'MongoDBUpdateMany',
+    meta: { meta: true },
+  });
+});
+
 test('updateMany upsert false', async () => {
   const request = {
     filter: { _id: 'updateMany_upsert_false' },
@@ -140,6 +311,49 @@ test('updateMany upsert false', async () => {
   });
 });
 
+test('updateMany logCollection upsert false', async () => {
+  const request = {
+    filter: { _id: 'updateMany_upsert_false_log' },
+    update: { $set: { v: 'after' } },
+    options: { upsert: false },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBUpdateMany({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateMany_upsert_false_log',
+    connection,
+  });
+  expect(res).toEqual({
+    modifiedCount: 0,
+    upsertedId: null,
+    upsertedCount: 0,
+    matchedCount: 0,
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateMany_upsert_false_log',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateMany_upsert_false_log',
+    type: 'MongoDBUpdateMany',
+    meta: { meta: true },
+  });
+});
+
 test('updateMany upsert default false', async () => {
   const request = {
     filter: { _id: 'updateMany_upsert_default_false' },
@@ -157,6 +371,48 @@ test('updateMany upsert default false', async () => {
     upsertedId: null,
     upsertedCount: 0,
     matchedCount: 0,
+  });
+});
+
+test('updateMany logCollection upsert default false', async () => {
+  const request = {
+    filter: { _id: 'updateMany_upsert_default_false_log' },
+    update: { $set: { v: 'after' } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBUpdateMany({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateMany_upsert_default_false_log',
+    connection,
+  });
+  expect(res).toEqual({
+    modifiedCount: 0,
+    upsertedId: null,
+    upsertedCount: 0,
+    matchedCount: 0,
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateMany_upsert_default_false_log',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateMany_upsert_default_false_log',
+    type: 'MongoDBUpdateMany',
+    meta: { meta: true },
   });
 });
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/MongoDBUpdateOne.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/MongoDBUpdateOne.js
@@ -28,7 +28,7 @@ async function MongodbUpdateOne({
   requestId,
 }) {
   const deserializedRequest = deserialize(request);
-  const { filter, update, options } = deserializedRequest;
+  const { filter, update, options, disableNoMatchError } = deserializedRequest;
   const { collection, logCollection } = await getCollection({ connection });
   let response;
   if (logCollection) {
@@ -51,6 +51,10 @@ async function MongodbUpdateOne({
       upsertedId,
       upsertedCount: upsertedId ? 1 : 0,
     };
+    // Throw before writing the log record so a no-match update never logs.
+    if (!disableNoMatchError && !options?.upsert && matched === 0 && !upsertedId) {
+      throw new Error('No matching record to update.');
+    }
     await logCollection.insertOne({
       args: { filter, update, options },
       blockId,
@@ -66,6 +70,9 @@ async function MongodbUpdateOne({
     });
   } else {
     response = await collection.updateOne(filter, update, options);
+    if (!disableNoMatchError && !options?.upsert && response.matchedCount === 0) {
+      throw new Error('No matching record to update.');
+    }
   }
   return serialize(response);
 }

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/MongoDBUpdateOne.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/MongoDBUpdateOne.js
@@ -21,7 +21,7 @@ import schema from './schema.js';
 async function MongodbUpdateOne({ connection, request }) {
   const deserializedRequest = deserialize(request);
   const { filter, update, options } = deserializedRequest;
-  const collection = await getCollection({ connection });
+  const { collection } = await getCollection({ connection });
   const response = await collection.updateOne(filter, update, options);
   return serialize(response);
 }

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/MongoDBUpdateOne.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/MongoDBUpdateOne.js
@@ -18,11 +18,55 @@ import getCollection from '../getCollection.js';
 import { serialize, deserialize } from '../serialize.js';
 import schema from './schema.js';
 
-async function MongodbUpdateOne({ connection, request }) {
+async function MongodbUpdateOne({
+  blockId,
+  connection,
+  connectionId,
+  pageId,
+  payload,
+  request,
+  requestId,
+}) {
   const deserializedRequest = deserialize(request);
   const { filter, update, options } = deserializedRequest;
-  const { collection } = await getCollection({ connection });
-  const response = await collection.updateOne(filter, update, options);
+  const { collection, logCollection } = await getCollection({ connection });
+  let response;
+  if (logCollection) {
+    // findOneAndUpdate instead of updateOne to capture before and after
+    // documents for the change log. The response shape matches the updateOne
+    // response so it is invariant to the connection having a changeLog.
+    const before = await collection.findOne(filter);
+    const result = await collection.findOneAndUpdate(filter, update, {
+      ...options,
+      includeResultMetadata: true,
+      returnDocument: 'after',
+    });
+    const after = result.value ?? null;
+    const upsertedId = result.lastErrorObject?.upserted ?? null;
+    const matched = result.lastErrorObject?.updatedExisting ? 1 : 0;
+    response = {
+      acknowledged: true,
+      matchedCount: matched,
+      modifiedCount: matched,
+      upsertedId,
+      upsertedCount: upsertedId ? 1 : 0,
+    };
+    await logCollection.insertOne({
+      args: { filter, update, options },
+      blockId,
+      connectionId,
+      pageId,
+      payload,
+      requestId,
+      before,
+      after,
+      timestamp: new Date(),
+      type: 'MongoDBUpdateOne',
+      meta: connection.changeLog?.meta,
+    });
+  } else {
+    response = await collection.updateOne(filter, update, options);
+  }
   return serialize(response);
 }
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/MongoDBUpdateOne.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/MongoDBUpdateOne.test.js
@@ -16,6 +16,7 @@
 
 import { validate } from '@lowdefy/ajv';
 import MongoDBUpdateOne from './MongoDBUpdateOne.js';
+import findLogCollectionRecordTestMongoDb from '../../../../test/findLogCollectionRecordTestMongoDb.js';
 import populateTestMongoDb from '../../../../test/populateTestMongoDb.js';
 
 const { checkRead, checkWrite } = MongoDBUpdateOne.meta;
@@ -24,7 +25,11 @@ const schema = MongoDBUpdateOne.schema;
 const databaseUri = process.env.MONGO_URL;
 const databaseName = 'test';
 const collection = 'updateOne';
-const documents = [{ _id: 'updateOne', v: 'before' }];
+const logCollection = 'logCollection';
+const documents = [
+  { _id: 'updateOne', v: 'before' },
+  { _id: null, v: 'sentinel' },
+];
 
 beforeAll(() => {
   return populateTestMongoDb({ collection, documents });
@@ -51,6 +56,51 @@ test('updateOne', async () => {
   });
 });
 
+test('updateOne logCollection', async () => {
+  const request = {
+    filter: { _id: 'updateOne' },
+    update: { $set: { v: 'afterLog' } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBUpdateOne({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateOne',
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    matchedCount: 1,
+    modifiedCount: 1,
+    upsertedId: null,
+    upsertedCount: 0,
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateOne',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateOne',
+    before: { _id: 'updateOne', v: 'after' },
+    after: { _id: 'updateOne', v: 'afterLog' },
+    type: 'MongoDBUpdateOne',
+    meta: { meta: true },
+  });
+});
+
 test('updateOne upsert', async () => {
   const request = {
     filter: { _id: 'updateOne_upsert' },
@@ -73,11 +123,151 @@ test('updateOne upsert', async () => {
   });
 });
 
+test('updateOne upsert logCollection', async () => {
+  const request = {
+    filter: { _id: 'updateOne_upsert_log' },
+    update: { $set: { v: 'after' } },
+    options: { upsert: true },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBUpdateOne({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateOne_upsert_log',
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    matchedCount: 0,
+    modifiedCount: 0,
+    upsertedId: 'updateOne_upsert_log',
+    upsertedCount: 1,
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateOne_upsert_log',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateOne_upsert_log',
+    before: null,
+    after: { _id: 'updateOne_upsert_log', v: 'after' },
+    type: 'MongoDBUpdateOne',
+    meta: { meta: true },
+  });
+});
+
 test('updateOne upsert false', async () => {
   const request = {
     filter: { _id: 'updateOne_upsert_false' },
     update: { $set: { v: 'after' } },
     options: { upsert: false },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    write: true,
+  };
+  expect(async () => {
+    await MongoDBUpdateOne({ request, connection });
+  }).rejects.toThrow('No matching record to update.');
+});
+
+test('updateOne upsert false logCollection', async () => {
+  const request = {
+    filter: { _id: 'updateOne_upsert_false' },
+    update: { $set: { v: 'after' } },
+    options: { upsert: false },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  await expect(async () => {
+    await MongoDBUpdateOne({
+      request,
+      blockId: 'blockId',
+      connectionId: 'connectionId',
+      pageId: 'pageId',
+      payload: { payload: true },
+      requestId: 'updateOne_upsert_false',
+      connection,
+    });
+  }).rejects.toThrow('No matching record to update.');
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateOne_upsert_false',
+  });
+  expect(logged).toBeNull();
+});
+
+test('updateOne upsert default false', async () => {
+  const request = {
+    filter: { _id: 'updateOne_upsert_default_false' },
+    update: { $set: { v: 'after' } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    write: true,
+  };
+  expect(async () => {
+    await MongoDBUpdateOne({ request, connection });
+  }).rejects.toThrow('No matching record to update.');
+});
+
+test('updateOne upsert default false logCollection', async () => {
+  const request = {
+    filter: { _id: 'updateOne_upsert_default_false' },
+    update: { $set: { v: 'after' } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  await expect(async () => {
+    await MongoDBUpdateOne({
+      request,
+      blockId: 'blockId',
+      connectionId: 'connectionId',
+      pageId: 'pageId',
+      payload: { payload: true },
+      requestId: 'updateOne_upsert_default_false',
+      connection,
+    });
+  }).rejects.toThrow('No matching record to update.');
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateOne_upsert_default_false',
+  });
+  expect(logged).toBeNull();
+});
+
+test('updateOne disableNoMatchError', async () => {
+  const request = {
+    filter: { _id: 'updateOne_disable_no_match_error' },
+    update: { $set: { v: 'after' } },
+    disableNoMatchError: true,
   };
   const connection = {
     databaseUri,
@@ -95,10 +285,57 @@ test('updateOne upsert false', async () => {
   });
 });
 
-test('updateOne upsert default false', async () => {
+test('updateOne disableNoMatchError logCollection', async () => {
   const request = {
-    filter: { _id: 'updateOne_upsert_default_false' },
+    filter: { _id: 'updateOne_disable_no_match_error' },
     update: { $set: { v: 'after' } },
+    disableNoMatchError: true,
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBUpdateOne({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateOne_disable_no_match_error',
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    matchedCount: 0,
+    modifiedCount: 0,
+    upsertedId: null,
+    upsertedCount: 0,
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateOne_disable_no_match_error',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateOne_disable_no_match_error',
+    before: null,
+    after: null,
+    type: 'MongoDBUpdateOne',
+    meta: { meta: true },
+  });
+});
+
+test('updateOne disableNoMatchError false', async () => {
+  const request = {
+    filter: { _id: 'updateOne_disable_no_match_error_false' },
+    update: { $set: { v: 'after' } },
+    disableNoMatchError: false,
   };
   const connection = {
     databaseUri,
@@ -106,14 +343,120 @@ test('updateOne upsert default false', async () => {
     collection,
     write: true,
   };
-  const res = await MongoDBUpdateOne({ request, connection });
+  expect(async () => {
+    await MongoDBUpdateOne({ request, connection });
+  }).rejects.toThrow('No matching record to update.');
+});
+
+test('updateOne disableNoMatchError false logCollection', async () => {
+  const request = {
+    filter: { _id: 'updateOne_disable_no_match_error_false' },
+    update: { $set: { v: 'after' } },
+    disableNoMatchError: false,
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  await expect(async () => {
+    await MongoDBUpdateOne({
+      request,
+      blockId: 'blockId',
+      connectionId: 'connectionId',
+      pageId: 'pageId',
+      payload: { payload: true },
+      requestId: 'updateOne_disable_no_match_error_false',
+      connection,
+    });
+  }).rejects.toThrow('No matching record to update.');
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateOne_disable_no_match_error_false',
+  });
+  expect(logged).toBeNull();
+});
+
+test('updateOne no-match logCollection does not pick up _id:null doc as after', async () => {
+  const request = {
+    filter: { _id: 'updateOne_no_match_id_null_regression' },
+    update: { $set: { v: 'after' } },
+    disableNoMatchError: true,
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBUpdateOne({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateOne_no_match_id_null_regression',
+    connection,
+  });
   expect(res).toEqual({
     acknowledged: true,
+    matchedCount: 0,
     modifiedCount: 0,
     upsertedId: null,
     upsertedCount: 0,
-    matchedCount: 0,
   });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateOne_no_match_id_null_regression',
+  });
+  expect(logged.before).toBeNull();
+  expect(logged.after).toBeNull();
+});
+
+test('updateOne response shape is invariant to logCollection', async () => {
+  const baseConnection = { databaseUri, databaseName, collection, write: true };
+  const logConnection = {
+    ...baseConnection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+  };
+
+  const match = {
+    filter: { _id: 'updateOne_invariance_match' },
+    update: { $set: { v: 'after' } },
+    options: { upsert: true },
+  };
+  const upsert = {
+    filter: { _id: 'updateOne_invariance_upsert' },
+    update: { $set: { v: 'after' } },
+    options: { upsert: true },
+  };
+  const noMatch = {
+    filter: { _id: 'updateOne_invariance_no_match' },
+    update: { $set: { v: 'after' } },
+    disableNoMatchError: true,
+  };
+
+  // Pre-seed the match doc so the matched-case response is identical in both branches.
+  await MongoDBUpdateOne({ request: match, connection: baseConnection });
+
+  const expectedKeys = ['acknowledged', 'matchedCount', 'modifiedCount', 'upsertedCount', 'upsertedId'];
+  for (const request of [match, upsert, noMatch]) {
+    const resNoLog = await MongoDBUpdateOne({ request, connection: baseConnection });
+    const resWithLog = await MongoDBUpdateOne({
+      request,
+      blockId: 'blockId',
+      connectionId: 'connectionId',
+      pageId: 'pageId',
+      payload: { payload: true },
+      requestId: `invariance_${request.filter._id}`,
+      connection: logConnection,
+    });
+    expect(Object.keys(resNoLog).sort()).toEqual(expectedKeys);
+    expect(Object.keys(resWithLog).sort()).toEqual(expectedKeys);
+  }
 });
 
 test('updateOne connection error', async () => {

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/schema.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/schema.js
@@ -41,6 +41,14 @@ export default {
         type: 'MongoDBUpdateOne request property "options" should be an object.',
       },
     },
+    disableNoMatchError: {
+      type: 'boolean',
+      description:
+        'Do not throw an error when no document matches the filter. By default the request throws "No matching record to update." when nothing matched and upsert is not set.',
+      errorMessage: {
+        type: 'MongoDBUpdateOne request property "disableNoMatchError" should be a boolean.',
+      },
+    },
   },
   errorMessage: {
     type: 'MongoDBUpdateOne request properties should be an object.',

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBVersionedUpdateOne/MongoDBVersionedUpdateOne.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBVersionedUpdateOne/MongoDBVersionedUpdateOne.js
@@ -1,0 +1,103 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import getCollection from '../getCollection.js';
+import { serialize, deserialize } from '../serialize.js';
+import schema from './schema.js';
+
+async function MongoDBVersionedUpdateOne({
+  blockId,
+  connection,
+  connectionId,
+  pageId,
+  payload,
+  request,
+  requestId,
+}) {
+  const deserializedRequest = deserialize(request);
+  const { filter, update, options, disableNoMatchError } = deserializedRequest;
+  const { collection, logCollection } = await getCollection({ connection });
+  const findOptions = options?.find;
+  const insertOptions = options?.insert;
+  const updateOptions = options?.update;
+
+  // The matched document is re-inserted under a new _id so the previous
+  // version is preserved, then the update is applied to the new copy.
+  const document = await collection.findOne(filter, { ...findOptions });
+  let insertedDocument;
+  if (document) {
+    delete document._id;
+    insertedDocument = await collection.insertOne(document, { ...insertOptions });
+  }
+
+  let response;
+  if (logCollection) {
+    const result = await collection.findOneAndUpdate(
+      insertedDocument ? { _id: insertedDocument.insertedId } : filter,
+      update,
+      {
+        ...updateOptions,
+        includeResultMetadata: true,
+        returnDocument: 'after',
+      }
+    );
+    const after = result.value ?? null;
+    const upsertedId = result.lastErrorObject?.upserted ?? null;
+    const matched = result.lastErrorObject?.updatedExisting ? 1 : 0;
+    response = {
+      acknowledged: true,
+      matchedCount: matched,
+      modifiedCount: matched,
+      upsertedId,
+      upsertedCount: upsertedId ? 1 : 0,
+    };
+    // Throw before writing the log record so a no-match update never logs.
+    if (!disableNoMatchError && !updateOptions?.upsert && matched === 0 && !upsertedId) {
+      throw new Error('No matching record to update.');
+    }
+    await logCollection.insertOne({
+      args: { filter, update, options },
+      blockId,
+      connectionId,
+      pageId,
+      payload,
+      requestId,
+      before: document,
+      after,
+      timestamp: new Date(),
+      type: 'MongoDBVersionedUpdateOne',
+      meta: connection.changeLog?.meta,
+    });
+  } else {
+    response = await collection.updateOne(
+      insertedDocument ? { _id: insertedDocument.insertedId } : filter,
+      update,
+      { ...updateOptions }
+    );
+    if (!disableNoMatchError && !updateOptions?.upsert && response.matchedCount === 0) {
+      throw new Error('No matching record to update.');
+    }
+  }
+  return serialize(response);
+}
+
+MongoDBVersionedUpdateOne.schema = schema;
+MongoDBVersionedUpdateOne.meta = {
+  checkRead: false,
+  checkWrite: true,
+};
+
+export default MongoDBVersionedUpdateOne;

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBVersionedUpdateOne/MongoDBVersionedUpdateOne.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBVersionedUpdateOne/MongoDBVersionedUpdateOne.test.js
@@ -1,0 +1,608 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { validate } from '@lowdefy/ajv';
+import MongoDBVersionedUpdateOne from './MongoDBVersionedUpdateOne.js';
+import findLogCollectionRecordTestMongoDb from '../../../../test/findLogCollectionRecordTestMongoDb.js';
+import populateTestMongoDb from '../../../../test/populateTestMongoDb.js';
+import getTestCollection from '../../../../test/getTestCollection.js';
+
+const { checkRead, checkWrite } = MongoDBVersionedUpdateOne.meta;
+const schema = MongoDBVersionedUpdateOne.schema;
+
+const databaseUri = process.env.MONGO_URL;
+const databaseName = 'test';
+const collection = 'updateInsertOne';
+const logCollection = 'logCollection';
+const documents = [{ _id: 'uniqueId', v: 'before', doc_id: 'updateInsertOne' }];
+
+beforeEach(() => {
+  return populateTestMongoDb({ collection, documents });
+});
+
+test('updateInsertOne', async () => {
+  const request = {
+    filter: { doc_id: 'updateInsertOne' },
+    update: { $set: { v: 'after' } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    write: true,
+  };
+  const res = await MongoDBVersionedUpdateOne({ request, connection });
+  expect(res).toEqual({
+    acknowledged: true,
+    modifiedCount: 1,
+    upsertedId: null,
+    upsertedCount: 0,
+    matchedCount: 1,
+  });
+});
+
+test('updateInsertOne logCollection', async () => {
+  const request = {
+    filter: { doc_id: 'updateInsertOne' },
+    update: { $set: { v: 'afterLog' } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBVersionedUpdateOne({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateInsertOne',
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    matchedCount: 1,
+    modifiedCount: 1,
+    upsertedId: null,
+    upsertedCount: 0,
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateInsertOne',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateInsertOne',
+    before: { doc_id: 'updateInsertOne', v: 'before' },
+    after: { doc_id: 'updateInsertOne', v: 'afterLog' },
+    type: 'MongoDBVersionedUpdateOne',
+    meta: { meta: true },
+  });
+});
+
+test('updateInsertOne logCollection with find options', async () => {
+  const request = {
+    filter: { doc_id: 'updateInsertOne' },
+    update: { $set: { v: 'afterLog' } },
+    options: { find: { projection: { doc_id: 0 } } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBVersionedUpdateOne({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateInsertOneFindOptions',
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    matchedCount: 1,
+    modifiedCount: 1,
+    upsertedId: null,
+    upsertedCount: 0,
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateInsertOneFindOptions',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateInsertOneFindOptions',
+    before: { v: 'before' },
+    after: { v: 'afterLog' },
+    type: 'MongoDBVersionedUpdateOne',
+    meta: { meta: true },
+  });
+});
+
+test('updateInsertOne upsert', async () => {
+  const request = {
+    filter: { _id: 'uniqueId_upsert', doc_id: 'updateInsertOne' },
+    update: { $set: { v: 'after' } },
+    options: { update: { upsert: true } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    write: true,
+  };
+  const res = await MongoDBVersionedUpdateOne({ request, connection });
+  expect(res).toEqual({
+    acknowledged: true,
+    modifiedCount: 0,
+    upsertedId: 'uniqueId_upsert',
+    upsertedCount: 1,
+    matchedCount: 0,
+  });
+});
+
+test('updateInsertOne upsert logCollection', async () => {
+  const request = {
+    filter: { _id: 'uniqueId_upsert_log', doc_id: 'updateInsertOne' },
+    update: { $set: { v: 'after' } },
+    options: { update: { upsert: true } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBVersionedUpdateOne({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'uniqueId_upsert_log',
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    matchedCount: 0,
+    modifiedCount: 0,
+    upsertedId: 'uniqueId_upsert_log',
+    upsertedCount: 1,
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'uniqueId_upsert_log',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'uniqueId_upsert_log',
+    before: null,
+    after: { _id: 'uniqueId_upsert_log', v: 'after', doc_id: 'updateInsertOne' },
+    type: 'MongoDBVersionedUpdateOne',
+    meta: { meta: true },
+  });
+});
+
+test('updateInsertOne upsert false', async () => {
+  const request = {
+    filter: { doc_id: 'uniqueId_upsert_false' },
+    update: { $set: { v: 'after' } },
+    options: { update: { upsert: false } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    write: true,
+  };
+  expect(async () => {
+    await MongoDBVersionedUpdateOne({ request, connection });
+  }).rejects.toThrow('No matching record to update.');
+});
+
+test('updateInsertOne upsert false logCollection', async () => {
+  const request = {
+    filter: { doc_id: 'updateInsertOne_upsert_false' },
+    update: { $set: { v: 'after' } },
+    options: { update: { upsert: false } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  await expect(async () => {
+    await MongoDBVersionedUpdateOne({
+      request,
+      blockId: 'blockId',
+      connectionId: 'connectionId',
+      pageId: 'pageId',
+      payload: { payload: true },
+      requestId: 'uniqueId_upsert_false',
+      connection,
+    });
+  }).rejects.toThrow('No matching record to update.');
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'uniqueId_upsert_false',
+  });
+  expect(logged).toBeNull();
+});
+
+test('updateInsertOne upsert default false', async () => {
+  const request = {
+    filter: { doc_id: 'updateInsertOne_upsert_default_false' },
+    update: { $set: { v: 'after' } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    write: true,
+  };
+  expect(async () => {
+    await MongoDBVersionedUpdateOne({ request, connection });
+  }).rejects.toThrow('No matching record to update.');
+});
+
+test('updateInsertOne upsert default false logCollection', async () => {
+  const request = {
+    filter: { doc_id: 'updateInsertOne_upsert_default_false' },
+    update: { $set: { v: 'after' } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  await expect(async () => {
+    await MongoDBVersionedUpdateOne({
+      request,
+      blockId: 'blockId',
+      connectionId: 'connectionId',
+      pageId: 'pageId',
+      payload: { payload: true },
+      requestId: 'updateInsertOne_upsert_default_false',
+      connection,
+    });
+  }).rejects.toThrow('No matching record to update.');
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateInsertOne_upsert_default_false',
+  });
+  expect(logged).toBeNull();
+});
+
+test('updateInsertOne disableNoMatchError', async () => {
+  const request = {
+    filter: { doc_id: 'updateInsertOne_disable_no_match_error' },
+    update: { $set: { v: 'after' } },
+    disableNoMatchError: true,
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    write: true,
+  };
+  const res = await MongoDBVersionedUpdateOne({ request, connection });
+  expect(res).toEqual({
+    acknowledged: true,
+    modifiedCount: 0,
+    upsertedId: null,
+    upsertedCount: 0,
+    matchedCount: 0,
+  });
+});
+
+test('updateInsertOne disableNoMatchError logCollection', async () => {
+  const request = {
+    filter: { doc_id: 'updateInsertOne_disable_no_match_error' },
+    update: { $set: { v: 'after' } },
+    disableNoMatchError: true,
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  const res = await MongoDBVersionedUpdateOne({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateInsertOne_disable_no_match_error',
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    matchedCount: 0,
+    modifiedCount: 0,
+    upsertedId: null,
+    upsertedCount: 0,
+  });
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateInsertOne_disable_no_match_error',
+  });
+  expect(logged).toMatchObject({
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateInsertOne_disable_no_match_error',
+    before: null,
+    after: null,
+    type: 'MongoDBVersionedUpdateOne',
+    meta: { meta: true },
+  });
+});
+
+test('updateInsertOne disableNoMatchError false', async () => {
+  const request = {
+    filter: { doc_id: 'updateInsertOne_disable_no_match_error_false' },
+    update: { $set: { v: 'after' } },
+    disableNoMatchError: false,
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    write: true,
+  };
+  expect(async () => {
+    await MongoDBVersionedUpdateOne({ request, connection });
+  }).rejects.toThrow('No matching record to update.');
+});
+
+test('updateInsertOne disableNoMatchError false logCollection', async () => {
+  const request = {
+    filter: { doc_id: 'updateInsertOne_disable_no_match_error_false' },
+    update: { $set: { v: 'after' } },
+    disableNoMatchError: false,
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+    write: true,
+  };
+  await expect(async () => {
+    await MongoDBVersionedUpdateOne({
+      request,
+      blockId: 'blockId',
+      connectionId: 'connectionId',
+      pageId: 'pageId',
+      payload: { payload: true },
+      requestId: 'updateInsertOne_disable_no_match_error_false',
+      connection,
+    });
+  }).rejects.toThrow('No matching record to update.');
+  const logged = await findLogCollectionRecordTestMongoDb({
+    logCollection,
+    requestId: 'updateInsertOne_disable_no_match_error_false',
+  });
+  expect(logged).toBeNull();
+});
+
+test('updateInsertOne response shape is invariant to logCollection', async () => {
+  const baseConnection = { databaseUri, databaseName, collection, write: true };
+  const logConnection = {
+    ...baseConnection,
+    changeLog: { collection: logCollection, meta: { meta: true } },
+  };
+
+  const match = {
+    filter: { doc_id: 'updateInsertOne' },
+    update: { $set: { v: 'after' } },
+  };
+  const upsert = {
+    filter: { _id: 'invariance_upsert', doc_id: 'updateInsertOne' },
+    update: { $set: { v: 'after' } },
+    options: { update: { upsert: true } },
+  };
+  const noMatch = {
+    filter: { doc_id: 'invariance_no_match' },
+    update: { $set: { v: 'after' } },
+    disableNoMatchError: true,
+  };
+
+  const expectedKeys = ['acknowledged', 'matchedCount', 'modifiedCount', 'upsertedCount', 'upsertedId'];
+  for (const request of [match, upsert, noMatch]) {
+    const resNoLog = await MongoDBVersionedUpdateOne({ request, connection: baseConnection });
+    const resWithLog = await MongoDBVersionedUpdateOne({
+      request,
+      blockId: 'blockId',
+      connectionId: 'connectionId',
+      pageId: 'pageId',
+      payload: { payload: true },
+      requestId: `invariance_${request.filter._id ?? request.filter.doc_id}`,
+      connection: logConnection,
+    });
+    expect(Object.keys(resNoLog).sort()).toEqual(expectedKeys);
+    expect(Object.keys(resWithLog).sort()).toEqual(expectedKeys);
+  }
+});
+
+test('updateInsertOne connection error', async () => {
+  const request = {
+    filter: { doc_id: 'updateInsertOne_connection_error' },
+    update: { $set: { v: 'after' } },
+  };
+  const connection = {
+    databaseUri: 'bad_uri',
+    databaseName,
+    collection,
+    write: true,
+  };
+  await expect(MongoDBVersionedUpdateOne({ request, connection })).rejects.toThrow(
+    'Invalid scheme, expected connection string to start with "mongodb://" or "mongodb+srv://"'
+  );
+});
+
+test('updateInsertOne mongodb error', async () => {
+  const request = {
+    filter: { doc_id: 'updateInsertOne_mongodb_error' },
+    update: { $badOp: { v: 'after' } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    write: true,
+  };
+  await expect(MongoDBVersionedUpdateOne({ request, connection })).rejects.toThrow(
+    'Unknown modifier: $badOp'
+  );
+});
+
+test('updateInsertOne validate write', async () => {
+  const request = {
+    filter: { doc_id: 'updateInsertOne' },
+    update: { $set: { v: 'after' } },
+  };
+  const connection = {
+    databaseUri,
+    databaseName,
+    collection,
+    write: true,
+  };
+  const res = await MongoDBVersionedUpdateOne({
+    request,
+    blockId: 'blockId',
+    connectionId: 'connectionId',
+    pageId: 'pageId',
+    payload: { payload: true },
+    requestId: 'updateInsertOne_validate_write',
+    connection,
+  });
+  expect(res).toEqual({
+    acknowledged: true,
+    modifiedCount: 1,
+    upsertedId: null,
+    upsertedCount: 0,
+    matchedCount: 1,
+  });
+  const { collection: testCollection, client } = await getTestCollection({
+    collection: 'updateInsertOne',
+  });
+  const cursor = await testCollection.find(
+    { doc_id: 'updateInsertOne' },
+    { projection: { _id: 0 } }
+  );
+  const records = await cursor.toArray();
+  expect(records).toEqual([
+    { doc_id: 'updateInsertOne', v: 'before' },
+    { doc_id: 'updateInsertOne', v: 'after' },
+  ]);
+  await client.close();
+});
+
+test('checkRead should be false', async () => {
+  expect(checkRead).toBe(false);
+});
+
+test('checkWrite should be true', async () => {
+  expect(checkWrite).toBe(true);
+});
+
+test('request not an object', async () => {
+  const request = 'request';
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBVersionedUpdateOne request properties should be an object.'
+  );
+});
+
+test('request no filter', async () => {
+  const request = { update: {} };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBVersionedUpdateOne request should have required property "filter".'
+  );
+});
+
+test('request no update', async () => {
+  const request = { filter: {} };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBVersionedUpdateOne request should have required property "update".'
+  );
+});
+
+test('request update not an object', async () => {
+  const request = { update: 'update', filter: {} };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBVersionedUpdateOne request property "update" should be an object.'
+  );
+});
+
+test('request filter not an object', async () => {
+  const request = { update: {}, filter: 'filter' };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBVersionedUpdateOne request property "filter" should be an object.'
+  );
+});
+
+test('request options not an object', async () => {
+  const request = { update: {}, filter: {}, options: 'options' };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBVersionedUpdateOne request property "options" should be an object.'
+  );
+});
+
+test('request update options not an object', async () => {
+  const request = { update: {}, filter: {}, options: { update: 'update' } };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBVersionedUpdateOne request property option "update" should be an object.'
+  );
+});
+
+test('request find options not an object', async () => {
+  const request = { update: {}, filter: {}, options: { find: 'find' } };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBVersionedUpdateOne request property option "find" should be an object.'
+  );
+});
+
+test('request insert options not an object', async () => {
+  const request = { update: {}, filter: {}, options: { insert: 'insert' } };
+  expect(() => validate({ schema, data: request })).toThrow(
+    'MongoDBVersionedUpdateOne request property option "insert" should be an object.'
+  );
+});

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBVersionedUpdateOne/schema.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBVersionedUpdateOne/schema.js
@@ -1,0 +1,83 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+export default {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'Lowdefy Request Schema - MongoDBVersionedUpdateOne',
+  type: 'object',
+  required: ['filter', 'update'],
+  properties: {
+    filter: {
+      type: 'object',
+      description: 'The filter used to select the document to find and insert.',
+      errorMessage: {
+        type: 'MongoDBVersionedUpdateOne request property "filter" should be an object.',
+      },
+    },
+    update: {
+      type: ['object', 'array'],
+      description: 'The update operations to be applied to the new inserted document.',
+      errorMessage: {
+        type: 'MongoDBVersionedUpdateOne request property "update" should be an object.',
+      },
+    },
+    options: {
+      type: 'object',
+      description: 'Optional settings for each mongodb operation.',
+      errorMessage: {
+        type: 'MongoDBVersionedUpdateOne request property "options" should be an object.',
+      },
+      properties: {
+        find: {
+          type: 'object',
+          description: 'Find options for mongodb find one.',
+          errorMessage: {
+            type: 'MongoDBVersionedUpdateOne request property option "find" should be an object.',
+          },
+        },
+        insert: {
+          type: 'object',
+          description: 'Insert options for mongodb insert one.',
+          errorMessage: {
+            type: 'MongoDBVersionedUpdateOne request property option "insert" should be an object.',
+          },
+        },
+        update: {
+          type: 'object',
+          description: 'Update options for mongodb find one and update.',
+          errorMessage: {
+            type: 'MongoDBVersionedUpdateOne request property option "update" should be an object.',
+          },
+        },
+      },
+    },
+    disableNoMatchError: {
+      type: 'boolean',
+      description:
+        'Do not throw an error when no document matches the filter. By default the request throws "No matching record to update." when nothing matched and upsert is not set.',
+      errorMessage: {
+        type: 'MongoDBVersionedUpdateOne request property "disableNoMatchError" should be a boolean.',
+      },
+    },
+  },
+  errorMessage: {
+    type: 'MongoDBVersionedUpdateOne request properties should be an object.',
+    required: {
+      filter: 'MongoDBVersionedUpdateOne request should have required property "filter".',
+      update: 'MongoDBVersionedUpdateOne request should have required property "update".',
+    },
+  },
+};

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getCollection.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getCollection.js
@@ -19,7 +19,7 @@ import { type } from '@lowdefy/helpers';
 import getClient from './getClient.js';
 
 async function getCollection({ connection }) {
-  const { collection, databaseName, databaseUri, options } = connection;
+  const { changeLog, collection, databaseName, databaseUri, options } = connection;
   if (!type.isString(databaseUri)) {
     throw new Error('Database URI must be a string');
   }
@@ -30,7 +30,12 @@ async function getCollection({ connection }) {
     throw new Error('Collection name must be a string');
   }
   const client = await getClient({ databaseUri, options });
-  return client.db(databaseName).collection(collection);
+  const db = client.db(databaseName);
+  return {
+    client,
+    collection: db.collection(collection),
+    logCollection: changeLog?.collection ? db.collection(changeLog.collection) : undefined,
+  };
 }
 
 export default getCollection;

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getCollection.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getCollection.test.js
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-import { Collection } from 'mongodb';
+import { Collection, MongoClient } from 'mongodb';
 
 import getCollection from './getCollection.js';
 
@@ -25,8 +25,10 @@ test('get collection', async () => {
     databaseName: 'test',
     collection: 'getCollection',
   };
-  const res = await getCollection({ connection });
-  expect(res).toBeInstanceOf(Collection);
+  const { client, collection, logCollection } = await getCollection({ connection });
+  expect(client).toBeInstanceOf(MongoClient);
+  expect(collection).toBeInstanceOf(Collection);
+  expect(logCollection).toBe(undefined);
 });
 
 test('get collection, no databaseName, uses databaseUri', async () => {
@@ -34,8 +36,23 @@ test('get collection, no databaseName, uses databaseUri', async () => {
     databaseUri,
     collection: 'getCollection',
   };
-  const res = await getCollection({ connection });
-  expect(res).toBeInstanceOf(Collection);
+  const { collection } = await getCollection({ connection });
+  expect(collection).toBeInstanceOf(Collection);
+});
+
+test('get collection with changeLog returns logCollection', async () => {
+  const connection = {
+    databaseUri,
+    databaseName: 'test',
+    collection: 'getCollection',
+    changeLog: {
+      collection: 'getCollectionLog',
+    },
+  };
+  const { collection, logCollection } = await getCollection({ connection });
+  expect(collection).toBeInstanceOf(Collection);
+  expect(logCollection).toBeInstanceOf(Collection);
+  expect(logCollection.collectionName).toBe('getCollectionLog');
 });
 
 test('invalid databaseUri scheme', async () => {

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getConsecutiveIdIndex.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getConsecutiveIdIndex.js
@@ -14,24 +14,27 @@
   limitations under the License.
 */
 
-export default {
-  connections: ['MongoDBCollection'],
-  requests: [
-    'MongoDBAggregation',
-    'MongoDBBulkWrite',
-    'MongoDBDeleteMany',
-    'MongoDBDeleteOne',
-    'MongoDBFind',
-    'MongoDBFindOne',
-    'MongoDBInsertConsecutiveId',
-    'MongoDBInsertMany',
-    'MongoDBInsertManyConsecutiveIds',
-    'MongoDBInsertOne',
-    'MongoDBUpdateMany',
-    'MongoDBUpdateOne',
-    'MongoDBVersionedUpdateOne',
-  ],
-  auth: {
-    adapters: ['MongoDBAdapter'],
-  },
-};
+async function getConsecutiveIdIndex({ collection, prefix, session }) {
+  const previous = await collection
+    .aggregate(
+      [
+        { $match: { _id: { $regex: `^${prefix}\\d+$` } } },
+        {
+          $project: {
+            index: { $toInt: { $replaceOne: { input: '$_id', find: prefix, replacement: '' } } },
+          },
+        },
+        {
+          $sort: {
+            index: -1,
+          },
+        },
+        { $limit: 1 },
+      ],
+      { session }
+    )
+    .toArray();
+  return (previous?.[0]?.index ?? 0) + 1;
+}
+
+export default getConsecutiveIdIndex;

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/schema.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/schema.js
@@ -41,6 +41,34 @@ export default {
         type: 'MongoDBCollection connection property "collection" should be a string.',
       },
     },
+    changeLog: {
+      type: 'object',
+      required: ['collection'],
+      description: 'Log all changes made by write requests to a log collection.',
+      properties: {
+        collection: {
+          type: 'string',
+          description: 'Name of the collection change log records are written to.',
+          errorMessage: {
+            type: 'MongoDBCollection connection property "changeLog.collection" should be a string.',
+          },
+        },
+        meta: {
+          type: 'object',
+          description: 'Additional data to include in every change log record.',
+          errorMessage: {
+            type: 'MongoDBCollection connection property "changeLog.meta" should be an object.',
+          },
+        },
+      },
+      errorMessage: {
+        type: 'MongoDBCollection connection property "changeLog" should be an object.',
+        required: {
+          collection:
+            'MongoDBCollection connection property "changeLog" should have required property "collection".',
+        },
+      },
+    },
     read: {
       type: 'boolean',
       default: true,

--- a/packages/plugins/connections/connection-mongodb/test/findLogCollectionRecordTestMongoDb.js
+++ b/packages/plugins/connections/connection-mongodb/test/findLogCollectionRecordTestMongoDb.js
@@ -1,0 +1,29 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { MongoClient } from 'mongodb';
+
+async function findLogCollectionRecordTestMongoDb({ logCollection, requestId }) {
+  const client = new MongoClient(process.env.MONGO_URL);
+  await client.connect();
+  const db = client.db();
+  const record = await db.collection(logCollection).findOne({ requestId });
+
+  await client.close();
+  return record;
+}
+
+export default findLogCollectionRecordTestMongoDb;

--- a/packages/plugins/connections/connection-mongodb/test/getTestCollection.js
+++ b/packages/plugins/connections/connection-mongodb/test/getTestCollection.js
@@ -14,22 +14,16 @@
   limitations under the License.
 */
 
-export default {
-  connections: ['MongoDBCollection'],
-  requests: [
-    'MongoDBAggregation',
-    'MongoDBBulkWrite',
-    'MongoDBDeleteMany',
-    'MongoDBDeleteOne',
-    'MongoDBFind',
-    'MongoDBFindOne',
-    'MongoDBInsertMany',
-    'MongoDBInsertOne',
-    'MongoDBUpdateMany',
-    'MongoDBUpdateOne',
-    'MongoDBVersionedUpdateOne',
-  ],
-  auth: {
-    adapters: ['MongoDBAdapter'],
-  },
-};
+import { MongoClient } from 'mongodb';
+
+async function getTestCollection({ collection }) {
+  const client = new MongoClient(process.env.MONGO_URL);
+  await client.connect();
+  const db = client.db();
+  return {
+    client,
+    collection: db.collection(collection),
+  };
+}
+
+export default getTestCollection;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,7 +83,7 @@ importers:
         version: 0.2.39(@swc/core@1.15.18)
       jest:
         specifier: 28.1.3
-        version: 28.1.3(@types/node@16.18.101)
+        version: 28.1.3(@types/node@20.6.2)
 
   packages/build:
     dependencies:
@@ -1448,13 +1448,16 @@ importers:
         version: link:../../../utils/helpers
       '@next-auth/mongodb-adapter':
         specifier: 1.1.3
-        version: 1.1.3(mongodb@6.3.0(@aws-sdk/credential-providers@3.425.0)(socks@2.7.1))(next-auth@4.24.10(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 1.1.3(mongodb@6.3.0(@aws-sdk/credential-providers@3.425.0)(socks@2.7.1))(next-auth@4.24.10(next@16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       mongodb:
         specifier: 6.3.0
         version: 6.3.0(@aws-sdk/credential-providers@3.425.0)(socks@2.7.1)
       saslprep:
         specifier: 1.0.3
         version: 1.0.3
+      uuid:
+        specifier: 13.0.0
+        version: 13.0.0
     devDependencies:
       '@lowdefy/ajv':
         specifier: 5.4.0
@@ -1473,13 +1476,13 @@ importers:
         version: 0.2.39(@swc/core@1.15.18)
       jest:
         specifier: 28.1.3
-        version: 28.1.3(@types/node@20.6.2)
+        version: 28.1.3(@types/node@16.18.101)
       jest-environment-node:
         specifier: 28.1.3
         version: 28.1.3
       next:
         specifier: 16.1.6
-        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-auth:
         specifier: 4.24.10
         version: 4.24.10(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -2022,7 +2025,7 @@ importers:
     dependencies:
       next:
         specifier: '>=16'
-        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-auth:
         specifier: '>=4.24'
         version: 4.24.10(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -2119,7 +2122,7 @@ importers:
         version: 1.11.19
       next:
         specifier: 16.1.6
-        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-auth:
         specifier: 4.24.10
         version: 4.24.10(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -2270,7 +2273,7 @@ importers:
         version: 16.3.1
       next:
         specifier: 16.1.6
-        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-auth:
         specifier: 4.24.10
         version: 4.24.10(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -2397,7 +2400,7 @@ importers:
         version: 1.11.19
       next:
         specifier: 16.1.6
-        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       pino:
         specifier: 8.16.2
         version: 8.16.2
@@ -15330,7 +15333,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next-auth/mongodb-adapter@1.1.3(mongodb@6.3.0(@aws-sdk/credential-providers@3.425.0)(socks@2.7.1))(next-auth@4.24.10(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+  '@next-auth/mongodb-adapter@1.1.3(mongodb@6.3.0(@aws-sdk/credential-providers@3.425.0)(socks@2.7.1))(next-auth@4.24.10(next@16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
       mongodb: 6.3.0(@aws-sdk/credential-providers@3.425.0)(socks@2.7.1)
       next-auth: 4.24.10(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -16347,7 +16350,7 @@ snapshots:
       '@sentry/vercel-edge': 8.53.0
       '@sentry/webpack-plugin': 2.22.7(encoding@0.1.13)(webpack@5.94.0)
       chalk: 3.0.0
-      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       resolve: 1.22.8
       rollup: 3.29.5
       stacktrace-parser: 0.1.11
@@ -23048,7 +23051,7 @@ snapshots:
       '@panva/hkdf': 1.1.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       oauth: 0.9.15
       openid-client: 5.6.0
       preact: 10.28.3
@@ -23088,7 +23091,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -23097,7 +23100,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.6(react@18.2.0)
+      styled-jsx: 5.1.6(@babel/core@7.23.3)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.6
       '@next/swc-darwin-x64': 16.1.6
@@ -24816,10 +24819,12 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
-  styled-jsx@5.1.6(react@18.2.0):
+  styled-jsx@5.1.6(@babel/core@7.23.3)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
+    optionalDependencies:
+      '@babel/core': 7.23.3
 
   stylis@4.3.6: {}
 


### PR DESCRIPTION
## Summary

Ports all features of `@lowdefy/community-plugin-mongodb` into the core MongoDB connection so MongoDB functionality is maintained in lowdefy itself. Once apps migrate (drop the plugin dependency — connection and request names are identical), the community plugin can be archived. All community code is adapted to the cached-client model introduced in #2261: no per-request `client.close()`, sessions end with `endSession()` only.

## Changes

- **@lowdefy/connection-mongodb**: `getCollection` returns `{ client, collection, logCollection }`; new `changeLog` connection property with audit logging on all six write requests (before/after snapshots for UpdateOne/DeleteOne via `findOneAndUpdate`/`findOneAndDelete`, response shapes invariant); `MongoDBUpdateOne` now throws `No matching record to update.` on no-match (opt-out via `disableNoMatchError`); new requests `MongoDBVersionedUpdateOne`, `MongoDBInsertConsecutiveId`, `MongoDBInsertManyConsecutiveIds` (transactional, replica set required); new `MultiAppMongoDBAdapter` next-auth adapter (shared `user-contacts` model with per-app membership and invite flow). Test suite grows from 176 to 264 tests, now running on a single-node replica-set memory server so transactions are tested live.
- **@lowdefy/codemods**: New 5.5.0 registry entry with a codemod that adds `disableNoMatchError: true` to existing `MongoDBUpdateOne` requests (skipping upsert requests and community-plugin apps) and emits a per-request report for author review.
- **@lowdefy/docs**: Corrected the stale "response differs with a log collection" notes (the operation differs, the response shape does not), documented `changeLog`, the no-match error, the three new requests, and a new `MultiAppMongoDBAdapter` reference page.

## Key Files

- `packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getCollection.js` — new return shape feeding client/logCollection to requests
- `packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/MongoDBUpdateOne.js` — changeLog snapshots + no-match error
- `packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/getConsecutiveIdIndex.js` — shared transactional id lookup (fixes a community bug where the aggregation ran outside the transaction)
- `packages/plugins/connections/connection-mongodb/src/auth/adapters/MultiAppMongoDBAdapter/MultiAppMongoDBAdapter.js` — ported adapter factory
- `packages/codemods/v5-5-0/01-add-disable-no-match-error.md` — upgrade codemod

## Breaking Changes

- `MongoDBUpdateOne` throws `No matching record to update.` when no document matches and `upsert` is not set. Migration: run `lowdefy upgrade` (codemod adds `disableNoMatchError: true` to existing requests), or set the flag manually where silent no-match is intended. Apps already on `@lowdefy/community-plugin-mongodb` are unaffected.
- `MongoDBInsertMany` now also returns `insertedIds` (additive, matches the community plugin).

## Notes

- `MongoDBChangeStream` is intentionally excluded — it is already ported on the `feat/websockets` branch (a2dae6984); that branch should rebase over this one since both touch `connection-mongodb`.
- `MongoDBVersionedUpdateOne` is not transactional (version insert and update are separate operations), matching community behavior — documented as a caveat.
- Consecutive-id request schemas now require `prefix` (community allowed omitting it, which produced `undefined1` ids).
- `MongoDBBulkWrite` still has no changeLog support (community never had it) — possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)