### PR TITLE
Keep long sidebar menus fully reachable

### DIFF
--- a/.changeset/fix-sidebar-layout-long-menu-scroll.md
+++ b/.changeset/fix-sidebar-layout-long-menu-scroll.md
@@ -1,0 +1,16 @@
+---
+'@lowdefy/blocks-antd': patch
+---
+
+fix: Keep long sidebar menus fully reachable.
+
+Two related sidebar scrolling issues are fixed:
+
+- When the sidebar is collapsed, hovering a menu group with a long nested list opened a
+  flyout whose top was pushed above the screen, so the first items were cut off and
+  unreachable — most noticeable for groups low down the menu on shorter screens. Flyout
+  menus now stay within the viewport and scroll, so every item is reachable.
+
+- When the sidebar is expanded with a menu taller than the screen, the last item could be
+  hidden behind the logo/profile footer with no way to scroll it into view. The menu now
+  scrolls between a fixed toggle and footer, so the last item is always reachable.

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Menu/Menu.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Menu/Menu.js
@@ -24,6 +24,7 @@ import { withBlockDefaults } from '@lowdefy/block-utils';
 import withTheme from '../withTheme.js';
 import useItemShortcuts from '../useItemShortcuts.js';
 import { buildMenuItems } from '../buildMenuItems.js';
+import './style.module.css';
 
 const getDefaultMenu = (menus, menuId = 'default', links) => {
   if (type.isArray(links)) return links;

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Menu/style.module.css
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Menu/style.module.css
@@ -1,0 +1,26 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+@layer components {
+  /* Cap side-opening flyouts (collapsed sidebar) to half the viewport so a long popup near a
+     low trigger stays on-screen and scrolls (50vh always fits the taller side of the trigger).
+     !important beats antd's unlayered, more-specific cap. */
+  :global(.ant-menu-submenu-popup[class*='-placement-right'] .ant-menu-sub),
+  :global(.ant-menu-submenu-popup[class*='-placement-left'] .ant-menu-sub) {
+    max-height: 50vh !important;
+    overflow-y: auto !important;
+  }
+}

--- a/packages/plugins/blocks/blocks-antd/src/blocks/PageSidebarLayout/PageSidebarLayout.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/PageSidebarLayout/PageSidebarLayout.js
@@ -179,46 +179,47 @@ const PageSidebarLayout = ({
                         }}
                       />
                     )}
-                    <Menu
-                      blockId={`${blockId}_menu`}
-                      components={{ Icon, Link, ShortcutBadge }}
-                      basePath={basePath}
-                      classNames={{ element: classNames.menu ?? 'hidden lg:block' }}
-                      events={events}
-                      methods={methods}
-                      menus={menus}
-                      pageId={pageId}
-                      properties={mergeObjects([
-                        {
-                          mode: 'inline',
-                          collapsed: !openSiderState,
-                        },
-                        properties.menu,
-                        properties.menuLg,
-                      ])}
-                      styles={{ element: styles.menu }}
-                      rename={{
-                        events: {
-                          onClick: 'onMenuItemClick',
-                          onSelect: 'onMenuItemSelect',
-                          onToggleMenuGroup: 'onToggleMenuGroup',
-                        },
-                      }}
-                    />
-                    {openSiderState && content.siderOpen && (
-                      <div style={{ flex: '0 0 auto' }}>{content.siderOpen()}</div>
-                    )}
-                    {!openSiderState && content.siderClosed && (
-                      <div style={{ flex: '0 0 auto' }}>{content.siderClosed()}</div>
-                    )}
-                    <div style={{ flex: '1 0 auto' }} />
+                    {/* Menu scrolls here between the fixed toggle and footer so the last item
+                        can't hide behind the footer; min-height:0 lets it shrink to scroll. */}
+                    <div style={{ flex: '1 1 auto', minHeight: 0, overflowY: 'auto' }}>
+                      <Menu
+                        blockId={`${blockId}_menu`}
+                        components={{ Icon, Link, ShortcutBadge }}
+                        basePath={basePath}
+                        classNames={{ element: classNames.menu ?? 'hidden lg:block' }}
+                        events={events}
+                        methods={methods}
+                        menus={menus}
+                        pageId={pageId}
+                        properties={mergeObjects([
+                          {
+                            mode: 'inline',
+                            collapsed: !openSiderState,
+                          },
+                          properties.menu,
+                          properties.menuLg,
+                        ])}
+                        styles={{ element: styles.menu }}
+                        rename={{
+                          events: {
+                            onClick: 'onMenuItemClick',
+                            onSelect: 'onMenuItemSelect',
+                            onToggleMenuGroup: 'onToggleMenuGroup',
+                          },
+                        }}
+                      />
+                      {openSiderState && content.siderOpen && (
+                        <div style={{ flex: '0 0 auto' }}>{content.siderOpen()}</div>
+                      )}
+                      {!openSiderState && content.siderClosed && (
+                        <div style={{ flex: '0 0 auto' }}>{content.siderClosed()}</div>
+                      )}
+                    </div>
                     <div
                       style={{
-                        position: 'sticky',
-                        bottom: 0,
-                        background:
-                          'linear-gradient(to bottom, transparent 0%, color-mix(in srgb, var(--ant-color-bg-container) 85%, transparent) 32px, color-mix(in srgb, var(--ant-color-bg-container) 95%, transparent) 100%)',
-                        padding: '40px 8px 8px',
+                        flex: '0 0 auto',
+                        background: 'var(--ant-color-bg-container)',
+                        padding: '8px',
                         display: 'flex',
                         flexDirection: 'column',
                         alignItems: 'center',


### PR DESCRIPTION
## Summary

Fixes two sidebar menu scrolling issues in `@lowdefy/blocks-antd` where long menus became partly unreachable on shorter screens: when the sidebar is collapsed, a menu group's hover flyout could open with its top pushed above the viewport (first items unreachable); and when expanded, a menu taller than the screen could leave its last item hidden behind the logo/profile footer with no way to scroll to it.

## Changes

- **@lowdefy/blocks-antd**:
  - **Collapsed flyout popups** are capped to half the viewport and scroll, so a long flyout (e.g. a group low in the menu) stays on-screen instead of opening with its top off-screen. Scoped to side-opening popups (placement right/left) so horizontal menu dropdowns are left untouched.
  - **Expanded sidebar** now uses an app-shell layout — a fixed toggle and footer bracket a scrolling menu region — so the last item always clears the footer. The sider keeps `overflow: auto` as a fallback, and the footer's old overlap gradient/padding (from the previous sticky-footer design) is simplified to a solid, compact footer.

## Notes

- The flyout cap uses `!important` because antd's popup rule is unlayered and out-specifies component styles; the reason is documented inline in the CSS module.
- **Out of scope:** `PageSiderMenu` (a sibling page-shell block) inherits the flyout fix for free via the shared `Menu` stylesheet, but its `Affix`-based footer is a different structure and isn't touched here.
- Verified manually in a dev app at short viewports — collapsed flyout stays on-screen and scrolls; expanded long menu's last item clears the footer.