### PR TITLE
fix(build): Align the auth.email schema with the connection-based runtime

### DIFF
--- a/packages/api/src/routes/auth/getBetterAuthConfig.test.js
+++ b/packages/api/src/routes/auth/getBetterAuthConfig.test.js
@@ -34,8 +34,6 @@ const { default: getBetterAuthConfig } = await import('./getBetterAuthConfig.js'
 
 const emailConfig = {
   connectionId: 'auth_email',
-  from: 'noreply@example.com',
-  provider: { properties: { host: 'smtp.example.com', port: 587 } },
 };
 
 beforeEach(() => {
@@ -496,8 +494,7 @@ test('adds sendResetPassword and emailVerification when email is configured', ()
     appMeta,
     authJson: createAuthJson({
       email: {
-        from: 'noreply@example.com',
-        provider: { properties: { host: 'smtp.example.com', port: 587 } },
+        connectionId: 'auth_email',
       },
     }),
     getAuth,
@@ -812,8 +809,7 @@ test('pushes the magic-link plugin when magicLink is enabled', () => {
     appMeta,
     authJson: createAuthJson({
       email: {
-        from: 'noreply@example.com',
-        provider: { properties: { host: 'smtp.example.com', port: 587 } },
+        connectionId: 'auth_email',
       },
       magicLink: { enabled: true, expiresIn: 300, disableSignUp: false },
     }),
@@ -1008,8 +1004,7 @@ test('an email.verified hook sets emailVerification.afterEmailVerification and p
     appMeta,
     authJson: createAuthJson({
       email: {
-        from: 'noreply@example.com',
-        provider: { type: 'smtp', properties: { host: 'localhost', port: 1025 } },
+        connectionId: 'auth_email',
       },
       hooks: [{ id: 'on-verified', point: 'email.verified', endpointId: 'auth/on-verified' }],
     }),
@@ -1310,8 +1305,7 @@ test('wires the engine-tier magic-link send gate as options.hooks.before when ma
     appMeta,
     authJson: createAuthJson({
       email: {
-        from: 'noreply@example.com',
-        provider: { properties: { host: 'smtp.example.com', port: 587 } },
+        connectionId: 'auth_email',
       },
       magicLink: { enabled: true, expiresIn: 300, disableSignUp: false },
     }),

--- a/packages/build/src/build/buildAuth/resolveAuthConfigProjection.test.js
+++ b/packages/build/src/build/buildAuth/resolveAuthConfigProjection.test.js
@@ -141,7 +141,7 @@ test('resolveAuthConfigProjection collects a self-reference error for _build.aut
   await resolveAuthConfigProjection({ context });
   expect(context.errors).toHaveLength(1);
   expect(context.errors[0].message).toContain(
-    '_build.authConfig is not available here.'
+    '_build.authConfig cannot be used inside the auth block — the auth config projection is not available while the auth block resolves.'
   );
 });
 
@@ -162,6 +162,6 @@ signup:
   await resolveAuthConfigProjection({ context });
   expect(context.errors).toHaveLength(1);
   expect(context.errors[0].message).toContain(
-    '_build.authConfig is not available here.'
+    '_build.authConfig cannot be used inside the auth block — the auth config projection is not available while the auth block resolves.'
   );
 });

--- a/packages/build/src/build/buildAuth/validateAuthConfig.test.js
+++ b/packages/build/src/build/buildAuth/validateAuthConfig.test.js
@@ -216,12 +216,62 @@ test('validateAuthConfig passes with a magicLink mechanism when email is configu
       database: validDatabase,
       magicLink: { enabled: true },
       email: {
-        from: 'noreply@example.com',
-        provider: { type: 'smtp', properties: {} },
+        connectionId: 'email',
       },
     },
   };
   expect(() => validateAuthConfig({ components, context })).not.toThrow();
+});
+
+test('validateAuthConfig passes with email templates overrides', () => {
+  const components = {
+    auth: {
+      secret: validSecret,
+      database: validDatabase,
+      magicLink: { enabled: true },
+      email: {
+        connectionId: 'email',
+        templates: {
+          verifyEmail: 'verify-email-notification',
+          resetPassword: 'reset-password-notification',
+          magicLink: 'magic-link-notification',
+          invitation: 'invite-notification',
+        },
+      },
+    },
+  };
+  expect(() => validateAuthConfig({ components, context })).not.toThrow();
+});
+
+test('validateAuthConfig throws when email is missing connectionId', () => {
+  const components = {
+    auth: {
+      secret: validSecret,
+      database: validDatabase,
+      magicLink: { enabled: true },
+      email: {},
+    },
+  };
+  expect(() => validateAuthConfig({ components, context })).toThrow(
+    'Auth "email" should have required property "connectionId" — the id of an SMTP connection in "connections". The old inline "from"/"provider" transport shape moved onto the SMTP connection.'
+  );
+});
+
+test('validateAuthConfig throws on the old inline from/provider email shape', () => {
+  const components = {
+    auth: {
+      secret: validSecret,
+      database: validDatabase,
+      magicLink: { enabled: true },
+      email: {
+        from: 'noreply@example.com',
+        provider: { type: 'smtp', properties: { host: 'smtp.example.com', port: 587 } },
+      },
+    },
+  };
+  expect(() => validateAuthConfig({ components, context })).toThrow(
+    'Auth "email" should only have properties "connectionId" and "templates". The old inline "from"/"provider" transport shape moved onto the SMTP connection referenced by "connectionId".'
+  );
 });
 
 test('validateAuthConfig throws on duplicate provider ids', () => {

--- a/packages/build/src/lowdefySchema.js
+++ b/packages/build/src/lowdefySchema.js
@@ -570,105 +570,69 @@ export default {
             },
           },
         },
+        // Auth email references an SMTP connection by id — the connection owns
+        // "from", "replyTo", the transport, and the delivery filter. There is
+        // no inline transport shape; the runtime reads only connectionId and
+        // templates (createSendEmail / renderAuthEmail).
         email: {
           type: 'object',
           additionalProperties: false,
-          required: ['from', 'provider'],
+          required: ['connectionId'],
           properties: {
             '~ignoreBuildChecks': {},
             '~r': {},
             '~l': {},
-            from: {
-              type: ['string', 'object'],
+            connectionId: {
+              type: 'string',
               errorMessage: {
-                type: 'Auth "email.from" should be a string or _secret operator reference.',
+                type: 'Auth "email.connectionId" should be a string — the id of an SMTP connection in "connections".',
               },
             },
-            provider: {
+            templates: {
               type: 'object',
               additionalProperties: false,
-              required: ['type'],
               properties: {
                 '~ignoreBuildChecks': {},
                 '~r': {},
                 '~l': {},
-                type: {
+                verifyEmail: {
                   type: 'string',
-                  enum: ['smtp'],
                   errorMessage: {
-                    type: 'Auth "email.provider.type" should be a string.',
-                    enum: 'Auth "email.provider.type" should be "smtp".',
+                    type: 'Auth "email.templates.verifyEmail" should be a string — a notification id from "notifications".',
                   },
                 },
-                properties: {
-                  type: 'object',
-                  additionalProperties: false,
-                  properties: {
-                    '~ignoreBuildChecks': {},
-                    '~r': {},
-                    '~l': {},
-                    host: {
-                      type: ['string', 'object'],
-                      errorMessage: {
-                        type: 'Auth "email.provider.properties.host" should be a string or _secret operator reference.',
-                      },
-                    },
-                    port: {
-                      type: ['integer', 'object'],
-                      errorMessage: {
-                        type: 'Auth "email.provider.properties.port" should be an integer or _secret operator reference.',
-                      },
-                    },
-                    secure: {
-                      type: ['boolean', 'object'],
-                      errorMessage: {
-                        type: 'Auth "email.provider.properties.secure" should be a boolean or _secret operator reference.',
-                      },
-                    },
-                    auth: {
-                      type: 'object',
-                      additionalProperties: false,
-                      properties: {
-                        '~ignoreBuildChecks': {},
-                        '~r': {},
-                        '~l': {},
-                        user: {
-                          type: ['string', 'object'],
-                          errorMessage: {
-                            type: 'Auth "email.provider.properties.auth.user" should be a string or _secret operator reference.',
-                          },
-                        },
-                        pass: {
-                          type: ['string', 'object'],
-                          errorMessage: {
-                            type: 'Auth "email.provider.properties.auth.pass" should be a string or _secret operator reference.',
-                          },
-                        },
-                      },
-                      errorMessage: {
-                        type: 'Auth "email.provider.properties.auth" should be an object.',
-                      },
-                    },
-                  },
+                resetPassword: {
+                  type: 'string',
                   errorMessage: {
-                    type: 'Auth "email.provider.properties" should be an object.',
+                    type: 'Auth "email.templates.resetPassword" should be a string — a notification id from "notifications".',
+                  },
+                },
+                magicLink: {
+                  type: 'string',
+                  errorMessage: {
+                    type: 'Auth "email.templates.magicLink" should be a string — a notification id from "notifications".',
+                  },
+                },
+                invitation: {
+                  type: 'string',
+                  errorMessage: {
+                    type: 'Auth "email.templates.invitation" should be a string — a notification id from "notifications".',
                   },
                 },
               },
               errorMessage: {
-                type: 'Auth "email.provider" should be an object.',
-                required: {
-                  type: 'Auth "email.provider" should have required property "type".',
-                },
+                type: 'Auth "email.templates" should be an object mapping auth email flows (verifyEmail, resetPassword, magicLink, invitation) to notification ids.',
               },
             },
           },
           errorMessage: {
             type: 'Auth "email" should be an object.',
             required: {
-              from: 'Auth "email" should have required property "from".',
-              provider: 'Auth "email" should have required property "provider".',
+              connectionId:
+                'Auth "email" should have required property "connectionId" — the id of an SMTP connection in "connections". The old inline "from"/"provider" transport shape moved onto the SMTP connection.',
             },
+            additionalProperties:
+              'Auth "email" should only have properties "connectionId" and "templates". The old inline "from"/"provider" transport shape moved onto the SMTP connection referenced by "connectionId".',
           },
         },
         providers: {


### PR DESCRIPTION
## Problem

The auth-emails refactor (bde7575e7) moved auth email onto an app `SMTP` connection — the runtime reads only `auth.email.connectionId` and `auth.email.templates[flow]` — but the build schema still described the pre-refactor shape. That left the current experimental line self-contradictory:

- The old inline `from`/`provider` shape **passes the build** and then breaks every auth email at runtime with `ConfigError: Connection id is missing` (hit in real testing: signup verification emails silently never sent).
- The shape the runtime actually reads (`connectionId`) is **rejected at build** ("Auth must NOT have additional properties").

No config shape both builds and sends mail. (`~ignoreBuildChecks` is not a workaround: the auth schema check throws inside the `buildAuth` step, so suppressing it skips `setAuthConfigured` and the server reports "Auth not configured".)

## Fix

- `lowdefySchema` `authConfig.email`: require `connectionId` (string), allow optional `templates` (`verifyEmail` / `resetPassword` / `magicLink` / `invitation` → notification ids), drop the inline transport shape. Error messages teach the migration.
- Test fixtures updated to the connectionId shape; new cases for templates, missing `connectionId`, and the old shape's teaching rejection.
- Drive-by: two stale assertions in `resolveAuthConfigProjection.test.js` updated to the current `_build.authConfig` error message (failing on the base branch).

Matches the shape documented in `packages/docs/migration/auth-upgrade.yaml` and verified end-to-end against a running app (build passes, verification email delivered via the SMTP connection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)