### PR TITLE
fix(server-dev): One dev-session source, shaped like a real signed-in user

### DIFF
--- a/.changeset/fix-dev-mock-session-client.md
+++ b/.changeset/fix-dev-mock-session-client.md
@@ -1,0 +1,9 @@
+---
+'@lowdefy/server-dev': patch
+---
+
+fix: Serve the dev mock session to the browser client
+
+With a mock user (`auth.dev.mockUser` / `LOWDEFY_DEV_USER` / `lowdefy dev --mock-user`) or a headless renderer session, server-side requests authenticated but the browser client's session stayed empty — `GET /api/auth/session` was answered by Auth.js alone, which knows nothing about dev sessions. Client-side `_user` values (roles, custom userFields like tenant claims) were missing, breaking auth-driven routing; apps could remount-loop between pages whose conditions read `_user`.
+
+Dev sessions are now built in one place (`getDevSession`) and served from it to both the server request context and the browser session endpoint, so the two can never diverge. The dev user also runs through the identical Auth.js session callback a real sign-in uses — userFields mapping, custom session-callback plugins, roles validation, `hashed_id` — so mock and headless sessions behave exactly like a production authenticated user.

--- a/.changeset/fix-feedback-annotations-over-modals.md
+++ b/.changeset/fix-feedback-annotations-over-modals.md
@@ -6,5 +6,5 @@
 fix(server-dev): Annotations now work over open modals, plus an annotate hint on dev server startup.
 
 - The annotation overlay is now rendered into the document body, so its comment box stays clickable and typeable even when a modal is open on the page.
-- On startup the dev server now reports that the agent docs & MCP endpoint is live (with the `lowdefy agent-setup` command to connect an agent), followed by a notice box explaining the Cmd/Ctrl+/ annotation shortcut.
+- On startup the dev server now prints a notice box for coding agents: the docs & MCP endpoint URL with the `lowdefy agent-setup` command to connect an agent, and the Cmd/Ctrl+/ annotation shortcut.
 - `lowdefy agent-setup` now enables the `lowdefy-docs` MCP server in the committed `.claude/settings.json`, so everyone on the project has it approved without a prompt.

--- a/packages/docs/users/auth-configuration.yaml
+++ b/packages/docs/users/auth-configuration.yaml
@@ -146,7 +146,7 @@ _ref:
                 - The environment variable takes precedence over the config file if both are set
                 - A warning is logged at dev server startup: "Mock user active - login bypassed"
                 - The mock user goes through the normal session callback, so `userFields` mappings and custom callbacks still apply
-                - The `_user` operator returns values from the mock user
+                - The `_user` operator returns values from the mock user, on the server and in the browser client — the dev server serves the mock session to both
                 - Protected pages are accessible based on the mock user's roles
                 - The dev server's headless renderer (used by the AI-agent screenshot and state-inspection tools) renders as the mock user, so it can capture pages with roles the default user lacks
 

--- a/packages/servers/server-dev/lib/server/auth/getDevSession.js
+++ b/packages/servers/server-dev/lib/server/auth/getDevSession.js
@@ -1,0 +1,70 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { createSessionCallback } from '@lowdefy/api';
+
+import authJson from '../../build/auth.js';
+import callbacks from '../../../build/plugins/auth/callbacks.js';
+import getHeadlessUser from './getHeadlessUser.js';
+import getMockUser from './getMockUser.js';
+
+// THE single source of dev sessions (mock user, headless renderer). Two
+// invariants live here, by construction rather than by convention:
+//
+// 1. Prod parity: the dev user runs through the identical Auth.js session
+//    callback a real sign-in uses (OIDC claim copy, userFields mapping,
+//    custom session-callback plugins, roles validation, hashed_id) — so what
+//    a mock or headless session sees is exactly what a real authenticated
+//    user would see in production, and dev validates prod behaviour.
+// 2. Client/server parity: every consumer — the server request context
+//    (session.js) and the browser client's GET /api/auth/session
+//    (routes/auth.js) — obtains the session from this one function, so the
+//    two can never diverge.
+//
+// Auth.js sessions carry an expires timestamp (the client SessionProvider
+// schedules refetches off it); dev sessions never expire while the server
+// runs, a day keeps polling calm.
+const DEV_SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+async function getDevSession(c) {
+  const user = getMockUser() ?? getHeadlessUser(c);
+  if (!user) {
+    return undefined;
+  }
+  // Without auth configured nothing is protected and there is no session
+  // callback pipeline to run — a dev session would not match any prod
+  // behaviour. (A configured mock user already threw in getMockUser.)
+  if (authJson.configured !== true) {
+    return undefined;
+  }
+
+  const sessionCallback = createSessionCallback({
+    authConfig: authJson,
+    plugins: { callbacks },
+  });
+
+  // The dev user acts as both token and user, exactly how a decoded JWT
+  // reaches the session callback on a real request.
+  const session = await sessionCallback({
+    session: { user: {} },
+    token: user,
+    user,
+  });
+  session.expires = new Date(Date.now() + DEV_SESSION_MAX_AGE_MS).toISOString();
+  return session;
+}
+
+export default getDevSession;

--- a/packages/servers/server-dev/lib/server/auth/getDevSession.test.mjs
+++ b/packages/servers/server-dev/lib/server/auth/getDevSession.test.mjs
@@ -1,0 +1,138 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { jest } from '@jest/globals';
+
+// Only the auth build artifact is mocked — createSessionCallback is the REAL
+// @lowdefy/api pipeline, because prod parity is exactly what these tests
+// exist to prove: a dev session must be shaped by the same userFields
+// mapping, roles validation, and hashed_id stamping as a real sign-in.
+jest.unstable_mockModule('../../build/auth.js', () => ({
+  default: {
+    configured: true,
+    callbacks: [],
+    userFields: {
+      id: 'user.id',
+      roles: 'user.roles',
+      global_attributes: 'user.global_attributes',
+    },
+  },
+}));
+
+// getDevSession statically imports the app build's auth callbacks module,
+// which only exists in a built app (build/** is gitignored). Materialize an
+// empty one — exactly what a build without custom auth callback plugins
+// writes — so the import resolves; clean up only if this test created it.
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const callbacksDir = path.resolve(dirname, '../../../build/plugins/auth');
+const callbacksPath = path.join(callbacksDir, 'callbacks.js');
+const createdCallbacksFixture = !fs.existsSync(callbacksPath);
+if (createdCallbacksFixture) {
+  fs.mkdirSync(callbacksDir, { recursive: true });
+  fs.writeFileSync(callbacksPath, 'export default {};\n');
+}
+
+afterAll(() => {
+  if (createdCallbacksFixture) {
+    fs.rmSync(callbacksPath, { force: true });
+  }
+});
+
+const { default: getDevSession } = await import('./getDevSession.js');
+const { HEADLESS_USER_COOKIE, headlessUser } = await import('./headlessUser.js');
+
+function createContext({ cookie } = {}) {
+  return { req: { header: (name) => (name === 'cookie' ? (cookie ?? '') : undefined) } };
+}
+
+function headlessCookie(user = headlessUser) {
+  return `${HEADLESS_USER_COOKIE}=${Buffer.from(JSON.stringify(user)).toString('base64')}`;
+}
+
+const originalDevUser = process.env.LOWDEFY_DEV_USER;
+
+afterEach(() => {
+  if (originalDevUser === undefined) {
+    delete process.env.LOWDEFY_DEV_USER;
+  } else {
+    process.env.LOWDEFY_DEV_USER = originalDevUser;
+  }
+});
+
+test('getDevSession returns undefined with no mock user and no headless cookie', async () => {
+  delete process.env.LOWDEFY_DEV_USER;
+  expect(await getDevSession(createContext())).toBe(undefined);
+});
+
+test('mock user session is built by the real session callback — userFields, hashed_id, expires', async () => {
+  // The claim shape a consuming app's tenant convention uses (e.g.
+  // global_attributes.company_ids) must survive to session.user on BOTH the
+  // server request path and the client session endpoint — this session is
+  // what both serve.
+  process.env.LOWDEFY_DEV_USER = JSON.stringify({
+    id: 'dev-user',
+    sub: 'dev-user',
+    name: 'Dev User',
+    roles: ['admin'],
+    global_attributes: { company_ids: ['C-1'] },
+  });
+
+  const session = await getDevSession(createContext());
+  expect(session.user.id).toEqual('dev-user');
+  expect(session.user.name).toEqual('Dev User');
+  expect(session.user.roles).toEqual(['admin']);
+  expect(session.user.global_attributes).toEqual({ company_ids: ['C-1'] });
+  // Prod-session markers from the real pipeline:
+  expect(typeof session.hashed_id).toBe('string');
+  expect(session.hashed_id.length).toBeGreaterThan(0);
+  expect(new Date(session.expires).getTime()).toBeGreaterThan(Date.now());
+});
+
+test('headless cookie session runs through the same pipeline as a real sign-in', async () => {
+  delete process.env.LOWDEFY_DEV_USER;
+
+  const session = await getDevSession(createContext({ cookie: headlessCookie() }));
+  expect(session.user.id).toEqual(headlessUser.id);
+  expect(session.user.roles).toEqual([]);
+  expect(typeof session.hashed_id).toBe('string');
+});
+
+test('mock user takes precedence over the headless cookie', async () => {
+  process.env.LOWDEFY_DEV_USER = JSON.stringify({ id: 'mock-wins', roles: [] });
+
+  const session = await getDevSession(createContext({ cookie: headlessCookie() }));
+  expect(session.user.id).toEqual('mock-wins');
+});
+
+test('invalid roles are rejected by the real pipeline, exactly as in prod', async () => {
+  process.env.LOWDEFY_DEV_USER = JSON.stringify({ id: 'bad', roles: 'admin' });
+
+  await expect(getDevSession(createContext())).rejects.toThrow(
+    'session.user.roles must be an array of strings.'
+  );
+});
+
+test('invalid JSON in LOWDEFY_DEV_USER throws a clear error', async () => {
+  process.env.LOWDEFY_DEV_USER = 'not json';
+
+  await expect(getDevSession(createContext())).rejects.toThrow(
+    'Invalid JSON in LOWDEFY_DEV_USER environment variable.'
+  );
+});

--- a/packages/servers/server-dev/lib/server/auth/getHeadlessUser.js
+++ b/packages/servers/server-dev/lib/server/auth/getHeadlessUser.js
@@ -16,11 +16,13 @@
 
 import { HEADLESS_USER_COOKIE } from './headlessUser.js';
 
-// Mirrors the e2e user-injection pattern (server-e2e/lib/server/auth/session.js):
-// the headless renderer sets a base64-JSON user cookie on its own browser
-// context, so its /api/* fetches carry a session while the developer's real
-// browser (no cookie) is unaffected.
-function getHeadlessSession(c) {
+// Decodes the headless renderer's user cookie (set by getBrowser.js openPage
+// on its own browser context, base64-encoded JSON) into the raw user object.
+// Returns just the user; getDevSession.js turns it into a session through
+// the same pipeline a real sign-in uses, so headless requests carry a
+// prod-shaped session while the developer's real browser (no cookie) is
+// unaffected.
+function getHeadlessUser(c) {
   const cookieHeader = c.req.header('cookie') ?? '';
   const match = cookieHeader.match(new RegExp(`${HEADLESS_USER_COOKIE}=([^;]+)`));
   if (!match) {
@@ -29,11 +31,10 @@ function getHeadlessSession(c) {
 
   try {
     const decoded = Buffer.from(decodeURIComponent(match[1]), 'base64').toString();
-    const user = JSON.parse(decoded);
-    return { user };
+    return JSON.parse(decoded);
   } catch {
     return undefined;
   }
 }
 
-export default getHeadlessSession;
+export default getHeadlessUser;

--- a/packages/servers/server-dev/lib/server/auth/getMockUser.js
+++ b/packages/servers/server-dev/lib/server/auth/getMockUser.js
@@ -14,13 +14,15 @@
   limitations under the License.
 */
 
-import { createSessionCallback } from '@lowdefy/api';
 import { serializer } from '@lowdefy/helpers';
 
 import authJson from '../../build/auth.js';
-import callbacks from '../../../build/plugins/auth/callbacks.js';
 
-async function getMockSession() {
+// Resolves the raw mock user object — LOWDEFY_DEV_USER env var first (the
+// `lowdefy dev --mock-user` flag sets it), then auth.dev.mockUser from the
+// build config. Returns just the user object; getDevSession.js turns it into
+// a session through the same pipeline a real sign-in uses.
+function getMockUser() {
   const mockUserJson = process.env.LOWDEFY_DEV_USER;
   let mockUser;
 
@@ -38,9 +40,6 @@ async function getMockSession() {
     return undefined;
   }
 
-  // Deserialize to restore arrays from ~arr markers and remove other build markers
-  mockUser = serializer.deserialize(mockUser);
-
   if (authJson.configured !== true) {
     throw new Error(
       'Mock user configured but auth is not configured in lowdefy.yaml. ' +
@@ -48,20 +47,8 @@ async function getMockSession() {
     );
   }
 
-  // Create session callback to transform mock user
-  const sessionCallback = createSessionCallback({
-    authConfig: authJson,
-    plugins: { callbacks },
-  });
-
-  // Transform mock user through session callback (mock user acts as token)
-  const session = await sessionCallback({
-    session: { user: {} },
-    token: mockUser,
-    user: mockUser,
-  });
-
-  return session;
+  // Deserialize to restore arrays from ~arr markers and remove other build markers
+  return serializer.deserialize(mockUser);
 }
 
-export default getMockSession;
+export default getMockUser;

--- a/packages/servers/server-dev/lib/server/auth/headlessUser.js
+++ b/packages/servers/server-dev/lib/server/auth/headlessUser.js
@@ -15,7 +15,7 @@
 */
 
 // Shared between the headless renderer (getBrowser.js, which sets the cookie on
-// its browser context) and the dev getSession (getHeadlessSession.js, which
+// its browser context) and the dev session resolution (getHeadlessUser.js, which
 // decodes it) so the cookie name and injected user shape live in one place.
 const HEADLESS_USER_COOKIE = 'lowdefy_headless_user';
 

--- a/packages/servers/server-dev/lib/server/auth/session.js
+++ b/packages/servers/server-dev/lib/server/auth/session.js
@@ -17,20 +17,17 @@
 import { getAuthUser } from '@hono/auth-js';
 
 import authJson from '../../build/auth.js';
-import getHeadlessSession from './getHeadlessSession.js';
-import getMockSession from './getMockSession.js';
+import getDevSession from './getDevSession.js';
 
-// Replaces getServerSession.js — mock user first (dev only), then the headless
-// renderer's injected user cookie, then the session from the Hono context
-// populated by initAuthConfig.
+// Replaces getServerSession.js — dev sessions (mock user, headless renderer)
+// first, then the session from the Hono context populated by initAuthConfig.
+// getDevSession is the same function the client's GET /api/auth/session is
+// answered from (routes/auth.js), so server and client sessions match by
+// construction.
 async function getSession(c) {
-  const mockSession = await getMockSession();
-  if (mockSession) {
-    return mockSession;
-  }
-  const headlessSession = getHeadlessSession(c);
-  if (headlessSession) {
-    return headlessSession;
+  const devSession = await getDevSession(c);
+  if (devSession) {
+    return devSession;
   }
   if (authJson.configured !== true) {
     return undefined;

--- a/packages/servers/server-dev/manager/run.mjs
+++ b/packages/servers/server-dev/manager/run.mjs
@@ -110,19 +110,18 @@ try {
 
   startServer(context);
   await wait(800);
-  const appUrl = `http://localhost:${context.options.port}`;
-  context.logger.info(
-    { color: 'blue' },
-    `Agent docs & MCP live at ${appUrl}/lowdefy-docs — run \`lowdefy agent-setup\` to connect your coding agent.`
-  );
+  const docsUrl = `http://localhost:${context.options.port}/lowdefy-docs`;
   context.logger.info(
     { color: 'blue' },
     formatNoticeBox({
-      title: 'Annotate for your agent',
+      title: 'Lowdefy coding agent tools',
       lines: [
-        'Press Cmd/Ctrl+/ in the browser to point, draw, and comment',
-        'on the running app, then paste the copied feedback into your',
-        'coding agent session.',
+        `Docs & MCP  ${docsUrl}`,
+        '            run `lowdefy agent-setup` to connect your agent',
+        '',
+        'Annotate    Press Cmd/Ctrl+/ in the browser to point, draw,',
+        '            and comment on the running app, then paste the',
+        '            copied feedback into your coding agent session.',
       ],
     })
   );

--- a/packages/servers/server-dev/src/routes/auth.js
+++ b/packages/servers/server-dev/src/routes/auth.js
@@ -17,6 +17,7 @@
 import { authHandler } from '@hono/auth-js';
 
 import authJson from '../../lib/build/auth.js';
+import getDevSession from '../../lib/server/auth/getDevSession.js';
 
 // Replaces pages/api/auth/[...nextauth].js. Hono routes HEAD requests through
 // GET handlers, so the corporate-email pre-check branch must live inside the
@@ -30,6 +31,16 @@ function authMiddleware() {
     }
     if (c.req.method === 'HEAD') {
       return c.body(null, 200);
+    }
+    // Dev sessions (mock user, headless renderer cookie) exist outside
+    // Auth.js. getDevSession is the same function the server request
+    // context uses (lib/server/auth/session.js), so the session the browser
+    // client sees here is identical to the one requests authenticate with.
+    if (c.req.method === 'GET' && c.req.path.endsWith('/api/auth/session')) {
+      const devSession = await getDevSession(c);
+      if (devSession) {
+        return c.json(devSession);
+      }
     }
     return handler(c, next);
   };

--- a/packages/servers/server-dev/src/routes/auth.test.mjs
+++ b/packages/servers/server-dev/src/routes/auth.test.mjs
@@ -1,0 +1,84 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { Hono } from 'hono';
+import { jest } from '@jest/globals';
+
+// Only the route wiring is under test here — getDevSession's own behaviour
+// (mock/headless resolution, session-callback parity) is covered in
+// lib/server/auth/getDevSession.test.mjs, and the real Auth.js engine is
+// stubbed with a sentinel handler so "delegated to Auth.js" is observable.
+const mockAuthHandler = jest.fn(() => (c) => c.json({ delegated: true }));
+jest.unstable_mockModule('@hono/auth-js', () => ({
+  authHandler: mockAuthHandler,
+}));
+jest.unstable_mockModule('../../lib/build/auth.js', () => ({
+  default: { configured: true },
+}));
+const mockGetDevSession = jest.fn(async () => undefined);
+jest.unstable_mockModule('../../lib/server/auth/getDevSession.js', () => ({
+  default: mockGetDevSession,
+}));
+
+const { default: authMiddleware } = await import('./auth.js');
+
+function createApp() {
+  const app = new Hono();
+  app.use('/api/auth/*', authMiddleware());
+  return app;
+}
+
+afterEach(() => {
+  mockGetDevSession.mockReset();
+  mockGetDevSession.mockResolvedValue(undefined);
+});
+
+test('GET /api/auth/session returns the dev session so the client matches the server', async () => {
+  const devSession = {
+    user: {
+      id: 'dev-mock-user',
+      roles: ['admin'],
+      global_attributes: { company_ids: ['C-1'] },
+    },
+    hashed_id: 'abc',
+    expires: '2100-01-01T00:00:00.000Z',
+  };
+  mockGetDevSession.mockResolvedValue(devSession);
+
+  const res = await createApp().request('/api/auth/session');
+  expect(res.status).toEqual(200);
+  expect(await res.json()).toEqual(devSession);
+});
+
+test('GET /api/auth/session delegates to Auth.js when no dev session exists', async () => {
+  const res = await createApp().request('/api/auth/session');
+  expect(res.status).toEqual(200);
+  expect(await res.json()).toEqual({ delegated: true });
+});
+
+test('other auth routes delegate to Auth.js even when a dev session exists', async () => {
+  mockGetDevSession.mockResolvedValue({ user: { id: 'mock' } });
+
+  const res = await createApp().request('/api/auth/csrf');
+  expect(await res.json()).toEqual({ delegated: true });
+});
+
+test('POST /api/auth/session delegates to Auth.js even when a dev session exists', async () => {
+  mockGetDevSession.mockResolvedValue({ user: { id: 'mock' } });
+
+  const res = await createApp().request('/api/auth/session', { method: 'POST' });
+  expect(await res.json()).toEqual({ delegated: true });
+});


### PR DESCRIPTION
## Problem

Found during headless verification in a consuming app: with a mock user, server-side requests authenticated (tenant claims like `global_attributes` present) but the browser client's session stayed empty — `GET /api/auth/session` was answered by Auth.js alone, which knows nothing about dev sessions. Client-side `_user` reads diverged from the server, and `_user`-driven routing remount-looped (~19 remounts/sec dashboard↔get-started) in headless MCP sessions. The headless-renderer session also bypassed the session callback entirely, so it never had prod shape.

## Fix — parity by construction

- **`getDevSession.js`** is the single source of dev sessions: resolves the dev user (mock via `getMockUser.js`, then headless cookie via `getHeadlessUser.js`) and runs it through the **identical Auth.js session callback a real sign-in uses** — userFields mapping, custom session-callback plugins, roles validation, `hashed_id`.
- Both consumers — the server request context (`session.js`) and the client's `GET /api/auth/session` (`routes/auth.js`) — obtain the session only from that function, so client and server can never diverge.
- `getMockSession.js` / `getHeadlessSession.js` deleted so the old two-path split cannot resurface.
- With auth not configured, dev sessions are consistently absent everywhere.

## Verification

- `getDevSession.test.mjs` proves parity through the REAL `@lowdefy/api` pipeline: userFields (incl. `global_attributes.company_ids`) survive, `hashed_id` stamped, invalid roles rejected exactly as prod.
- Route tests cover endpoint wiring + delegation. Full server-dev suite: 159 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)