### PR TITLE
fix(blocks-antd-x): Key AgentChat useChat by conversationId

### DIFF
--- a/.changeset/fix-agentchat-conversation-id.md
+++ b/.changeset/fix-agentchat-conversation-id.md
@@ -1,0 +1,9 @@
+---
+'@lowdefy/blocks-antd-x': patch
+---
+
+fix: AgentChat sends under the current conversationId after a conversation switch
+
+`useChat` was called without an `id`, so the AI SDK created its Chat instance once per mount and captured that transport — the transport rebuilt when the `conversationId` property changed was silently ignored. Every send in a page session therefore posted under the mount-time conversationId: selecting a saved conversation and continuing it persisted the whole restored transcript under the stale id, creating a duplicate conversation document (without the original's data parts).
+
+`useChat` is now keyed by `id: effectiveConversationId`, so changing the conversation swaps the Chat instance and adopts the rebuilt transport. The existing clear-on-id-change and external-message-sync behaviour is unchanged.

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
@@ -109,6 +109,16 @@ function AgentChat({ blockId, components: { Icon }, methods, pageId, properties 
     regenerate,
     clearError,
   } = useChat({
+    // Key the Chat instance by conversation: without an id, useChat creates its
+    // Chat once per mount and CAPTURES that transport — the transport rebuilt by
+    // the useMemo above on a conversationId change is silently ignored, so every
+    // send posts under the mount-time conversationId. Continuing a conversation
+    // the app selected later then persists the whole transcript under the stale
+    // id (a duplicate conversation doc). Keying by id makes useChat swap Chat
+    // instances — and adopt the rebuilt transport — when the conversation
+    // changes; the clear-on-id-change and external-message-sync effects below
+    // compose with the swap unchanged.
+    id: effectiveConversationId,
     transport,
     experimental_throttle: 50,
     sendAutomaticallyWhen: (args) =>


### PR DESCRIPTION
## Summary

`AgentChat` calls `useChat({ transport, ... })` without an `id`. The AI SDK (v5) creates its `Chat` instance once per mount and **captures the transport at construction** — the transport the block carefully rebuilds in `useMemo` when the `conversationId` property changes is silently ignored. Every send in a page session therefore posts to `?conversationId=<mount-time id>`, no matter which conversation the app has since selected.

Observable failure (reproduced against a real app): select a saved conversation, restore its messages via `properties.messages`, ask a new question → the whole restored transcript + new turn is persisted under the **stale mount-time conversationId**, creating a duplicate conversation document (without the original's data parts). Verified in the data: the duplicate doc had `createdAt == updatedAt` (single save), message count = restored + new exchange, zero data parts, and `_id` equal to the page-load id.

## Fix

Key `useChat` by `id: effectiveConversationId`. Changing the conversation then swaps the `Chat` instance — which adopts the rebuilt transport — so sends post under the current conversation. The block's existing clear-on-id-change effect and external-message sync (count + last-ID guard) compose with the swap unchanged: the clear effect's `setMessages([])` and the sync's restore both operate on the new instance.

One-line change plus a changeset (`@lowdefy/blocks-antd-x` patch).

## Test plan

- Reproduced the duplicate-conversation bug in a consuming app (chat page with a conversations sidebar: select saved conversation → continue chatting → new duplicate doc under the mount-time id).
- Applied this exact change via `pnpm patch` in that app: sends land on the selected conversation's id after switching, switching back and forth, and after leave-page-and-return → select; no new duplicate docs.
- No behaviour change for the single-conversation case (stable `id` per mount, same as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
