### PR TITLE
fix(blocks-antd): PageSidebarLayout header slot row stretches full width

### DIFF
--- a/.changeset/fix-pagesidebarlayout-header-slot-width.md
+++ b/.changeset/fix-pagesidebarlayout-header-slot-width.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/blocks-antd': patch
+---
+
+PageSidebarLayout's header slot row now stretches to the full header width, so header blocks can use `layout: grow` spacers to position content (e.g. push an item to the far right). A new `headerContent` cssKey allows overriding the slot row's style, matching PageHeaderMenu and PageSiderMenu.

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PageSidebarLayout/PageSidebarLayout.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PageSidebarLayout/PageSidebarLayout.js
@@ -403,7 +403,18 @@ const PageSidebarLayout = ({
                                 properties.header?.contentStyle,
                               ])}
                             >
-                              {content.header()}
+                              {content.header(
+                                mergeObjects([
+                                  {
+                                    display: 'flex',
+                                    flex: '1 1 auto',
+                                    width: '100%',
+                                    minWidth: 0,
+                                    alignItems: 'center',
+                                  },
+                                  styles.headerContent,
+                                ])
+                              )}
                             </div>
                           ),
                         }}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PageSidebarLayout/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PageSidebarLayout/meta.js
@@ -50,6 +50,7 @@ export default {
     mobileMenu: 'The PageSidebarLayout mobile menu.',
     header: 'The PageSidebarLayout header.',
     headerActions: 'The header actions container (notifications, profile, dark mode toggle).',
+    headerContent: 'The PageSidebarLayout header content area (the header slot row).',
     logo: 'The PageSidebarLayout logo.',
     notifications: 'The notification bell button.',
     notificationsBadge: 'The notification badge wrapper.',


### PR DESCRIPTION
## Problem

PageSidebarLayout renders its header slot by calling `content.header()` with no `contentStyle` argument, so the slot's Area (`.lf-row`) never receives a width or flex value. As a plain flex child it shrink-wraps to its children's max-content width, which means header-slot blocks using `layout: { grow: 1 }` (e.g. a spacer to push an item to the far right) have zero leftover space to grow into — the grow value compiles correctly (`flex: 1 1 auto`) but the row itself never spans the header.

PageHeaderMenu and PageSiderMenu don't have this hole: both forward a style object into `content.header(...)` and expose a `headerContent` cssKey so callers can override it. PageSidebarLayout had neither — its closure ignored the argument entirely, so there was no config-level way to fix this from an app.

## Fix

- Forward `{ display: flex, flex: '1 1 auto', width: 100%, minWidth: 0, alignItems: center }` merged with `styles.headerContent` into `content.header(...)`, matching the other two page blocks' mechanism. Full-width is the right default here: PageSidebarLayout's header is a full-width bar, unlike the compact right-aligned clusters of PageHeaderMenu/PageSiderMenu, so their shrink-wrap default is intentionally not copied.
- Add the `headerContent` cssKey to meta.js so the default remains overridable.

With this, a header slot like `[search] [Box layout:{grow:1}] [org label]` lays out as expected: search left, label hard right.

## Verification

- `pnpm build` on blocks-antd compiles clean.
- Root-caused and reproduced in a consuming app (header-slot grow spacer had no effect; DOM probe showed the `.lf-row` at max-content width inside a `flex: 1 0 auto` wrapper).