### PR TITLE
test(build): Restore the authConfig boundary-error assertions to the source message

### DIFF
--- a/packages/build/src/build/buildAuth/resolveAuthConfigProjection.test.js
+++ b/packages/build/src/build/buildAuth/resolveAuthConfigProjection.test.js
@@ -141,7 +141,7 @@ test('resolveAuthConfigProjection collects a self-reference error for _build.aut
   await resolveAuthConfigProjection({ context });
   expect(context.errors).toHaveLength(1);
   expect(context.errors[0].message).toContain(
-    '_build.authConfig cannot be used inside the auth block — the auth config projection is not available while the auth block resolves.'
+    '_build.authConfig is not available here.'
   );
 });
 
@@ -162,6 +162,6 @@ signup:
   await resolveAuthConfigProjection({ context });
   expect(context.errors).toHaveLength(1);
   expect(context.errors[0].message).toContain(
-    '_build.authConfig cannot be used inside the auth block — the auth config projection is not available while the auth block resolves.'
+    '_build.authConfig is not available here.'
   );
 });


### PR DESCRIPTION
PR #2285's drive-by pointed two `resolveAuthConfigProjection` assertions at the old `_build.authConfig` operator error text. That edit was made against a stale local `operators-js` **dist** — the source (ec268620a) throws the "is not available here" boundary message, so the drive-by direction was wrong and the two tests fail wherever the dist is freshly built. This restores the assertions to the source message.

Verified: full `packages/build` suite green (2002/2002) with a freshly built `operators-js` dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)