### PR TITLE
fix(blocks-antd): Search trigger shortcut badge sits at the end of wide triggers

### DIFF
--- a/.changeset/fix-search-trigger-badge-end.md
+++ b/.changeset/fix-search-trigger-badge-end.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/blocks-antd': patch
+---
+
+The Search block's keyboard shortcut badge now sits at the end of the trigger button when the trigger is styled wider than its content, with the label left-aligned filling the space between.

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Search/style.css
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Search/style.css
@@ -79,6 +79,13 @@
     gap: var(--ant-margin-xs);
   }
 
+  /* Grow the label so the shortcut badge sits at the end of the trigger when
+     it is wider than its content (e.g. a min-width styled trigger). */
+  .lf-search-trigger-label {
+    flex: 1 1 auto;
+    text-align: left;
+  }
+
   .lf-search-recent-header {
     display: flex;
     align-items: center;


### PR DESCRIPTION
The trigger's label span had no flex, so styling the trigger wider than its content (e.g. min-width: 320px) centred the icon/label/badge as one bunch. The label now grows (flex: 1 1 auto, text-align: left) so the icon+label anchor left and the shortcut badge sits at the trigger's end — the conventional cmd-K affordance. Content-width triggers are unaffected (nothing to grow into), and the <=640px media query that hides the label still applies.