### PR TITLE
Annotation capture fidelity and dev tooling fixes

### DIFF
--- a/.changeset/feat-dev-feedback-panel-send.md
+++ b/.changeset/feat-dev-feedback-panel-send.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/server-dev': minor
+---
+
+feat(server-dev): Send feedback annotations directly from the annotation panel.
+
+The separate review step is gone: "Copy for agent" now sends straight from the panel and always includes the annotation you are writing, "Add another" banks it and returns to picking, and banked annotations stay visible in a pending tray where they can be removed before sending. Enter triggers the send in both states.

--- a/.changeset/fix-blocks-antd-logo-breakpoint.md
+++ b/.changeset/fix-blocks-antd-logo-breakpoint.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/blocks-antd': patch
+---
+
+fix(blocks-antd): Default logo width switches at the same breakpoint as the logo image.
+
+PageHeaderMenu and PageSiderMenu swapped the desktop/mobile logo image at 577px but the default width classes switched at 640px, so between those widths the desktop wordmark rendered squeezed into the mobile slot.

--- a/.changeset/fix-build-skeleton-scalar-refs.md
+++ b/.changeset/fix-build-skeleton-scalar-refs.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/build': patch
+---
+
+fix(build): Rebuild dev app-level artifacts when root-referenced files change.
+
+Files referenced directly from `lowdefy.yaml` that resolve to plain values — like `app.html.appendHead: {_ref: head.html}` — were missing from the dev server's rebuild trigger list, so editing them served stale HTML until a manual restart. They now correctly trigger a skeleton rebuild.

--- a/.changeset/fix-dev-capture-responsive-images.md
+++ b/.changeset/fix-dev-capture-responsive-images.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/server-dev': patch
+---
+
+fix(server-dev): Annotated screenshots render responsive images correctly.
+
+Tab captures embedded each image's fallback `src` instead of the variant the browser was displaying, warping `<picture>`/`srcset` images — most visibly the header logo squashed into its mobile mark. Captures now pin every responsive image to the displayed variant and restore the page afterwards.

--- a/.changeset/fix-dev-findconfig-page-scope.md
+++ b/.changeset/fix-dev-findconfig-page-scope.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/server-dev': patch
+---
+
+fix(server-dev): `/lowdefy-docs/find/{id}?pageId=` only matches config on that page.
+
+Built pages share identical key paths for same-named block ids, so a page-scoped find could return locations from other pages. Matches are now resolved against the requested page's own config tree, and the no-match message suggests retrying without `pageId` to scan everything. Cmd/Ctrl+click open-in-editor no longer sends an empty `pageId`.

--- a/.changeset/fix-layout-column-flex-basis.md
+++ b/.changeset/fix-layout-column-flex-basis.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/layout': patch
+---
+
+fix(layout): Blocks in column-direction areas size their height by content.
+
+Blocks inside a `direction: column` area no longer get a percentage flex-basis on the vertical axis. This fixes blocks wrapping into a phantom side-by-side column whenever the area's height became definite — most visibly in dev annotated screenshots, where lists shifted out of their panel, and in column areas with an explicit height. `span` still controls block width in column areas.

--- a/packages/build/src/build/jit/collectSkeletonSourceFiles.js
+++ b/packages/build/src/build/jit/collectSkeletonSourceFiles.js
@@ -55,6 +55,20 @@ function collectSkeletonSourceFiles({ components, context }) {
     walkRefIds(moduleEntry.consumerVars, refIds);
   }
 
+  // The walker only ~r-tags resolved _ref content, never the root file's own
+  // objects — so a scalar ref parented directly on the root (e.g.
+  // app.html.appendHead: {_ref: head.html}) has no collected ancestor and
+  // would be missed by the descendant scan. Add the root ref id explicitly.
+  if (context.rootRefDef?.id != null) {
+    refIds.add(context.rootRefDef.id);
+  }
+
+  // Page refs are stop boundaries for the descendant scan: with the root id
+  // collected, a scalar ref'd inside a page file would otherwise reach the
+  // root through its page ref and wrongly become a skeleton source.
+  const pageRefIds = new Set();
+  walkRefIds(components.pages ?? [], pageRefIds);
+
   const sourceFiles = new Set();
 
   // Walk parent chains for each collected ref ID
@@ -75,6 +89,7 @@ function collectSkeletonSourceFiles({ components, context }) {
   // their paths if any ancestor in their parent chain is a collected ref ID.
   for (const [id, entry] of Object.entries(context.refMap)) {
     if (refIds.has(id)) continue;
+    if (pageRefIds.has(id)) continue;
     let current = entry.parent;
     while (current != null) {
       if (refIds.has(current)) {
@@ -83,6 +98,7 @@ function collectSkeletonSourceFiles({ components, context }) {
         }
         break;
       }
+      if (pageRefIds.has(current)) break;
       const parentEntry = context.refMap[current];
       if (!parentEntry) break;
       current = parentEntry.parent;

--- a/packages/build/src/build/jit/collectSkeletonSourceFiles.test.js
+++ b/packages/build/src/build/jit/collectSkeletonSourceFiles.test.js
@@ -276,6 +276,46 @@ test('descendant scan picks up scalar _ref leaves under module consumerVars', ()
   expect(result.has('modules/layout/page-type.yaml')).toBe(true);
 });
 
+test('collects scalar refs parented directly on the root ref', () => {
+  // app.html.appendHead: {_ref: head.html} resolves to a string. The root
+  // file's own objects carry no ~r markers, so the scalar's only ancestor is
+  // the root ref id — which must be collected via context.rootRefDef.
+  const components = {
+    app: { html: { appendHead: '<link rel="stylesheet">' } },
+  };
+  const context = {
+    refMap: {
+      'ref-root': { parent: null, path: 'lowdefy.yaml' },
+      'ref-head': { parent: 'ref-root', path: 'head.html' },
+    },
+    rootRefDef: { id: 'ref-root' },
+  };
+  const result = collectSkeletonSourceFiles({ components, context });
+  expect(result.has('head.html')).toBe(true);
+  expect(result.has('lowdefy.yaml')).toBe(true);
+});
+
+test('root ref id does not pull in scalar refs from inside page files', () => {
+  // A scalar ref'd inside a page reaches the root through its page ref.
+  // Page refs are stop boundaries — page content edits must stay JIT-only.
+  const page = setRefMarker({ id: 'page1' }, 'ref-page');
+  const components = {
+    pages: [page],
+  };
+  const context = {
+    refMap: {
+      'ref-root': { parent: null, path: 'lowdefy.yaml' },
+      'ref-page': { parent: 'ref-root', path: 'pages/my-page.yaml' },
+      'ref-page-scalar': { parent: 'ref-page', path: 'pages/title.md' },
+    },
+    rootRefDef: { id: 'ref-root' },
+  };
+  const result = collectSkeletonSourceFiles({ components, context });
+  expect(result.has('pages/title.md')).toBe(false);
+  expect(result.has('pages/my-page.yaml')).toBe(false);
+  expect(result.has('lowdefy.yaml')).toBe(true);
+});
+
 test('returns empty set when context has no modules key', () => {
   // Existing call sites and tests don't supply context.modules; the ?? {}
   // fallback must keep the function a no-op for the new branch.

--- a/packages/build/src/build/jit/skeletonSourceFilesAppHtml.integration.test.js
+++ b/packages/build/src/build/jit/skeletonSourceFilesAppHtml.integration.test.js
@@ -1,0 +1,91 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Regression: files _ref'd from app-level config that resolve to scalars
+// (e.g. app.html.appendHead: {_ref: head.html}) must be recorded in
+// skeletonSourceFiles.json — otherwise the dev server treats an edit to
+// head.html as a page-only change and never rebuilds the app artifact that
+// embeds it, so the served HTML goes stale until a manual restart.
+
+import { jest } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+process.env.AUTH_SECRET = 'test-secret-for-integration-test';
+
+jest.unstable_mockModule('../full/updateServerPackageJson.js', () => ({
+  default: jest.fn(async () => {}),
+}));
+jest.unstable_mockModule('../copyPublicFolder.js', () => ({
+  default: jest.fn(async () => {}),
+}));
+jest.unstable_mockModule('../copyAgentFileSystems.js', () => ({
+  default: jest.fn(async () => {}),
+}));
+
+const { default: shallowBuild } = await import('./shallowBuild.js');
+const { snapshotTypesMap } = await import('../../test-utils/runBuildForSnapshots.js');
+
+test('skeleton source files include scalar-resolving refs from app config', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ldf-skeleton-head-'));
+  const configDir = path.join(root, 'config');
+  const buildDir = path.join(root, '.lowdefy', 'server', 'build');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.mkdirSync(buildDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(configDir, 'head.html'),
+    '<link href="https://example.com/fonts.css" rel="stylesheet" crossorigin="anonymous">\n'
+  );
+  fs.writeFileSync(
+    path.join(configDir, 'lowdefy.yaml'),
+    `lowdefy: local
+name: Skeleton Head Test
+
+app:
+  html:
+    appendHead:
+      _ref: head.html
+
+pages:
+  - id: home
+    type: Box
+`
+  );
+
+  await shallowBuild({
+    customTypesMap: snapshotTypesMap,
+    directories: {
+      config: configDir,
+      build: buildDir,
+      server: path.join(root, '.lowdefy', 'server'),
+    },
+    logger: {
+      info: () => {},
+      log: () => {},
+      warn: () => {},
+      error: () => {},
+      succeed: () => {},
+    },
+    stage: 'dev',
+  });
+
+  const skeletonSourceFiles = JSON.parse(
+    fs.readFileSync(path.join(buildDir, 'skeletonSourceFiles.json'), 'utf8')
+  );
+  expect(skeletonSourceFiles).toContain('head.html');
+});

--- a/packages/layout/src/Area.js
+++ b/packages/layout/src/Area.js
@@ -38,11 +38,12 @@ const JUSTIFY_MAP = {
 const Area = ({ area = {}, areaKey, children, id, layout, className, style }) => {
   const derivedArea = layoutParamsToArea({ area, areaKey, layout });
   const gapStyle = deriveAreaStyle(derivedArea);
+  const isColumn = (derivedArea.direction ?? '').startsWith('column');
 
   return (
     <div
       id={id}
-      className={['lf-row', className].filter(Boolean).join(' ')}
+      className={['lf-row', isColumn && 'lf-row-column', className].filter(Boolean).join(' ')}
       style={{
         ...gapStyle,
         alignItems: ALIGN_MAP[derivedArea.align],

--- a/packages/layout/src/grid.css
+++ b/packages/layout/src/grid.css
@@ -110,6 +110,24 @@
     order: var(--lf-order, 0);
   }
 
+  /* =====================================================
+     Column-direction areas
+
+     The span flex-basis formula sizes the MAIN axis, which in
+     a column-direction area is vertical. A percentage basis
+     against the area's indefinite height resolves to content
+     size, so it happens to render correctly — but as soon as
+     the height becomes definite (an explicit height, or a
+     DOM-cloning rasterizer like html-to-image inlining
+     computed px heights) basis 100% overflows the area and
+     wrap spills blocks into a new column. Blocks in column
+     areas size their height by content; span still constrains
+     width via max-width.
+     ===================================================== */
+  .lf-row-column > .lf-col {
+    flex-basis: auto;
+  }
+
   /* Push/pull: only apply positioning when class is present */
   .lf-col-push {
     position: relative;

--- a/packages/layout/src/tests/__snapshots__/col.test.js.snap
+++ b/packages/layout/src/tests/__snapshots__/col.test.js.snap
@@ -47,6 +47,49 @@ exports[`center content 1`] = `
 </div>
 `;
 
+exports[`column direction area 1`] = `
+<div>
+  <div
+    class="lf-col"
+    id="bl-column direction area23456"
+    style="--lf-span: 24; --lf-span-md: 24;"
+  >
+    <div
+      id="column direction area23456"
+    >
+      <div
+        class="lf-row lf-row-column"
+        id="column direction area-content23456"
+        style="flex-direction: column; flex-wrap: wrap;"
+      >
+        <div
+          class="lf-col"
+          id="bl-One23456"
+          style="--lf-span: 24; --lf-span-md: 24; background: rgb(64, 160, 255);"
+        >
+          <div
+            id="One23456"
+          >
+            ONE Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          </div>
+        </div>
+        <div
+          class="lf-col"
+          id="bl-Two23456"
+          style="--lf-span: 24; --lf-span-md: 24; background: rgb(255, 79, 175);"
+        >
+          <div
+            id="Two23456"
+          >
+            TWO Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`grow 0 0 1`] = `
 <div>
   <div

--- a/packages/layout/src/tests/col.yaml
+++ b/packages/layout/src/tests/col.yaml
@@ -317,3 +317,20 @@
             span: 4
           style:
             background: '#40AA55'
+- id: 'column direction area'
+  type: Box
+  layout:
+    direction: column
+  blocks:
+    - id: One
+      type: Paragraph
+      style:
+        background: '#40a0FF'
+      properties:
+        content: 'ONE Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+    - id: Two
+      type: Paragraph
+      style:
+        background: '#FF4FaF'
+      properties:
+        content: 'TWO Lorem ipsum dolor sit amet, consectetur adipiscing elit.'

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PageHeaderMenu/PageHeaderMenu.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PageHeaderMenu/PageHeaderMenu.js
@@ -97,7 +97,7 @@ const PageHeaderMenu = ({
                           alt={properties.logo?.alt ?? 'Lowdefy'}
                           className={
                             classNames.logo ??
-                            'mx-1.5 sm:mx-2.5 md:mx-4 lg:mx-[30px] shrink w-10 sm:w-[130px]'
+                            'mx-1.5 sm:mx-2.5 md:mx-4 lg:mx-[30px] shrink w-10 min-[577px]:w-[130px]'
                           }
                           style={styles.logo}
                         />

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PageSiderMenu/PageSiderMenu.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PageSiderMenu/PageSiderMenu.js
@@ -179,7 +179,7 @@ const PageSiderMenu = ({
                           alt={properties.logo?.alt ?? 'Lowdefy'}
                           className={
                             classNames.logo ??
-                            'mr-[30px] shrink w-10 sm:w-[130px] mx-1.5 sm:mx-2.5 md:mx-4'
+                            'mr-[30px] shrink w-10 min-[577px]:w-[130px] mx-1.5 sm:mx-2.5 md:mx-4'
                           }
                           style={styles.logo}
                         />

--- a/packages/servers/server-dev/client/feedback/FeedbackOverlay.jsx
+++ b/packages/servers/server-dev/client/feedback/FeedbackOverlay.jsx
@@ -76,7 +76,7 @@ function rectToXY(rect) {
 }
 
 const initialState = {
-  phase: 'picking', // picking | annotating | drawing | review | sent
+  phase: 'picking', // picking | annotating | drawing | sent
   hoverBlock: null, // { blockId, rect }
   selection: null, // { kind, blockId, blockChain, tag, classes, text, rect }
   draftComment: '',
@@ -123,10 +123,12 @@ function reducer(state, action) {
       };
     case 'CANCEL_DRAWING':
       return { ...state, phase: 'annotating', draftTool: null };
+    // "Add another" — bank the current draft and go straight back to picking;
+    // the banked annotations show in the pending tray until sent.
     case 'SAVE_ANNOTATION':
       return {
         ...state,
-        phase: 'review',
+        phase: 'picking',
         batch: [...state.batch, action.annotation],
         selection: null,
         draftComment: '',
@@ -145,12 +147,8 @@ function reducer(state, action) {
       };
     case 'REMOVE_FROM_BATCH':
       return { ...state, batch: state.batch.filter((annotation) => annotation.id !== action.id) };
-    case 'ADD_ANOTHER':
-      return { ...state, phase: 'picking' };
     case 'DISCARD_ALL':
       return { ...state, phase: 'picking', batch: [] };
-    case 'BACK_TO_PICKING':
-      return { ...state, phase: 'picking' };
     case 'SEND_START':
       return { ...state, sending: true, sendError: null };
     case 'SEND_SUCCESS':
@@ -190,7 +188,7 @@ function buildAnnotation(state) {
   };
 }
 
-function buildBatch({ state, pageId }) {
+function buildBatch({ annotations, includeScreenshot, pageId }) {
   return {
     batchId: generateId(),
     timestamp: new Date().toISOString(),
@@ -204,8 +202,8 @@ function buildBatch({ state, pageId }) {
       scrollY: window.scrollY,
       dpr: window.devicePixelRatio,
     },
-    annotations: state.batch,
-    includeScreenshot: state.includeScreenshot,
+    annotations,
+    includeScreenshot,
     stateRef: { captured: true, pageId },
   };
 }
@@ -218,10 +216,6 @@ function handleEscape({ stateRef, dispatch, onClose }) {
   }
   if (phase === 'annotating') {
     dispatch({ type: 'DISCARD_DRAFT' });
-    return;
-  }
-  if (phase === 'review') {
-    dispatch({ type: 'BACK_TO_PICKING' });
     return;
   }
   // picking (or sent, though Esc is irrelevant there)
@@ -315,7 +309,7 @@ function FeedbackOverlay({ basePath, pageId, onClose }) {
   // Capture-phase keydown suppressor: blocks every key from reaching the
   // app's own shortcut manager while the overlay is active, except when the
   // developer is typing inside the overlay itself (e.g. the comment
-  // textarea). Esc and $mod+Enter are handled here first, before deciding
+  // textarea). Esc and Enter are handled here first, before deciding
   // whether to suppress, so they always work regardless of focus.
   useEffect(() => {
     function onKeyDown(event) {
@@ -330,18 +324,15 @@ function FeedbackOverlay({ basePath, pageId, onClose }) {
           return;
         }
 
-        // Enter drives the primary (blue) action for the current phase;
-        // Shift+Enter still inserts a newline in the comment textarea.
+        // Enter drives the primary (blue) action for the current phase —
+        // copy for agent, including the in-flight draft. Shift+Enter still
+        // inserts a newline in the comment textarea.
         const isPlainEnter = event.key === 'Enter' && !event.shiftKey;
         if (isPlainEnter) {
           const current = stateRef.current;
-          if (current.phase === 'annotating' && current.selection) {
-            event.preventDefault();
-            dispatch({ type: 'SAVE_ANNOTATION', annotation: buildAnnotation(current) });
-            event.stopImmediatePropagation();
-            return;
-          }
-          if (current.phase === 'review' && !current.sending && current.batch.length > 0) {
+          const canSendDraft = current.phase === 'annotating' && current.selection;
+          const canSendBatch = current.phase === 'picking' && current.batch.length > 0;
+          if (!current.sending && (canSendDraft || canSendBatch)) {
             event.preventDefault();
             primarySendRef.current?.();
             event.stopImmediatePropagation();
@@ -412,6 +403,11 @@ function FeedbackOverlay({ basePath, pageId, onClose }) {
 
     function onClickCapture(event) {
       try {
+        // Clicks on the overlay's own UI (the pending tray) are real button
+        // clicks, not element picks.
+        if (event.target instanceof Element && event.target.closest(FEEDBACK_ROOT_SELECTOR)) {
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         const el = document.elementFromPoint(event.clientX, event.clientY);
@@ -602,7 +598,7 @@ function FeedbackOverlay({ basePath, pageId, onClose }) {
     }
   }
 
-  function handleSave() {
+  function handleAddAnother() {
     try {
       if (!state.selection) {
         return;
@@ -615,14 +611,27 @@ function FeedbackOverlay({ basePath, pageId, onClose }) {
 
   async function handleSend() {
     try {
+      // The in-flight draft is part of the send — copying from the panel
+      // must not require banking the draft as a separate step first.
+      const current = stateRef.current;
+      const annotations = current.selection
+        ? [...current.batch, buildAnnotation(current)]
+        : current.batch;
+      if (current.sending || annotations.length === 0) {
+        return;
+      }
       dispatch({ type: 'SEND_START' });
-      const batch = buildBatch({ state, pageId });
+      const batch = buildBatch({
+        annotations,
+        includeScreenshot: current.includeScreenshot,
+        pageId,
+      });
       // Capture the annotated screenshot in THIS tab — the pixels the
       // developer is actually looking at (theme, loaded data) — and ship it
       // with the batch for the server to save. On failure the field is
       // absent and the server falls back to its headless capture.
-      if (state.includeScreenshot) {
-        const screenshot = await captureTabScreenshot({ annotations: state.batch });
+      if (current.includeScreenshot) {
+        const screenshot = await captureTabScreenshot({ annotations });
         if (screenshot) {
           batch.screenshot = screenshot;
         }
@@ -655,8 +664,8 @@ function FeedbackOverlay({ basePath, pageId, onClose }) {
       });
     }
   }
-  // Enter in the review tray triggers the primary action via the capture
-  // handler above — a ref keeps the freshest closure without re-binding.
+  // Enter triggers the send via the capture handler above — a ref keeps the
+  // freshest closure without re-binding.
   primarySendRef.current = handleSend;
 
   let content = null;
@@ -665,7 +674,7 @@ function FeedbackOverlay({ basePath, pageId, onClose }) {
       state,
       dispatch,
       textareaRef,
-      handleSave,
+      handleAddAnother,
       handleSend,
       handleDrawPointerDown,
       handleDrawPointerMove,
@@ -694,7 +703,7 @@ function renderOverlayContent({
   state,
   dispatch,
   textareaRef,
-  handleSave,
+  handleAddAnother,
   handleSend,
   handleDrawPointerDown,
   handleDrawPointerMove,
@@ -709,8 +718,16 @@ function renderOverlayContent({
   const showAnnotatingPanel =
     (state.phase === 'annotating' || state.phase === 'drawing') && state.selection;
   const showSvg = state.phase === 'drawing';
-  const showReview = state.phase === 'review';
+  // Annotations banked via "Add another" — visible while picking the next
+  // element so they stay reviewable/removable without a separate step.
+  const showPendingTray = state.phase === 'picking' && state.batch.length > 0;
   const showSent = state.phase === 'sent';
+  // The panel's send includes the in-flight draft on top of the banked batch.
+  const draftSendCount = state.batch.length + 1;
+  let draftSendLabel = draftSendCount > 1 ? `Copy ${draftSendCount} for agent` : 'Copy for agent';
+  if (state.sending) {
+    draftSendLabel = 'Copying…';
+  }
 
   return (
     <div data-lowdefy-feedback style={overlayContainer}>
@@ -796,6 +813,16 @@ function renderOverlayContent({
           {state.draftShapes.length > 0 && (
             <div style={descriptorRow}>{state.draftShapes.length} shape(s) drawn</div>
           )}
+          <label style={consoleCountRow}>
+            <input
+              checked={state.includeScreenshot}
+              onChange={() => dispatch({ type: 'TOGGLE_SCREENSHOT' })}
+              style={{ marginRight: 6, verticalAlign: 'middle' }}
+              type="checkbox"
+            />
+            Include annotated screenshot
+          </label>
+          {state.sendError && <div style={errorRow}>{state.sendError}</div>}
           <div style={buttonRow}>
             <button
               type="button"
@@ -804,14 +831,22 @@ function renderOverlayContent({
             >
               Cancel
             </button>
-            <button type="button" style={primaryButton} onClick={handleSave}>
-              Save annotation
+            <button type="button" style={secondaryButton} onClick={handleAddAnother}>
+              Add another
+            </button>
+            <button
+              type="button"
+              style={primaryButton}
+              disabled={state.sending}
+              onClick={handleSend}
+            >
+              {draftSendLabel}
             </button>
           </div>
         </div>
       )}
 
-      {showReview && (
+      {showPendingTray && (
         <div style={reviewTray}>
           <div style={panelHeading}>Pending feedback ({state.batch.length})</div>
           {state.batch.map((annotation, index) => (
@@ -837,15 +872,6 @@ function renderOverlayContent({
               </button>
             </div>
           ))}
-          <label style={consoleCountRow}>
-            <input
-              checked={state.includeScreenshot}
-              onChange={() => dispatch({ type: 'TOGGLE_SCREENSHOT' })}
-              style={{ marginRight: 6, verticalAlign: 'middle' }}
-              type="checkbox"
-            />
-            Include annotated screenshot
-          </label>
           {state.sendError && <div style={errorRow}>{state.sendError}</div>}
           <div style={buttonRow}>
             <button
@@ -857,15 +883,8 @@ function renderOverlayContent({
             </button>
             <button
               type="button"
-              style={secondaryButton}
-              onClick={() => dispatch({ type: 'ADD_ANOTHER' })}
-            >
-              Add another
-            </button>
-            <button
-              type="button"
               style={primaryButton}
-              disabled={state.sending || state.batch.length === 0}
+              disabled={state.sending}
               onClick={handleSend}
             >
               {state.sending ? 'Copying…' : `Copy ${state.batch.length} for agent`}

--- a/packages/servers/server-dev/client/feedback/captureTabScreenshot.js
+++ b/packages/servers/server-dev/client/feedback/captureTabScreenshot.js
@@ -17,6 +17,7 @@
 import { toPng } from 'html-to-image';
 
 import drawAnnotationsSvg from './drawAnnotationsSvg.js';
+import pinResponsiveImages from './pinResponsiveImages.js';
 
 // Chrome caps canvas dimensions well above this, but rasterizing a very long
 // page at retina density burns memory for no feedback value — drop to 1x
@@ -46,7 +47,9 @@ function resolveBackgroundColor() {
 // theme, un-settled requests, no client-only state). Returns null on any
 // failure so the server can fall back to the headless capture.
 async function captureTabScreenshot({ annotations }) {
+  let restoreImages = () => {};
   try {
+    restoreImages = pinResponsiveImages();
     drawAnnotationsSvg(annotations ?? []);
     const pixelRatio =
       Math.max(document.documentElement.scrollWidth, document.documentElement.scrollHeight) *
@@ -70,6 +73,7 @@ async function captureTabScreenshot({ annotations }) {
     return null;
   } finally {
     try {
+      restoreImages();
       document.getElementById('lowdefy-feedback-annotations-svg')?.remove();
     } catch {
       // Never let cleanup break the send flow.

--- a/packages/servers/server-dev/client/feedback/pinResponsiveImages.js
+++ b/packages/servers/server-dev/client/feedback/pinResponsiveImages.js
@@ -1,0 +1,59 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// html-to-image embeds img.src and clones srcset/<source> attributes as-is:
+// the selection the browser actually displays (img.currentSrc) is ignored, so
+// a <picture> rasterizes its fallback src stretched into the displayed box
+// (e.g. the PageHeaderMenu square logo warped into the wordmark's slot), and
+// remote srcset candidates can't load inside the sandboxed SVG rasterization
+// anyway. Pin every responsive image to its currentSrc for the capture — the
+// URL the tab already displays, so nothing changes visually — and return a
+// restore function for the caller's finally block.
+function pinResponsiveImages() {
+  const restores = [];
+
+  document.querySelectorAll('img').forEach((img) => {
+    const isResponsive =
+      img.hasAttribute('srcset') || (img.currentSrc && img.currentSrc !== img.src);
+    if (!img.currentSrc || !isResponsive) return;
+    const src = img.getAttribute('src');
+    const srcset = img.getAttribute('srcset');
+    restores.push(() => {
+      if (src === null) {
+        img.removeAttribute('src');
+      } else {
+        img.setAttribute('src', src);
+      }
+      if (srcset !== null) {
+        img.setAttribute('srcset', srcset);
+      }
+    });
+    img.setAttribute('src', img.currentSrc);
+    img.removeAttribute('srcset');
+  });
+
+  document.querySelectorAll('picture > source[srcset]').forEach((source) => {
+    const srcset = source.getAttribute('srcset');
+    restores.push(() => source.setAttribute('srcset', srcset));
+    source.removeAttribute('srcset');
+  });
+
+  return function restore() {
+    restores.forEach((fn) => fn());
+  };
+}
+
+export default pinResponsiveImages;

--- a/packages/servers/server-dev/client/openInEditor/findBlockLocation.js
+++ b/packages/servers/server-dev/client/openInEditor/findBlockLocation.js
@@ -21,9 +21,11 @@
 // sendFeedback.js — a dev-only feature must never throw into the app.
 async function findBlockLocation({ basePath, blockId, pageId }) {
   try {
+    // Omit pageId when unknown — an empty ?pageId= reads as an unknown page
+    // on the server, while no param falls back to scanning all built pages.
+    const query = pageId ? `?pageId=${encodeURIComponent(pageId)}` : '';
     const response = await fetch(
-      `${basePath}/lowdefy-docs/find/${encodeURIComponent(blockId)}` +
-        `?pageId=${encodeURIComponent(pageId ?? '')}`
+      `${basePath}/lowdefy-docs/find/${encodeURIComponent(blockId)}${query}`
     );
     if (!response.ok) {
       return null;

--- a/packages/servers/server-dev/lib/docs/docs.test.mjs
+++ b/packages/servers/server-dev/lib/docs/docs.test.mjs
@@ -43,6 +43,13 @@ jest.unstable_mockModule('../server/createLowdefyContext.js', () => ({
   default: mockCreateLowdefyContext,
 }));
 
+// findConfig force-builds a page when pageId is passed — the fixture pages
+// only exist as pre-written build artifacts, so stub the JIT builder out.
+const mockBuildPageIfNeeded = jest.fn(async () => true);
+jest.unstable_mockModule('../server/jitPageBuilder.js', () => ({
+  default: mockBuildPageIfNeeded,
+}));
+
 const { default: listTypes } = await import('./listTypes.js');
 const { default: listPlugins } = await import('./listPlugins.js');
 const { default: getSchema } = await import('./getSchema.js');
@@ -226,11 +233,52 @@ test('findConfig resolves a known pageId to its source file', async () => {
 });
 
 test('findConfig scans keyMap for a matching id when no pageId is given', async () => {
+  // my_button exists on both built pages — an unscoped scan returns both.
   const result = await findConfig({ id: 'my_button' });
-  expect(result.matches.length).toEqual(1);
-  expect(result.matches[0].keyPath).toEqual('root.pages[0:home].blocks[2:my_button:Button]');
+  expect(result.matches.length).toEqual(2);
+  expect(result.matches[0].keyPath).toEqual('root.blocks[2:my_button:Button]');
   expect(result.matches[0].location.source).toContain('pages/home.yaml:5');
+  expect(result.matches[1].keyPath).toEqual('root.blocks[0:my_button:Button]');
   expect(result.note).toContain('Pass ?pageId=');
+});
+
+test('findConfig with pageId only returns matches on that page', async () => {
+  // Both pages hold a my_button whose JIT key paths are indistinguishable
+  // (`root.blocks[N:my_button:Button]`) — scoping must resolve through the
+  // ~k_parent chain to the page's own subtree root.
+  const result = await findConfig({ id: 'my_button', pageId: 'other' });
+  expect(result.matches.length).toEqual(1);
+  expect(result.matches[0].keyPath).toEqual('root.blocks[0:my_button:Button]');
+  expect(result.matches[0].location.source).toContain('pages/other.yaml:4');
+});
+
+test('findConfig with pageId resolves the same id to each page respectively', async () => {
+  const result = await findConfig({ id: 'my_button', pageId: 'home' });
+  expect(result.matches.length).toEqual(1);
+  expect(result.matches[0].keyPath).toEqual('root.blocks[2:my_button:Button]');
+  expect(result.matches[0].location.source).toContain('pages/home.yaml:5');
+});
+
+test('findConfig scopes skeleton-built pages via the page key segment', async () => {
+  // Pages built during the skeleton build (e.g. the default 404) chain to the
+  // shared config root — the page segment in the key path identifies them.
+  const result = await findConfig({ id: 'legal_button', pageId: 'legal' });
+  expect(result.matches.length).toEqual(1);
+  expect(result.matches[0].keyPath).toEqual('root.pages[2:legal].blocks[0:legal_button:Button]');
+  expect(result.matches[0].location.source).toContain('pages/legal.yaml:3');
+});
+
+test('findConfig with a skeleton-built pageId does not leak other pages ids', async () => {
+  const result = await findConfig({ id: 'my_button', pageId: 'legal' });
+  expect(result.matches).toEqual([]);
+});
+
+test('findConfig with pageId does not match ids that only exist on other pages', async () => {
+  // my_list.$.item_title only exists on home — scoped to "other" it must not
+  // resolve, instead of falling back to the wrong page.
+  const result = await findConfig({ id: 'my_list.0.item_title', pageId: 'other' });
+  expect(result.matches).toEqual([]);
+  expect(result.note).toContain('No config found with id "my_list.0.item_title" on page "other"');
 });
 
 test('findConfig resolves a runtime list item id to its $ placeholder config id', async () => {
@@ -240,6 +288,12 @@ test('findConfig resolves a runtime list item id to its $ placeholder config id'
   expect(result.matches.length).toEqual(1);
   expect(result.matches[0].keyPath).toContain('[0:my_list.$.item_title:Title]');
   expect(result.matches[0].location.source).toContain('pages/home.yaml:9');
+});
+
+test('findConfig resolves a runtime list item id within a pageId scope', async () => {
+  const result = await findConfig({ id: 'my_list.0.item_title', pageId: 'home' });
+  expect(result.matches.length).toEqual(1);
+  expect(result.matches[0].keyPath).toContain('[0:my_list.$.item_title:Title]');
 });
 
 test('findConfig de-indexes any list index, not just the first item', async () => {
@@ -252,7 +306,7 @@ test('findConfig prefers an exact id match over de-indexing', async () => {
   // my_button contains no indices — exact scan must resolve it without the
   // de-index retry changing anything.
   const result = await findConfig({ id: 'my_button' });
-  expect(result.matches[0].keyPath).toEqual('root.pages[0:home].blocks[2:my_button:Button]');
+  expect(result.matches[0].keyPath).toEqual('root.blocks[2:my_button:Button]');
 });
 
 test('findConfig returns empty matches with a note when nothing matches', async () => {

--- a/packages/servers/server-dev/lib/docs/findConfig.js
+++ b/packages/servers/server-dev/lib/docs/findConfig.js
@@ -34,19 +34,121 @@ function buildIdPattern(id) {
   return new RegExp(`\\[\\d+:${escapeRegExp(id)}(:[^\\]]*)?\\]`);
 }
 
-function scanKeyMap({ id, keyMap, refMap, configDirectory }) {
+// The JIT page build runs addKeys on the page object itself (see
+// packages/build/src/build/jit/buildPageJit.js), so a built page's keyMap
+// subtree is keyed `root`, `root.blocks[...]` — the key path carries NO page
+// segment, and every built page looks identical by prefix. The page a keyMap
+// entry belongs to is only recoverable structurally: walk ~k_parent up to the
+// subtree root and compare against the page's own root. The page's root is
+// found from its build artifact — block objects in pages/<pageId>.json keep
+// their ~k, and any of them chains up to the page root. Skeleton-style keys
+// (`root.pages[N:pageId]...`) carry the page segment inline, so a containment
+// pattern covers those.
+function buildPageScope({ pageId, keyMap }) {
+  let rootKeyId = findPageRootKeyId({ pageId, keyMap });
+  // A page built during the skeleton build (e.g. the default 404 page) chains
+  // to the global config root, which every skeleton entry shares — useless as
+  // a page discriminator. Those pages' keys carry the page segment inline, so
+  // the pattern branch identifies them instead.
+  if (!type.isNone(rootKeyId) && rootKeyId === findGlobalRootId(keyMap)) {
+    rootKeyId = null;
+  }
+  return {
+    rootKeyId,
+    pagePattern: new RegExp(`\\bpages\\[\\d+:${escapeRegExp(pageId)}(:[^\\]]*)?\\]`),
+  };
+}
+
+function findGlobalRootId(keyMap) {
+  for (const [keyId, entry] of Object.entries(keyMap)) {
+    if (entry?.key === 'root.pages') {
+      return resolveChainRootId({ keyId, keyMap });
+    }
+  }
+  return null;
+}
+
+function findPageRootKeyId({ pageId, keyMap }) {
+  const artifact = readBuildArtifact({ name: `pages/${pageId}.json`, deserialize: true });
+  const keyId = findFirstKeyId(artifact);
+  if (type.isNone(keyId)) {
+    return null;
+  }
+  return resolveChainRootId({ keyId, keyMap });
+}
+
+function findFirstKeyId(node) {
+  if (type.isString(node?.['~k'])) {
+    return node['~k'];
+  }
+  if (type.isArray(node)) {
+    for (const item of node) {
+      const keyId = findFirstKeyId(item);
+      if (keyId) {
+        return keyId;
+      }
+    }
+    return null;
+  }
+  if (!type.isObject(node)) {
+    return null;
+  }
+  for (const key of Object.keys(node)) {
+    const keyId = findFirstKeyId(node[key]);
+    if (keyId) {
+      return keyId;
+    }
+  }
+  return null;
+}
+
+// Walk ~k_parent to the top of the entry's subtree. addKeys assigns the tree
+// root a parent id that is never written to keyMap, so "parent not in keyMap"
+// is the root. The seen-set guards against a corrupt artifact cycling forever.
+function resolveChainRootId({ keyId, keyMap }) {
+  let currentId = keyId;
+  const seen = new Set();
+  while (!seen.has(currentId)) {
+    seen.add(currentId);
+    const parentId = keyMap[currentId]?.['~k_parent'];
+    if (type.isNone(parentId) || type.isUndefined(keyMap[parentId])) {
+      return currentId;
+    }
+    currentId = parentId;
+  }
+  return currentId;
+}
+
+function belongsToPage({ keyId, entry, keyMap, pageScope }) {
+  if (pageScope.pagePattern.test(entry.key)) {
+    return true;
+  }
+  if (type.isNone(pageScope.rootKeyId)) {
+    return false;
+  }
+  return resolveChainRootId({ keyId, keyMap }) === pageScope.rootKeyId;
+}
+
+function scanKeyMap({ id, keyMap, refMap, configDirectory, pageScope }) {
   const pattern = buildIdPattern(id);
   const matches = [];
   for (const [keyId, entry] of Object.entries(keyMap)) {
     if (matches.length >= MAX_MATCHES) {
       break;
     }
-    if (type.isString(entry?.key) && pattern.test(entry.key)) {
-      matches.push({
-        keyPath: entry.key,
-        location: resolveConfigLocation({ configKey: keyId, keyMap, refMap, configDirectory }),
-      });
+    if (!type.isString(entry?.key)) {
+      continue;
     }
+    if (!pattern.test(entry.key)) {
+      continue;
+    }
+    if (pageScope && !belongsToPage({ keyId, entry, keyMap, pageScope })) {
+      continue;
+    }
+    matches.push({
+      keyPath: entry.key,
+      location: resolveConfigLocation({ configKey: keyId, keyMap, refMap, configDirectory }),
+    });
   }
   return matches;
 }
@@ -61,8 +163,8 @@ function deIndexId(id) {
   return id.replace(/\.\d+(?=\.|$)/g, () => '.$');
 }
 
-function scanKeyMapWithDeIndex({ id, keyMap, refMap, configDirectory }) {
-  const matches = scanKeyMap({ id, keyMap, refMap, configDirectory });
+function scanKeyMapWithDeIndex({ id, keyMap, refMap, configDirectory, pageScope }) {
+  const matches = scanKeyMap({ id, keyMap, refMap, configDirectory, pageScope });
   if (matches.length > 0) {
     return matches;
   }
@@ -70,7 +172,7 @@ function scanKeyMapWithDeIndex({ id, keyMap, refMap, configDirectory }) {
   if (deIndexedId === id) {
     return matches;
   }
-  return scanKeyMap({ id: deIndexedId, keyMap, refMap, configDirectory });
+  return scanKeyMap({ id: deIndexedId, keyMap, refMap, configDirectory, pageScope });
 }
 
 // Locates a block/request/connection/etc by id, or a page by pageId. Block
@@ -115,10 +217,21 @@ async function findConfig({ id, pageId }) {
 
     const keyMap = readBuildArtifact({ name: 'keyMap.json' }) ?? {};
     const refMap = readBuildArtifact({ name: 'refMap.json' }) ?? {};
-    const matches = scanKeyMapWithDeIndex({ id, keyMap, refMap, configDirectory });
+    const matches = scanKeyMapWithDeIndex({
+      id,
+      keyMap,
+      refMap,
+      configDirectory,
+      pageScope: buildPageScope({ pageId, keyMap }),
+    });
     return matches.length > 0
       ? { matches }
-      : { matches, note: `No config found with id "${id}" on page "${pageId}".` };
+      : {
+          matches,
+          note:
+            `No config found with id "${id}" on page "${pageId}". Retry without ?pageId= to ` +
+            'scan all built pages and app-level config (connections, menus, api).',
+        };
   }
 
   const keyMap = readBuildArtifact({ name: 'keyMap.json' }) ?? {};

--- a/packages/servers/server-dev/lib/docs/setupTestFixtures.mjs
+++ b/packages/servers/server-dev/lib/docs/setupTestFixtures.mjs
@@ -150,20 +150,36 @@ function setupTestFixtures() {
 
   write('build/pageRegistry.json', {
     home: { pageId: 'home', auth: null, refId: 'ref-home', refPath: 'pages/home.yaml' },
+    other: { pageId: 'other', auth: null, refId: 'ref-other', refPath: 'pages/other.yaml' },
+    legal: { pageId: 'legal', auth: null, refId: 'ref-legal', refPath: 'pages/legal.yaml' },
     unbuilt: { pageId: 'unbuilt', auth: null, refId: 'ref-unbuilt', refPath: 'pages/unbuilt.yaml' },
   });
 
+  // Mirrors the real dev keyMap shape: the skeleton build keys the whole
+  // config (`root.pages[N:id]` page stubs only), while each JIT page build
+  // runs addKeys on the page object itself — so page CONTENT keys are
+  // `root.blocks[...]` with no page segment, one `root`-keyed subtree per
+  // built page, distinguishable only via the ~k_parent chain. Tree roots
+  // reference a parent id that is never written to keyMap.
   write('build/keyMap.json', {
-    'key-root': { key: 'root', '~k_parent': null },
+    'key-root': { key: 'root', '~k_parent': 'key-root-parent' },
     'key-pages': { key: 'root.pages', '~k_parent': 'key-root', '~r': 'ref-home' },
-    'key-home': {
+    'key-home-stub': {
       key: 'root.pages[0:home]',
       '~k_parent': 'key-pages',
       '~r': 'ref-home',
       '~l': 1,
     },
+    'key-other-stub': {
+      key: 'root.pages[1:other]',
+      '~k_parent': 'key-pages',
+      '~r': 'ref-other',
+      '~l': 1,
+    },
+    // JIT subtree for page "home".
+    'key-home': { key: 'root', '~k_parent': 'key-home-jit-parent', '~r': 'ref-home', '~l': 1 },
     'key-button': {
-      key: 'root.pages[0:home].blocks[2:my_button:Button]',
+      key: 'root.blocks[2:my_button:Button]',
       '~k_parent': 'key-home',
       '~r': 'ref-home',
       '~l': 5,
@@ -171,15 +187,42 @@ function setupTestFixtures() {
     // List item block — config ids inside lists carry the `$` placeholder;
     // runtime block ids have array indices applied (`my_list.0.item_title`).
     'key-list-item': {
-      key: 'root.pages[0:home].blocks[3:my_list:List].blocks[0:my_list.$.item_title:Title]',
+      key: 'root.blocks[3:my_list:List].blocks[0:my_list.$.item_title:Title]',
       '~k_parent': 'key-home',
       '~r': 'ref-home',
       '~l': 9,
+    },
+    // JIT subtree for page "other" — holds a block id that also exists on
+    // home, with an IDENTICAL key shape. findConfig must scope pageId scans
+    // via the ~k_parent chain, not the key path.
+    'key-other': { key: 'root', '~k_parent': 'key-other-jit-parent', '~r': 'ref-other', '~l': 1 },
+    'key-other-button': {
+      key: 'root.blocks[0:my_button:Button]',
+      '~k_parent': 'key-other',
+      '~r': 'ref-other',
+      '~l': 4,
+    },
+    // Skeleton-built page (like the default 404) — content is keyed inside
+    // the global config tree with the page segment inline, and chains to the
+    // shared config root rather than a page-specific one.
+    'key-legal': {
+      key: 'root.pages[2:legal]',
+      '~k_parent': 'key-pages',
+      '~r': 'ref-legal',
+      '~l': 1,
+    },
+    'key-legal-button': {
+      key: 'root.pages[2:legal].blocks[0:legal_button:Button]',
+      '~k_parent': 'key-legal',
+      '~r': 'ref-legal',
+      '~l': 3,
     },
   });
 
   write('build/refMap.json', {
     'ref-home': { parent: null, path: 'pages/home.yaml' },
+    'ref-other': { parent: null, path: 'pages/other.yaml' },
+    'ref-legal': { parent: null, path: 'pages/legal.yaml' },
   });
 
   write('build/pages/home.json', {
@@ -197,6 +240,18 @@ function setupTestFixtures() {
       { id: 'request:home:req-write', requestId: 'req-write', payload: {} },
       { id: 'request:home:req-unknown', requestId: 'req-unknown', payload: {} },
     ],
+  });
+
+  write('build/pages/other.json', {
+    pageId: 'other',
+    blocks: [{ id: 'my_button', type: 'Button', '~k': 'key-other-button' }],
+    requests: [],
+  });
+
+  write('build/pages/legal.json', {
+    pageId: 'legal',
+    blocks: [{ id: 'legal_button', type: 'Button', '~k': 'key-legal-button' }],
+    requests: [],
   });
 
   // Per-request artifacts (packages/build/src/build/full/writeRequests.js


### PR DESCRIPTION
## Summary

Annotated screenshots from the dev feedback overlay diverged from what the developer was actually looking at: lists in column-direction areas wrapped into a phantom second column, and responsive images (like the header logo) rasterized warped. Tracing those led to two more latent bugs — root-referenced files like `head.html` never triggering a dev rebuild, and the default logo width classes switching at a different breakpoint than the logo image. This PR also carries two dev-tooling improvements: page-scoped `findConfig` and a streamlined feedback overlay send flow.

## Changes

- **@lowdefy/layout**: Blocks in `direction: column` areas get `flex-basis: auto` instead of the row-oriented percentage basis. A percentage basis on the vertical axis only rendered correctly while the area height was indefinite; any definite height (explicit `height`, or html-to-image freezing computed styles during captures) made `basis: 100%` overflow and wrap blocks sideways. `span` still controls width via `max-width`.
- **@lowdefy/server-dev**: Tab captures pin every responsive image to its `currentSrc` (and strip unfetchable `srcset` candidates) before rasterizing, restoring the DOM afterwards — fixes `<picture>`/`srcset` images embedding the wrong variant. `findConfig` with `?pageId=` now resolves matches through the `~k_parent` chain to the page's own subtree, so same-named ids on other built pages no longer leak in. The feedback overlay drops the separate review phase: send from the panel includes the in-flight draft, and banked annotations stay in a pending tray.
- **@lowdefy/build**: `collectSkeletonSourceFiles` now collects the root ref id, with page refs as stop boundaries — scalar-resolving refs parented on `lowdefy.yaml` (e.g. `app.html.appendHead: {_ref: head.html}`) correctly trigger skeleton rebuilds in dev instead of serving stale HTML.
- **@lowdefy/blocks-antd**: PageHeaderMenu/PageSiderMenu default logo width now switches at the same 577px breakpoint as the `<picture>` source, fixing the squeezed wordmark between 577–640px.

## Key Files

- `packages/layout/src/grid.css` — the `.lf-row-column > .lf-col { flex-basis: auto; }` rule
- `packages/build/src/build/jit/collectSkeletonSourceFiles.js` — root ref id + page-boundary scan
- `packages/servers/server-dev/client/feedback/pinResponsiveImages.js` — responsive image pinning for captures
- `packages/servers/server-dev/lib/docs/findConfig.js` — structural page-scope resolution via `~k_parent` chains
- `packages/servers/server-dev/client/feedback/FeedbackOverlay.jsx` — review phase removed, draft-inclusive send

## Notes

- The layout change alters behavior only in the undocumented case of relying on `span` as a *height* fraction inside a fixed-height column area; a `column direction area` snapshot fixture locks in the new class.
- Capture fidelity was verified end-to-end against a live app: native Playwright screenshots vs the shipped in-tab capture module are pixel-identical after these fixes (previously the list wrapped 380px right and the logo warped).
- The repo test app gained a `layout-columns` validation page (`app/` is gitignored, so it is not part of this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)