### PR TITLE
feat(api): resolve a caller awaiting an organization under tenant

### DIFF
--- a/.changeset/feat-org-less-caller.md
+++ b/.changeset/feat-org-less-caller.md
@@ -1,0 +1,9 @@
+---
+'@lowdefy/api': minor
+---
+
+Under `auth.organizations.policy: tenant`, a session carrying no organization now resolves to a caller with identity, no membership and no roles, marked `awaitingOrganization` — the invited user before they accept. Authorization refuses that caller wherever `auth.public` is false, roles or not, so no protected page or request opens up; public pages can now tell an invited user from a stranger.
+
+Fixes the invitation flow under `tenant`: an invited person's pre-accept session resolved to no caller, so the accept page read them as signed out and offered sign-in, which produced another organization-less session and the same screen.
+
+Unchanged under `policy: pinned`, and unchanged for a member removed mid-session, whose session still resolves to unauthenticated.

--- a/.changeset/feat-org-less-caller.md
+++ b/.changeset/feat-org-less-caller.md
@@ -1,9 +1,0 @@
----
-'@lowdefy/api': minor
----
-
-Under `auth.organizations.policy: tenant`, a session carrying no organization now resolves to a caller with identity, no membership and no roles, marked `awaitingOrganization` — the invited user before they accept. Authorization refuses that caller wherever `auth.public` is false, roles or not, so no protected page or request opens up; public pages can now tell an invited user from a stranger.
-
-Fixes the invitation flow under `tenant`: an invited person's pre-accept session resolved to no caller, so the accept page read them as signed out and offered sign-in, which produced another organization-less session and the same screen.
-
-Unchanged under `policy: pinned`, and unchanged for a member removed mid-session, whose session still resolves to unauthenticated.

--- a/packages/api/src/context/createAuthorize.js
+++ b/packages/api/src/context/createAuthorize.js
@@ -25,6 +25,15 @@ function createAuthorize({ user, system }) {
   // resolveAuthentication is the single writer of context.user - a resolved
   // caller object when authenticated, else null.
   const authenticated = !type.isNone(user);
+  // A caller awaiting an organization is signed in and holds no membership -
+  // under tenant, the invited user before they accept (resolveAuthentication).
+  // They are known so the public accept page can address them, and refused
+  // everywhere auth.public is false, roles or not: empty roles is not a wall
+  // (user-model Decision 2), so authenticated alone must not admit them to a
+  // role-less protected page. Strategy callers (apiKey, jwt) also hold no
+  // organization but are deliberately outside the membership boundary, so the
+  // test is this explicit marker, never the absence of an organization.
+  const awaitingOrganization = user?.awaitingOrganization === true;
   const roles = user?.roles ?? [];
   if (!Array.isArray(roles) || roles.some((role) => !type.isString(role))) {
     throw new ConfigError('user.roles must be an array of strings.', {
@@ -42,6 +51,7 @@ function createAuthorize({ user, system }) {
     const { auth } = config;
     if (auth.public === true) return true;
     if (auth.public === false) {
+      if (awaitingOrganization) return false;
       if (auth.roles) {
         return authenticated && auth.roles.some((role) => roles.includes(role));
       }

--- a/packages/api/src/context/createAuthorize.test.js
+++ b/packages/api/src/context/createAuthorize.test.js
@@ -156,6 +156,46 @@ test('an unset context.system applies the normal auth.public / auth.roles matchi
   expect(authorize({ auth: { public: true } })).toBe(true);
 });
 
+test('a caller awaiting an organization is refused wherever auth.public is false', () => {
+  const user = { sub: 'sub', roles: [], awaitingOrganization: true };
+  const authorize = createAuthorize({ user });
+
+  // Public pages must still admit them - the accept page is public, and being
+  // addressable there is the whole point of the state.
+  expect(authorize({ auth: { public: true } })).toBe(true);
+  // Role-less protected pages are the case authenticated-alone would open.
+  expect(authorize({ auth: { public: false } })).toBe(false);
+  expect(authorize({ auth: { public: false, roles: ['role1'] } })).toBe(false);
+});
+
+test('the awaiting-organization marker beats any roles on the caller', () => {
+  // Nothing writes roles onto an awaiting caller today; the marker must win
+  // regardless, so a future writer cannot open a protected page by accident.
+  const user = { sub: 'sub', roles: ['role1'], awaitingOrganization: true };
+  const authorize = createAuthorize({ user });
+
+  expect(authorize({ auth: { public: false, roles: ['role1'] } })).toBe(false);
+});
+
+test('a caller with no organization but no marker is authorized normally', () => {
+  // Strategy callers (apiKey, jwt) hold no organization and are deliberately
+  // outside the membership boundary.
+  const user = { id: 'apiKey:partner-access:acme', roles: ['partner'] };
+  const authorize = createAuthorize({ user });
+
+  expect(authorize({ auth: { public: false } })).toBe(true);
+  expect(authorize({ auth: { public: false, roles: ['partner'] } })).toBe(true);
+});
+
+test('a system context still passes with an awaiting-organization caller', () => {
+  const authorize = createAuthorize({
+    user: { sub: 'sub', awaitingOrganization: true },
+    system: true,
+  });
+
+  expect(authorize({ auth: { public: false } })).toBe(true);
+});
+
 test('throws ConfigError with configKey for location tracing', () => {
   const authorize = createAuthorize({});
   try {

--- a/packages/api/src/context/resolveAuthentication.js
+++ b/packages/api/src/context/resolveAuthentication.js
@@ -18,6 +18,7 @@
 
 import { type } from '@lowdefy/helpers';
 
+import getOrganizationBinding from '../routes/auth/organizations/getOrganizationBinding.js';
 import resolveStrategyCaller from './resolveStrategyCaller.js';
 
 // resolveAuthentication is the single writer of context.user - nothing
@@ -32,10 +33,16 @@ import resolveStrategyCaller from './resolveStrategyCaller.js';
 // every request so membership removal and role changes take effect
 // immediately - roles are deliberately not stamped onto the session. A
 // session whose user holds no member row in the active org resolves to
-// unauthenticated: an invitee's pre-accept session (the session.create
-// carve-out), a stale cookie from another app's deployment, and a member
-// removed mid-session are all treated as logged out, not logged-in with no
-// roles.
+// unauthenticated: a stale cookie from another app's deployment and a member
+// removed mid-session are treated as logged out, not logged-in with no roles.
+//
+// A session carrying no active organization at all is the one case that
+// differs by policy. Under pinned it resolves to unauthenticated on the same
+// reasoning. Under tenant it resolves to a caller carrying identity, no
+// membership and no roles, marked awaitingOrganization - the invited user
+// before they accept. Authorization refuses that caller wherever auth.public
+// is false (createAuthorize), so the marker widens no access; it exists so the
+// public accept page can tell an invited user from a stranger.
 //
 // member.role stores multiple roles as a comma-separated string - split back
 // into the array Lowdefy authorization expects. context.user.attributes is
@@ -64,34 +71,53 @@ async function resolveAuthentication(context, { auth, headers, strategies }) {
   }
   const activeOrganizationId = session.session.activeOrganizationId;
   if (type.isNone(activeOrganizationId)) {
-    context.user = null;
-    return;
+    // Under tenant a session legitimately carries no organization: the invited
+    // user, before they accept. Resolving them to null makes the accept page
+    // unable to tell them from a stranger, and the page it needs is the one
+    // page they can reach. They become a caller carrying identity and no
+    // membership, marked awaitingOrganization - createAuthorize refuses that
+    // caller wherever auth.public is false, so no protected page opens up.
+    // Under pinned the state has no meaning: one organization exists, and
+    // someone outside it has no reason to be known to the app.
+    if (getOrganizationBinding({ auth })?.policy !== 'tenant') {
+      context.user = null;
+      return;
+    }
+    context.user = {
+      ...session.user,
+      roles: [],
+      // The per-organization half of the bag needs a member row, so an
+      // awaiting caller carries the global attributes alone.
+      attributes: session.user.attributes ?? {},
+      awaitingOrganization: true,
+    };
+  } else {
+    const { adapter } = await auth.$context;
+    const member = await adapter.findOne({
+      model: 'member',
+      where: [
+        { field: 'userId', value: session.user.id },
+        { field: 'organizationId', value: activeOrganizationId },
+      ],
+    });
+    if (type.isNone(member)) {
+      context.user = null;
+      return;
+    }
+    const roles = (member.role ?? '')
+      .split(',')
+      .map((role) => role.trim())
+      .filter(Boolean);
+    context.user = {
+      ...session.user,
+      roles,
+      attributes: {
+        ...(session.user.attributes ?? {}),
+        ...(member.attributes ?? {}),
+      },
+      activeOrganizationId,
+    };
   }
-  const { adapter } = await auth.$context;
-  const member = await adapter.findOne({
-    model: 'member',
-    where: [
-      { field: 'userId', value: session.user.id },
-      { field: 'organizationId', value: activeOrganizationId },
-    ],
-  });
-  if (type.isNone(member)) {
-    context.user = null;
-    return;
-  }
-  const roles = (member.role ?? '')
-    .split(',')
-    .map((role) => role.trim())
-    .filter(Boolean);
-  context.user = {
-    ...session.user,
-    roles,
-    attributes: {
-      ...(session.user.attributes ?? {}),
-      ...(member.attributes ?? {}),
-    },
-    activeOrganizationId,
-  };
   // impersonatedBy is a BetterAuth admin plugin session field - present only
   // while an admin is impersonating this session. Steps read it off the
   // settled _user surface, so it is omitted (not set to undefined) when absent.

--- a/packages/api/src/context/resolveAuthentication.test.js
+++ b/packages/api/src/context/resolveAuthentication.test.js
@@ -17,6 +17,7 @@
 import { jest } from '@jest/globals';
 
 import resolveAuthentication from './resolveAuthentication.js';
+import { registerOrganizationBinding } from '../routes/auth/organizations/getOrganizationBinding.js';
 
 function mockAuth({ session, member }) {
   const findOne = jest.fn().mockResolvedValue(member ?? null);
@@ -333,4 +334,90 @@ test('a session rejected by the membership wall does not fall through to strateg
 
   expect(context.user).toBe(null);
   expect(strategies[0].verify).not.toHaveBeenCalled();
+});
+
+test('resolves a caller awaiting an organization when a tenant session carries none', async () => {
+  const { auth, findOne } = mockAuth({
+    session: {
+      user: { id: 'user_1', email: 'invited@example.com', name: 'Invited' },
+      session: { id: 'sess_1' },
+    },
+  });
+  registerOrganizationBinding({ auth, organizations: { policy: 'tenant' } });
+  const context = {};
+
+  await resolveAuthentication(context, { auth, headers: {} });
+
+  expect(context.user).toEqual({
+    id: 'user_1',
+    email: 'invited@example.com',
+    name: 'Invited',
+    roles: [],
+    attributes: {},
+    awaitingOrganization: true,
+  });
+  // No organization means there is no member row to read.
+  expect(findOne).not.toHaveBeenCalled();
+});
+
+test('a caller awaiting an organization carries the global attributes alone', async () => {
+  const { auth } = mockAuth({
+    session: {
+      user: { id: 'user_1', attributes: { region: 'eu' } },
+      session: { id: 'sess_1' },
+    },
+  });
+  registerOrganizationBinding({ auth, organizations: { policy: 'tenant' } });
+  const context = {};
+
+  await resolveAuthentication(context, { auth, headers: {} });
+
+  expect(context.user.attributes).toEqual({ region: 'eu' });
+  expect(context.user.activeOrganizationId).toBeUndefined();
+});
+
+test('a session carrying no organization stays unauthenticated under pinned', async () => {
+  const { auth, findOne } = mockAuth({
+    session: { user: { id: 'user_1' }, session: { id: 'sess_1' } },
+  });
+  registerOrganizationBinding({ auth, organizations: { policy: 'pinned', org: 'team-portal' } });
+  const context = {};
+
+  await resolveAuthentication(context, { auth, headers: {} });
+
+  expect(context.user).toBe(null);
+  expect(findOne).not.toHaveBeenCalled();
+});
+
+test('a tenant member removed mid-session stays unauthenticated', async () => {
+  const { auth } = mockAuth({
+    session: {
+      user: { id: 'user_1' },
+      session: { id: 'sess_1', activeOrganizationId: 'org_1' },
+    },
+    member: null,
+  });
+  registerOrganizationBinding({ auth, organizations: { policy: 'tenant' } });
+  const context = {};
+
+  await resolveAuthentication(context, { auth, headers: {} });
+
+  // Awaiting an organization covers a session carrying none at all. It must
+  // never become a way around revocation.
+  expect(context.user).toBe(null);
+});
+
+test('impersonation rides a caller awaiting an organization', async () => {
+  const { auth } = mockAuth({
+    session: {
+      user: { id: 'user_1' },
+      session: { id: 'sess_1', impersonatedBy: 'admin_1' },
+    },
+  });
+  registerOrganizationBinding({ auth, organizations: { policy: 'tenant' } });
+  const context = {};
+
+  await resolveAuthentication(context, { auth, headers: {} });
+
+  expect(context.user.impersonatedBy).toBe('admin_1');
 });


### PR DESCRIPTION
Implements step 1 of [amendment 1 to the user-model design](https://github.com/lowdefy/lowdefy-design/blob/main/designs/auth-upgrade/concepts/user-model/amendment-1-org-less-caller.md).

## The bug this fixes

Under `auth.organizations.policy: tenant`, an invited person cannot accept their invitation.

Their pre-accept session carries no organization, by design — they are about to join someone else's, so the engine deliberately mints none. But a session with no organization resolved to no caller, and the browser sees the same value the server does (`/user` returns `context.user ?? null`). The accept page reads `_user: id` to decide whether anyone is signed in, so it showed the invited person the "sign in first" screen. They sign in. The new session still has no organization. Same screen. No way out.

This survives testing because someone who signs up *before* being invited already holds an auto-created organization, so their `_user` resolves and the page behaves. The organization we hand out is what makes the accept page work, and the rule that correctly withholds it from invited people is what breaks the page.

## The change

`resolveAuthentication` builds a caller for that session under `tenant`: identity from the session, no `activeOrganizationId`, no roles, the global `attributes` alone, marked `awaitingOrganization`.

`createAuthorize` refuses that caller wherever `auth.public` is false, roles or not. This pairing is the whole safety story and the two halves must not be separated: `createAuthorize` admits any authenticated caller to a `protected: true` page that lists no `roles:`, so without the refusal the new state would open every role-less protected page. Empty roles is not a wall (user-model Decision 2, which this amendment keeps).

The test is the explicit marker, never the absence of an organization — strategy callers (apiKey, jwt) also hold no organization and are outside the membership boundary deliberately (user-model open question, "API strategy callers").

Unchanged under `pinned`, where the state has no meaning. Unchanged for a member removed mid-session, who still resolves to unauthenticated: awaiting an organization covers a session carrying none at all, and must not become a way around revocation.

No module change is needed — the accept page is public, and a public page now receives the caller.

## Deliberately not in this PR

- **The tenant wall's explicit refusal.** Today nothing can reach a walled request without an organization because there is no such caller; that safety is an accident of the missing state rather than a rule, so the wall must state it. The wall source is not on `auth-upgrade` (it lives on `feat/mongodb-tenant-wall`), so there is nothing to open here — but the merge that brings the wall must bring the refusal with it.
- **A per-page opt-in** (`requireOrganization`). No page needs it yet: page auth is authored app-level (`auth.pages.protected` / `public`) and `getAlwaysPublicPageIds` forces `authPages` pages public, so the accept page — and any future create-organization page — is public either way.
- **`authPages.organization`**, the destination for a refused organization-less caller. Nothing to point it at until organizations can be created self-serve. Until then such a caller navigating to a protected page gets the standard `/404`, where they previously got a sign-in page that could not help them.
- **`organizations.create: auto | self-serve | operator`**, and extending `signup: invite-only` to `tenant` (accepted and silently ignored there today).

## Verification

`packages/api`: 78 suites, 791 tests pass. New tests cover the tenant caller, the pinned no-change, mid-session revocation, impersonation, the authorization refusal, the marker beating roles, and strategy callers staying authorized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)