### PR TITLE
Fix module page resolver paths in JIT dev builds

### DIFF
--- a/.changeset/fix-build-jit-module-resolver-path.md
+++ b/.changeset/fix-build-jit-module-resolver-path.md
@@ -1,0 +1,13 @@
+---
+'@lowdefy/build': patch
+---
+
+fix(build): resolve module page resolver/transformer paths against the module root in JIT dev builds.
+
+A module page backed by a `resolver:` (or `transformer:`) declares its path relative to the module
+(e.g. `resolvers/makeActionPages.js`). The full build rebases this against the module root in the ref
+walker, but the JIT dev path (`buildPageJit`) rebuilt the page refDef directly from the un-rebased
+authored `_ref` and called `getRefContent` without going through the walker — so the relative path was
+resolved against the app config dir, producing a `ConfigError` (`Error importing resolvers/...`) when a
+module page was rebuilt on request. `buildPageJit` now applies the same module-root rebasing to
+`path`/`resolver`/`transformer` before resolving content. File-based module pages were unaffected.

--- a/packages/build/src/build/buildRefs/rebaseModuleRefPaths.js
+++ b/packages/build/src/build/buildRefs/rebaseModuleRefPaths.js
@@ -1,0 +1,34 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import path from 'path';
+import { type } from '@lowdefy/helpers';
+
+// Module refs author their path/resolver/transformer relative to the module
+// (e.g. "resolvers/makeActionPages.js"). Rebase those relative paths against the
+// module root so they resolve from the module, not the app config dir. Mutates
+// refDef in place. No-op when moduleRoot is not set or a path is already absolute.
+function rebaseModuleRefPaths({ refDef, moduleRoot }) {
+  if (!moduleRoot) return refDef;
+  for (const field of ['path', 'resolver', 'transformer']) {
+    if (type.isString(refDef[field]) && !path.isAbsolute(refDef[field])) {
+      refDef[field] = path.resolve(moduleRoot, refDef[field]);
+    }
+  }
+  return refDef;
+}
+
+export default rebaseModuleRefPaths;

--- a/packages/build/src/build/buildRefs/walker.js
+++ b/packages/build/src/build/buildRefs/walker.js
@@ -20,6 +20,7 @@ import { get, serializer, type } from '@lowdefy/helpers';
 import { ConfigError } from '@lowdefy/errors';
 import { evaluateOperators } from '@lowdefy/operators';
 import makeRefDefinition from './makeRefDefinition.js';
+import rebaseModuleRefPaths from './rebaseModuleRefPaths.js';
 import getRefContent from './getRefContent.js';
 import getModuleRefContent from './getModuleRefContent.js';
 import runTransformer from './runTransformer.js';
@@ -545,17 +546,7 @@ async function resolveRef(node, ctx) {
   }
 
   // 4. Module path resolution: resolve relative paths from the module root
-  if (ctx.moduleRoot) {
-    if (type.isString(refDef.path) && !path.isAbsolute(refDef.path)) {
-      refDef.path = path.resolve(ctx.moduleRoot, refDef.path);
-    }
-    if (type.isString(refDef.resolver) && !path.isAbsolute(refDef.resolver)) {
-      refDef.resolver = path.resolve(ctx.moduleRoot, refDef.resolver);
-    }
-    if (type.isString(refDef.transformer) && !path.isAbsolute(refDef.transformer)) {
-      refDef.transformer = path.resolve(ctx.moduleRoot, refDef.transformer);
-    }
-  }
+  rebaseModuleRefPaths({ refDef, moduleRoot: ctx.moduleRoot });
 
   // 5. Update refMap with resolved path; store original for resolver refs
   ctx.refMap[refDef.id].path = refDef.path;

--- a/packages/build/src/build/jit/buildPageJit.js
+++ b/packages/build/src/build/jit/buildPageJit.js
@@ -35,6 +35,7 @@ import evaluateStaticOperators from '../buildRefs/evaluateStaticOperators.js';
 import getRefContent from '../buildRefs/getRefContent.js';
 import jsMapParser from '../buildJs/jsMapParser.js';
 import makeRefDefinition from '../buildRefs/makeRefDefinition.js';
+import rebaseModuleRefPaths from '../buildRefs/rebaseModuleRefPaths.js';
 import { resolve, WalkContext, cloneForResolve, tagRefDeep } from '../buildRefs/walker.js';
 import validateOperatorsDynamic from '../validateOperatorsDynamic.js';
 import writeMaps from '../writeMaps.js';
@@ -161,6 +162,21 @@ async function buildPageJit({ pageId, pageRegistry, context, directories, logger
         : pageEntry.refPath;
       refDef = makeRefDefinition(refDefinition, null, buildContext.refMap);
       buildContext.refMap[refDef.id].path = refDef.path;
+    }
+
+    // Module path resolution: resolve relative path/resolver/transformer from the
+    // module root. The full build does this in walker.js step 4 when an _ref node
+    // is encountered, but the JIT path builds the page refDef directly from
+    // resolverOriginal (the un-rebased authored _ref) and calls getRefContent
+    // without going through the walker — so a module resolver like
+    // "resolvers/makeActionPages.js" would otherwise resolve against the app
+    // config dir instead of the module root. (File-based module pages are
+    // unaffected: their paths are stored already-rebased in refMap.)
+    if (moduleEntry?.moduleRoot) {
+      rebaseModuleRefPaths({ refDef, moduleRoot: moduleEntry.moduleRoot });
+      if (type.isString(refDef.path)) {
+        buildContext.refMap[refDef.id].path = refDef.path;
+      }
     }
 
     const pageContent = await getRefContent({

--- a/packages/build/src/build/jit/buildPageJit.test.js
+++ b/packages/build/src/build/jit/buildPageJit.test.js
@@ -14,6 +14,7 @@
   limitations under the License.
 */
 
+import path from 'path';
 import { jest } from '@jest/globals';
 
 const realNodeUtils = await import('@lowdefy/node-utils');
@@ -527,6 +528,56 @@ type: PageHeaderMenu
       'Referenced file does not exist: "components/missing.yaml"'
     );
   }
+});
+
+test('buildPageJit resolves a module page resolver relative to the module root, not the app config dir', async () => {
+  const context = createTestContext();
+  // The app config dir does NOT contain the resolver — only the module root
+  // does. A module authors its resolver path relative to itself
+  // (e.g. "resolvers/makeActionPages.js"); the JIT path must rebase it against
+  // the module root the same way walker.js step 4 does in the full build.
+  // Without rebasing, the relative path resolves against directories.config and
+  // the import fails.
+  context.directories.config = path.resolve('src/test-utils');
+  const moduleRoot = path.resolve('src/test-utils/buildRefs');
+  context.modules = {
+    mymod: {
+      id: 'mymod',
+      moduleRoot,
+      packageRoot: moduleRoot,
+      moduleDependencies: null,
+    },
+  };
+  mockFiles([]);
+
+  const pageRegistry = new Map([
+    [
+      'mymod/home',
+      {
+        pageId: 'mymod/home',
+        auth: { public: true },
+        refId: 'ref-resolver',
+        refPath: null,
+        unresolvedVars: null,
+        moduleEntryId: 'mymod',
+        // Authored relative to the module — must rebase against moduleRoot.
+        resolverOriginal: {
+          resolver: 'testJitPageResolver.js',
+          vars: { pageId: 'home', app_name: 'ModuleApp' },
+        },
+      },
+    ],
+  ]);
+
+  const result = await buildPageJit({
+    pageId: 'mymod/home',
+    pageRegistry,
+    context,
+  });
+
+  expect(result.id).toBe('page:mymod/home');
+  expect(result.type).toBe('PageHeaderMenu');
+  expect(result.properties.title).toBe('ModuleApp');
 });
 
 test('buildPageJit resolver page traces errors back to resolver when inner _ref fails', async () => {


### PR DESCRIPTION
## Problem

A module page backed by a resolver/transformer declares its path relative to the module root, e.g.:

```yaml
pages:
  - _ref:
      resolver: resolvers/makeActionPages.js
```

The full build rebases this path against the module root in the ref walker (step 4), so `lowdefy build` + `lowdefy start` work correctly. But the JIT dev path (`buildPageJit.js`) rebuilds the page refDef directly from the un-rebased authored `_ref` (`pageEntry.resolverOriginal`) and calls `getRefContent` without going through the walker. The relative resolver path then resolves against the app config directory instead of the module root, and navigating to a module resolver page under `lowdefy dev` fails with:

```
[ConfigError] Error importing resolvers/makeActionPages.js.
  Caused by: [Error] Cannot find module '{app}/resolvers/makeActionPages.js'
```

## Fix

Cherry-pick of b790a6587 from the `vite-hono` branch (applies cleanly to `develop`):

- **`rebaseModuleRefPaths.js`** — new shared helper that rebases relative `path`/`resolver`/`transformer` against the module root.
- **`walker.js`** — replace the inline step 4 rebasing block with the helper (identical logic, prevents drift).
- **`buildPageJit.js`** — apply the helper to the page refDef before resolving module page content; keep the JIT-specific refMap update at the call site.
- **`buildPageJit.test.js`** — new test covering a module resolver page: resolver path rebased against the module root, not the app config dir.

## Testing

`packages/build`: all 9 suites / 288 tests pass for `src/build/jit/buildPageJit.test.js` and `src/build/buildRefs/`.