### PR TITLE
fix(blocks-antd): Search loading spinner while documents load; live index rebuild

### DIFF
--- a/.changeset/fix-search-documents-loading.md
+++ b/.changeset/fix-search-documents-loading.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/blocks-antd': patch
+---
+
+The Search block now shows a loading spinner while its search data is still loading, instead of incorrectly reporting "No results found." When documents arrive while the modal is open — for example a request that resolves after the user opens search — the index now rebuilds live and the current query re-runs, so results appear without closing and reopening the modal. A new `loading` cssKey styles the spinner container.

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Search/SearchModal.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Search/SearchModal.js
@@ -15,7 +15,7 @@
 */
 
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import { Empty, Input, Modal, Skeleton } from 'antd';
+import { Empty, Input, Modal, Spin } from 'antd';
 import { ClockCircleOutlined, SearchOutlined } from '@ant-design/icons';
 import { cn } from '@lowdefy/block-utils';
 
@@ -116,6 +116,15 @@ function SearchModal({
     }
   }, [open]);
 
+  // When the index (re)builds while the modal is open — documents resolved
+  // after opening, or the bound request refreshed — re-run the current query
+  // so the spinner hands over to real results without a close/reopen.
+  useEffect(() => {
+    if (!open || !query) return;
+    setResults(searchIndex.search(query));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchIndex.version]);
+
   useEffect(() => {
     if (open && inputRef.current) {
       setTimeout(() => inputRef.current?.focus(), 100);
@@ -123,7 +132,10 @@ function SearchModal({
   }, [open]);
 
   const showRecent =
-    !query && properties.recentSearches !== false && recentSearches.recentSearches.length > 0;
+    !query &&
+    !searchIndex.loading &&
+    properties.recentSearches !== false &&
+    recentSearches.recentSearches.length > 0;
 
   return (
     <Modal
@@ -148,8 +160,11 @@ function SearchModal({
         onKeyDown={onKeyDown}
       />
       {searchIndex.loading && (
-        <div style={{ padding: 16 }}>
-          <Skeleton active paragraph={{ rows: 3 }} />
+        <div
+          className={cn('lf-search-loading', classNames.loading)}
+          style={{ display: 'flex', justifyContent: 'center', padding: 32, ...styles.loading }}
+        >
+          <Spin />
         </div>
       )}
       {!searchIndex.loading && query && flatResults.length === 0 && (

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Search/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Search/meta.js
@@ -33,6 +33,7 @@ export default {
     itemDescription: 'The description/snippet in a result item.',
     highlight: 'Highlighted match text (<mark> elements).',
     empty: 'The empty state message.',
+    loading: 'The loading spinner container.',
   },
   methods: {
     toggleOpen: 'Toggle the search modal open or closed.',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Search/useSearchIndex.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Search/useSearchIndex.js
@@ -14,7 +14,8 @@
   limitations under the License.
 */
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { type } from '@lowdefy/helpers';
 import MiniSearch from 'minisearch';
 
 const indexCache = new Map();
@@ -22,6 +23,9 @@ const indexCache = new Map();
 function useSearchIndex({ indexUrl, documents, fields, storeFields, searchOptions }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  // Incremented whenever an index (re)builds, so an open modal can re-run its
+  // current query against the fresh index instead of waiting for a reopen.
+  const [version, setVersion] = useState(0);
   const indexMetaRef = useRef({
     searchDefaults: {},
     resultDefaults: {},
@@ -79,6 +83,7 @@ function useSearchIndex({ indexUrl, documents, fields, storeFields, searchOption
           groups: first.groups ?? [],
         };
         loadedRef.current = true;
+        setVersion((v) => v + 1);
       } catch (err) {
         setError(err);
       } finally {
@@ -97,7 +102,17 @@ function useSearchIndex({ indexUrl, documents, fields, storeFields, searchOption
     instance.addAll(documents);
     instancesRef.current = [instance];
     loadedRef.current = true;
+    setVersion((v) => v + 1);
   }, [documents, fields, storeFields]);
+
+  // Documents typically arrive async (e.g. bound to a request result). Rebuild
+  // whenever the array reference changes so an already-open modal picks up data
+  // that resolved after ensureLoaded ran.
+  useEffect(() => {
+    if (documents && documentsRef.current !== documents) {
+      buildFromDocuments();
+    }
+  }, [documents, buildFromDocuments]);
 
   const ensureLoaded = useCallback(async () => {
     if (loadedRef.current && !documents) return;
@@ -126,11 +141,17 @@ function useSearchIndex({ indexUrl, documents, fields, storeFields, searchOption
     [searchOptions]
   );
 
+  // Documents mode with the data still in flight (e.g. a request that has not
+  // resolved yet evaluates to null/undefined): report loading so the modal can
+  // show a spinner instead of a false "No results found."
+  const waitingForDocuments = type.isNone(indexUrl) && type.isNone(documents) && !loadedRef.current;
+
   return {
     search,
-    loading,
+    loading: loading || waitingForDocuments,
     error,
     ensureLoaded,
+    version,
     searchDefaults: indexMetaRef.current.searchDefaults,
     resultDefaults: indexMetaRef.current.resultDefaults,
     groups: indexMetaRef.current.groups,


### PR DESCRIPTION
## Problem

In documents mode (documents bound to a request result), the Search block has no loading state:

- `searchIndex.loading` is only ever set by `loadIndexes` (indexUrl mode). If the modal opens while the documents request is still in flight, typing shows a false **"No results found."** with no indication data is loading.
- `ensureLoaded` only runs from `handleOpen`, and nothing watches `documents`, so data resolving *while the modal is open* never builds the index — the user has to close and reopen search to get results.

## Fix

- `useSearchIndex`: report `loading` when documents mode is still waiting on data (`indexUrl` and `documents` both none and nothing built yet); rebuild the index whenever the `documents` reference changes (request resolved or refreshed); expose a `version` counter bumped on every (re)build.
- `SearchModal`: render a centred `Spin` in the results area while loading (replaces the indexUrl-mode `Skeleton` for one consistent loading state, with a new `loading` cssKey + `lf-search-loading` class); hide recent searches while loading; when `version` bumps while the modal is open with a live query, re-run the search so the spinner hands over to results without a reopen.
- `meta.js`: add the `loading` cssKey.

## Verification

- `pnpm build` (swc) compiles clean.
- Flow exercised against a consuming app whose header search binds `documents` to a per-org request fired on page mount.