### PR TITLE
Fix dev-server JIT building-screen strand after login

### DIFF
--- a/packages/api/src/context/resolveAuthentication.js
+++ b/packages/api/src/context/resolveAuthentication.js
@@ -64,6 +64,9 @@ async function resolveAuthentication(context, { auth, headers, strategies }) {
   }
   const activeOrganizationId = session.session.activeOrganizationId;
   if (type.isNone(activeOrganizationId)) {
+    context.logger.debug(
+      `Session for user "${session.user.id}" has no active organization - resolved unauthenticated.`
+    );
     context.user = null;
     return;
   }
@@ -76,6 +79,9 @@ async function resolveAuthentication(context, { auth, headers, strategies }) {
     ],
   });
   if (type.isNone(member)) {
+    context.logger.debug(
+      `User "${session.user.id}" has no member row in organization "${activeOrganizationId}" - resolved unauthenticated.`
+    );
     context.user = null;
     return;
   }

--- a/packages/api/src/context/resolveAuthentication.test.js
+++ b/packages/api/src/context/resolveAuthentication.test.js
@@ -54,12 +54,15 @@ test('sets context.user to null when the session has no active organization', as
   const { auth, findOne } = mockAuth({
     session: { user: { id: 'user_1' }, session: { id: 'sess_1' } },
   });
-  const context = {};
+  const context = { logger: mockLogger() };
 
   await resolveAuthentication(context, { auth, headers: {} });
 
   expect(context.user).toBe(null);
   expect(findOne).not.toHaveBeenCalled();
+  expect(context.logger.debug).toHaveBeenCalledWith(
+    'Session for user "user_1" has no active organization - resolved unauthenticated.'
+  );
 });
 
 test('sets context.user to null when the user holds no member row in the active org', async () => {
@@ -70,7 +73,7 @@ test('sets context.user to null when the user holds no member row in the active 
     },
     member: null,
   });
-  const context = {};
+  const context = { logger: mockLogger() };
 
   await resolveAuthentication(context, { auth, headers: {} });
 
@@ -82,6 +85,9 @@ test('sets context.user to null when the user holds no member row in the active 
       { field: 'organizationId', value: 'org_1' },
     ],
   });
+  expect(context.logger.debug).toHaveBeenCalledWith(
+    'User "user_1" has no member row in organization "org_1" - resolved unauthenticated.'
+  );
 });
 
 test('resolves roles from the active member row, splitting the CSV role string', async () => {

--- a/packages/servers/server-dev/client/Page.jsx
+++ b/packages/servers/server-dev/client/Page.jsx
@@ -20,7 +20,7 @@ import Client from '@lowdefy/client';
 
 import BuildErrorPage from '../lib/client/BuildErrorPage.jsx';
 import InstallingPluginsPage from '../lib/client/InstallingPluginsPage.jsx';
-import RestartingPage from '../lib/client/RestartingPage.jsx';
+import RedirectingPage from '../lib/client/RedirectingPage.jsx';
 import usePageConfig from '../lib/client/utils/usePageConfig.js';
 
 const Page = ({
@@ -47,9 +47,21 @@ const Page = ({
     }
   }, [pageConfig?._warnings, lowdefy]);
 
+  // Full load to the sign-in page so it can return here after sign-in — an
+  // effect, not a fetcher side effect, so the redirect re-fires if the same
+  // cached result renders again.
+  useEffect(() => {
+    if (pageConfig?.authRedirect) {
+      window.location.assign(pageConfig.authRedirect);
+    }
+  }, [pageConfig?.authRedirect]);
+
   if (!pageConfig) {
     router.replace({ pathname: '/404' });
     return '';
+  }
+  if (pageConfig.authRedirect) {
+    return <RedirectingPage redirect={pageConfig.authRedirect} />;
   }
   if (pageConfig.buildError) {
     return (
@@ -62,9 +74,6 @@ const Page = ({
   }
   if (pageConfig.installing) {
     return <InstallingPluginsPage packages={pageConfig.packages} />;
-  }
-  if (resetContext.restarting) {
-    return <RestartingPage />;
   }
 
   // Merge dynamic JS entries fetched after JIT build with the static jsMap

--- a/packages/servers/server-dev/client/Reload.jsx
+++ b/packages/servers/server-dev/client/Reload.jsx
@@ -28,9 +28,9 @@ const Reload = ({ children, basePath, lowdefy }) => {
   // reset is a one-shot boolean the engine lowers only after a page mounts
   // (getContext.js) — while a page is suspended it stays true and setReset(true)
   // bails out of re-rendering. The tick always changes, so every reload event
-  // re-renders Routing, which re-reads reloadVersion and mints a fresh
-  // Suspense/SWR key — a suspended tab recovers instead of stranding on the
-  // building screen.
+  // re-invokes Routing's render prop, which re-reads reloadVersion and mints a
+  // fresh Suspense/SWR key — a suspended tab recovers instead of stranding on
+  // the building screen.
   const [, setReloadTick] = useState(0);
   const mutateCache = useMutateCache(basePath);
   useEffect(() => {

--- a/packages/servers/server-dev/client/Reload.jsx
+++ b/packages/servers/server-dev/client/Reload.jsx
@@ -25,6 +25,13 @@ import waitForRestartedServer from '../lib/client/utils/waitForRestartedServer.j
 const Reload = ({ children, basePath, lowdefy }) => {
   const [reset, setReset] = useState(false);
   const [restarting, setRestarting] = useState(false);
+  // reset is a one-shot boolean the engine lowers only after a page mounts
+  // (getContext.js) — while a page is suspended it stays true and setReset(true)
+  // bails out of re-rendering. The tick always changes, so every reload event
+  // re-renders Routing, which re-reads reloadVersion and mints a fresh
+  // Suspense/SWR key — a suspended tab recovers instead of stranding on the
+  // building screen.
+  const [, setReloadTick] = useState(0);
   const mutateCache = useMutateCache(basePath);
   useEffect(() => {
     const sse = new EventSource(`${basePath}/api/reload`);
@@ -38,6 +45,7 @@ const Reload = ({ children, basePath, lowdefy }) => {
           lowdefy._internal.initialised = false;
         }
         setReset(true);
+        setReloadTick((tick) => tick + 1);
         console.log('Reloaded config.');
       }, 600);
     });

--- a/packages/servers/server-dev/client/Routing.jsx
+++ b/packages/servers/server-dev/client/Routing.jsx
@@ -20,6 +20,7 @@ import Head from '@lowdefy/client/adapters/Head.js';
 import createLinkComponent from '@lowdefy/client/adapters/Link.js';
 
 import BuildingPage from '../lib/client/BuildingPage.jsx';
+import RestartingPage from '../lib/client/RestartingPage.jsx';
 import FeedbackMount from './feedback/FeedbackMount.jsx';
 import Inspector from './Inspector.jsx';
 import OpenInEditorListener from './openInEditor/OpenInEditorListener.jsx';
@@ -75,29 +76,36 @@ function Routing({ auth, lowdefy, router }) {
       <FeedbackMount basePath={router.basePath} lowdefy={lowdefy} pageId={pageId} />
       <OpenInEditorListener basePath={router.basePath} pageId={pageId} />
       <Reload basePath={router.basePath} lowdefy={lowdefy}>
-        {(resetContext) => (
-          <Suspense key={`${pageId}_${getReloadVersion()}`} fallback={<BuildingPage />}>
-            <Page
-              auth={auth}
-              Components={{ Head, Link }}
-              config={{
-                rootConfig,
-              }}
-              jsMap={staticJsMap}
-              lowdefy={lowdefy}
-              pageId={pageId}
-              resetContext={resetContext}
-              router={router}
-              types={{
-                actions,
-                blockMetas,
-                blocks,
-                icons,
-                operators,
-              }}
-            />
-          </Suspense>
-        )}
+        {(resetContext) =>
+          // Rendered here, not in Page — Page sits below the Suspense boundary
+          // and cannot render anything while its config fetch is suspended, so
+          // a restarting server would present as "Building page..." forever.
+          resetContext.restarting ? (
+            <RestartingPage />
+          ) : (
+            <Suspense key={`${pageId}_${getReloadVersion()}`} fallback={<BuildingPage />}>
+              <Page
+                auth={auth}
+                Components={{ Head, Link }}
+                config={{
+                  rootConfig,
+                }}
+                jsMap={staticJsMap}
+                lowdefy={lowdefy}
+                pageId={pageId}
+                resetContext={resetContext}
+                router={router}
+                types={{
+                  actions,
+                  blockMetas,
+                  blocks,
+                  icons,
+                  operators,
+                }}
+              />
+            </Suspense>
+          )
+        }
       </Reload>
     </>
   );

--- a/packages/servers/server-dev/lib/client/RedirectingPage.jsx
+++ b/packages/servers/server-dev/lib/client/RedirectingPage.jsx
@@ -1,0 +1,56 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import React from 'react';
+
+// Shown while the 401 sign-in redirect navigates. The link is the escape
+// hatch for a dropped navigation - the tab must never depend on a single
+// window.location.assign to leave this screen.
+const RedirectingPage = ({ redirect }) => {
+  return (
+    <div
+      style={{
+        height: '100vh',
+        textAlign: 'center',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'var(--ant-color-bg-layout)',
+        color: 'var(--ant-color-text)',
+        fontFamily:
+          "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
+      }}
+    >
+      <div
+        style={{
+          verticalAlign: 'middle',
+          display: 'inline-block',
+        }}
+      >
+        <h3>Redirecting to sign-in...</h3>
+        <p>
+          <a href={redirect} style={{ color: 'var(--ant-color-primary)' }}>
+            Continue to sign-in
+          </a>{' '}
+          if you are not redirected automatically.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default RedirectingPage;

--- a/packages/servers/server-dev/lib/client/utils/usePageConfig.js
+++ b/packages/servers/server-dev/lib/client/utils/usePageConfig.js
@@ -29,7 +29,9 @@ function parseJsModule(text) {
 
 async function fetchJsEntries(basePath) {
   try {
-    const res = await fetch(`${basePath}/api/js/client`);
+    const res = await fetch(`${basePath}/api/js/client`, {
+      signal: AbortSignal.timeout(10_000),
+    });
     if (!res.ok) return {};
     return parseJsModule(await res.text());
   } catch {
@@ -39,7 +41,9 @@ async function fetchJsEntries(basePath) {
 
 async function fetchDynamicIcons(basePath) {
   try {
-    const res = await fetch(`${basePath}/api/icons/dynamic`);
+    const res = await fetch(`${basePath}/api/icons/dynamic`, {
+      signal: AbortSignal.timeout(10_000),
+    });
     if (!res.ok) return {};
     return parseJsModule(await res.text());
   } catch {
@@ -48,18 +52,37 @@ async function fetchDynamicIcons(basePath) {
 }
 
 async function fetchPageConfig(url) {
-  const res = await fetch(url, {
-    headers: { 'Content-Type': 'application/json' },
-  });
+  // A stalled request (server restart mid-request, exhausted sockets) must
+  // become a visible error, never an eternal Suspense fallback — the reload
+  // recovery path cannot fire while the page tree is suspended.
+  let res;
+  try {
+    res = await fetch(url, {
+      headers: { 'Content-Type': 'application/json' },
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (error) {
+    if (error.name === 'TimeoutError' || error.name === 'AbortError') {
+      throw new Error(
+        `Page config request "${url}" timed out - the dev server may be restarting. Reload the page.`
+      );
+    }
+    throw error;
+  }
   if (res.status === 404) {
     return null;
   }
   if (res.status === 401) {
-    // Logged-out navigation to a protected page - full load to the login
-    // page so it can return here after sign-in.
+    // Logged-out navigation to a protected page - Page renders a redirect
+    // screen and full-loads to the login page so it can return here after
+    // sign-in. Returning a settled value (never a parked promise) keeps the
+    // SWR key healthy: if the navigation is dropped, the tab still recovers
+    // on the next reload event or via the manual link on the redirect screen.
     const { redirect } = await res.json();
-    window.location.assign(redirect ?? '/404');
-    return new Promise(() => {});
+    const basePath = url.replace(/\/api\/page\/.*$/, '');
+    const authRedirect = redirect ?? `${basePath}/404`;
+    console.warn(`Lowdefy dev: "${url}" returned 401 - redirecting to "${authRedirect}".`);
+    return { authRedirect };
   }
   const data = await res.json();
   if (data?.buildError) {

--- a/packages/servers/server-dev/lib/client/utils/usePageConfig.js
+++ b/packages/servers/server-dev/lib/client/utils/usePageConfig.js
@@ -52,6 +52,7 @@ async function fetchDynamicIcons(basePath) {
 }
 
 async function fetchPageConfig(url) {
+  const basePath = url.replace(/\/api\/page\/.*$/, '');
   // A stalled request (server restart mid-request, exhausted sockets) must
   // become a visible error, never an eternal Suspense fallback — the reload
   // recovery path cannot fire while the page tree is suspended.
@@ -79,7 +80,6 @@ async function fetchPageConfig(url) {
     // SWR key healthy: if the navigation is dropped, the tab still recovers
     // on the next reload event or via the manual link on the redirect screen.
     const { redirect } = await res.json();
-    const basePath = url.replace(/\/api\/page\/.*$/, '');
     const authRedirect = redirect ?? `${basePath}/404`;
     console.warn(`Lowdefy dev: "${url}" returned 401 - redirecting to "${authRedirect}".`);
     return { authRedirect };
@@ -97,8 +97,6 @@ async function fetchPageConfig(url) {
 
   // Fetch jsMap and dynamic icons after page build completes
   // (JIT build may have added new entries).
-  // Extract basePath from the URL to construct the endpoints.
-  const basePath = url.replace(/\/api\/page\/.*$/, '');
   const [jsEntries, dynamicIcons] = await Promise.all([
     fetchJsEntries(basePath),
     fetchDynamicIcons(basePath),

--- a/packages/servers/server-dev/src/routes/jitPage.js
+++ b/packages/servers/server-dev/src/routes/jitPage.js
@@ -77,6 +77,9 @@ async function jitPageHandler(c) {
     // The client follows this redirect with a full page load, so the login
     // page can return to the requested page after sign-in.
     const callbackUrl = `${basePath}/${pageId}`;
+    context.logger.debug(
+      `Page config request for "${pageId}" resolved unauthenticated - returning a sign-in redirect.`
+    );
     return c.json(
       {
         redirect: `${basePath}${authJson.authPages.signIn}?callbackUrl=${encodeURIComponent(


### PR DESCRIPTION
## Summary

Investigating the demo-app auth-testing findings (users-fixes F12) showed the dev client can permanently strand a tab on the "Building page…" screen right after a login redirect — a new tab on the same URL always cleared it. The screen is the Suspense fallback around the `/api/page` fetch, and three compounding traps made it permanent: the 401 handler returned a never-settling promise that poisoned the tab's SWR key, the SSE reload recovery signal was a one-shot boolean the engine can only lower after a page mounts (unreachable while suspended), and no page-config fetch had a timeout. This PR makes the dev client un-strandable and adds observability for the trigger.

## Changes

- **@lowdefy/server-dev**: The 401 page-config path now settles with an `authRedirect` value rendered as a redirect screen (with a manual sign-in link as escape hatch) and navigates from an effect. A monotonic reload tick re-renders Routing on every SSE reload event so suspended tabs mint fresh Suspense/SWR keys and recover. All three page-config fetches get `AbortSignal.timeout`, turning stalls into visible ErrorBoundary errors. `RestartingPage` is hoisted above the Suspense boundary so restarts no longer present as "Building page…". Unauthenticated page-config requests are debug-logged.
- **@lowdefy/api**: `resolveAuthentication` debug-logs its two silent unauthenticated exits (session without an active organization, member-row miss) so a 401-after-login is explained by one log line. Membership-wall semantics are unchanged.

## Notes

- The `jitPage.js` 401 response contract (frozen dev-client contract) is unchanged — only the client-side handling of it changed.
- Root-cause analysis lives in the modules-mongodb repo at `designs/users-fixes/06-investigate/findings.md` (F12). The sibling findings F11 (Login without callbackUrl never navigates) and F19 (UpdateSession never refreshes the client session store) are separate framework bugs, deferred to their own passes — this fix de-flakes their verification.
- Verified: full `@lowdefy/api` (782) and `@lowdefy/server-dev` (155) test suites pass, including new log assertions. Live browser checks (blocked redirect, reload-while-suspended recovery, restart visibility, timeout) still need a protected-pages dev app — planned against the modules-mongodb demo on the next experimental snapshot.
- No changeset on this PR by choice — versioning is batched on the auth-upgrade branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)