### PR TITLE
feat(connections): Mail send requests return per-message results with post-filter to

### DIFF
--- a/.changeset/feat-mail-send-results.md
+++ b/.changeset/feat-mail-send-results.md
@@ -1,0 +1,13 @@
+---
+'@lowdefy/connection-sendgrid': minor
+'@lowdefy/connection-smtp': minor
+---
+
+feat: Mail send requests return per-message send results
+
+`SendGridMailSend` and `SMTPMailSend` now return a `results` array with one entry per message sent, so routines can record delivery outcomes:
+
+- Each result includes the post-filter `to` — the address mail was actually delivered to after the connection `filter` (`replaceAddress`, `allowlist`, `regex`) is applied. When a filter redirects mail to a test inbox, routines can now persist both the intended recipient and where the message really went.
+- Messages dropped entirely by the filter return `{ messageId: null, to: null, filtered: true }`.
+- `SendGridMailSend` previously discarded send results and returned only a response string; it now returns `results` with the SendGrid `messageId` per message, matching `SMTPMailSend`.
+- `SMTPMailSend` results keep nodemailer's `accepted` and `rejected` alongside the new `to`.

--- a/packages/plugins/connections/connection-sendgrid/src/connections/SendGridMail/SendGridMailSend/SendGridMailSend.js
+++ b/packages/plugins/connections/connection-sendgrid/src/connections/SendGridMail/SendGridMailSend/SendGridMailSend.js
@@ -22,10 +22,11 @@ import schema from './schema.js';
 async function SendGridMailSend({ request, connection }) {
   const messages = type.isArray(request) ? request : [request];
   // Send per message so the connection mail filter is enforced in one place.
+  const results = [];
   for (const mail of messages) {
-    await send({ connection, mail });
+    results.push(await send({ connection, mail }));
   }
-  return { response: 'Mail sent successfully' };
+  return { response: 'Mail sent successfully', results };
 }
 
 SendGridMailSend.schema = schema;

--- a/packages/plugins/connections/connection-sendgrid/src/connections/SendGridMail/SendGridMailSend/SendGridMailSend.test.js
+++ b/packages/plugins/connections/connection-sendgrid/src/connections/SendGridMail/SendGridMailSend/SendGridMailSend.test.js
@@ -70,6 +70,7 @@ test('send with valid request and connection', async () => {
   ]);
   expect(send).toEqual({
     response: 'Mail sent successfully',
+    results: [{ messageId: 'test-message-id', to: 'a@b.com' }],
   });
 });
 
@@ -99,6 +100,12 @@ test('send to list of emails', async () => {
   ]);
   expect(send).toEqual({
     response: 'Mail sent successfully',
+    results: [
+      {
+        messageId: 'test-message-id',
+        to: ['a@b.com', 'aaa bbb <aaa@bbb.com>', { email: 'ddd@eee.com', name: 'ccc' }],
+      },
+    ],
   });
 });
 
@@ -145,6 +152,71 @@ test('send a list of different emails', async () => {
   ]);
   expect(send).toEqual({
     response: 'Mail sent successfully',
+    results: [
+      { messageId: 'test-message-id', to: 'a@b.com' },
+      { messageId: 'test-message-id', to: 'b@b.com' },
+    ],
+  });
+});
+
+test('SendGridMailSend includes filtered results for filtered-out messages', async () => {
+  const SendGridMailSend = (await import('./SendGridMailSend.js')).default;
+  const request = [
+    {
+      to: 'a@allowed.com',
+      subject: 'A',
+      text: 'A',
+    },
+    {
+      to: 'b@other.com',
+      subject: 'B',
+      text: 'B',
+    },
+  ];
+  const connection = {
+    apiKey: 'X',
+    from: 'x@y.com',
+    filter: { allowlist: ['allowed.com'] },
+  };
+  const send = await SendGridMailSend({ request, connection });
+  expect(mockSend.mock.calls).toEqual([
+    [
+      {
+        from: 'x@y.com',
+        mailSettings: undefined,
+        subject: 'A',
+        templateId: undefined,
+        text: 'A',
+        to: 'a@allowed.com',
+      },
+    ],
+  ]);
+  expect(send).toEqual({
+    response: 'Mail sent successfully',
+    results: [
+      { messageId: 'test-message-id', to: 'a@allowed.com' },
+      { messageId: null, to: null, filtered: true },
+    ],
+  });
+});
+
+test('SendGridMailSend returns the replaced address when the filter redirects mail', async () => {
+  const SendGridMailSend = (await import('./SendGridMailSend.js')).default;
+  const request = {
+    to: 'a@b.com',
+    subject: 'A',
+    text: 'B',
+  };
+  const connection = {
+    apiKey: 'X',
+    from: 'x@y.com',
+    filter: { replaceAddress: 'dev@test.com' },
+  };
+  const send = await SendGridMailSend({ request, connection });
+  expect(mockSend.mock.calls[0][0].to).toEqual('dev@test.com');
+  expect(send).toEqual({
+    response: 'Mail sent successfully',
+    results: [{ messageId: 'test-message-id', to: 'dev@test.com' }],
   });
 });
 

--- a/packages/plugins/connections/connection-sendgrid/src/connections/SendGridMail/send.js
+++ b/packages/plugins/connections/connection-sendgrid/src/connections/SendGridMail/send.js
@@ -26,7 +26,7 @@ async function send({ connection, mail }) {
   sendgrid.setApiKey(apiKey);
   const filtered = applyMailFilter({ filter, mail });
   if (filtered === null) {
-    return { messageId: null, filtered: true };
+    return { messageId: null, to: null, filtered: true };
   }
   const message = {
     ...filtered,
@@ -39,7 +39,9 @@ async function send({ connection, mail }) {
   };
   try {
     const [response] = await sendgrid.send(message);
-    return { messageId: response?.headers?.['x-message-id'] ?? null };
+    // Return the post-filter to so callers can record where mail actually went
+    // when a connection filter (replaceAddress/allowlist/regex) rewrites it.
+    return { messageId: response?.headers?.['x-message-id'] ?? null, to: filtered.to };
   } catch (error) {
     if (error.response) {
       throw new Error('SendGrid request failed.', { cause: error });

--- a/packages/plugins/connections/connection-sendgrid/src/connections/SendGridMail/send.test.js
+++ b/packages/plugins/connections/connection-sendgrid/src/connections/SendGridMail/send.test.js
@@ -53,7 +53,7 @@ test('send sets the api key and returns the messageId from response headers', as
       },
     ],
   ]);
-  expect(result).toEqual({ messageId: 'message-id-1' });
+  expect(result).toEqual({ messageId: 'message-id-1', to: 'a@b.com' });
 });
 
 test('send returns messageId null when response has no message id header', async () => {
@@ -63,13 +63,13 @@ test('send returns messageId null when response has no message id header', async
     connection: { apiKey: 'X', from: 'from@x.com' },
     mail: { to: 'a@b.com' },
   });
-  expect(result).toEqual({ messageId: null });
+  expect(result).toEqual({ messageId: null, to: 'a@b.com' });
 });
 
 test('send applies the connection filter to the mail', async () => {
   const send = (await import('./send.js')).default;
   mockSend.mockResolvedValue([{ headers: { 'x-message-id': 'message-id-1' } }]);
-  await send({
+  const result = await send({
     connection: { apiKey: 'X', from: 'from@x.com', filter: { allowlist: ['allowed.com'] } },
     mail: { to: ['a@allowed.com', 'b@other.com'], cc: 'c@other.com', subject: 'A' },
   });
@@ -87,6 +87,18 @@ test('send applies the connection filter to the mail', async () => {
       },
     ],
   ]);
+  expect(result).toEqual({ messageId: 'message-id-1', to: ['a@allowed.com'] });
+});
+
+test('send returns the replaced address when the filter redirects mail', async () => {
+  const send = (await import('./send.js')).default;
+  mockSend.mockResolvedValue([{ headers: { 'x-message-id': 'message-id-1' } }]);
+  const result = await send({
+    connection: { apiKey: 'X', from: 'from@x.com', filter: { replaceAddress: 'dev@test.com' } },
+    mail: { to: 'a@b.com', subject: 'A' },
+  });
+  expect(mockSend.mock.calls[0][0].to).toEqual('dev@test.com');
+  expect(result).toEqual({ messageId: 'message-id-1', to: 'dev@test.com' });
 });
 
 test('send returns filtered result without calling sendgrid when no to recipients survive', async () => {
@@ -95,7 +107,7 @@ test('send returns filtered result without calling sendgrid when no to recipient
     connection: { apiKey: 'X', from: 'from@x.com', filter: { allowlist: ['allowed.com'] } },
     mail: { to: 'a@other.com', subject: 'A' },
   });
-  expect(result).toEqual({ messageId: null, filtered: true });
+  expect(result).toEqual({ messageId: null, to: null, filtered: true });
   expect(mockSend).not.toHaveBeenCalled();
 });
 

--- a/packages/plugins/connections/connection-smtp/src/connections/SMTP/SMTPMailSend/SMTPMailSend.test.js
+++ b/packages/plugins/connections/connection-smtp/src/connections/SMTP/SMTPMailSend/SMTPMailSend.test.js
@@ -27,6 +27,7 @@ beforeEach(() => {
   mockSend.mockImplementation(({ mail }) => {
     return Promise.resolve({
       messageId: `<${mail.to}>`,
+      to: mail.to,
       accepted: [mail.to],
       rejected: [],
     });
@@ -62,6 +63,7 @@ test('SMTPMailSend sends a single object request through send', async () => {
     results: [
       {
         messageId: '<someone@example.com>',
+        to: 'someone@example.com',
         accepted: ['someone@example.com'],
         rejected: [],
       },
@@ -115,11 +117,13 @@ test('SMTPMailSend sends each message in an array request through send sequentia
     results: [
       {
         messageId: '<a@example.com>',
+        to: 'a@example.com',
         accepted: ['a@example.com'],
         rejected: [],
       },
       {
         messageId: '<b@example.com>',
+        to: 'b@example.com',
         accepted: ['b@example.com'],
         rejected: [],
       },
@@ -129,7 +133,7 @@ test('SMTPMailSend sends each message in an array request through send sequentia
 
 test('SMTPMailSend includes filtered results for filtered-out messages', async () => {
   const SMTPMailSend = (await import('./SMTPMailSend.js')).default;
-  mockSend.mockResolvedValue({ messageId: null, filtered: true });
+  mockSend.mockResolvedValue({ messageId: null, to: null, filtered: true });
   const connection = {
     host: 'smtp.example.com',
     from: 'from@example.com',
@@ -142,7 +146,7 @@ test('SMTPMailSend includes filtered results for filtered-out messages', async (
   const result = await SMTPMailSend({ request, connection });
   expect(result).toEqual({
     response: 'Mail sent successfully',
-    results: [{ messageId: null, filtered: true }],
+    results: [{ messageId: null, to: null, filtered: true }],
   });
 });
 

--- a/packages/plugins/connections/connection-smtp/src/connections/SMTP/send.js
+++ b/packages/plugins/connections/connection-smtp/src/connections/SMTP/send.js
@@ -22,7 +22,7 @@ async function send({ connection, mail }) {
   const { from, replyTo, filter, ...transportOptions } = connection;
   const filtered = applyMailFilter({ filter, mail });
   if (filtered === null) {
-    return { messageId: null, filtered: true };
+    return { messageId: null, to: null, filtered: true };
   }
   const transport = nodemailer.createTransport(transportOptions);
   try {
@@ -37,7 +37,14 @@ async function send({ connection, mail }) {
       html: filtered.html,
       attachments: filtered.attachments,
     });
-    return { messageId: info.messageId, accepted: info.accepted, rejected: info.rejected };
+    // Return the post-filter to so callers can record where mail actually went
+    // when a connection filter (replaceAddress/allowlist/regex) rewrites it.
+    return {
+      messageId: info.messageId,
+      to: filtered.to,
+      accepted: info.accepted,
+      rejected: info.rejected,
+    };
   } finally {
     // close matters when pool: true is passed through in transport options
     transport.close();

--- a/packages/plugins/connections/connection-smtp/src/connections/SMTP/send.test.js
+++ b/packages/plugins/connections/connection-smtp/src/connections/SMTP/send.test.js
@@ -133,7 +133,7 @@ test('send mail replyTo overrides connection replyTo', async () => {
   expect(mockSendMail.mock.calls[0][0].replyTo).toEqual('mail-reply@example.com');
 });
 
-test('send returns messageId, accepted and rejected from transport info', async () => {
+test('send returns messageId, to, accepted and rejected from transport info', async () => {
   const send = (await import('./send.js')).default;
   mockSendMail.mockResolvedValue({
     messageId: '<id@example.com>',
@@ -152,9 +152,26 @@ test('send returns messageId, accepted and rejected from transport info', async 
   const result = await send({ connection, mail });
   expect(result).toEqual({
     messageId: '<id@example.com>',
+    to: 'someone@example.com',
     accepted: ['someone@example.com'],
     rejected: ['rejected@example.com'],
   });
+});
+
+test('send returns the replaced address when the filter redirects mail', async () => {
+  const send = (await import('./send.js')).default;
+  const connection = {
+    host: 'smtp.example.com',
+    from: 'from@example.com',
+    filter: { replaceAddress: 'dev@test.com' },
+  };
+  const mail = {
+    to: 'someone@example.com',
+    subject: 'A',
+  };
+  const result = await send({ connection, mail });
+  expect(mockSendMail.mock.calls[0][0].to).toEqual('dev@test.com');
+  expect(result.to).toEqual('dev@test.com');
 });
 
 test('send returns filtered result without creating a transport when mail is filtered out', async () => {
@@ -169,7 +186,7 @@ test('send returns filtered result without creating a transport when mail is fil
     subject: 'A',
   };
   const result = await send({ connection, mail });
-  expect(result).toEqual({ messageId: null, filtered: true });
+  expect(result).toEqual({ messageId: null, to: null, filtered: true });
   expect(mockCreateTransport).not.toHaveBeenCalled();
   expect(mockSendMail).not.toHaveBeenCalled();
 });
@@ -185,8 +202,9 @@ test('send applies the connection filter to mail recipients', async () => {
     to: ['someone@example.com', 'blocked@blocked.org'],
     subject: 'A',
   };
-  await send({ connection, mail });
+  const result = await send({ connection, mail });
   expect(mockSendMail.mock.calls[0][0].to).toEqual(['someone@example.com']);
+  expect(result.to).toEqual(['someone@example.com']);
 });
 
 test('send closes the transport after a successful send', async () => {


### PR DESCRIPTION
## What

`SendGridMailSend` and `SMTPMailSend` now return a `results` array with one entry per message sent, each including the post-filter `to` — the address mail was actually delivered to after the connection `filter` (`replaceAddress` / `allowlist` / `regex`) is applied.

- **SendGrid**: `SendGridMailSend` previously discarded `send()` results and returned only `{ response: 'Mail sent successfully' }`. It now collects per-message results like `SMTPMailSend` already did, so the SendGrid `messageId` finally reaches routines.
- **Both plugins**: `send()` returns `to: filtered.to` on success, and `{ messageId: null, to: null, filtered: true }` when the filter drops the message entirely.
- `applyMailFilter` is untouched in both plugins — the final `to` is read off its existing return value.

## Why

Notification routines persist a record per email (e.g. the modules-mongodb notifications module). With a `replaceAddress` dev-redirect active, the record's intended recipient and the actual delivered-to address silently diverge, and nothing in the data shows the redirect fired. Surfacing the post-filter `to` lets routines record both — intended (`email`) and actual (`email_result.to`).

## Tests

- Updated SendGrid `SendGridMailSend.test.js` result assertions (now `results` array), added filtered-drop and `replaceAddress` redirect cases.
- Updated `send.test.js` in both plugins for the new `to` field, added redirect cases.
- Updated `SMTPMailSend.test.js` mock + assertions for the `to` passthrough.
- `pnpm --filter=@lowdefy/connection-sendgrid test`: 55 passed. `--filter=@lowdefy/connection-smtp test`: 47 passed. Both at 100% statement coverage; both packages build.

Changeset included (minor, `@lowdefy/connection-sendgrid` + `@lowdefy/connection-smtp`).