### PR TITLE
feat(server-dev,cli): Headless renderer auth + `--mock-user`; annotation overlay fixes

### DIFF
--- a/.changeset/feat-dev-mock-user-headless-auth.md
+++ b/.changeset/feat-dev-mock-user-headless-auth.md
@@ -1,0 +1,11 @@
+---
+'@lowdefy/server-dev': minor
+'lowdefy': minor
+---
+
+feat: Authenticate the dev server as a mock user for headless rendering and agent tools
+
+The dev server's headless renderer (used by the AI-agent screenshot and state-inspection tools) now authenticates, so auth-protected pages render instead of returning 404.
+
+- **New `lowdefy dev --mock-user [user]` flag** — start the development server authenticated as a mock user. Pass a JSON user object to set the identity and roles (e.g. `--mock-user '{"sub":"dev","roles":["admin"]}'`), or use the bare flag for a default user. This drives the same `auth.dev.mockUser` mechanism from the command line.
+- **Headless renderer authenticates** — the docs/MCP headless browser now carries an authenticated session, so `lowdefy_screenshot_page` and headless state inspection work on pages with `auth.public: false`. The developer's real browser session is unaffected. To render role-gated pages, configure `auth.dev.mockUser` (or `--mock-user`) with matching roles.

--- a/packages/cli/src/commands/dev/resolveMockUser.js
+++ b/packages/cli/src/commands/dev/resolveMockUser.js
@@ -1,0 +1,44 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const defaultMockUser = {
+  sub: 'lowdefy-dev',
+  id: 'lowdefy-dev',
+  name: 'Lowdefy Dev User',
+  roles: [],
+};
+
+// Turns the `--mock-user [user]` CLI option into the JSON string the dev server
+// reads from LOWDEFY_DEV_USER. Bare flag (commander yields `true`) → a default
+// roleless user. A supplied value is validated here so an invalid `--mock-user`
+// fails at the CLI with a clear message instead of deep in the server runtime.
+function resolveMockUser(mockUser) {
+  if (mockUser === true) {
+    return JSON.stringify(defaultMockUser);
+  }
+  try {
+    return JSON.stringify(JSON.parse(mockUser));
+  } catch (error) {
+    throw new Error(
+      `Invalid --mock-user value. Expected a JSON user object, received ${JSON.stringify(
+        mockUser
+      )}.`,
+      { cause: error }
+    );
+  }
+}
+
+export default resolveMockUser;

--- a/packages/cli/src/commands/dev/resolveMockUser.test.js
+++ b/packages/cli/src/commands/dev/resolveMockUser.test.js
@@ -1,0 +1,38 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import resolveMockUser from './resolveMockUser.js';
+
+test('resolveMockUser returns a default roleless user for the bare flag', () => {
+  expect(JSON.parse(resolveMockUser(true))).toEqual({
+    sub: 'lowdefy-dev',
+    id: 'lowdefy-dev',
+    name: 'Lowdefy Dev User',
+    roles: [],
+  });
+});
+
+test('resolveMockUser normalizes a valid JSON user string', () => {
+  expect(resolveMockUser('{ "sub": "dev", "roles": ["admin"] }')).toEqual(
+    '{"sub":"dev","roles":["admin"]}'
+  );
+});
+
+test('resolveMockUser throws on invalid JSON', () => {
+  expect(() => resolveMockUser('not json')).toThrow(
+    'Invalid --mock-user value. Expected a JSON user object, received "not json".'
+  );
+});

--- a/packages/cli/src/commands/dev/runDevServer.js
+++ b/packages/cli/src/commands/dev/runDevServer.js
@@ -17,7 +17,24 @@
 import { spawnProcess } from '@lowdefy/node-utils';
 import { createStdOutLineHandler } from '@lowdefy/logger/cli';
 
+import resolveMockUser from './resolveMockUser.js';
+
 async function runDevServer({ context, directory }) {
+  const env = {
+    ...process.env,
+    LOWDEFY_BUILD_REF_RESOLVER: context.options.refResolver,
+    LOWDEFY_DIRECTORY_CONFIG: context.directories.config,
+    LOWDEFY_LOG_LEVEL: context.options.logLevel,
+    LOWDEFY_SERVER_DEV_OPEN_BROWSER: !!context.options.open,
+    LOWDEFY_SERVER_DEV_WATCH: JSON.stringify(context.options.watch),
+    LOWDEFY_SERVER_DEV_WATCH_IGNORE: JSON.stringify(context.options.watchIgnore),
+    PORT: context.options.port,
+  };
+  // Set only when requested — an undefined value would clobber the LOWDEFY_DEV_USER
+  // inherited from process.env above.
+  if (context.options.mockUser) {
+    env.LOWDEFY_DEV_USER = resolveMockUser(context.options.mockUser);
+  }
   await spawnProcess({
     args: ['run', 'start'],
     command: context.pnpmCmd,
@@ -26,16 +43,7 @@ async function runDevServer({ context, directory }) {
       cwd: directory,
       // https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high
       shell: process.platform === 'win32',
-      env: {
-        ...process.env,
-        LOWDEFY_BUILD_REF_RESOLVER: context.options.refResolver,
-        LOWDEFY_DIRECTORY_CONFIG: context.directories.config,
-        LOWDEFY_LOG_LEVEL: context.options.logLevel,
-        LOWDEFY_SERVER_DEV_OPEN_BROWSER: !!context.options.open,
-        LOWDEFY_SERVER_DEV_WATCH: JSON.stringify(context.options.watch),
-        LOWDEFY_SERVER_DEV_WATCH_IGNORE: JSON.stringify(context.options.watchIgnore),
-        PORT: context.options.port,
-      },
+      env,
     },
     silent: false,
   });

--- a/packages/cli/src/program.js
+++ b/packages/cli/src/program.js
@@ -58,6 +58,10 @@ const options = {
     .choices(['error', 'warn', 'info', 'debug'])
     .default('info')
     .env('LOWDEFY_LOG_LEVEL'),
+  mockUser: new Option(
+    '--mock-user [user]',
+    'Start the dev server authenticated as a mock user (auth.dev.mockUser). Pass a JSON user object to set identity/roles, e.g. \'{"sub":"dev","roles":["admin"]}\'. Bare flag uses a default roleless user. Dev only.'
+  ).env('LOWDEFY_DEV_USER'),
   port: new Option(
     '--port <port>',
     'Change the port the development server is hosted at. Default is 3000.'
@@ -124,6 +128,7 @@ program
   .addOption(options.devDirectory)
   .addOption(options.disableTelemetry)
   .addOption(options.logLevel)
+  .addOption(options.mockUser)
   .option('--no-open', 'Do not open a new tab in the default browser.')
   .addOption(options.port)
   .addOption(options.refResolver)

--- a/packages/docs/concepts/ai-agent-docs.md
+++ b/packages/docs/concepts/ai-agent-docs.md
@@ -70,6 +70,10 @@ The dev server rebuilds automatically when config changes, so an agent works in 
 
 When you have a page open in your browser, the agent can read its **actual live state** — page state, request results, and the event log of recent actions — via `lowdefy_inspect_state`. Reproduce a problem by clicking through the app, then ask the agent to look: it inspects your exact tab, not a guess. `lowdefy_eval_operator` then evaluates any operator expression (like `{"_state": "customer.name"}`) against that same live context, so `_state`/`_request` binding bugs get debugged against real data. With no tab open, both tools run the page headless instead.
 
+## Auth-protected pages
+
+The headless renderer behind `lowdefy_screenshot_page` and `lowdefy_inspect_state` authenticates as a signed-in user, so pages with `auth.public: false` render for the agent instead of returning a 404. To render pages that require specific roles, start the dev server with a mock user carrying those roles — `lowdefy dev --mock-user '{"sub":"dev","roles":["admin"]}'` (or configure `auth.dev.mockUser`). See [Auth Configuration](/auth-configuration#mock-user-for-testing-dev-server-only).
+
 ## State checkpoints — put the app in a known state
 
 `lowdefy_snapshot_state` captures a moment — page state plus every request's recorded response — into a folder you can commit:

--- a/packages/docs/concepts/cli.yaml
+++ b/packages/docs/concepts/cli.yaml
@@ -75,6 +75,7 @@ _ref:
             - `--dev-directory <dev-directory>`: Change the dev directory, the directory in which the development server is placed. The default is `<config-directory>/.lowdefy/dev`.
             - `--disable-telemetry`: Disable telemetry.
             - `--log-level <level>`: The minimum severity of logs to show in the CLI output. Options are `debug`, `info`, `warn` or `error`. The default is `info`.
+            - `--mock-user [user]`: Start the dev server authenticated as a mock user, bypassing the login flow. Pass a JSON user object to set the identity and roles (e.g. `--mock-user '{"sub":"dev","roles":["admin"]}'`), or use the bare flag for a default user with no roles. This is the same mechanism as `auth.dev.mockUser`. Dev server only. See [Auth Configuration](/auth-configuration#mock-user-for-testing-dev-server-only).
             - `--no-open`: Do not open a new tab in the default browser.
             - `--port <port>`: Change the port the server is hosted at. The default is `3000`.
             - `--ref-resolver <ref-resolver-function-path>`: Path to a JavaScript file containing a `_ref` resolver function to be used as the app default `_ref` resolver.

--- a/packages/docs/users/auth-configuration.yaml
+++ b/packages/docs/users/auth-configuration.yaml
@@ -96,7 +96,17 @@ _ref:
 
                 When developing and testing Lowdefy apps, you can bypass the login flow by configuring a mock user. This is useful for testing authenticated flows without going through OAuth login.
 
-                The mock user can be configured in two ways:
+                The mock user can be configured in three ways:
+
+                ### CLI Flag
+
+                Pass `--mock-user` to `lowdefy dev` to start the server as a mock user for that run. Supply a JSON user object to set the identity and roles, or use the bare flag for a default user with no roles:
+
+                ```bash
+                lowdefy dev --mock-user '{"sub":"test-user","email":"test@example.com","roles":["admin"]}'
+                ```
+
+                The flag sets `LOWDEFY_DEV_USER` for the dev server process, so it takes precedence over `auth.dev.mockUser` in the config file.
 
                 ### Environment Variable
 
@@ -138,6 +148,7 @@ _ref:
                 - The mock user goes through the normal session callback, so `userFields` mappings and custom callbacks still apply
                 - The `_user` operator returns values from the mock user
                 - Protected pages are accessible based on the mock user's roles
+                - The dev server's headless renderer (used by the AI-agent screenshot and state-inspection tools) renders as the mock user, so it can capture pages with roles the default user lacks
 
                 > **Note:** Mock users only work with the development server (`lowdefy dev`). The production server ignores mock user configuration for security.
 

--- a/packages/servers/server-dev/lib/docs/getBrowser.js
+++ b/packages/servers/server-dev/lib/docs/getBrowser.js
@@ -18,6 +18,7 @@ import { chromium } from 'playwright-core';
 import { type } from '@lowdefy/helpers';
 
 import lowdefyConfig from '../build/config.js';
+import { HEADLESS_USER_COOKIE, headlessUser } from '../server/auth/headlessUser.js';
 
 // playwright-core does not bundle a browser (unlike @playwright/test) — it
 // only drives one that is already installed. `channel: 'chrome'` picks up a
@@ -73,6 +74,16 @@ function buildPageUrl({ origin, pageId }) {
 async function openPage({ browser, origin, pageId, width = 1280, height = 800, timeout = 15000 }) {
   const url = buildPageUrl({ origin, pageId });
   const context = await browser.newContext({ viewport: { width, height } });
+  // Inject an authenticated user so auth-protected pages don't 404 for the
+  // cookieless headless context. Mirrors the e2e user-cookie pattern; scoped to
+  // `origin` so it rides along on the same-origin /api/* fetches.
+  await context.addCookies([
+    {
+      name: HEADLESS_USER_COOKIE,
+      value: Buffer.from(JSON.stringify(headlessUser)).toString('base64'),
+      url: origin,
+    },
+  ]);
   const page = await context.newPage();
   try {
     await page.goto(url, { waitUntil: 'networkidle', timeout });

--- a/packages/servers/server-dev/lib/server/auth/getHeadlessSession.js
+++ b/packages/servers/server-dev/lib/server/auth/getHeadlessSession.js
@@ -1,0 +1,39 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { HEADLESS_USER_COOKIE } from './headlessUser.js';
+
+// Mirrors the e2e user-injection pattern (server-e2e/lib/server/auth/session.js):
+// the headless renderer sets a base64-JSON user cookie on its own browser
+// context, so its /api/* fetches carry a session while the developer's real
+// browser (no cookie) is unaffected.
+function getHeadlessSession(c) {
+  const cookieHeader = c.req.header('cookie') ?? '';
+  const match = cookieHeader.match(new RegExp(`${HEADLESS_USER_COOKIE}=([^;]+)`));
+  if (!match) {
+    return undefined;
+  }
+
+  try {
+    const decoded = Buffer.from(decodeURIComponent(match[1]), 'base64').toString();
+    const user = JSON.parse(decoded);
+    return { user };
+  } catch {
+    return undefined;
+  }
+}
+
+export default getHeadlessSession;

--- a/packages/servers/server-dev/lib/server/auth/headlessUser.js
+++ b/packages/servers/server-dev/lib/server/auth/headlessUser.js
@@ -1,0 +1,29 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Shared between the headless renderer (getBrowser.js, which sets the cookie on
+// its browser context) and the dev getSession (getHeadlessSession.js, which
+// decodes it) so the cookie name and injected user shape live in one place.
+const HEADLESS_USER_COOKIE = 'lowdefy_headless_user';
+
+const headlessUser = {
+  sub: 'lowdefy-headless',
+  id: 'lowdefy-headless',
+  name: 'Lowdefy Headless',
+  roles: [],
+};
+
+export { HEADLESS_USER_COOKIE, headlessUser };

--- a/packages/servers/server-dev/lib/server/auth/session.js
+++ b/packages/servers/server-dev/lib/server/auth/session.js
@@ -17,14 +17,20 @@
 import { getAuthUser } from '@hono/auth-js';
 
 import authJson from '../../build/auth.js';
+import getHeadlessSession from './getHeadlessSession.js';
 import getMockSession from './getMockSession.js';
 
-// Replaces getServerSession.js — mock user first (dev only), then the
-// session from the Hono context populated by initAuthConfig.
+// Replaces getServerSession.js — mock user first (dev only), then the headless
+// renderer's injected user cookie, then the session from the Hono context
+// populated by initAuthConfig.
 async function getSession(c) {
   const mockSession = await getMockSession();
   if (mockSession) {
     return mockSession;
+  }
+  const headlessSession = getHeadlessSession(c);
+  if (headlessSession) {
+    return headlessSession;
   }
   if (authJson.configured !== true) {
     return undefined;


### PR DESCRIPTION
## Problem

The dev server's `/lowdefy-docs` headless renderer — driving `lowdefy_screenshot_page` and headless `lowdefy_inspect_state` for AI agents — opened a **fresh, cookieless** Playwright context. For any page with `auth.public: false`, its `/api/page/*` fetch had no session, so `authorize()` failed, `getPageConfig` returned `null`, and the page **404'd**. Agents saw a 404 instead of the protected page.

## Changes

**Headless renderer authenticates (`@lowdefy/server-dev`)** — replicates the proven `@lowdefy/server-e2e` user-injection pattern:
- `headlessUser.js` *(new)* — shared cookie name + default user object.
- `getHeadlessSession.js` *(new)* — decodes the base64-JSON user cookie into `{ user }` (mirrors `server-e2e/.../session.js`).
- `session.js` — dev `getSession` consults the headless cookie after the mock user, before real auth.
- `getBrowser.js` — `openPage` sets that cookie on its browser context (scoped to `origin`) before navigating; covers every headless caller (screenshot, inspect-state, eval-operator, checkpoint load).

The developer's real browser is untouched (never carries the cookie); prod (`@lowdefy/server`) is untouched.

**`lowdefy dev --mock-user` flag (`lowdefy` CLI)**:
- `program.js` — new `--mock-user [user]` option (env fallback `LOWDEFY_DEV_USER`).
- `resolveMockUser.js` *(new)* — bare flag → default roleless user; JSON value validated at the CLI with a clear error.
- `runDevServer.js` — threads it into the child server's `LOWDEFY_DEV_USER` env, only when set.

**Docs**: `concepts/cli.yaml` (`--mock-user` bullet), `users/auth-configuration.yaml` (CLI flag as a third mock-user method + headless note), `concepts/ai-agent-docs.md` (new "Auth-protected pages" section).

## Design note

Like the e2e cookie, the headless-user cookie is **unsigned** — matching the dev server's existing trust model (the process-wide `LOWDEFY_DEV_USER` / `auth.dev.mockUser` bypass), dev-only + localhost. Role-gated pages still require a mock user with matching roles (`--mock-user '{"roles":["admin"]}'` or `auth.dev.mockUser`).

## Verification

- `resolveMockUser` unit tests + full CLI suite pass (101 tests, 5 snapshots).
- Cookie encode (getBrowser) ↔ decode (getHeadlessSession) round-trips; no-cookie/garbage → `undefined`.
- `createAuthorize` with the headless session: public ✅, login-only protected ✅, role-gated ❌ (as designed).
- Not driven live: full Chromium screenshot against an auth app (needs monorepo build + auth app + Chromium) — uses the same Playwright `addCookies` API as the e2e helper.

Base is `vite-hono` because the entire `/lowdefy-docs` headless MCP feature lives there.

---

## Also in this PR — annotation overlay fixes (`fix(server-dev)`)

Follow-on fixes to the Cmd/Ctrl+/ annotation ("Lowdefy Annotate") feedback tooling:

- **Annotations now work over an open modal.** The overlay was rendered inline in the app root, so an ancestor stacking context in the app layout trapped its `z-index` and an open antd modal (portalled to `document.body`, `z-index ~1000`) painted on top — the comment textarea couldn't be clicked or typed into. The overlay now renders via `createPortal(content, document.body)`, so it's a top-level sibling of the modal in the root stacking context and its `z-index` wins regardless of the app's layout. (`FeedbackOverlay.jsx`)
- **Dev-server startup hint.** On startup the manager now logs a reminder that pressing `Cmd/Ctrl+/` opens annotation mode for copying feedback to a coding agent. (`run.mjs`)
- **`agent-setup` pre-approves the docs MCP server.** `lowdefy agent-setup` now merges `"enabledMcpjsonServers": ["lowdefy-docs"]` into the **committed** `.claude/settings.json` (not the gitignored `settings.local.json`), so the whole team gets the server approved from version control. Idempotent; preserves existing keys/servers. (`agentSetup.js`, `upsertClaudeSettings.js` *(new)*, `agentSetup.test.js` — create/merge/idempotent/invalid-JSON cases)

Changeset: patch bumps for `@lowdefy/server-dev` and `lowdefy`.

**Verification (annotation fixes):** CLI suite passes with the new `upsertClaudeSettings` cases (34 agent-setup tests green); lint + prettier clean. Root cause of the modal bug confirmed by elimination (rc-dialog 1.8.4 focuses once — no focus trap; panel `pointer-events:auto`; `z-index` 2.1B) — leaving stacking-context confinement, which portaling to `document.body` resolves. A full browser repro needs an app with a modal (the trapping stacking context is app-specific).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
