### PR TITLE
Resolve Dynamic page content from urlQuery under e2e

### DIFF
--- a/.changeset/fix-e2e-utils-set-url-query-router.md
+++ b/.changeset/fix-e2e-utils-set-url-query-router.md
@@ -6,4 +6,4 @@ fix: Set urlQuery through the app router.
 
 `ldf.urlQuery('key').do.set(value)` called `history.pushState` directly, which changed the URL without notifying the Lowdefy router. The page config was never re-fetched, so a Dynamic page kept showing content resolved from the previous query and tests asserting on the update failed.
 
-`do.set` now navigates through the app's router — the same path a `Link` or `SetUrlQuery` action takes — and waits for the re-resolved page config to arrive before resolving, so a following assertion cannot read stale content.
+`do.set` now navigates through the app's router — the same path a `Link` or `SetUrlQuery` action takes. On a Dynamic page it waits for the engine to rebuild the page context from the newly resolved config, so a following assertion or `value()` read cannot see content resolved from the previous query.

--- a/.changeset/fix-e2e-utils-set-url-query-router.md
+++ b/.changeset/fix-e2e-utils-set-url-query-router.md
@@ -1,0 +1,9 @@
+---
+'@lowdefy/e2e-utils': patch
+---
+
+fix: Set urlQuery through the app router.
+
+`ldf.urlQuery('key').do.set(value)` called `history.pushState` directly, which changed the URL without notifying the Lowdefy router. The page config was never re-fetched, so a Dynamic page kept showing content resolved from the previous query and tests asserting on the update failed.
+
+`do.set` now navigates through the app's router — the same path a `Link` or `SetUrlQuery` action takes — and waits for the re-resolved page config to arrive before resolving, so a following assertion cannot read stale content.

--- a/.changeset/fix-server-e2e-page-url-query.md
+++ b/.changeset/fix-server-e2e-page-url-query.md
@@ -1,0 +1,12 @@
+---
+'@lowdefy/server-e2e': patch
+---
+
+fix: Pass urlQuery to getPageConfig in the e2e server.
+
+Dynamic pages built with `lowdefy build --server e2e` received an empty `urlQuery` object, so endpoints reading `_payload: urlQuery.*` resolved no URL parameters. Pages that work in development and production failed only under e2e tests.
+
+The e2e server now resolves dynamic content with the request query string on both paths, matching `@lowdefy/server`:
+
+- The initial HTML render passes `urlQuery` to `getPageConfig`.
+- Client-side navigation forwards the current query string on its `/api/page/*` fetch, and the route reads it.

--- a/packages/servers/server-e2e/client/Page.jsx
+++ b/packages/servers/server-e2e/client/Page.jsx
@@ -47,7 +47,11 @@ function Page({ auth, config, lowdefy }) {
     const unsubscribe = router.subscribe(async ({ pageId }) => {
       const targetPageId = pageId ?? config.rootConfig.home.pageId;
       try {
-        const res = await fetch(`${router.basePath}/api/page/${targetPageId}`);
+        // Forward the current query string so server-side Dynamic block
+        // resolution sees the same urlQuery as an initial HTML load.
+        const res = await fetch(
+          `${router.basePath}/api/page/${targetPageId}${window.location.search}`
+        );
         if (!res.ok) {
           if (targetPageId !== '404') {
             router.replace({ pathname: '/404' });

--- a/packages/servers/server-e2e/src/html/renderPage.js
+++ b/packages/servers/server-e2e/src/html/renderPage.js
@@ -42,7 +42,10 @@ async function renderPage(c, { pageId, status = 200 }) {
     resolvedPageId = home.pageId;
   }
 
-  const pageConfig = await getPageConfig(context, { pageId: resolvedPageId });
+  const pageConfig = await getPageConfig(context, {
+    pageId: resolvedPageId,
+    urlQuery: c.req.query(),
+  });
 
   if (!pageConfig) {
     if (resolvedPageId === '404') {

--- a/packages/servers/server-e2e/src/routes/apiPage.js
+++ b/packages/servers/server-e2e/src/routes/apiPage.js
@@ -23,7 +23,9 @@ import getPathSegments from '../lib/getPathSegments.js';
 async function apiPageHandler(c) {
   const context = c.get('lowdefyContext');
   const pageId = getPathSegments(c, '/api/page/').join('/');
-  const pageConfig = await getPageConfig(context, { pageId });
+  // The client forwards its current query string on the fetch so Dynamic block
+  // resolution sees the same urlQuery as an initial HTML load.
+  const pageConfig = await getPageConfig(context, { pageId, urlQuery: c.req.query() });
   if (!pageConfig) {
     context.logger.info({ event: 'api_page_not_found', pageId });
     return c.json({ pageConfig: null }, 404);

--- a/packages/utils/e2e-utils/README.md
+++ b/packages/utils/e2e-utils/README.md
@@ -151,6 +151,8 @@ await ldf.url().expect.toMatch(/\/tickets\/\d+/);
 
 // Query params
 await ldf.urlQuery('filter').expect.toBe('active');
+// do.set navigates through the app router, so a Dynamic page re-resolves its
+// content for the new query before this resolves.
 await ldf.urlQuery('page').do.set('2');
 
 // Get raw values

--- a/packages/utils/e2e-utils/src/core/url.js
+++ b/packages/utils/e2e-utils/src/core/url.js
@@ -14,7 +14,25 @@
   limitations under the License.
 */
 
+import { type } from '@lowdefy/helpers';
+
 import { waitForReady } from './navigation.js';
+
+// The client router's createUrl prepends basePath, so the pathname handed to it
+// must have basePath stripped or a basePath app receives it twice.
+function createTargetLocation({ basePath = '', href, key, value }) {
+  const url = new URL(href);
+  if (type.isNone(value)) {
+    url.searchParams.delete(key);
+  } else {
+    url.searchParams.set(key, value);
+  }
+  const pathname =
+    basePath && url.pathname.startsWith(basePath)
+      ? url.pathname.slice(basePath.length)
+      : url.pathname;
+  return { pathname, query: url.searchParams.toString() };
+}
 
 // Navigates through the app's own router rather than calling history.pushState
 // directly. A bare pushState updates the URL without notifying the router, so
@@ -22,41 +40,61 @@ import { waitForReady } from './navigation.js';
 // resolved from the previous urlQuery. Routing through the router is what a
 // Link or SetUrlQuery action in the app does.
 async function setUrlQuery(page, { key, value }) {
-  // A router navigation always re-fetches the page config, so wait for that
-  // response before returning — otherwise a test can read a Dynamic page before
-  // the content resolved from the new urlQuery has been applied. Listening
-  // starts before the navigation so the response cannot be missed. On timeout,
-  // fall through and let the test's own assertion report the failure.
+  const { basePath, dynamic, href } = await page.evaluate(() => {
+    const lowdefy = window.lowdefy;
+    const router = lowdefy?._internal?.router;
+    if (!router) {
+      throw new Error('Lowdefy client not initialized. Call goto() before setting urlQuery.');
+    }
+    return {
+      basePath: router.basePath ?? '',
+      dynamic: lowdefy.contexts[`page:${lowdefy.pageId}`]?._internal?.pageConfig?.dynamic === true,
+      href: window.location.href,
+    };
+  });
+
+  // A router navigation always re-fetches the page config, and blocks reading
+  // _url_query re-render only once that config is applied. Listening starts
+  // before the navigation so the response cannot be missed.
   const pageConfigFetched = page
     .waitForResponse((response) => response.url().includes('/api/page/'), { timeout: 30000 })
-    .catch(() => undefined);
+    .catch((error) => {
+      // A response that never arrives must not hang the suite — fall through and
+      // let the test's own assertion report it. Anything else is a real fault.
+      if (error.name !== 'TimeoutError') throw error;
+    });
 
-  await page.evaluate(
-    ({ k, v }) => {
-      const router = window.lowdefy?._internal?.router;
-      if (!router) {
-        throw new Error('Lowdefy client not initialized. Call goto() before setting urlQuery.');
-      }
-      const url = new URL(window.location.href);
-      if (v === null || v === undefined) {
-        url.searchParams.delete(k);
-      } else {
-        url.searchParams.set(k, v);
-      }
-      const basePath = router.basePath ?? '';
-      const pathname =
-        basePath && url.pathname.startsWith(basePath)
-          ? url.pathname.slice(basePath.length)
-          : url.pathname;
-      // scroll: false keeps the viewport where it was — a query change is not a
-      // page navigation from the test's point of view.
-      router.push({ pathname, query: url.searchParams.toString(), scroll: false });
-    },
-    { k: key, v: value }
-  );
+  // A Dynamic page's content is resolved server-side from urlQuery, and the
+  // engine rebuilds its context whenever a new config object arrives (see
+  // getContext). Waiting for that rebuild proves the re-resolved content is in
+  // place; the response arriving only proves it is on its way. Static pages keep
+  // a memoized context, so there is no identity change to wait for.
+  const previousPageConfig = dynamic
+    ? await page.evaluateHandle(
+        () => window.lowdefy.contexts[`page:${window.lowdefy.pageId}`]._internal.pageConfig
+      )
+    : null;
+
+  await page.evaluate(({ pathname, query }) => {
+    // scroll: false keeps the viewport where it was — a query change is not a
+    // page navigation from the test's point of view.
+    window.lowdefy._internal.router.push({ pathname, query, scroll: false });
+  }, createTargetLocation({ basePath, href, key, value }));
 
   await pageConfigFetched;
+
+  if (previousPageConfig) {
+    await page.waitForFunction(
+      (previous) =>
+        window.lowdefy.contexts[`page:${window.lowdefy.pageId}`]?._internal?.pageConfig !==
+        previous,
+      previousPageConfig,
+      { timeout: 30000 }
+    );
+    await previousPageConfig.dispose();
+  }
+
   await waitForReady(page);
 }
 
-export { setUrlQuery };
+export { createTargetLocation, setUrlQuery };

--- a/packages/utils/e2e-utils/src/core/url.js
+++ b/packages/utils/e2e-utils/src/core/url.js
@@ -14,19 +14,49 @@
   limitations under the License.
 */
 
+import { waitForReady } from './navigation.js';
+
+// Navigates through the app's own router rather than calling history.pushState
+// directly. A bare pushState updates the URL without notifying the router, so
+// the page config is never re-fetched and Dynamic pages keep serving content
+// resolved from the previous urlQuery. Routing through the router is what a
+// Link or SetUrlQuery action in the app does.
 async function setUrlQuery(page, { key, value }) {
+  // A router navigation always re-fetches the page config, so wait for that
+  // response before returning — otherwise a test can read a Dynamic page before
+  // the content resolved from the new urlQuery has been applied. Listening
+  // starts before the navigation so the response cannot be missed. On timeout,
+  // fall through and let the test's own assertion report the failure.
+  const pageConfigFetched = page
+    .waitForResponse((response) => response.url().includes('/api/page/'), { timeout: 30000 })
+    .catch(() => undefined);
+
   await page.evaluate(
     ({ k, v }) => {
+      const router = window.lowdefy?._internal?.router;
+      if (!router) {
+        throw new Error('Lowdefy client not initialized. Call goto() before setting urlQuery.');
+      }
       const url = new URL(window.location.href);
       if (v === null || v === undefined) {
         url.searchParams.delete(k);
       } else {
         url.searchParams.set(k, v);
       }
-      window.history.pushState({}, '', url);
+      const basePath = router.basePath ?? '';
+      const pathname =
+        basePath && url.pathname.startsWith(basePath)
+          ? url.pathname.slice(basePath.length)
+          : url.pathname;
+      // scroll: false keeps the viewport where it was — a query change is not a
+      // page navigation from the test's point of view.
+      router.push({ pathname, query: url.searchParams.toString(), scroll: false });
     },
     { k: key, v: value }
   );
+
+  await pageConfigFetched;
+  await waitForReady(page);
 }
 
 export { setUrlQuery };

--- a/packages/utils/e2e-utils/src/core/url.test.js
+++ b/packages/utils/e2e-utils/src/core/url.test.js
@@ -1,0 +1,111 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { createTargetLocation } from './url.js';
+
+test('createTargetLocation adds a query key to a url that has none', () => {
+  expect(
+    createTargetLocation({ href: 'http://localhost:3000/items', key: 'page', value: '2' })
+  ).toEqual({ pathname: '/items', query: 'page=2' });
+});
+
+test('createTargetLocation overwrites an existing query key', () => {
+  expect(
+    createTargetLocation({ href: 'http://localhost:3000/items?page=1', key: 'page', value: '2' })
+  ).toEqual({ pathname: '/items', query: 'page=2' });
+});
+
+test('createTargetLocation preserves unrelated query keys', () => {
+  expect(
+    createTargetLocation({
+      href: 'http://localhost:3000/items?filter=active&page=1',
+      key: 'page',
+      value: '2',
+    })
+  ).toEqual({ pathname: '/items', query: 'filter=active&page=2' });
+});
+
+test('createTargetLocation deletes the query key when value is null', () => {
+  expect(
+    createTargetLocation({
+      href: 'http://localhost:3000/items?filter=active&page=1',
+      key: 'page',
+      value: null,
+    })
+  ).toEqual({ pathname: '/items', query: 'filter=active' });
+});
+
+test('createTargetLocation deletes the query key when value is undefined', () => {
+  expect(createTargetLocation({ href: 'http://localhost:3000/items?page=1', key: 'page' })).toEqual(
+    { pathname: '/items', query: '' }
+  );
+});
+
+test('createTargetLocation keeps a value of 0, which is not a none value', () => {
+  expect(
+    createTargetLocation({ href: 'http://localhost:3000/items', key: 'page', value: 0 })
+  ).toEqual({ pathname: '/items', query: 'page=0' });
+});
+
+test('createTargetLocation keeps an empty string value, which is not a none value', () => {
+  expect(
+    createTargetLocation({ href: 'http://localhost:3000/items', key: 'filter', value: '' })
+  ).toEqual({ pathname: '/items', query: 'filter=' });
+});
+
+test('createTargetLocation strips basePath from the pathname so the router does not double it', () => {
+  expect(
+    createTargetLocation({
+      basePath: '/app',
+      href: 'http://localhost:3000/app/items?page=1',
+      key: 'page',
+      value: '2',
+    })
+  ).toEqual({ pathname: '/items', query: 'page=2' });
+});
+
+test('createTargetLocation leaves the pathname alone when it does not start with basePath', () => {
+  expect(
+    createTargetLocation({
+      basePath: '/app',
+      href: 'http://localhost:3000/items',
+      key: 'page',
+      value: '2',
+    })
+  ).toEqual({ pathname: '/items', query: 'page=2' });
+});
+
+test('createTargetLocation returns the root pathname for the home page', () => {
+  expect(createTargetLocation({ href: 'http://localhost:3000/', key: 'page', value: '2' })).toEqual(
+    { pathname: '/', query: 'page=2' }
+  );
+});
+
+test('createTargetLocation encodes values that need escaping', () => {
+  expect(
+    createTargetLocation({ href: 'http://localhost:3000/items', key: 'q', value: 'a b&c' })
+  ).toEqual({ pathname: '/items', query: 'q=a+b%26c' });
+});
+
+test('createTargetLocation keeps nested page ids in the pathname', () => {
+  expect(
+    createTargetLocation({
+      href: 'http://localhost:3000/users/settings?tab=profile',
+      key: 'tab',
+      value: 'billing',
+    })
+  ).toEqual({ pathname: '/users/settings', query: 'tab=billing' });
+});


### PR DESCRIPTION
## Summary

A Dynamic page's endpoint reading `_payload: urlQuery.*` received an empty `urlQuery` object under `lowdefy build --server e2e`, while working correctly in development and production. Pages that function fine for users produced false e2e test failures.

The e2e server scaffold omitted `urlQuery` at both `getPageConfig` call sites. Fixing those surfaced a second gap in the same path: the e2e client never sent a query string on its SPA page-config fetch, and the e2e harness's `setUrlQuery` mutated the URL behind the router's back, so a Dynamic page never re-resolved.

## Changes

- **@lowdefy/server-e2e**: Pass `urlQuery` to `getPageConfig` on the initial HTML render and on the `/api/page/*` route, matching `@lowdefy/server`. The SPA page-config fetch in `client/Page.jsx` now appends `window.location.search` so the route has a query string to read — without this the route fix is inert on client-side navigation. `src/routes/apiPage.js` is now byte-identical to the production server's module, and `client/Page.jsx` differs only by the intentional `stage="e2e"` prop.
- **@lowdefy/e2e-utils**: `ldf.urlQuery(key).do.set(value)` navigates through the app's router instead of calling `history.pushState` directly. A bare `pushState` never notifies the router, so the page config was never re-fetched. `do.set` now also waits for the re-resolved config to arrive, so a following assertion cannot read stale content.

## Notes

- `router.push` was chosen over dispatching a synthetic `popstate` because it is the path a `Link` or `SetUrlQuery` action takes — the harness simulates the app rather than manipulating history directly. It relies on `window.lowdefy` being exposed for `stage === 'e2e'`, which `waitForReady` already depends on.
- `setUrlQuery` throws when the router is absent rather than falling back to `pushState`; a silent fallback would reintroduce the bug invisibly.
- Behaviour change for test authors: `do.set` now triggers a page-config fetch and awaits it. The wait is bounded at 30s and swallows only the timeout, so a missing response cannot hang a suite — the test's own assertion reports the real failure.
- **No tests added.** Neither server package has unit tests for these route modules, and there is no dynamic-page e2e fixture to regression-test against. The client-side half of this fix is exactly the kind of thing that regresses silently, so a fixture app with a Dynamic page reading `urlQuery` is a worthwhile follow-up.
- The module consolidation the issue suggests is not done here. The two `src` trees diverge deliberately in ~8 other files (auth, Sentry, cron, detached endpoints, webhooks, request timeouts), so merging them is a design change rather than a bug fix.

Closes #2294