### PR TITLE
feat(blocks-antd): Add TagSelector and TagMultipleSelector input blocks

### DIFF
--- a/.changeset/feat-blocks-antd-tag-selector.md
+++ b/.changeset/feat-blocks-antd-tag-selector.md
@@ -2,11 +2,13 @@
 '@lowdefy/blocks-antd': minor
 ---
 
-feat(blocks-antd): Add the `TagSelector` input block.
+feat(blocks-antd): Add the `TagSelector` and `TagMultipleSelector` input blocks.
 
-`TagSelector` is a multi-select input rendered as a row of toggleable tag pills, wrapped in the standard input label. Its value is the array of selected option values, and it fires `onChange` on every toggle.
+Two input blocks rendered as a row of toggleable tag pills, wrapped in the standard input label. They share the same pill rendering and stable per-value coloring, and differ only in value semantics.
 
-- `options` accept primitives or `{ label, value, color, disabled }`.
+- `TagSelector` is single-select: its value is one option value. Clicking a pill selects it; clicking the selected pill clears the value (sets it to `null`).
+- `TagMultipleSelector` is multi-select: its value is the array of selected option values, and toggling a pill adds or removes it.
+- Both fire `onChange` on every change, and accept `options` as primitives or `{ label, value, color, disabled }`.
 - Each option gets a stable color (an explicit `color` wins, otherwise a color is picked from a fixed palette based on the option's value), so a given value keeps the same hue on every render. Selected pills are filled with auto-contrast text; unselected pills are outlined with a hint of their color.
 - Set `colored: false` for single-accent pills that use the primary color.
-- Supports `title`, `label`, `size`, and `disabled` like the other selector blocks, plus per-option `disabled`.
+- Both support `title`, `label`, `size`, and `disabled` like the other selector blocks, plus per-option `disabled`.

--- a/.changeset/feat-blocks-antd-tag-selector.md
+++ b/.changeset/feat-blocks-antd-tag-selector.md
@@ -1,0 +1,12 @@
+---
+'@lowdefy/blocks-antd': minor
+---
+
+feat(blocks-antd): Add the `TagSelector` input block.
+
+`TagSelector` is a multi-select input rendered as a row of toggleable tag pills, wrapped in the standard input label. Its value is the array of selected option values, and it fires `onChange` on every toggle.
+
+- `options` accept primitives or `{ label, value, color, disabled }`.
+- Each option gets a stable color (an explicit `color` wins, otherwise a color is picked from a fixed palette based on the option's value), so a given value keeps the same hue on every render. Selected pills are filled with auto-contrast text; unselected pills are outlined with a hint of their color.
+- Set `colored: false` for single-accent pills that use the primary color.
+- Supports `title`, `label`, `size`, and `disabled` like the other selector blocks, plus per-option `disabled`.

--- a/.changeset/fix-feedback-annotations-over-modals.md
+++ b/.changeset/fix-feedback-annotations-over-modals.md
@@ -6,5 +6,5 @@
 fix(server-dev): Annotations now work over open modals, plus an annotate hint on dev server startup.
 
 - The annotation overlay is now rendered into the document body, so its comment box stays clickable and typeable even when a modal is open on the page.
-- On startup the dev server now reports that the agent docs & MCP endpoint is live (with the `lowdefy agent-setup` command to connect an agent), followed by a notice box explaining the Cmd/Ctrl+/ annotation shortcut.
+- On startup the dev server now prints a notice box for coding agents: the docs & MCP endpoint URL with the `lowdefy agent-setup` command to connect an agent, and the Cmd/Ctrl+/ annotation shortcut.
 - `lowdefy agent-setup` now enables the `lowdefy-docs` MCP server in the committed `.claude/settings.json`, so everyone on the project has it approved without a prompt.

--- a/packages/docs/blocks/input/TagMultipleSelector.yaml
+++ b/packages/docs/blocks/input/TagMultipleSelector.yaml
@@ -15,15 +15,15 @@
 _ref:
   path: templates/blocks/gallery.yaml.njk
   vars:
-    pageId: TagSelector
-    pageTitle: TagSelector
+    pageId: TagMultipleSelector
+    pageTitle: TagMultipleSelector
     section: Input Blocks
-    filePath: blocks/input/TagSelector.yaml
-    block_type: TagSelector
+    filePath: blocks/input/TagMultipleSelector.yaml
+    block_type: TagMultipleSelector
     antd_component: Tag
     antd_url: tag
-    github_path: packages/plugins/blocks/blocks-antd/src/blocks/TagSelector
-    schema: ../plugins/blocks/blocks-antd/src/blocks/TagSelector/meta.js
-    gallery: ../plugins/blocks/blocks-antd/src/blocks/TagSelector/gallery.yaml
+    github_path: packages/plugins/blocks/blocks-antd/src/blocks/TagMultipleSelector
+    schema: ../plugins/blocks/blocks-antd/src/blocks/TagMultipleSelector/meta.js
+    gallery: ../plugins/blocks/blocks-antd/src/blocks/TagMultipleSelector/gallery.yaml
     description: >
-      Single-select input rendered as a row of toggleable, colored tag pills.
+      Multi-select input rendered as a row of toggleable, colored tag pills.

--- a/packages/docs/blocks/input/TagSelector.yaml
+++ b/packages/docs/blocks/input/TagSelector.yaml
@@ -1,0 +1,29 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_ref:
+  path: templates/blocks/gallery.yaml.njk
+  vars:
+    pageId: TagSelector
+    pageTitle: TagSelector
+    section: Input Blocks
+    filePath: blocks/input/TagSelector.yaml
+    block_type: TagSelector
+    antd_component: Tag
+    antd_url: tag
+    github_path: packages/plugins/blocks/blocks-antd/src/blocks/TagSelector
+    schema: ../plugins/blocks/blocks-antd/src/blocks/TagSelector/meta.js
+    gallery: ../plugins/blocks/blocks-antd/src/blocks/TagSelector/gallery.yaml
+    description: >
+      Multi-select input rendered as a row of toggleable, colored tag pills.

--- a/packages/docs/menus.yaml
+++ b/packages/docs/menus.yaml
@@ -510,6 +510,9 @@
         - id: Switch
           type: MenuLink
           pageId: Switch
+        - id: TagMultipleSelector
+          type: MenuLink
+          pageId: TagMultipleSelector
         - id: TagSelector
           type: MenuLink
           pageId: TagSelector

--- a/packages/docs/menus.yaml
+++ b/packages/docs/menus.yaml
@@ -510,6 +510,9 @@
         - id: Switch
           type: MenuLink
           pageId: Switch
+        - id: TagSelector
+          type: MenuLink
+          pageId: TagSelector
         - id: TextArea
           type: MenuLink
           pageId: TextArea

--- a/packages/docs/pages.yaml
+++ b/packages/docs/pages.yaml
@@ -106,6 +106,7 @@
 - _ref: blocks/input/S3UploadPhoto.yaml
 - _ref: blocks/input/Selector.yaml
 - _ref: blocks/input/Switch.yaml
+- _ref: blocks/input/TagMultipleSelector.yaml
 - _ref: blocks/input/TagSelector.yaml
 - _ref: blocks/input/TextArea.yaml
 - _ref: blocks/input/TextInput.yaml

--- a/packages/docs/pages.yaml
+++ b/packages/docs/pages.yaml
@@ -106,6 +106,7 @@
 - _ref: blocks/input/S3UploadPhoto.yaml
 - _ref: blocks/input/Selector.yaml
 - _ref: blocks/input/Switch.yaml
+- _ref: blocks/input/TagSelector.yaml
 - _ref: blocks/input/TextArea.yaml
 - _ref: blocks/input/TextInput.yaml
 - _ref: blocks/input/TiptapInput.yaml

--- a/packages/plugins/blocks/blocks-antd/e2e/app/lowdefy.yaml
+++ b/packages/plugins/blocks/blocks-antd/e2e/app/lowdefy.yaml
@@ -47,6 +47,7 @@ pages:
   # Step 1.5: Special Inputs
   - _ref: ../../src/blocks/PhoneNumberInput/tests/PhoneNumberInput.e2e.yaml
   - _ref: ../../src/blocks/Tag/tests/Tag.e2e.yaml
+  - _ref: ../../src/blocks/TagMultipleSelector/tests/TagMultipleSelector.e2e.yaml
   - _ref: ../../src/blocks/TagSelector/tests/TagSelector.e2e.yaml
   # Step 2.1: Text Display
   - _ref: ../../src/blocks/Title/tests/Title.e2e.yaml

--- a/packages/plugins/blocks/blocks-antd/e2e/app/lowdefy.yaml
+++ b/packages/plugins/blocks/blocks-antd/e2e/app/lowdefy.yaml
@@ -47,6 +47,7 @@ pages:
   # Step 1.5: Special Inputs
   - _ref: ../../src/blocks/PhoneNumberInput/tests/PhoneNumberInput.e2e.yaml
   - _ref: ../../src/blocks/Tag/tests/Tag.e2e.yaml
+  - _ref: ../../src/blocks/TagSelector/tests/TagSelector.e2e.yaml
   # Step 2.1: Text Display
   - _ref: ../../src/blocks/Title/tests/Title.e2e.yaml
   - _ref: ../../src/blocks/Paragraph/tests/Paragraph.e2e.yaml

--- a/packages/plugins/blocks/blocks-antd/src/TagPillRow.js
+++ b/packages/plugins/blocks/blocks-antd/src/TagPillRow.js
@@ -1,0 +1,110 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import React from 'react';
+import { cn } from '@lowdefy/block-utils';
+
+import Label from './blocks/Label/Label.js';
+import getTagColor from './getTagColor.js';
+import getContrastTextColor from './getContrastTextColor.js';
+
+import './tagSelectorStyle.css';
+
+// Shared body for TagSelector (single) and TagMultipleSelector (multi): the
+// input Label wrapping a row of toggleable tag pills. Value semantics differ
+// between the two blocks, so selection state and toggling are injected as
+// `isSelected` / `onToggle`; everything visual — stable per-value colors,
+// filled-selected / outlined-unselected pills, per-option and whole-block
+// disabling — lives here so both blocks render identically. Colors are stable
+// per option (see getTagColor); `properties.colored: false` gives single-accent
+// pills that use the primary color.
+function TagPillRow({
+  blockId,
+  classNames = {},
+  components: { Icon },
+  events,
+  isSelected,
+  loading,
+  methods,
+  onToggle,
+  options,
+  properties,
+  required,
+  styles = {},
+  validation,
+}) {
+  const colored = properties.colored !== false;
+  return (
+    <Label
+      blockId={blockId}
+      methods={methods}
+      classNames={classNames}
+      components={{ Icon }}
+      events={events}
+      properties={{ title: properties.title, size: properties.size, ...properties.label }}
+      required={required}
+      styles={styles}
+      validation={validation}
+      content={{
+        content: () => (
+          <div
+            id={`${blockId}_input`}
+            className={cn('lf-tag-selector', classNames.element)}
+            style={styles.element}
+          >
+            {options.map((opt) => {
+              const selected = isSelected(opt.value);
+              const color = getTagColor({ option: opt, colored });
+              // Filled when selected: solid hue + black/white contrast text.
+              // Outlined with a hue-tinted border when off.
+              let colorStyle = {};
+              if (color && selected) {
+                colorStyle = {
+                  background: color,
+                  borderColor: color,
+                  color: getContrastTextColor(color) || '#fff',
+                };
+              } else if (color) {
+                colorStyle = {
+                  borderColor: `color-mix(in srgb, ${color} 45%, var(--ant-color-border))`,
+                };
+              }
+              return (
+                <button
+                  key={`${opt.value}`}
+                  type="button"
+                  disabled={opt.disabled || properties.disabled || loading}
+                  aria-pressed={selected}
+                  className={cn(
+                    'lf-tag-selector-tag',
+                    selected && 'lf-tag-selector-tag-selected',
+                    classNames.tag
+                  )}
+                  style={{ ...colorStyle, ...styles.tag }}
+                  onClick={() => onToggle(opt)}
+                >
+                  {opt.label}
+                </button>
+              );
+            })}
+          </div>
+        ),
+      }}
+    />
+  );
+}
+
+export default TagPillRow;

--- a/packages/plugins/blocks/blocks-antd/src/blocks.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks.js
@@ -83,6 +83,7 @@ export { default as Steps } from './blocks/Steps/Steps.js';
 export { default as Switch } from './blocks/Switch/Switch.js';
 export { default as Tabs } from './blocks/Tabs/Tabs.js';
 export { default as Tag } from './blocks/Tag/Tag.js';
+export { default as TagMultipleSelector } from './blocks/TagMultipleSelector/TagMultipleSelector.js';
 export { default as TagSelector } from './blocks/TagSelector/TagSelector.js';
 export { default as TimelineList } from './blocks/TimelineList/TimelineList.js';
 export { default as TextArea } from './blocks/TextArea/TextArea.js';

--- a/packages/plugins/blocks/blocks-antd/src/blocks.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks.js
@@ -83,6 +83,7 @@ export { default as Steps } from './blocks/Steps/Steps.js';
 export { default as Switch } from './blocks/Switch/Switch.js';
 export { default as Tabs } from './blocks/Tabs/Tabs.js';
 export { default as Tag } from './blocks/Tag/Tag.js';
+export { default as TagSelector } from './blocks/TagSelector/TagSelector.js';
 export { default as TimelineList } from './blocks/TimelineList/TimelineList.js';
 export { default as TextArea } from './blocks/TextArea/TextArea.js';
 export { default as TextInput } from './blocks/TextInput/TextInput.js';

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TagMultipleSelector/TagMultipleSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TagMultipleSelector/TagMultipleSelector.js
@@ -21,22 +21,25 @@ import { type } from '@lowdefy/helpers';
 import TagPillRow from '../../TagPillRow.js';
 import getTagSelectorOptions from '../../getTagSelectorOptions.js';
 
-// Single-select tag input: `value` is one option value (or null). Clicking a
-// pill selects it; clicking the already-selected pill clears the value. Purely
-// controlled — the value is read from props each render. See TagPillRow for the
-// shared rendering/color logic and TagMultipleSelector for the multi-select
-// variant whose value is the array of selected values.
-const TagSelector = (props) => {
+// Multi-select tag input: `value` is the array of selected option values.
+// Clicking a pill toggles it in or out of the selection. Purely controlled —
+// the selection is read from props each render. See TagPillRow for the shared
+// rendering/color logic and TagSelector for the single-select variant whose
+// value is one option value.
+const TagMultipleSelector = (props) => {
   const { loading, methods, properties, value } = props;
   const options = getTagSelectorOptions({ options: properties.options });
-  const isSelected = (optionValue) => !type.isNone(value) && value === optionValue;
+  const selected = type.isArray(value) ? value : [];
+  const isSelected = (optionValue) => selected.includes(optionValue);
   const onToggle = (option) => {
     if (option.disabled || properties.disabled || loading) return;
-    const next = value === option.value ? null : option.value;
+    const next = selected.includes(option.value)
+      ? selected.filter((v) => v !== option.value)
+      : [...selected, option.value];
     methods.setValue(next);
     methods.triggerEvent({ name: 'onChange', event: { value: next } });
   };
   return <TagPillRow {...props} options={options} isSelected={isSelected} onToggle={onToggle} />;
 };
 
-export default withBlockDefaults(TagSelector);
+export default withBlockDefaults(TagMultipleSelector);

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TagMultipleSelector/e2e.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TagMultipleSelector/e2e.js
@@ -1,0 +1,42 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { createBlockHelper, escapeId } from '@lowdefy/e2e-utils';
+import { expect } from '@playwright/test';
+
+const locator = (page, blockId) => page.locator(`#${escapeId(blockId)}_input`);
+
+export default createBlockHelper({
+  locator,
+  do: {
+    select: (page, blockId, text) =>
+      locator(page, blockId).locator('.lf-tag-selector-tag').filter({ hasText: text }).click(),
+  },
+  expect: {
+    value: (page, blockId, text) =>
+      expect(
+        locator(page, blockId).locator('.lf-tag-selector-tag-selected').filter({ hasText: text })
+      ).toBeVisible(),
+    disabled: (page, blockId, text) =>
+      expect(
+        locator(page, blockId).locator('.lf-tag-selector-tag').filter({ hasText: text })
+      ).toBeDisabled(),
+    enabled: (page, blockId, text) =>
+      expect(
+        locator(page, blockId).locator('.lf-tag-selector-tag').filter({ hasText: text })
+      ).toBeEnabled(),
+  },
+});

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TagMultipleSelector/gallery.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TagMultipleSelector/gallery.yaml
@@ -15,9 +15,9 @@
 - title: Basic String Options
   blocks:
     - id: basic_strings
-      type: TagSelector
+      type: TagMultipleSelector
       properties:
-        title: Domain
+        title: Domains
         options:
           - Ethics
           - Environment
@@ -28,9 +28,9 @@
 - title: Label-Value Options
   blocks:
     - id: label_value
-      type: TagSelector
+      type: TagMultipleSelector
       properties:
-        title: Status
+        title: Status Filter
         options:
           - label: Draft
             value: draft
@@ -45,9 +45,9 @@
 - title: Explicit Colors and Single Accent
   blocks:
     - id: explicit_colors
-      type: TagSelector
+      type: TagMultipleSelector
       properties:
-        title: Priority
+        title: Priorities
         options:
           - label: Low
             value: low
@@ -59,9 +59,9 @@
             value: high
             color: '#E15759'
     - id: single_accent
-      type: TagSelector
+      type: TagMultipleSelector
       properties:
-        title: Interest
+        title: Interests
         colored: false
         options:
           - Design

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TagMultipleSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TagMultipleSelector/meta.js
@@ -20,19 +20,19 @@ import { disabled, inputTitle, sizeSmallDefaultLarge } from '../../schemas/input
 
 export default {
   category: 'input',
-  valueType: 'any',
+  valueType: 'array',
   icons: [...LabelMeta.icons],
   cssKeys: {
-    element: 'The TagSelector tag row.',
+    element: 'The TagMultipleSelector tag row.',
     tag: 'Each tag pill.',
-    label: 'The TagSelector label.',
-    extra: 'The TagSelector extra content.',
-    feedback: 'The TagSelector validation feedback.',
+    label: 'The TagMultipleSelector label.',
+    extra: 'The TagMultipleSelector extra content.',
+    feedback: 'The TagMultipleSelector validation feedback.',
   },
   events: {
     onChange: {
       description: 'Trigger actions when the selection is changed.',
-      event: { value: 'The selected value.' },
+      event: { value: 'The array of selected values.' },
     },
     onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
   },
@@ -52,7 +52,7 @@ export default {
               description: 'Tag label. Defaults to the value.',
             },
             value: {
-              description: 'Option value set as the selection when the tag is selected.',
+              description: 'Option value written into the selection array.',
               docs: {
                 displayType: 'yaml',
               },

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TagMultipleSelector/tests/TagMultipleSelector.e2e.spec.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TagMultipleSelector/tests/TagMultipleSelector.e2e.spec.js
@@ -18,14 +18,14 @@ import { test, expect } from '@playwright/test';
 import { getBlock, navigateToTestPage } from '@lowdefy/block-dev-e2e';
 import { escapeId } from '@lowdefy/e2e-utils';
 
-// TagSelector renders its tag row with an _input suffix.
+// TagMultipleSelector renders its tag row with an _input suffix.
 const getTags = (page, blockId) => page.locator(`#${escapeId(blockId)}_input`);
 const tag = (page, blockId, text) =>
   getTags(page, blockId).locator('.lf-tag-selector-tag').filter({ hasText: text });
 
-test.describe('TagSelector Block', () => {
+test.describe('TagMultipleSelector Block', () => {
   test.beforeEach(async ({ page }) => {
-    await navigateToTestPage(page, 'tag_selector');
+    await navigateToTestPage(page, 'tag_multiple_selector');
   });
 
   // ============================================
@@ -33,7 +33,7 @@ test.describe('TagSelector Block', () => {
   // ============================================
 
   test('renders tag pills with options', async ({ page }) => {
-    const tags = getTags(page, 'tag_basic');
+    const tags = getTags(page, 'tms_basic');
     await expect(tags).toBeVisible();
     await expect(tags).toContainText('Ethics');
     await expect(tags).toContainText('Environment');
@@ -44,33 +44,26 @@ test.describe('TagSelector Block', () => {
   // SELECTION / EVENT TESTS
   // ============================================
 
-  test('selects a single value, fires onChange and updates state', async ({ page }) => {
-    await tag(page, 'tag_change', 'Option A').click();
-    await expect(tag(page, 'tag_change', 'Option A')).toHaveClass(/lf-tag-selector-tag-selected/);
+  test('toggles selection, fires onChange and updates state', async ({ page }) => {
+    await tag(page, 'tms_change', 'Option A').click();
+    await expect(tag(page, 'tms_change', 'Option A')).toHaveClass(/lf-tag-selector-tag-selected/);
 
-    const display = getBlock(page, 'tag_change_display');
+    const display = getBlock(page, 'tms_change_display');
     await expect(display).toContainText('a');
 
-    // Single-select: selecting another option replaces the selection.
-    await tag(page, 'tag_change', 'Option B').click();
-    await expect(tag(page, 'tag_change', 'Option B')).toHaveClass(/lf-tag-selector-tag-selected/);
-    await expect(tag(page, 'tag_change', 'Option A')).not.toHaveClass(
-      /lf-tag-selector-tag-selected/
-    );
+    // Multi-select: a second toggle adds to the array.
+    await tag(page, 'tms_change', 'Option B').click();
+    await expect(tag(page, 'tms_change', 'Option B')).toHaveClass(/lf-tag-selector-tag-selected/);
+    await expect(tag(page, 'tms_change', 'Option A')).toHaveClass(/lf-tag-selector-tag-selected/);
+    await expect(display).toContainText('a');
     await expect(display).toContainText('b');
-  });
 
-  test('deselects when the selected pill is clicked again', async ({ page }) => {
-    await tag(page, 'tag_change', 'Option A').click();
-    await expect(tag(page, 'tag_change', 'Option A')).toHaveClass(/lf-tag-selector-tag-selected/);
-
-    // Clicking the selected pill clears the value.
-    await tag(page, 'tag_change', 'Option A').click();
-    await expect(tag(page, 'tag_change', 'Option A')).not.toHaveClass(
+    // Toggling off removes it and keeps the selection controlled.
+    await tag(page, 'tms_change', 'Option A').click();
+    await expect(tag(page, 'tms_change', 'Option A')).not.toHaveClass(
       /lf-tag-selector-tag-selected/
     );
-    const display = getBlock(page, 'tag_change_display');
-    await expect(display).toHaveText('');
+    await expect(tag(page, 'tms_change', 'Option B')).toHaveClass(/lf-tag-selector-tag-selected/);
   });
 
   // ============================================
@@ -78,12 +71,12 @@ test.describe('TagSelector Block', () => {
   // ============================================
 
   test('disables the whole selector', async ({ page }) => {
-    await expect(tag(page, 'tag_disabled', 'X')).toBeDisabled();
-    await expect(tag(page, 'tag_disabled', 'Y')).toBeDisabled();
+    await expect(tag(page, 'tms_disabled', 'X')).toBeDisabled();
+    await expect(tag(page, 'tms_disabled', 'Y')).toBeDisabled();
   });
 
   test('disables a single option while others stay enabled', async ({ page }) => {
-    await expect(tag(page, 'tag_disabled_option', 'Enabled')).toBeEnabled();
-    await expect(tag(page, 'tag_disabled_option', 'Locked')).toBeDisabled();
+    await expect(tag(page, 'tms_disabled_option', 'Enabled')).toBeEnabled();
+    await expect(tag(page, 'tms_disabled_option', 'Locked')).toBeDisabled();
   });
 });

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TagMultipleSelector/tests/TagMultipleSelector.e2e.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TagMultipleSelector/tests/TagMultipleSelector.e2e.yaml
@@ -1,0 +1,93 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: tag_multiple_selector
+type: Box
+
+blocks:
+  # ============================================
+  # BASIC RENDERING
+  # ============================================
+
+  - id: tms_basic
+    type: TagMultipleSelector
+    properties:
+      label:
+        disabled: true
+      options:
+        - Ethics
+        - Environment
+        - Governance
+
+  # ============================================
+  # EVENT / SELECTION TESTS
+  # ============================================
+
+  - id: tms_change
+    type: TagMultipleSelector
+    properties:
+      label:
+        disabled: true
+      options:
+        - label: Option A
+          value: a
+        - label: Option B
+          value: b
+    events:
+      onChange:
+        - id: set_tms_result
+          type: SetState
+          params:
+            tms_result:
+              _event: value
+
+  - id: tms_change_display
+    type: Paragraph
+    properties:
+      content:
+        _if:
+          test:
+            _ne:
+              - _state: tms_result
+              - null
+          then:
+            _json.stringify:
+              - _state: tms_result
+          else: ''
+
+  # ============================================
+  # DISABLED TESTS
+  # ============================================
+
+  - id: tms_disabled
+    type: TagMultipleSelector
+    properties:
+      label:
+        disabled: true
+      disabled: true
+      options:
+        - X
+        - Y
+
+  - id: tms_disabled_option
+    type: TagMultipleSelector
+    properties:
+      label:
+        disabled: true
+      options:
+        - label: Enabled
+          value: enabled
+        - label: Locked
+          value: locked
+          disabled: true

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TagSelector/TagSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TagSelector/TagSelector.js
@@ -1,0 +1,156 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import React from 'react';
+import { cn, withBlockDefaults } from '@lowdefy/block-utils';
+import { type } from '@lowdefy/helpers';
+
+import Label from '../Label/Label.js';
+import getContrastTextColor from '../../getContrastTextColor.js';
+
+import './style.css';
+
+// Tableau-10 categorical palette — mid-saturation hues that read on both the
+// light and dark canvas.
+const PALETTE = [
+  '#4E79A7',
+  '#F28E2B',
+  '#E15759',
+  '#76B7B2',
+  '#59A14F',
+  '#EDC948',
+  '#B07AA1',
+  '#FF9DA7',
+  '#9C755F',
+  '#BAB0AC',
+];
+
+// djb2 — tiny, deterministic string hash for stable palette assignment.
+function hashString(s) {
+  let h = 5381;
+  for (let i = 0; i < s.length; i += 1) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return Math.abs(h);
+}
+
+// A multi-select input rendered as a row of toggleable tag pills. Purely
+// controlled: `value` (the array of selected option values) is read from props
+// each render, so SetState / onInit seeding shows up immediately. Colors are
+// stable per option — an explicit option.color wins, otherwise a hash of the
+// option value picks from the palette so a given value keeps the same hue on
+// every render. Selected tags render filled; unselected tags are outlined with
+// a hint of their hue. properties.colored: false gives single-accent pills.
+const TagSelector = ({
+  blockId,
+  classNames = {},
+  components: { Icon },
+  events,
+  loading,
+  methods,
+  properties,
+  required,
+  styles = {},
+  validation,
+  value,
+}) => {
+  const selected = type.isArray(value) ? value : [];
+  const colored = properties.colored !== false;
+  const options = (properties.options || []).map((opt) =>
+    type.isPrimitive(opt)
+      ? { label: `${opt}`, value: opt }
+      : {
+          label: type.isNone(opt.label) ? `${opt.value}` : opt.label,
+          value: opt.value,
+          color: opt.color,
+          disabled: opt.disabled,
+        }
+  );
+
+  const colorFor = (opt) => {
+    if (opt.color) return opt.color;
+    if (!colored) return null; // single-accent mode → CSS handles the primary look
+    return PALETTE[hashString(`${opt.value}`) % PALETTE.length];
+  };
+
+  const toggle = (opt) => {
+    if (opt.disabled || properties.disabled || loading) return;
+    const next = selected.includes(opt.value)
+      ? selected.filter((v) => v !== opt.value)
+      : [...selected, opt.value];
+    methods.setValue(next);
+    methods.triggerEvent({ name: 'onChange', event: { value: next } });
+  };
+
+  return (
+    <Label
+      blockId={blockId}
+      methods={methods}
+      classNames={classNames}
+      components={{ Icon }}
+      events={events}
+      properties={{ title: properties.title, size: properties.size, ...properties.label }}
+      required={required}
+      styles={styles}
+      validation={validation}
+      content={{
+        content: () => (
+          <div
+            id={`${blockId}_input`}
+            className={cn('lf-tag-selector', classNames.element)}
+            style={styles.element}
+          >
+            {options.map((opt) => {
+              const isSelected = selected.includes(opt.value);
+              const color = colorFor(opt);
+              // Filled when selected: solid hue + black/white contrast text.
+              // Outlined with a hue-tinted border when off.
+              let colorStyle = {};
+              if (color && isSelected) {
+                colorStyle = {
+                  background: color,
+                  borderColor: color,
+                  color: getContrastTextColor(color) || '#fff',
+                };
+              } else if (color) {
+                colorStyle = {
+                  borderColor: `color-mix(in srgb, ${color} 45%, var(--ant-color-border))`,
+                };
+              }
+              return (
+                <button
+                  key={`${opt.value}`}
+                  type="button"
+                  disabled={opt.disabled || properties.disabled || loading}
+                  aria-pressed={isSelected}
+                  className={cn(
+                    'lf-tag-selector-tag',
+                    isSelected && 'lf-tag-selector-tag-selected',
+                    classNames.tag
+                  )}
+                  style={{ ...colorStyle, ...styles.tag }}
+                  onClick={() => toggle(opt)}
+                >
+                  {opt.label}
+                </button>
+              );
+            })}
+          </div>
+        ),
+      }}
+    />
+  );
+};
+
+export default withBlockDefaults(TagSelector);

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TagSelector/e2e.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TagSelector/e2e.js
@@ -1,0 +1,42 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { createBlockHelper, escapeId } from '@lowdefy/e2e-utils';
+import { expect } from '@playwright/test';
+
+const locator = (page, blockId) => page.locator(`#${escapeId(blockId)}_input`);
+
+export default createBlockHelper({
+  locator,
+  do: {
+    select: (page, blockId, text) =>
+      locator(page, blockId).locator('.lf-tag-selector-tag').filter({ hasText: text }).click(),
+  },
+  expect: {
+    value: (page, blockId, text) =>
+      expect(
+        locator(page, blockId).locator('.lf-tag-selector-tag-selected').filter({ hasText: text })
+      ).toBeVisible(),
+    disabled: (page, blockId, text) =>
+      expect(
+        locator(page, blockId).locator('.lf-tag-selector-tag').filter({ hasText: text })
+      ).toBeDisabled(),
+    enabled: (page, blockId, text) =>
+      expect(
+        locator(page, blockId).locator('.lf-tag-selector-tag').filter({ hasText: text })
+      ).toBeEnabled(),
+  },
+});

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TagSelector/gallery.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TagSelector/gallery.yaml
@@ -1,0 +1,70 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- title: Basic String Options
+  blocks:
+    - id: basic_strings
+      type: TagSelector
+      properties:
+        title: Domains
+        options:
+          - Ethics
+          - Environment
+          - Governance
+          - Social
+          - Data Privacy
+
+- title: Label-Value Options
+  blocks:
+    - id: label_value
+      type: TagSelector
+      properties:
+        title: Status Filter
+        options:
+          - label: Draft
+            value: draft
+          - label: In Review
+            value: in_review
+          - label: Published
+            value: published
+          - label: Archived
+            value: archived
+            disabled: true
+
+- title: Explicit Colors and Single Accent
+  blocks:
+    - id: explicit_colors
+      type: TagSelector
+      properties:
+        title: Priority
+        options:
+          - label: Low
+            value: low
+            color: '#59A14F'
+          - label: Medium
+            value: medium
+            color: '#EDC948'
+          - label: High
+            value: high
+            color: '#E15759'
+    - id: single_accent
+      type: TagSelector
+      properties:
+        title: Interests
+        colored: false
+        options:
+          - Design
+          - Engineering
+          - Product
+          - Research

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TagSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TagSelector/meta.js
@@ -1,0 +1,88 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import LabelMeta from '../Label/meta.js';
+import label from '../../schemas/label.js';
+import { disabled, inputTitle, sizeSmallDefaultLarge } from '../../schemas/inputProperties.js';
+
+export default {
+  category: 'input',
+  valueType: 'array',
+  icons: [...LabelMeta.icons],
+  cssKeys: {
+    element: 'The TagSelector tag row.',
+    tag: 'Each tag pill.',
+    label: 'The TagSelector label.',
+    extra: 'The TagSelector extra content.',
+    feedback: 'The TagSelector validation feedback.',
+  },
+  events: {
+    onChange: {
+      description: 'Trigger actions when the selection is changed.',
+      event: { value: 'The array of selected values.' },
+    },
+    onTooltipClick: 'Trigger actions when the tooltip icon is clicked.',
+  },
+  properties: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      options: {
+        type: 'array',
+        description:
+          'Options to select from. Primitives, or { label, value, color, disabled } - an explicit color overrides the stable palette color.',
+        items: {
+          type: ['string', 'number', 'boolean', 'object'],
+          properties: {
+            label: {
+              type: 'string',
+              description: 'Tag label. Defaults to the value.',
+            },
+            value: {
+              description: 'Option value written into the selection array.',
+              docs: {
+                displayType: 'yaml',
+              },
+            },
+            color: {
+              type: 'string',
+              description:
+                'Explicit tag color (hex or CSS color). Overrides the stable palette color.',
+              docs: {
+                displayType: 'color',
+              },
+            },
+            disabled: {
+              type: 'boolean',
+              default: false,
+              description: 'Disable this tag.',
+            },
+          },
+        },
+      },
+      colored: {
+        type: 'boolean',
+        default: true,
+        description:
+          'Give each option a stable color (hash of its value over a fixed palette). false = single primary accent.',
+      },
+      disabled,
+      size: sizeSmallDefaultLarge,
+      label,
+      title: inputTitle,
+    },
+  },
+};

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TagSelector/style.css
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TagSelector/style.css
@@ -1,0 +1,67 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/* The tag row. Per-option colors are inline (computed in JS from the stable
+   palette); everything structural and theme-token-driven lives here. */
+@layer components {
+  .lf-tag-selector {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    width: 100%;
+  }
+
+  .lf-tag-selector-tag {
+    appearance: none;
+    font: inherit;
+    font-size: 12px;
+    line-height: 1.4;
+    padding: 2px 12px;
+    border-radius: 999px;
+    border: 1px solid var(--ant-color-border);
+    background: transparent;
+    color: var(--ant-color-text-secondary);
+    cursor: pointer;
+    user-select: none;
+    transition:
+      color 0.15s ease,
+      border-color 0.15s ease,
+      background 0.15s ease;
+  }
+
+  .lf-tag-selector-tag:hover:not(:disabled) {
+    color: var(--ant-color-text);
+  }
+
+  .lf-tag-selector-tag:focus-visible {
+    outline: 2px solid var(--ant-color-primary);
+    outline-offset: 1px;
+  }
+
+  .lf-tag-selector-tag:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  /* Filled selected state. In colored mode the inline style (solid hue +
+     contrast text) overrides these; this is the colored:false primary look. */
+  .lf-tag-selector-tag-selected {
+    font-weight: 600;
+    background: var(--ant-color-primary);
+    border-color: var(--ant-color-primary);
+    color: #fff;
+  }
+}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TagSelector/tests/TagSelector.e2e.spec.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TagSelector/tests/TagSelector.e2e.spec.js
@@ -1,0 +1,79 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { test, expect } from '@playwright/test';
+import { getBlock, navigateToTestPage } from '@lowdefy/block-dev-e2e';
+import { escapeId } from '@lowdefy/e2e-utils';
+
+// TagSelector renders its tag row with an _input suffix.
+const getTags = (page, blockId) => page.locator(`#${escapeId(blockId)}_input`);
+const tag = (page, blockId, text) =>
+  getTags(page, blockId).locator('.lf-tag-selector-tag').filter({ hasText: text });
+
+test.describe('TagSelector Block', () => {
+  test.beforeEach(async ({ page }) => {
+    await navigateToTestPage(page, 'tag_selector');
+  });
+
+  // ============================================
+  // BASIC RENDERING TESTS
+  // ============================================
+
+  test('renders tag pills with options', async ({ page }) => {
+    const tags = getTags(page, 'tag_basic');
+    await expect(tags).toBeVisible();
+    await expect(tags).toContainText('Ethics');
+    await expect(tags).toContainText('Environment');
+    await expect(tags).toContainText('Governance');
+  });
+
+  // ============================================
+  // SELECTION / EVENT TESTS
+  // ============================================
+
+  test('toggles selection, fires onChange and updates state', async ({ page }) => {
+    await tag(page, 'tag_change', 'Option A').click();
+    await expect(tag(page, 'tag_change', 'Option A')).toHaveClass(/lf-tag-selector-tag-selected/);
+
+    const display = getBlock(page, 'tag_change_display');
+    await expect(display).toContainText('a');
+
+    // Multi-select: a second toggle adds to the array.
+    await tag(page, 'tag_change', 'Option B').click();
+    await expect(tag(page, 'tag_change', 'Option B')).toHaveClass(/lf-tag-selector-tag-selected/);
+    await expect(display).toContainText('b');
+
+    // Toggling off removes it and keeps the selection controlled.
+    await tag(page, 'tag_change', 'Option A').click();
+    await expect(tag(page, 'tag_change', 'Option A')).not.toHaveClass(
+      /lf-tag-selector-tag-selected/
+    );
+  });
+
+  // ============================================
+  // DISABLED TESTS
+  // ============================================
+
+  test('disables the whole selector', async ({ page }) => {
+    await expect(tag(page, 'tag_disabled', 'X')).toBeDisabled();
+    await expect(tag(page, 'tag_disabled', 'Y')).toBeDisabled();
+  });
+
+  test('disables a single option while others stay enabled', async ({ page }) => {
+    await expect(tag(page, 'tag_disabled_option', 'Enabled')).toBeEnabled();
+    await expect(tag(page, 'tag_disabled_option', 'Locked')).toBeDisabled();
+  });
+});

--- a/packages/plugins/blocks/blocks-antd/src/blocks/TagSelector/tests/TagSelector.e2e.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/TagSelector/tests/TagSelector.e2e.yaml
@@ -1,0 +1,93 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: tag_selector
+type: Box
+
+blocks:
+  # ============================================
+  # BASIC RENDERING
+  # ============================================
+
+  - id: tag_basic
+    type: TagSelector
+    properties:
+      label:
+        disabled: true
+      options:
+        - Ethics
+        - Environment
+        - Governance
+
+  # ============================================
+  # EVENT / SELECTION TESTS
+  # ============================================
+
+  - id: tag_change
+    type: TagSelector
+    properties:
+      label:
+        disabled: true
+      options:
+        - label: Option A
+          value: a
+        - label: Option B
+          value: b
+    events:
+      onChange:
+        - id: set_tag_result
+          type: SetState
+          params:
+            tag_result:
+              _event: value
+
+  - id: tag_change_display
+    type: Paragraph
+    properties:
+      content:
+        _if:
+          test:
+            _ne:
+              - _state: tag_result
+              - null
+          then:
+            _json.stringify:
+              - _state: tag_result
+          else: ''
+
+  # ============================================
+  # DISABLED TESTS
+  # ============================================
+
+  - id: tag_disabled
+    type: TagSelector
+    properties:
+      label:
+        disabled: true
+      disabled: true
+      options:
+        - X
+        - Y
+
+  - id: tag_disabled_option
+    type: TagSelector
+    properties:
+      label:
+        disabled: true
+      options:
+        - label: Enabled
+          value: enabled
+        - label: Locked
+          value: locked
+          disabled: true

--- a/packages/plugins/blocks/blocks-antd/src/e2e.js
+++ b/packages/plugins/blocks/blocks-antd/src/e2e.js
@@ -72,6 +72,7 @@ export { default as Steps } from './blocks/Steps/e2e.js';
 export { default as Switch } from './blocks/Switch/e2e.js';
 export { default as Tabs } from './blocks/Tabs/e2e.js';
 export { default as Tag } from './blocks/Tag/e2e.js';
+export { default as TagMultipleSelector } from './blocks/TagMultipleSelector/e2e.js';
 export { default as TagSelector } from './blocks/TagSelector/e2e.js';
 export { default as TextArea } from './blocks/TextArea/e2e.js';
 export { default as TextInput } from './blocks/TextInput/e2e.js';

--- a/packages/plugins/blocks/blocks-antd/src/e2e.js
+++ b/packages/plugins/blocks/blocks-antd/src/e2e.js
@@ -72,6 +72,7 @@ export { default as Steps } from './blocks/Steps/e2e.js';
 export { default as Switch } from './blocks/Switch/e2e.js';
 export { default as Tabs } from './blocks/Tabs/e2e.js';
 export { default as Tag } from './blocks/Tag/e2e.js';
+export { default as TagSelector } from './blocks/TagSelector/e2e.js';
 export { default as TextArea } from './blocks/TextArea/e2e.js';
 export { default as TextInput } from './blocks/TextInput/e2e.js';
 export { default as TimelineList } from './blocks/TimelineList/e2e.js';

--- a/packages/plugins/blocks/blocks-antd/src/getTagColor.js
+++ b/packages/plugins/blocks/blocks-antd/src/getTagColor.js
@@ -1,0 +1,49 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Tableau-10 categorical palette — mid-saturation hues that read on both the
+// light and dark canvas.
+const PALETTE = [
+  '#4E79A7',
+  '#F28E2B',
+  '#E15759',
+  '#76B7B2',
+  '#59A14F',
+  '#EDC948',
+  '#B07AA1',
+  '#FF9DA7',
+  '#9C755F',
+  '#BAB0AC',
+];
+
+// djb2 — tiny, deterministic string hash for stable palette assignment.
+function hashString(s) {
+  let h = 5381;
+  for (let i = 0; i < s.length; i += 1) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return Math.abs(h);
+}
+
+// Resolve the pill color for a tag option. An explicit option.color wins;
+// otherwise a hash of the option value picks a stable palette color so a given
+// value keeps the same hue on every render. Returns null in single-accent mode
+// (colored: false) so the CSS primary look takes over.
+function getTagColor({ option, colored }) {
+  if (option.color) return option.color;
+  if (!colored) return null;
+  return PALETTE[hashString(`${option.value}`) % PALETTE.length];
+}
+
+export default getTagColor;

--- a/packages/plugins/blocks/blocks-antd/src/getTagSelectorOptions.js
+++ b/packages/plugins/blocks/blocks-antd/src/getTagSelectorOptions.js
@@ -1,0 +1,35 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { type } from '@lowdefy/helpers';
+
+// Normalize TagSelector / TagMultipleSelector options into a common
+// { label, value, color, disabled } shape. Primitives become
+// { label: `${value}`, value } so the rest of the pill rendering is uniform.
+function getTagSelectorOptions({ options }) {
+  return (options ?? []).map((option) =>
+    type.isPrimitive(option)
+      ? { label: `${option}`, value: option }
+      : {
+          label: type.isNone(option.label) ? `${option.value}` : option.label,
+          value: option.value,
+          color: option.color,
+          disabled: option.disabled,
+        }
+  );
+}
+
+export default getTagSelectorOptions;

--- a/packages/plugins/blocks/blocks-antd/src/metas.js
+++ b/packages/plugins/blocks/blocks-antd/src/metas.js
@@ -83,6 +83,7 @@ export { default as Steps } from './blocks/Steps/meta.js';
 export { default as Switch } from './blocks/Switch/meta.js';
 export { default as Tabs } from './blocks/Tabs/meta.js';
 export { default as Tag } from './blocks/Tag/meta.js';
+export { default as TagMultipleSelector } from './blocks/TagMultipleSelector/meta.js';
 export { default as TagSelector } from './blocks/TagSelector/meta.js';
 export { default as TextArea } from './blocks/TextArea/meta.js';
 export { default as TextInput } from './blocks/TextInput/meta.js';

--- a/packages/plugins/blocks/blocks-antd/src/metas.js
+++ b/packages/plugins/blocks/blocks-antd/src/metas.js
@@ -83,6 +83,7 @@ export { default as Steps } from './blocks/Steps/meta.js';
 export { default as Switch } from './blocks/Switch/meta.js';
 export { default as Tabs } from './blocks/Tabs/meta.js';
 export { default as Tag } from './blocks/Tag/meta.js';
+export { default as TagSelector } from './blocks/TagSelector/meta.js';
 export { default as TextArea } from './blocks/TextArea/meta.js';
 export { default as TextInput } from './blocks/TextInput/meta.js';
 export { default as TimelineList } from './blocks/TimelineList/meta.js';

--- a/packages/plugins/blocks/blocks-antd/src/tagSelectorStyle.css
+++ b/packages/plugins/blocks/blocks-antd/src/tagSelectorStyle.css
@@ -14,8 +14,9 @@
   limitations under the License.
 */
 
-/* The tag row. Per-option colors are inline (computed in JS from the stable
-   palette); everything structural and theme-token-driven lives here. */
+/* Shared tag row for TagSelector (single) and TagMultipleSelector (multi).
+   Per-option colors are inline (computed in JS from the stable palette);
+   everything structural and theme-token-driven lives here. */
 @layer components {
   .lf-tag-selector {
     display: flex;
@@ -27,7 +28,7 @@
   .lf-tag-selector-tag {
     appearance: none;
     font: inherit;
-    font-size: 12px;
+    font-size: var(--ant-font-size-sm, 12px);
     line-height: 1.4;
     padding: 2px 12px;
     border-radius: 999px;
@@ -62,6 +63,6 @@
     font-weight: 600;
     background: var(--ant-color-primary);
     border-color: var(--ant-color-primary);
-    color: #fff;
+    color: var(--ant-color-text-light-solid, #fff);
   }
 }

--- a/packages/servers/server-dev/manager/run.mjs
+++ b/packages/servers/server-dev/manager/run.mjs
@@ -110,19 +110,18 @@ try {
 
   startServer(context);
   await wait(800);
-  const appUrl = `http://localhost:${context.options.port}`;
-  context.logger.info(
-    { color: 'blue' },
-    `Agent docs & MCP live at ${appUrl}/lowdefy-docs — run \`lowdefy agent-setup\` to connect your coding agent.`
-  );
+  const docsUrl = `http://localhost:${context.options.port}/lowdefy-docs`;
   context.logger.info(
     { color: 'blue' },
     formatNoticeBox({
-      title: 'Annotate for your agent',
+      title: 'Lowdefy coding agent tools',
       lines: [
-        'Press Cmd/Ctrl+/ in the browser to point, draw, and comment',
-        'on the running app, then paste the copied feedback into your',
-        'coding agent session.',
+        `Docs & MCP  ${docsUrl}`,
+        '            run `lowdefy agent-setup` to connect your agent',
+        '',
+        'Annotate    Press Cmd/Ctrl+/ in the browser to point, draw,',
+        '            and comment on the running app, then paste the',
+        '            copied feedback into your coding agent session.',
       ],
     })
   );


### PR DESCRIPTION
## What

Two input blocks rendered as a row of toggleable, colored tag pills, wrapped in the standard input label. They share the same pill rendering and stable per-value coloring, and differ only in value semantics — mirroring the existing `Selector` / `MultipleSelector` pairing.

- **`TagSelector`** (single select): value is one option value. Clicking a pill selects it; clicking the selected pill clears the value (`null`).
- **`TagMultipleSelector`** (multi select): value is the array of selected option values; toggling a pill adds or removes it.
- Both fire `onChange` on every change, and accept `options` as primitives or `{ label, value, color, disabled }`.
- Stable per-value colors: an explicit `color` wins, otherwise a color is picked from a fixed palette keyed on the option's value, so a value keeps its hue across renders. Selected pills fill with auto-contrast text; unselected pills are outlined with a hint of their color.
- `colored: false` for single-accent pills using the primary color.
- Both support `title`, `label`, `size`, `disabled` like the other selector blocks, plus per-option `disabled`.

## How

Shared rendering/coloring is extracted so the two blocks never duplicate the pill implementation:

- `TagPillRow.js` — shared body (Label + pill row, coloring, disabled handling). Selection state and toggling are injected as `isSelected` / `onToggle`, so each block owns its value semantics.
- `getTagColor.js` — stable per-value palette color resolution.
- `getTagSelectorOptions.js` — option normalization.
- `tagSelectorStyle.css` — shared pill styles, using antd CSS tokens (`--ant-color-*`, `--ant-font-size-sm`, `--ant-color-text-light-solid`) where sensible.

Includes galleries, e2e app registration + e2e specs (single- and multi-select semantics), and docs pages for both blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)