### PR TITLE
feat(server-dev): Cmd/Ctrl+click opens a block's yaml in VS Code

### DIFF
--- a/.changeset/feat-cmd-click-open-in-editor.md
+++ b/.changeset/feat-cmd-click-open-in-editor.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/server-dev': minor
+---
+
+feat: Cmd/Ctrl+click any element to open its yaml in VS Code
+
+Hold Cmd (macOS) or Ctrl (Windows/Linux) and click any element in the running dev app to open the yaml file that defines its block in VS Code, at the exact line. While the modifier is held, the hovered block shows a blue highlight with its blockId and the cursor becomes a pointer, so you see exactly what a click will open. Blocks generated at runtime (list items, dynamic content) resolve to their nearest configured ancestor, and blocks defined in modules open the module file that defines them. Plain clicks, and Cmd/Ctrl+clicks outside any block, keep their normal behaviour. Dev server only.

--- a/.changeset/fix-feedback-annotations-over-modals.md
+++ b/.changeset/fix-feedback-annotations-over-modals.md
@@ -6,5 +6,5 @@
 fix(server-dev): Annotations now work over open modals, plus an annotate hint on dev server startup.
 
 - The annotation overlay is now rendered into the document body, so its comment box stays clickable and typeable even when a modal is open on the page.
-- On startup the dev server now reports that the agent docs & MCP endpoint is live (with the `lowdefy agent-setup` command to connect an agent), followed by a notice box explaining the Cmd/Ctrl+/ annotation shortcut.
+- On startup the dev server now prints a notice box for coding agents: the docs & MCP endpoint URL with the `lowdefy agent-setup` command to connect an agent, and the Cmd/Ctrl+/ annotation shortcut.
 - `lowdefy agent-setup` now enables the `lowdefy-docs` MCP server in the committed `.claude/settings.json`, so everyone on the project has it approved without a prompt.

--- a/packages/docs-content/content/concepts/ai-agent-docs.md
+++ b/packages/docs-content/content/concepts/ai-agent-docs.md
@@ -59,6 +59,10 @@ Feedback: 1 annotation(s) on page "orders" (/orders) — viewport 1280x800 @2x, 
 
 Esc cancels; the overlay never ships to production servers. The `/lowdefy-feedback` route prefix is reserved in dev.
 
+## Open code — Cmd/Ctrl+click jumps to the yaml
+
+Hold **Cmd** (macOS) or **Ctrl** (Windows/Linux) and click any element in your running dev app to open the yaml that defines its block in VS Code, at the exact line. While the modifier is held, the block under the cursor shows a blue highlight with its blockId — the same picking affordance as the annotation overlay — and the cursor becomes a pointer, so you see exactly what a click will open. The dev server resolves the clicked element to its block and looks up the config source the same way annotations do — blocks generated at runtime (list items, dynamic content) resolve to their nearest configured ancestor, and blocks defined in modules open the module file that defines them. Plain clicks, and Cmd/Ctrl+clicks outside any block, keep their normal behaviour. Dev server only.
+
 ## The feedback loop
 
 The dev server rebuilds automatically when config changes, so an agent works in a tight loop:
@@ -71,6 +75,10 @@ The dev server rebuilds automatically when config changes, so an agent works in 
 ## Live state — the agent sees what you see
 
 When you have a page open in your browser, the agent can read its **actual live state** — page state, request results, and the event log of recent actions — via `lowdefy_inspect_state`. Reproduce a problem by clicking through the app, then ask the agent to look: it inspects your exact tab, not a guess. `lowdefy_eval_operator` then evaluates any operator expression (like `{"_state": "customer.name"}`) against that same live context, so `_state`/`_request` binding bugs get debugged against real data. With no tab open, both tools run the page headless instead.
+
+## Auth-protected pages
+
+The headless renderer behind `lowdefy_screenshot_page` and `lowdefy_inspect_state` authenticates as a signed-in user, so pages with `auth.public: false` render for the agent instead of returning a 404. To render pages that require specific roles, start the dev server with a mock user carrying those roles — `lowdefy dev --mock-user '{"sub":"dev","roles":["admin"]}'` (or configure `auth.dev.mockUser`). See [Auth Configuration](/auth-configuration#mock-user-for-testing-dev-server-only).
 
 ## State checkpoints — put the app in a known state
 

--- a/packages/docs-content/content/concepts/cli.md
+++ b/packages/docs-content/content/concepts/cli.md
@@ -51,6 +51,7 @@ The `dev` command starts a Lowdefy development server, running locally. It can b
 - `--dev-directory <dev-directory>`: Change the dev directory, the directory in which the development server is placed. The default is `<config-directory>/.lowdefy/dev`.
 - `--disable-telemetry`: Disable telemetry.
 - `--log-level <level>`: The minimum severity of logs to show in the CLI output. Options are `debug`, `info`, `warn` or `error`. The default is `info`.
+- `--mock-user [user]`: Start the dev server authenticated as a mock user, bypassing the login flow. Pass a JSON user object to set the identity and roles (e.g. `--mock-user '{"sub":"dev","roles":["admin"]}'`), or use the bare flag for a default user with no roles. This is the same mechanism as `auth.dev.mockUser`. Dev server only. See [Auth Configuration](/auth-configuration#mock-user-for-testing-dev-server-only).
 - `--no-open`: Do not open a new tab in the default browser.
 - `--port <port>`: Change the port the server is hosted at. The default is `3000`.
 - `--ref-resolver <ref-resolver-function-path>`: Path to a JavaScript file containing a `_ref` resolver function to be used as the app default `_ref` resolver.

--- a/packages/docs-content/content/connections/mongodb.md
+++ b/packages/docs-content/content/connections/mongodb.md
@@ -44,6 +44,24 @@ When using MongoDBUpdateOne and MongoDBDeleteOne requests, take note that the re
 - `write: boolean`: Default: `false` - Allow write operations like update on the collection.
 - `options: object`: See the [driver documentation](https://mongodb.github.io/node-mongodb-native/4.0/interfaces/mongoclientoptions.html) for more information.
 
+#### Connection pooling
+
+The MongoDB client is created once per unique `databaseUri` and `options` combination and reused for all requests, so requests share the driver's connection pool instead of opening a new connection for every request. The pool can be tuned with the standard driver options, for example:
+
+```yaml
+connections:
+  - id: my_collection
+    type: MongoDBCollection
+    properties:
+      databaseUri:
+        _secret: MONGODB_URI
+      collection: my_collection_name
+      options:
+        maxPoolSize: 20
+        minPoolSize: 0
+        maxIdleTimeMS: 60000
+```
+
 #### Examples
 
 ###### MongoDB collection with reads and writes:

--- a/packages/docs-content/index.json
+++ b/packages/docs-content/index.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.3.0",
+  "version": "5.4.0",
   "docs": [
     {
       "slug": "other/introduction",

--- a/packages/docs/concepts/ai-agent-docs.md
+++ b/packages/docs/concepts/ai-agent-docs.md
@@ -57,6 +57,10 @@ Feedback: 1 annotation(s) on page "orders" (/orders) — viewport 1280x800 @2x, 
 
 Esc cancels; the overlay never ships to production servers. The `/lowdefy-feedback` route prefix is reserved in dev.
 
+## Open code — Cmd/Ctrl+click jumps to the yaml
+
+Hold **Cmd** (macOS) or **Ctrl** (Windows/Linux) and click any element in your running dev app to open the yaml that defines its block in VS Code, at the exact line. While the modifier is held, the block under the cursor shows a blue highlight with its blockId — the same picking affordance as the annotation overlay — and the cursor becomes a pointer, so you see exactly what a click will open. The dev server resolves the clicked element to its block and looks up the config source the same way annotations do — blocks generated at runtime (list items, dynamic content) resolve to their nearest configured ancestor, and blocks defined in modules open the module file that defines them. Plain clicks, and Cmd/Ctrl+clicks outside any block, keep their normal behaviour. Dev server only.
+
 ## The feedback loop
 
 The dev server rebuilds automatically when config changes, so an agent works in a tight loop:

--- a/packages/servers/server-dev/client/Routing.jsx
+++ b/packages/servers/server-dev/client/Routing.jsx
@@ -22,6 +22,7 @@ import createLinkComponent from '@lowdefy/client/adapters/Link.js';
 import BuildingPage from '../lib/client/BuildingPage.jsx';
 import FeedbackMount from './feedback/FeedbackMount.jsx';
 import Inspector from './Inspector.jsx';
+import OpenInEditorListener from './openInEditor/OpenInEditorListener.jsx';
 import Reload from './Reload.jsx';
 import Page from './Page.jsx';
 import setPageId from '../lib/client/setPageId.js';
@@ -72,6 +73,7 @@ function Routing({ auth, lowdefy, router }) {
     <>
       <Inspector basePath={router.basePath} lowdefy={lowdefy} pageId={pageId} />
       <FeedbackMount basePath={router.basePath} lowdefy={lowdefy} pageId={pageId} />
+      <OpenInEditorListener basePath={router.basePath} pageId={pageId} />
       <Reload basePath={router.basePath} lowdefy={lowdefy}>
         {(resetContext) => (
           <Suspense key={`${pageId}_${getReloadVersion()}`} fallback={<BuildingPage />}>

--- a/packages/servers/server-dev/client/feedback/FeedbackMount.jsx
+++ b/packages/servers/server-dev/client/feedback/FeedbackMount.jsx
@@ -34,6 +34,12 @@ function logBannerOnce() {
       'color: #4f9cf9; font-weight: bold;',
       'color: inherit;'
     );
+    // eslint-disable-next-line no-console
+    console.info(
+      '%cLowdefy Open Code%c — Cmd/Ctrl+click any element to open its yaml in VS Code.',
+      'color: #4f9cf9; font-weight: bold;',
+      'color: inherit;'
+    );
   } catch {
     // Never let a console-styling quirk break the app.
   }

--- a/packages/servers/server-dev/client/openInEditor/OpenInEditorListener.jsx
+++ b/packages/servers/server-dev/client/openInEditor/OpenInEditorListener.jsx
@@ -1,0 +1,261 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { blockAncestorChain, nearestBlock } from '../feedback/elementInspect.js';
+import { highlightBox, labelChip, overlayContainer } from '../feedback/feedbackStyles.js';
+import findBlockLocation from './findBlockLocation.js';
+
+const STYLE_TAG_ID = 'lowdefy-open-in-editor-style-tag';
+const BODY_CLASS = 'lowdefy-open-in-editor-target';
+
+// Cursor over arbitrary app descendants can't be forced from inline styles —
+// same trick as feedbackStyles' picking/drawing classes.
+function injectStyleTag() {
+  if (typeof document === 'undefined' || document.getElementById(STYLE_TAG_ID)) {
+    return;
+  }
+  const style = document.createElement('style');
+  style.id = STYLE_TAG_ID;
+  style.textContent = `
+    .${BODY_CLASS}, .${BODY_CLASS} * {
+      cursor: pointer !important;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function removeStyleTag() {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  document.getElementById(STYLE_TAG_ID)?.remove();
+}
+
+// The feedback overlay owns clicks while it is open (its picking mode claims
+// them) — the Cmd/Ctrl+click shortcut stays out of the way until it closes.
+// :not() skips this component's own highlight portal, which carries
+// data-lowdefy-feedback purely for screenshot/picking exclusion.
+function feedbackOverlayOpen() {
+  return Boolean(
+    document.querySelector('[data-lowdefy-feedback]:not([data-lowdefy-open-in-editor])')
+  );
+}
+
+// Dev-only: Cmd/Ctrl+click any element to open the YAML that defines its
+// block in VS Code (vscode://file deep link, at the exact line). While the
+// modifier is held, the hovered block shows the same blue highlight box and
+// blockId chip as the annotation overlay's picking mode, and the cursor
+// switches to a pointer — so the developer sees exactly what a click will
+// open. Mounted always-on from Routing.jsx alongside Inspector and
+// FeedbackMount, and follows their resilience contract — every handler is
+// try/caught so this can never take the app down with it.
+//
+// The click resolves the nearest block and, when that id is generated at
+// runtime (list items, Dynamic endpoints), falls back through the ancestor
+// block chain until an id resolves in config — the same strategy the
+// feedback pipeline uses in enrichFeedback.js.
+function OpenInEditorListener({ basePath, pageId }) {
+  const [hoverBlock, setHoverBlock] = useState(null); // { blockId, rect }
+  // Refs keep the freshest values without re-binding the capture listeners
+  // on every SPA navigation or hover change.
+  const pageIdRef = useRef(pageId);
+  pageIdRef.current = pageId;
+  const hoverRef = useRef(hoverBlock);
+  hoverRef.current = hoverBlock;
+  const lastPointerRef = useRef(null); // { x, y }
+
+  // Style tag lifecycle — the listener is always mounted, so this lives for
+  // the app's lifetime and only the body class toggles per hover.
+  useEffect(() => {
+    injectStyleTag();
+    return () => removeStyleTag();
+  }, []);
+
+  // Pointer cursor only while a block is highlighted — over non-block areas
+  // the cursor stays native, signalling the click would do nothing.
+  useEffect(() => {
+    try {
+      document.body.classList.toggle(BODY_CLASS, Boolean(hoverBlock));
+    } catch {
+      // no-op
+    }
+    return () => {
+      try {
+        document.body.classList.remove(BODY_CLASS);
+      } catch {
+        // no-op
+      }
+    };
+  }, [hoverBlock]);
+
+  useEffect(() => {
+    function clearHover() {
+      if (hoverRef.current) {
+        setHoverBlock(null);
+      }
+    }
+
+    function resolveHover() {
+      try {
+        const point = lastPointerRef.current;
+        if (!point || feedbackOverlayOpen()) {
+          clearHover();
+          return;
+        }
+        const el = document.elementFromPoint(point.x, point.y);
+        const blockId = nearestBlock(el);
+        const blockEl = blockId ? document.getElementById(`bl-${blockId}`) : null;
+        if (!blockEl) {
+          clearHover();
+          return;
+        }
+        const rect = blockEl.getBoundingClientRect();
+        setHoverBlock({
+          blockId,
+          rect: { top: rect.top, left: rect.left, width: rect.width, height: rect.height },
+        });
+      } catch {
+        clearHover();
+      }
+    }
+
+    function onPointerMove(event) {
+      try {
+        lastPointerRef.current = { x: event.clientX, y: event.clientY };
+        if (event.metaKey || event.ctrlKey) {
+          resolveHover();
+        } else {
+          clearHover();
+        }
+      } catch {
+        // Best-effort hover tracking.
+      }
+    }
+
+    // Modifier pressed/released while the mouse is stationary — pointermove
+    // alone would leave the highlight stale.
+    function onKeyDown(event) {
+      if (event.key === 'Meta' || event.key === 'Control') {
+        resolveHover();
+      }
+    }
+
+    function onKeyUp(event) {
+      if (event.key === 'Meta' || event.key === 'Control') {
+        clearHover();
+      }
+    }
+
+    // Cmd+Tab away releases the modifier without a keyup reaching the page.
+    function onBlur() {
+      clearHover();
+    }
+
+    // Keep the highlight glued to the block while the app scrolls under a
+    // stationary cursor.
+    function onScroll() {
+      if (hoverRef.current) {
+        resolveHover();
+      }
+    }
+
+    async function openBlockInEditor({ candidates }) {
+      for (const blockId of candidates) {
+        const location = await findBlockLocation({
+          basePath,
+          blockId,
+          pageId: pageIdRef.current,
+        });
+        if (location) {
+          window.location.assign(`vscode://file${location.file}:${location.line}`);
+          return;
+        }
+      }
+      try {
+        // eslint-disable-next-line no-console
+        console.info(
+          `Lowdefy: no config location found for "${candidates[0]}" — the block is generated at runtime.`
+        );
+      } catch {
+        // no-op
+      }
+    }
+
+    function onClickCapture(event) {
+      try {
+        if (!(event.metaKey || event.ctrlKey) || event.shiftKey || event.altKey) {
+          return;
+        }
+        if (feedbackOverlayOpen()) {
+          return;
+        }
+        const candidates = blockAncestorChain(event.target);
+        if (candidates.length === 0) {
+          return;
+        }
+        // Only claim the click once a block is under the cursor — plain
+        // Cmd/Ctrl+clicks elsewhere keep their default behaviour.
+        event.preventDefault();
+        event.stopPropagation();
+        void openBlockInEditor({ candidates });
+      } catch {
+        // Never let the shortcut break the developer's app.
+      }
+    }
+
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    window.addEventListener('blur', onBlur);
+    window.addEventListener('scroll', onScroll, true);
+    window.addEventListener('click', onClickCapture, { capture: true });
+    return () => {
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+      window.removeEventListener('blur', onBlur);
+      window.removeEventListener('scroll', onScroll, true);
+      window.removeEventListener('click', onClickCapture, { capture: true });
+    };
+  }, [basePath]);
+
+  if (!hoverBlock || typeof document === 'undefined' || !document.body) {
+    return null;
+  }
+  // data-lowdefy-feedback keeps this out of the annotation overlay's element
+  // picking and out of tab-captured screenshots (both exclude that root).
+  return createPortal(
+    <div data-lowdefy-feedback data-lowdefy-open-in-editor style={overlayContainer}>
+      <div
+        style={{
+          ...highlightBox,
+          top: hoverBlock.rect.top,
+          left: hoverBlock.rect.left,
+          width: hoverBlock.rect.width,
+          height: hoverBlock.rect.height,
+        }}
+      >
+        <span style={labelChip}>{hoverBlock.blockId}</span>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+export default OpenInEditorListener;

--- a/packages/servers/server-dev/client/openInEditor/findBlockLocation.js
+++ b/packages/servers/server-dev/client/openInEditor/findBlockLocation.js
@@ -1,0 +1,49 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Resolves a blockId to its YAML source via the dev server's existing
+// GET /lowdefy-docs/find/{id}?pageId= route (which JIT-builds the page's
+// keyMap on demand). Returns { file, line } with an absolute file path, or
+// null when the id has no configured location. Best-effort, matching
+// sendFeedback.js — a dev-only feature must never throw into the app.
+async function findBlockLocation({ basePath, blockId, pageId }) {
+  try {
+    const response = await fetch(
+      `${basePath}/lowdefy-docs/find/${encodeURIComponent(blockId)}` +
+        `?pageId=${encodeURIComponent(pageId ?? '')}`
+    );
+    if (!response.ok) {
+      return null;
+    }
+    const data = await response.json();
+    const source = data.matches?.[0]?.location?.source;
+    if (typeof source !== 'string' || source.length === 0) {
+      return null;
+    }
+    // source is "<absolute path>" or "<absolute path>:<line>" — a numeric
+    // suffix after the last colon is the 1-based line number. Splitting on
+    // the last colon keeps Windows drive-letter colons intact.
+    const match = source.match(/^(.*):(\d+)$/);
+    if (match) {
+      return { file: match[1], line: Number(match[2]) };
+    }
+    return { file: source, line: 1 };
+  } catch {
+    return null;
+  }
+}
+
+export default findBlockLocation;

--- a/packages/servers/server-dev/manager/run.mjs
+++ b/packages/servers/server-dev/manager/run.mjs
@@ -110,19 +110,18 @@ try {
 
   startServer(context);
   await wait(800);
-  const appUrl = `http://localhost:${context.options.port}`;
-  context.logger.info(
-    { color: 'blue' },
-    `Agent docs & MCP live at ${appUrl}/lowdefy-docs — run \`lowdefy agent-setup\` to connect your coding agent.`
-  );
+  const docsUrl = `http://localhost:${context.options.port}/lowdefy-docs`;
   context.logger.info(
     { color: 'blue' },
     formatNoticeBox({
-      title: 'Annotate for your agent',
+      title: 'Lowdefy coding agent tools',
       lines: [
-        'Press Cmd/Ctrl+/ in the browser to point, draw, and comment',
-        'on the running app, then paste the copied feedback into your',
-        'coding agent session.',
+        `Docs & MCP  ${docsUrl}`,
+        '            run `lowdefy agent-setup` to connect your agent',
+        '',
+        'Annotate    Press Cmd/Ctrl+/ in the browser to point, draw,',
+        '            and comment on the running app, then paste the',
+        '            copied feedback into your coding agent session.',
       ],
     })
   );

--- a/packages/servers/server-dev/manager/run.mjs
+++ b/packages/servers/server-dev/manager/run.mjs
@@ -122,6 +122,9 @@ try {
         'Annotate    Press Cmd/Ctrl+/ in the browser to point, draw,',
         '            and comment on the running app, then paste the',
         '            copied feedback into your coding agent session.',
+        '',
+        'Open code   Cmd/Ctrl+click any element in the browser to open',
+        '            its yaml in VS Code at the defining line.',
       ],
     })
   );


### PR DESCRIPTION
## What

Hold Cmd (macOS) / Ctrl (Windows/Linux) and click any element in the running dev app to open the yaml that defines its block in VS Code, at the exact line. While the modifier is held, the hovered block shows the annotation overlay's blue highlight + blockId chip and the cursor becomes a pointer — you see exactly what a click will open.

## How

Pure client feature — no server changes:
- `OpenInEditorListener.jsx`: always-on capture-phase click listener mounted in `Routing.jsx`; resolves the clicked element via the existing `bl-{id}` DOM walk; falls back through the ancestor block chain for runtime-generated blocks (same strategy as `enrichFeedback`); opens `vscode://file{path}:{line}`.
- `findBlockLocation.js`: fetch helper for the existing `GET /lowdefy-docs/find/{id}?pageId=` route (JIT-builds the page keyMap, absolute path + line already provided).
- Only claims the click when a block resolves — plain and non-block Cmd/Ctrl+clicks keep default behaviour; suppressed while the annotation overlay is open.
- Announced in the dev-server startup notice box and the browser console banner; documented in the "Docs for AI Agents" page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)