### PR TITLE
Default the post-auth callbackUrl to the app's home page

### DIFF
--- a/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
+++ b/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
@@ -2187,8 +2187,80 @@
             "description": "Send a magic sign-in link to the email address instead of using a password."
           },
           "callbackUrl": {
-            "type": "string",
-            "description": "URL to redirect to after login."
+            "oneOf": [
+              {
+                "type": "object",
+                "description": "Structured callback target for where a successful sign-in lands, basePath-prefixed. Defaults to the app's home page when omitted and no ?callbackUrl= query is present; a ?callbackUrl= query set by the unauthenticated-page redirect wins over that default, and this param wins over both.",
+                "properties": {
+                  "home": {
+                    "type": "boolean",
+                    "description": "Land on the app's home page."
+                  },
+                  "pageId": {
+                    "type": "string",
+                    "description": "The pageId to land on."
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external landing page."
+                  },
+                  "urlQuery": {
+                    "type": "object",
+                    "description": "The urlQuery to set on the destination."
+                  }
+                }
+              },
+              {
+                "enum": [
+                  false
+                ],
+                "description": "Do not navigate - the session store re-renders the page with the new user in place, for a login form in a modal or an embedded panel. Not valid for magic-link or social/OAuth sign-in, which redirect through an external hop."
+              }
+            ]
+          },
+          "newUserCallbackUrl": {
+            "type": "object",
+            "description": "Structured callback target for where a first-time user lands after a magic link (or social/OAuth sign-in) creates their account. Resolved like callbackUrl - basePath-prefixed. When omitted, BetterAuth defaults it to callbackUrl. Ignored by email and phone sign-in.",
+            "properties": {
+              "home": {
+                "type": "boolean",
+                "description": "Land on the app's home page."
+              },
+              "pageId": {
+                "type": "string",
+                "description": "The pageId to land on."
+              },
+              "url": {
+                "type": "string",
+                "description": "The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external landing page."
+              },
+              "urlQuery": {
+                "type": "object",
+                "description": "The urlQuery to set on the destination."
+              }
+            }
+          },
+          "errorCallbackUrl": {
+            "type": "object",
+            "description": "Structured callback target for where a failed or expired magic link (or social/OAuth sign-in) lands, carrying the ?error= reason. Resolved like callbackUrl - basePath-prefixed. When omitted, defaults to the app's authPages.error page (basePath-prefixed); if authPages.error is unset, BetterAuth's own fallback stands. Ignored by email and phone sign-in.",
+            "properties": {
+              "home": {
+                "type": "boolean",
+                "description": "Land on the app's home page."
+              },
+              "pageId": {
+                "type": "string",
+                "description": "The pageId to land on."
+              },
+              "url": {
+                "type": "string",
+                "description": "The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external landing page."
+              },
+              "urlQuery": {
+                "type": "object",
+                "description": "The urlQuery to set on the destination."
+              }
+            }
           },
           "captchaToken": {
             "type": "string",
@@ -2200,7 +2272,32 @@
     "Logout": {
       "type": "object",
       "params": {
-        "description": "Parameters passed to the logout method."
+        "type": "object",
+        "description": "Parameters passed to the logout method.",
+        "properties": {
+          "callbackUrl": {
+            "type": "object",
+            "description": "Structured callback target for where a signed-out user lands, basePath-prefixed. Unlike the sign-in actions this has no default and does not read the ?callbackUrl= query: with no target the session provider reloads the page and the server re-applies the page auth fork, which sends a protected page to the sign-in page.",
+            "properties": {
+              "home": {
+                "type": "boolean",
+                "description": "Land on the app's home page."
+              },
+              "pageId": {
+                "type": "string",
+                "description": "The pageId to land on."
+              },
+              "url": {
+                "type": "string",
+                "description": "The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external logout landing page."
+              },
+              "urlQuery": {
+                "type": "object",
+                "description": "The urlQuery to set on the destination."
+              }
+            }
+          }
+        }
       }
     },
     "Link": {

--- a/packages/build/src/tests/success/36-auth-roles-app/snapshot.json
+++ b/packages/build/src/tests/success/36-auth-roles-app/snapshot.json
@@ -2123,8 +2123,80 @@
             "description": "Send a magic sign-in link to the email address instead of using a password."
           },
           "callbackUrl": {
-            "type": "string",
-            "description": "URL to redirect to after login."
+            "oneOf": [
+              {
+                "type": "object",
+                "description": "Structured callback target for where a successful sign-in lands, basePath-prefixed. Defaults to the app's home page when omitted and no ?callbackUrl= query is present; a ?callbackUrl= query set by the unauthenticated-page redirect wins over that default, and this param wins over both.",
+                "properties": {
+                  "home": {
+                    "type": "boolean",
+                    "description": "Land on the app's home page."
+                  },
+                  "pageId": {
+                    "type": "string",
+                    "description": "The pageId to land on."
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external landing page."
+                  },
+                  "urlQuery": {
+                    "type": "object",
+                    "description": "The urlQuery to set on the destination."
+                  }
+                }
+              },
+              {
+                "enum": [
+                  false
+                ],
+                "description": "Do not navigate - the session store re-renders the page with the new user in place, for a login form in a modal or an embedded panel. Not valid for magic-link or social/OAuth sign-in, which redirect through an external hop."
+              }
+            ]
+          },
+          "newUserCallbackUrl": {
+            "type": "object",
+            "description": "Structured callback target for where a first-time user lands after a magic link (or social/OAuth sign-in) creates their account. Resolved like callbackUrl - basePath-prefixed. When omitted, BetterAuth defaults it to callbackUrl. Ignored by email and phone sign-in.",
+            "properties": {
+              "home": {
+                "type": "boolean",
+                "description": "Land on the app's home page."
+              },
+              "pageId": {
+                "type": "string",
+                "description": "The pageId to land on."
+              },
+              "url": {
+                "type": "string",
+                "description": "The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external landing page."
+              },
+              "urlQuery": {
+                "type": "object",
+                "description": "The urlQuery to set on the destination."
+              }
+            }
+          },
+          "errorCallbackUrl": {
+            "type": "object",
+            "description": "Structured callback target for where a failed or expired magic link (or social/OAuth sign-in) lands, carrying the ?error= reason. Resolved like callbackUrl - basePath-prefixed. When omitted, defaults to the app's authPages.error page (basePath-prefixed); if authPages.error is unset, BetterAuth's own fallback stands. Ignored by email and phone sign-in.",
+            "properties": {
+              "home": {
+                "type": "boolean",
+                "description": "Land on the app's home page."
+              },
+              "pageId": {
+                "type": "string",
+                "description": "The pageId to land on."
+              },
+              "url": {
+                "type": "string",
+                "description": "The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external landing page."
+              },
+              "urlQuery": {
+                "type": "object",
+                "description": "The urlQuery to set on the destination."
+              }
+            }
           },
           "captchaToken": {
             "type": "string",

--- a/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
+++ b/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
@@ -5899,8 +5899,80 @@
             "description": "Send a magic sign-in link to the email address instead of using a password."
           },
           "callbackUrl": {
-            "type": "string",
-            "description": "URL to redirect to after login."
+            "oneOf": [
+              {
+                "type": "object",
+                "description": "Structured callback target for where a successful sign-in lands, basePath-prefixed. Defaults to the app's home page when omitted and no ?callbackUrl= query is present; a ?callbackUrl= query set by the unauthenticated-page redirect wins over that default, and this param wins over both.",
+                "properties": {
+                  "home": {
+                    "type": "boolean",
+                    "description": "Land on the app's home page."
+                  },
+                  "pageId": {
+                    "type": "string",
+                    "description": "The pageId to land on."
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external landing page."
+                  },
+                  "urlQuery": {
+                    "type": "object",
+                    "description": "The urlQuery to set on the destination."
+                  }
+                }
+              },
+              {
+                "enum": [
+                  false
+                ],
+                "description": "Do not navigate - the session store re-renders the page with the new user in place, for a login form in a modal or an embedded panel. Not valid for magic-link or social/OAuth sign-in, which redirect through an external hop."
+              }
+            ]
+          },
+          "newUserCallbackUrl": {
+            "type": "object",
+            "description": "Structured callback target for where a first-time user lands after a magic link (or social/OAuth sign-in) creates their account. Resolved like callbackUrl - basePath-prefixed. When omitted, BetterAuth defaults it to callbackUrl. Ignored by email and phone sign-in.",
+            "properties": {
+              "home": {
+                "type": "boolean",
+                "description": "Land on the app's home page."
+              },
+              "pageId": {
+                "type": "string",
+                "description": "The pageId to land on."
+              },
+              "url": {
+                "type": "string",
+                "description": "The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external landing page."
+              },
+              "urlQuery": {
+                "type": "object",
+                "description": "The urlQuery to set on the destination."
+              }
+            }
+          },
+          "errorCallbackUrl": {
+            "type": "object",
+            "description": "Structured callback target for where a failed or expired magic link (or social/OAuth sign-in) lands, carrying the ?error= reason. Resolved like callbackUrl - basePath-prefixed. When omitted, defaults to the app's authPages.error page (basePath-prefixed); if authPages.error is unset, BetterAuth's own fallback stands. Ignored by email and phone sign-in.",
+            "properties": {
+              "home": {
+                "type": "boolean",
+                "description": "Land on the app's home page."
+              },
+              "pageId": {
+                "type": "string",
+                "description": "The pageId to land on."
+              },
+              "url": {
+                "type": "string",
+                "description": "The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external landing page."
+              },
+              "urlQuery": {
+                "type": "object",
+                "description": "The urlQuery to set on the destination."
+              }
+            }
           },
           "captchaToken": {
             "type": "string",

--- a/packages/client/src/auth/createAuthMethods.js
+++ b/packages/client/src/auth/createAuthMethods.js
@@ -28,6 +28,13 @@ function getCallbackUrl({ lowdefy, callbackUrl = {}, name = 'callbackUrl' }) {
   const query = type.isNone(urlQuery) ? '' : `${urlQueryFn.stringify(urlQuery)}`;
 
   if (home === true) {
+    // An app whose home config names no page has no resolvable home - return no
+    // target rather than interpolating the missing pageId into the path.
+    // getHomeAndMenus resolves pageId to null when there is no homePageId and no
+    // menu link to fall back on, which built the literal "/null".
+    if (lowdefy.home?.configured !== true && !type.isString(lowdefy.home?.pageId)) {
+      return undefined;
+    }
     return `/${lowdefy.home.configured ? '' : lowdefy.home.pageId}${query ? `?${query}` : ''}`;
   }
   if (type.isString(pageId)) {
@@ -59,11 +66,18 @@ function resolveTargetURL({ lowdefy, callbackUrl, name }) {
 
 // The action's callbackUrl param wins; otherwise honor the callbackUrl query
 // param set by the unauthenticated page redirect, so login returns to the
-// page the user asked for. Only relative paths are accepted from the query
-// to avoid open redirects. The query fallback is exclusive to the primary
-// callbackUrl - a new-user or error destination has no equivalent query
-// source, so reading it for them would misroute.
+// page the user asked for; otherwise the app's home page. Only relative paths
+// are accepted from the query to avoid open redirects. The query fallback is
+// exclusive to the primary callbackUrl - a new-user or error destination has no
+// equivalent query source, so reading it for them would misroute.
 function resolveCallbackURL({ lowdefy, callbackUrl }) {
+  // An explicit refusal to navigate, above the ladder so a bounced sign-in
+  // honors it too. Absence means "go home" below, so "stay put" needs its own
+  // spelling - a login form in a modal or an embedded panel relies on the
+  // session store re-rendering the tree with the new user in place.
+  if (callbackUrl === false) {
+    return undefined;
+  }
   const explicit = resolveTargetURL({ lowdefy, callbackUrl });
   if (!type.isNone(explicit)) {
     return explicit;
@@ -71,9 +85,37 @@ function resolveCallbackURL({ lowdefy, callbackUrl }) {
   const window = lowdefy._internal?.globals?.window;
   const fromQuery = new URLSearchParams(window?.location?.search ?? '').get('callbackUrl');
   if (type.isString(fromQuery) && fromQuery.startsWith('/')) {
+    // Returned raw, not through resolveTargetURL: both producers of this query
+    // param already bake basePath into the value they emit (renderPage.js,
+    // apiPage.js), so prefixing here would yield /app/app/reports.
     return fromQuery;
   }
-  return undefined;
+  // The bottom rung, below the query so a bounced sign-in still returns to the
+  // page the user asked for. Resolved through the same helper as the explicit
+  // rung, so basePath handling stays in one place.
+  const home = resolveTargetURL({ lowdefy, callbackUrl: { home: true } });
+  if (!type.isNone(home)) {
+    return home;
+  }
+  throw new Error(
+    'Invalid callbackUrl: no destination resolved. The app has no resolvable home page - set homePageId, give an explicit callbackUrl, or use "callbackUrl: false" to stay on the page.'
+  );
+}
+
+// callbackUrl: false suppresses Lowdefy's own window.location.assign, so it is
+// only honorable where that assign is the value's single consumer. The paths
+// that hand callbackURL to BetterAuth make it the destination of a later hop -
+// an emailed link, an OAuth return - which cannot be suppressed once the browser
+// has left. Both alternatives there are worse than an error: omitting the param
+// lands the user on BetterAuth's own "/" fallback, which resolves against the
+// auth baseURL and so drops basePath entirely, and silently substituting the
+// home default contradicts an explicit instruction.
+function assertCallbackUrlNavigable({ callbackUrl, path }) {
+  if (callbackUrl === false) {
+    throw new Error(
+      `Invalid callbackUrl: "false" is not valid for ${path}, which redirects through an external hop. Give a destination.`
+    );
+  }
 }
 
 // Maps the captchaToken action param onto the BetterAuth client's per-call
@@ -171,6 +213,7 @@ function createAuthMethods(lowdefy, auth) {
     }
 
     if (!type.isNone(providerId)) {
+      assertCallbackUrlNavigable({ callbackUrl, path: 'Login with a provider' });
       const provider = providers.find((configured) => configured.id === providerId);
       if (type.isNone(provider)) {
         throw new Error(`Login provider "${providerId}" is not a configured auth provider.`);
@@ -197,6 +240,7 @@ function createAuthMethods(lowdefy, auth) {
       );
     }
     if (magicLink === true) {
+      assertCallbackUrlNavigable({ callbackUrl, path: 'Login with magicLink' });
       if (!type.isString(email)) {
         throw new Error('Login with magicLink requires an "email" param.');
       }
@@ -250,6 +294,11 @@ function createAuthMethods(lowdefy, auth) {
   // Social, magic-link and passkey have no separate signup - the account is
   // created on first sign-in via login - so SignUp is email/password only.
   async function signUp({ callbackUrl, captchaToken, email, name, password, ...rest } = {}) {
+    // signUp is the case where the two consumers diverge: Lowdefy navigates on
+    // the session-bearing success, and BetterAuth puts the same value in the
+    // verification email. A value with two consumers cannot be suppressed for
+    // one of them alone.
+    assertCallbackUrlNavigable({ callbackUrl, path: 'SignUp' });
     const callbackURL = resolveCallbackURL({ lowdefy, callbackUrl });
     const data = await unwrap(
       auth.signUpEmail({
@@ -270,8 +319,14 @@ function createAuthMethods(lowdefy, auth) {
     return data;
   }
 
+  // Deliberately the one method outside resolveCallbackURL's ladder: it reads
+  // neither the ?callbackUrl= query nor the home default. With no callback the
+  // session provider's post-sign-out reload takes over and the server re-applies
+  // the page auth fork, which is the right landing for a sign-out - sending a
+  // signed-out user to the home page could land them on a page they may no
+  // longer see.
   async function logout({ callbackUrl } = {}) {
-    const callbackURL = getCallbackUrl({ lowdefy, callbackUrl });
+    const callbackURL = resolveTargetURL({ lowdefy, callbackUrl });
     const window = lowdefy._internal?.globals?.window;
     const willNavigate = Boolean(callbackURL && window);
     if (willNavigate && auth.suppressSignOutReload) {
@@ -281,12 +336,7 @@ function createAuthMethods(lowdefy, auth) {
     }
     const data = await unwrap(auth.signOut());
     if (willNavigate) {
-      // Prefix basePath only onto app-relative callbacks - absolute URLs
-      // (external logout landing pages) navigate as given.
-      const target = callbackURL.startsWith('/')
-        ? `${lowdefy.basePath ?? ''}${callbackURL}`
-        : callbackURL;
-      window.location.assign(target);
+      window.location.assign(callbackURL);
     }
     return data;
   }
@@ -503,6 +553,7 @@ function createAuthMethods(lowdefy, auth) {
   // where the emailed verification link lands after verifying, matching the
   // signUp param of the same name.
   async function sendVerificationEmail({ callbackUrl, captchaToken, email, ...rest } = {}) {
+    assertCallbackUrlNavigable({ callbackUrl, path: 'SendVerificationEmail' });
     if (!type.isString(email)) {
       throw new Error('SendVerificationEmail requires an "email" param.');
     }

--- a/packages/client/src/auth/createAuthMethods.js
+++ b/packages/client/src/auth/createAuthMethods.js
@@ -14,9 +14,26 @@
   limitations under the License.
 */
 
+import { getHomePathname } from '@lowdefy/engine';
 import { type, urlQuery as urlQueryFn } from '@lowdefy/helpers';
 
-function getCallbackUrl({ lowdefy, callbackUrl = {}, name = 'callbackUrl' }) {
+function getCallbackUrl({ lowdefy, callbackUrl, name = 'callbackUrl' }) {
+  // An absent target means "no target" - the ladder in resolveCallbackURL
+  // decides what absence falls back to. null is absence too: an operator with no
+  // matching branch (an `_if` without an `else`) resolves to null, and
+  // destructuring that throws a TypeError instead of falling to the default.
+  //
+  // A non-object target - notably the bare string these params were wrongly
+  // declared as before the schemas were corrected - expresses none of the four
+  // keys below and so resolves to no target, letting the ladder continue. It is
+  // deliberately not an error: apps written against the old string schema are
+  // common, and the two better-looking alternatives are both worse. Throwing
+  // fails a sign-in that works today, and reading a string as { url } would
+  // double-prefix basePath on the most common spelling of all, a string holding
+  // the already-prefixed ?callbackUrl= query.
+  if (!type.isObject(callbackUrl)) {
+    return undefined;
+  }
   const { home, pageId, urlQuery, url } = callbackUrl;
 
   const targets = [home, pageId, url].filter((target) => target);
@@ -32,10 +49,11 @@ function getCallbackUrl({ lowdefy, callbackUrl = {}, name = 'callbackUrl' }) {
     // target rather than interpolating the missing pageId into the path.
     // getHomeAndMenus resolves pageId to null when there is no homePageId and no
     // menu link to fall back on, which built the literal "/null".
-    if (lowdefy.home?.configured !== true && !type.isString(lowdefy.home?.pageId)) {
+    const pathname = getHomePathname({ lowdefy });
+    if (type.isNone(pathname)) {
       return undefined;
     }
-    return `/${lowdefy.home.configured ? '' : lowdefy.home.pageId}${query ? `?${query}` : ''}`;
+    return `${pathname}${query ? `?${query}` : ''}`;
   }
   if (type.isString(pageId)) {
     return `/${pageId}${query ? `?${query}` : ''}`;
@@ -64,12 +82,23 @@ function resolveTargetURL({ lowdefy, callbackUrl, name }) {
   return explicit;
 }
 
+// Accepts only a path-absolute URL from the ?callbackUrl= query. A bare
+// startsWith('/') is not enough: "//evil.com" and "/\evil.com" also start with
+// "/" but are protocol-relative (browsers normalize the backslash to a slash),
+// so a crafted sign-in link would navigate off-site with a fresh session. This
+// value is the one target that never reaches BetterAuth on the email, phone and
+// passkey paths - it goes straight into window.location.assign - so its
+// server-side originCheck / trustedOrigins do not cover it.
+function isAppRelativePath(value) {
+  return type.isString(value) && /^\/([^/\\]|$)/.test(value);
+}
+
 // The action's callbackUrl param wins; otherwise honor the callbackUrl query
 // param set by the unauthenticated page redirect, so login returns to the
-// page the user asked for; otherwise the app's home page. Only relative paths
-// are accepted from the query to avoid open redirects. The query fallback is
-// exclusive to the primary callbackUrl - a new-user or error destination has no
-// equivalent query source, so reading it for them would misroute.
+// page the user asked for; otherwise the app's home page. Only app-relative
+// paths are accepted from the query to avoid open redirects. The query fallback
+// is exclusive to the primary callbackUrl - a new-user or error destination has
+// no equivalent query source, so reading it for them would misroute.
 function resolveCallbackURL({ lowdefy, callbackUrl }) {
   // An explicit refusal to navigate, above the ladder so a bounced sign-in
   // honors it too. Absence means "go home" below, so "stay put" needs its own
@@ -84,7 +113,7 @@ function resolveCallbackURL({ lowdefy, callbackUrl }) {
   }
   const window = lowdefy._internal?.globals?.window;
   const fromQuery = new URLSearchParams(window?.location?.search ?? '').get('callbackUrl');
-  if (type.isString(fromQuery) && fromQuery.startsWith('/')) {
+  if (isAppRelativePath(fromQuery)) {
     // Returned raw, not through resolveTargetURL: both producers of this query
     // param already bake basePath into the value they emit (renderPage.js,
     // apiPage.js), so prefixing here would yield /app/app/reports.
@@ -110,10 +139,10 @@ function resolveCallbackURL({ lowdefy, callbackUrl }) {
 // lands the user on BetterAuth's own "/" fallback, which resolves against the
 // auth baseURL and so drops basePath entirely, and silently substituting the
 // home default contradicts an explicit instruction.
-function assertCallbackUrlNavigable({ callbackUrl, path }) {
+function assertCallbackUrlNavigable({ callbackUrl, method }) {
   if (callbackUrl === false) {
     throw new Error(
-      `Invalid callbackUrl: "false" is not valid for ${path}, which redirects through an external hop. Give a destination.`
+      `Invalid callbackUrl: "false" is not valid for ${method}, which redirects through an external hop. Give a destination.`
     );
   }
 }
@@ -213,7 +242,7 @@ function createAuthMethods(lowdefy, auth) {
     }
 
     if (!type.isNone(providerId)) {
-      assertCallbackUrlNavigable({ callbackUrl, path: 'Login with a provider' });
+      assertCallbackUrlNavigable({ callbackUrl, method: 'Login with a provider' });
       const provider = providers.find((configured) => configured.id === providerId);
       if (type.isNone(provider)) {
         throw new Error(`Login provider "${providerId}" is not a configured auth provider.`);
@@ -240,7 +269,7 @@ function createAuthMethods(lowdefy, auth) {
       );
     }
     if (magicLink === true) {
-      assertCallbackUrlNavigable({ callbackUrl, path: 'Login with magicLink' });
+      assertCallbackUrlNavigable({ callbackUrl, method: 'Login with magicLink' });
       if (!type.isString(email)) {
         throw new Error('Login with magicLink requires an "email" param.');
       }
@@ -298,7 +327,7 @@ function createAuthMethods(lowdefy, auth) {
     // the session-bearing success, and BetterAuth puts the same value in the
     // verification email. A value with two consumers cannot be suppressed for
     // one of them alone.
-    assertCallbackUrlNavigable({ callbackUrl, path: 'SignUp' });
+    assertCallbackUrlNavigable({ callbackUrl, method: 'SignUp' });
     const callbackURL = resolveCallbackURL({ lowdefy, callbackUrl });
     const data = await unwrap(
       auth.signUpEmail({
@@ -553,10 +582,10 @@ function createAuthMethods(lowdefy, auth) {
   // where the emailed verification link lands after verifying, matching the
   // signUp param of the same name.
   async function sendVerificationEmail({ callbackUrl, captchaToken, email, ...rest } = {}) {
-    assertCallbackUrlNavigable({ callbackUrl, path: 'SendVerificationEmail' });
     if (!type.isString(email)) {
       throw new Error('SendVerificationEmail requires an "email" param.');
     }
+    assertCallbackUrlNavigable({ callbackUrl, method: 'SendVerificationEmail' });
     const callbackURL = resolveCallbackURL({ lowdefy, callbackUrl });
     return unwrap(
       auth.sendVerificationEmail({

--- a/packages/client/src/auth/createAuthMethods.test.js
+++ b/packages/client/src/auth/createAuthMethods.test.js
@@ -23,6 +23,7 @@ function setup({ signInResult, signUpResult } = {}) {
     _internal: {
       globals: { window: { location: { assign, search: '' } } },
     },
+    home: { configured: false, pageId: 'home-page' },
   };
   const auth = {
     authConfig: { providers: [] },
@@ -942,7 +943,7 @@ test('login with a GenericOAuth provider forwards newUserCallbackUrl and errorCa
     [
       {
         providerId: 'keycloak',
-        callbackURL: undefined,
+        callbackURL: '/home-page',
         newUserCallbackURL: '/welcome',
         errorCallbackURL: '/sign-in-failed',
       },
@@ -1069,4 +1070,259 @@ test('phoneNumberSendOtp threads captchaToken as the x-captcha-response header',
       },
     ],
   ]);
+});
+
+// The callbackUrl precedence ladder: callbackUrl: false, then the explicit
+// param, then the ?callbackUrl= query, then the app's home page, then a throw.
+
+test('login with email and password lands on the home page when no callbackUrl and no query are given', async () => {
+  const { auth, lowdefy, assign } = setup({ signInResult: { token: 't', user: {} } });
+  const { login } = createAuthMethods(lowdefy, auth);
+  await login({ email: 'user@example.com', password: 'password123' });
+  expect(assign.mock.calls).toEqual([['/home-page']]);
+});
+
+test('an explicit callbackUrl still wins over a present ?callbackUrl= query', async () => {
+  const { auth, lowdefy, assign } = setup({ signInResult: { token: 't', user: {} } });
+  lowdefy._internal.globals.window.location.search = '?callbackUrl=%2Ffrom-query';
+  const { login } = createAuthMethods(lowdefy, auth);
+  await login({
+    email: 'user@example.com',
+    password: 'password123',
+    callbackUrl: { pageId: 'dashboard' },
+  });
+  expect(assign.mock.calls).toEqual([['/dashboard']]);
+});
+
+test('the ?callbackUrl= query wins over the home default', async () => {
+  const { auth, lowdefy, assign } = setup({ signInResult: { token: 't', user: {} } });
+  lowdefy._internal.globals.window.location.search = '?callbackUrl=%2Ffrom-query';
+  const { login } = createAuthMethods(lowdefy, auth);
+  await login({ email: 'user@example.com', password: 'password123' });
+  expect(assign.mock.calls).toEqual([['/from-query']]);
+});
+
+test('the ?callbackUrl= query rung is not re-prefixed with basePath', async () => {
+  const { auth, lowdefy, assign } = setup({ signInResult: { token: 't', user: {} } });
+  lowdefy.basePath = '/app';
+  // Both producers of this query param already bake basePath into the value.
+  lowdefy._internal.globals.window.location.search = '?callbackUrl=%2Fapp%2Freports';
+  const { login } = createAuthMethods(lowdefy, auth);
+  await login({ email: 'user@example.com', password: 'password123' });
+  expect(assign.mock.calls).toEqual([['/app/reports']]);
+});
+
+test('the home default is basePath-prefixed', async () => {
+  const { auth, lowdefy, assign } = setup({ signInResult: { token: 't', user: {} } });
+  lowdefy.basePath = '/app';
+  lowdefy.home = { configured: true, pageId: 'dashboard' };
+  const { login } = createAuthMethods(lowdefy, auth);
+  await login({ email: 'user@example.com', password: 'password123' });
+  expect(assign.mock.calls).toEqual([['/app/']]);
+});
+
+test('login with phoneNumber lands on the home page when no callbackUrl is given', async () => {
+  const { auth, lowdefy, assign } = setup({ signInResult: { token: 't', user: {} } });
+  const { login } = createAuthMethods(lowdefy, auth);
+  await login({ phoneNumber: '+27831234567', password: 'password123' });
+  expect(assign.mock.calls).toEqual([['/home-page']]);
+});
+
+test('passkeySignIn lands on the home page when no callbackUrl is given', async () => {
+  const { auth, lowdefy, assign } = setup();
+  const { passkeySignIn } = createAuthMethods(lowdefy, auth);
+  await passkeySignIn();
+  expect(assign.mock.calls).toEqual([['/home-page']]);
+});
+
+test('signUp navigates to the home page when a token is present and no callbackUrl is given', async () => {
+  const { auth, lowdefy, assign } = setup({ signUpResult: { token: 'session-token', user: {} } });
+  const { signUp } = createAuthMethods(lowdefy, auth);
+  await signUp({ email: 'user@example.com', password: 'password123' });
+  expect(auth.signUpEmail.mock.calls[0][0].callbackURL).toEqual('/home-page');
+  expect(assign.mock.calls).toEqual([['/home-page']]);
+});
+
+test('signUp with requireEmailVerification still does not navigate, though a destination now resolves', async () => {
+  const { auth, lowdefy, assign } = setup({ signUpResult: { token: null, user: {} } });
+  const { signUp } = createAuthMethods(lowdefy, auth);
+  await signUp({ email: 'user@example.com', password: 'password123' });
+  // The emailed verification link still carries the resolved destination.
+  expect(auth.signUpEmail.mock.calls[0][0].callbackURL).toEqual('/home-page');
+  expect(assign).not.toHaveBeenCalled();
+});
+
+test('sendVerificationEmail defaults the emailed link to the home page', async () => {
+  const { auth, lowdefy } = setup();
+  const { sendVerificationEmail } = createAuthMethods(lowdefy, auth);
+  await sendVerificationEmail({ email: 'user@example.com' });
+  expect(auth.sendVerificationEmail.mock.calls[0][0].callbackURL).toEqual('/home-page');
+});
+
+test('sendVerificationEmail lands the emailed link inside the app under a basePath', async () => {
+  const { auth, lowdefy } = setup();
+  lowdefy.basePath = '/app';
+  lowdefy.home = { configured: true, pageId: 'dashboard' };
+  const { sendVerificationEmail } = createAuthMethods(lowdefy, auth);
+  await sendVerificationEmail({ email: 'user@example.com' });
+  // Not "/", which BetterAuth would resolve against its baseURL to the origin
+  // root - outside the app.
+  expect(auth.sendVerificationEmail.mock.calls[0][0].callbackURL).toEqual('/app/');
+});
+
+test('login with magicLink defaults callbackURL to the home page inside the app', async () => {
+  const { auth, lowdefy } = setup();
+  lowdefy.basePath = '/app';
+  lowdefy.home = { configured: true, pageId: 'dashboard' };
+  auth.signInMagicLink = jest.fn(() => Promise.resolve({ data: { status: true }, error: null }));
+  const { login } = createAuthMethods(lowdefy, auth);
+  await login({ email: 'user@example.com', magicLink: true });
+  expect(auth.signInMagicLink.mock.calls[0][0].callbackURL).toEqual('/app/');
+});
+
+test('login with a social provider defaults callbackURL to the home page inside the app', async () => {
+  const { auth, lowdefy } = setup();
+  lowdefy.basePath = '/app';
+  lowdefy.home = { configured: true, pageId: 'dashboard' };
+  auth.authConfig.providers = [{ id: 'google', type: 'Google' }];
+  auth.signInSocial = jest.fn(() => Promise.resolve({ data: { url: 'x' }, error: null }));
+  const { login } = createAuthMethods(lowdefy, auth);
+  await login({ providerId: 'google' });
+  expect(auth.signInSocial.mock.calls[0][0].callbackURL).toEqual('/app/');
+});
+
+test('login throws when no destination resolves and the home config names no page', async () => {
+  const { auth, lowdefy, assign } = setup();
+  // What getHomeAndMenus returns for an app with no homePageId and no menu link.
+  lowdefy.home = { configured: false, pageId: null };
+  const { login } = createAuthMethods(lowdefy, auth);
+  await expect(login({ email: 'user@example.com', password: 'password123' })).rejects.toThrow(
+    'Invalid callbackUrl: no destination resolved. The app has no resolvable home page - set homePageId, give an explicit callbackUrl, or use "callbackUrl: false" to stay on the page.'
+  );
+  expect(assign).not.toHaveBeenCalled();
+});
+
+test('login throws the callbackUrl error, not a TypeError, when lowdefy.home is absent', async () => {
+  const { auth, lowdefy } = setup();
+  delete lowdefy.home;
+  const { login } = createAuthMethods(lowdefy, auth);
+  await expect(login({ email: 'user@example.com', password: 'password123' })).rejects.toThrow(
+    'Invalid callbackUrl: no destination resolved. The app has no resolvable home page - set homePageId, give an explicit callbackUrl, or use "callbackUrl: false" to stay on the page.'
+  );
+});
+
+test('an explicit callbackUrl home target throws instead of resolving to /undefined', async () => {
+  const { auth, lowdefy, assign } = setup();
+  lowdefy.home = { configured: false, pageId: null };
+  const { login } = createAuthMethods(lowdefy, auth);
+  await expect(
+    login({ email: 'user@example.com', password: 'password123', callbackUrl: { home: true } })
+  ).rejects.toThrow('Invalid callbackUrl: no destination resolved.');
+  expect(assign).not.toHaveBeenCalled();
+});
+
+test('logout with a home callbackUrl does not navigate when the home config names no page', async () => {
+  const { auth, lowdefy, assign } = setup();
+  lowdefy.home = { configured: false, pageId: null };
+  auth.signOut = jest.fn(() => Promise.resolve({ data: { success: true }, error: null }));
+  auth.suppressSignOutReload = jest.fn();
+  const { logout } = createAuthMethods(lowdefy, auth);
+  // logout gains no default and no throw, but inherits the correctness fix -
+  // the post-sign-out reload takes over instead of navigating to /undefined.
+  await logout({ callbackUrl: { home: true } });
+  expect(assign).not.toHaveBeenCalled();
+  expect(auth.suppressSignOutReload).not.toHaveBeenCalled();
+});
+
+test('login with email and callbackUrl false mints the session without navigating', async () => {
+  const { auth, lowdefy, assign } = setup({ signInResult: { token: 't', user: {} } });
+  const { login } = createAuthMethods(lowdefy, auth);
+  const data = await login({
+    email: 'user@example.com',
+    password: 'password123',
+    callbackUrl: false,
+  });
+  expect(assign).not.toHaveBeenCalled();
+  expect(data).toEqual({ token: 't', user: {} });
+});
+
+test('login with phoneNumber and callbackUrl false does not navigate', async () => {
+  const { auth, lowdefy, assign } = setup({ signInResult: { token: 't', user: {} } });
+  const { login } = createAuthMethods(lowdefy, auth);
+  await login({ phoneNumber: '+27831234567', password: 'password123', callbackUrl: false });
+  expect(assign).not.toHaveBeenCalled();
+});
+
+test('passkeySignIn with callbackUrl false does not navigate', async () => {
+  const { auth, lowdefy, assign } = setup();
+  const { passkeySignIn } = createAuthMethods(lowdefy, auth);
+  const data = await passkeySignIn({ callbackUrl: false });
+  expect(assign).not.toHaveBeenCalled();
+  expect(data).toEqual({ session: {}, user: {} });
+});
+
+test('callbackUrl false wins over a present ?callbackUrl= query', async () => {
+  const { auth, lowdefy, assign } = setup({ signInResult: { token: 't', user: {} } });
+  lowdefy._internal.globals.window.location.search = '?callbackUrl=%2Ffrom-query';
+  const { login } = createAuthMethods(lowdefy, auth);
+  await login({ email: 'user@example.com', password: 'password123', callbackUrl: false });
+  expect(assign).not.toHaveBeenCalled();
+});
+
+test('login with magicLink and callbackUrl false throws - the redirect hop is not ours to suppress', async () => {
+  const { auth, lowdefy } = setup();
+  auth.signInMagicLink = jest.fn(() => Promise.resolve({ data: { status: true }, error: null }));
+  const { login } = createAuthMethods(lowdefy, auth);
+  await expect(
+    login({ email: 'user@example.com', magicLink: true, callbackUrl: false })
+  ).rejects.toThrow(
+    'Invalid callbackUrl: "false" is not valid for Login with magicLink, which redirects through an external hop. Give a destination.'
+  );
+  expect(auth.signInMagicLink).not.toHaveBeenCalled();
+});
+
+test('login with a provider and callbackUrl false throws', async () => {
+  const { auth, lowdefy } = setup();
+  auth.authConfig.providers = [{ id: 'google', type: 'Google' }];
+  auth.signInSocial = jest.fn(() => Promise.resolve({ data: { url: 'x' }, error: null }));
+  const { login } = createAuthMethods(lowdefy, auth);
+  await expect(login({ providerId: 'google', callbackUrl: false })).rejects.toThrow(
+    'Invalid callbackUrl: "false" is not valid for Login with a provider, which redirects through an external hop. Give a destination.'
+  );
+  expect(auth.signInSocial).not.toHaveBeenCalled();
+});
+
+test('signUp with callbackUrl false throws - the same value is the emailed link', async () => {
+  const { auth, lowdefy } = setup();
+  const { signUp } = createAuthMethods(lowdefy, auth);
+  await expect(
+    signUp({ email: 'user@example.com', password: 'password123', callbackUrl: false })
+  ).rejects.toThrow(
+    'Invalid callbackUrl: "false" is not valid for SignUp, which redirects through an external hop. Give a destination.'
+  );
+  expect(auth.signUpEmail).not.toHaveBeenCalled();
+});
+
+test('sendVerificationEmail with callbackUrl false throws', async () => {
+  const { auth, lowdefy } = setup();
+  const { sendVerificationEmail } = createAuthMethods(lowdefy, auth);
+  await expect(
+    sendVerificationEmail({ email: 'user@example.com', callbackUrl: false })
+  ).rejects.toThrow(
+    'Invalid callbackUrl: "false" is not valid for SendVerificationEmail, which redirects through an external hop. Give a destination.'
+  );
+  expect(auth.sendVerificationEmail).not.toHaveBeenCalled();
+});
+
+test('logout with an empty url callbackUrl neither navigates nor suppresses the reload', async () => {
+  const { auth, lowdefy, assign } = setup();
+  lowdefy.basePath = '/base';
+  auth.signOut = jest.fn(() => Promise.resolve({ data: { success: true }, error: null }));
+  auth.suppressSignOutReload = jest.fn();
+  const { logout } = createAuthMethods(lowdefy, auth);
+  // The one input where resolving through resolveTargetURL changes when the
+  // basePath prefix is applied - willNavigate must stay false either way.
+  await logout({ callbackUrl: { url: '' } });
+  expect(assign).not.toHaveBeenCalled();
+  expect(auth.suppressSignOutReload).not.toHaveBeenCalled();
 });

--- a/packages/client/src/auth/createAuthMethods.test.js
+++ b/packages/client/src/auth/createAuthMethods.test.js
@@ -29,9 +29,7 @@ function setup({ signInResult, signUpResult } = {}) {
     authConfig: { providers: [] },
     acceptInvitation: jest.fn(() => Promise.resolve({ data: { member: {} }, error: null })),
     addPasskey: jest.fn(() => Promise.resolve({ data: { id: 'passkey-1' }, error: null })),
-    cancelInvitation: jest.fn(() =>
-      Promise.resolve({ data: { status: 'canceled' }, error: null })
-    ),
+    cancelInvitation: jest.fn(() => Promise.resolve({ data: { status: 'canceled' }, error: null })),
     changePassword: jest.fn(() =>
       Promise.resolve({ data: { token: null, user: {} }, error: null })
     ),
@@ -558,9 +556,7 @@ test('removeMember calls auth.removeMember with the memberIdOrEmail param', asyn
 test('removeMember throws when memberIdOrEmail is missing', async () => {
   const { auth, lowdefy } = setup();
   const { removeMember } = createAuthMethods(lowdefy, auth);
-  await expect(removeMember()).rejects.toThrow(
-    'RemoveMember requires a "memberIdOrEmail" param.'
-  );
+  await expect(removeMember()).rejects.toThrow('RemoveMember requires a "memberIdOrEmail" param.');
   expect(auth.removeMember).not.toHaveBeenCalled();
 });
 
@@ -595,9 +591,7 @@ test('updateOrganization wraps the name param in the update data object', async 
 test('updateOrganization throws when name is missing', async () => {
   const { auth, lowdefy } = setup();
   const { updateOrganization } = createAuthMethods(lowdefy, auth);
-  await expect(updateOrganization()).rejects.toThrow(
-    'UpdateOrganization requires a "name" param.'
-  );
+  await expect(updateOrganization()).rejects.toThrow('UpdateOrganization requires a "name" param.');
   expect(auth.updateOrganization).not.toHaveBeenCalled();
 });
 
@@ -1200,6 +1194,10 @@ test('login throws when no destination resolves and the home config names no pag
     'Invalid callbackUrl: no destination resolved. The app has no resolvable home page - set homePageId, give an explicit callbackUrl, or use "callbackUrl: false" to stay on the page.'
   );
   expect(assign).not.toHaveBeenCalled();
+  // The destination resolves before the sign-in call, so the throw mints no
+  // session - a login page mapping the failure to "sign-in failed" is telling
+  // the truth. Reordering the resolve below the call would make it a lie.
+  expect(auth.signInEmail).not.toHaveBeenCalled();
 });
 
 test('login throws the callbackUrl error, not a TypeError, when lowdefy.home is absent', async () => {
@@ -1325,4 +1323,103 @@ test('logout with an empty url callbackUrl neither navigates nor suppresses the 
   await logout({ callbackUrl: { url: '' } });
   expect(assign).not.toHaveBeenCalled();
   expect(auth.suppressSignOutReload).not.toHaveBeenCalled();
+});
+
+// The ?callbackUrl= query is attacker-supplied - a crafted sign-in link is the
+// whole point of an open redirect - and on the email, phone and passkey paths it
+// reaches window.location.assign without BetterAuth ever seeing it.
+
+test('a protocol-relative ?callbackUrl= query is rejected and falls through to the home default', async () => {
+  const { auth, lowdefy, assign } = setup({ signInResult: { token: 't', user: {} } });
+  lowdefy._internal.globals.window.location.search = '?callbackUrl=%2F%2Fevil.com';
+  const { login } = createAuthMethods(lowdefy, auth);
+  await login({ email: 'user@example.com', password: 'password123' });
+  expect(assign.mock.calls).toEqual([['/home-page']]);
+});
+
+test('a backslash-obfuscated protocol-relative ?callbackUrl= query is rejected', async () => {
+  const { auth, lowdefy, assign } = setup({ signInResult: { token: 't', user: {} } });
+  // Browsers normalize the backslash to a slash, making this off-site too.
+  lowdefy._internal.globals.window.location.search = '?callbackUrl=%2F%5Cevil.com';
+  const { login } = createAuthMethods(lowdefy, auth);
+  await login({ email: 'user@example.com', password: 'password123' });
+  expect(assign.mock.calls).toEqual([['/home-page']]);
+});
+
+test('an absolute ?callbackUrl= query is rejected and falls through to the home default', async () => {
+  const { auth, lowdefy, assign } = setup({ signInResult: { token: 't', user: {} } });
+  lowdefy._internal.globals.window.location.search = '?callbackUrl=https%3A%2F%2Fevil.com';
+  const { login } = createAuthMethods(lowdefy, auth);
+  await login({ email: 'user@example.com', password: 'password123' });
+  expect(assign.mock.calls).toEqual([['/home-page']]);
+});
+
+test('a bare "/" ?callbackUrl= query is still accepted', async () => {
+  const { auth, lowdefy, assign } = setup({ signInResult: { token: 't', user: {} } });
+  lowdefy._internal.globals.window.location.search = '?callbackUrl=%2F';
+  const { login } = createAuthMethods(lowdefy, auth);
+  await login({ email: 'user@example.com', password: 'password123' });
+  expect(assign.mock.calls).toEqual([['/']]);
+});
+
+// A callbackUrl that resolves to something other than an object is absence, not
+// an error - an operator with no matching branch resolves to null, and the bare
+// string the schemas wrongly declared before this change is still common in apps.
+
+test('a null callbackUrl falls through to the home default instead of throwing a TypeError', async () => {
+  const { auth, lowdefy, assign } = setup({ signInResult: { token: 't', user: {} } });
+  const { login } = createAuthMethods(lowdefy, auth);
+  await login({ email: 'user@example.com', password: 'password123', callbackUrl: null });
+  expect(assign.mock.calls).toEqual([['/home-page']]);
+});
+
+test('a null callbackUrl on logout neither navigates nor throws', async () => {
+  const { auth, lowdefy, assign } = setup();
+  auth.signOut = jest.fn(() => Promise.resolve({ data: { success: true }, error: null }));
+  const { logout } = createAuthMethods(lowdefy, auth);
+  await logout({ callbackUrl: null });
+  expect(assign).not.toHaveBeenCalled();
+});
+
+test('a string callbackUrl falls through the ladder rather than failing the sign-in', async () => {
+  const { auth, lowdefy, assign } = setup({ signInResult: { token: 't', user: {} } });
+  lowdefy.basePath = '/app';
+  lowdefy.home = { configured: true, pageId: 'router' };
+  const { login } = createAuthMethods(lowdefy, auth);
+  // The spelling the schemas wrongly declared before this change, still written
+  // by apps in the wild: it expresses none of the four target keys, so the home
+  // rung answers. Reading it as { url } instead would basePath-prefix a value
+  // that is usually the already-prefixed query, yielding /app/app/reports.
+  await login({ email: 'user@example.com', password: 'password123', callbackUrl: '/' });
+  expect(assign.mock.calls).toEqual([['/app/']]);
+});
+
+test('a string callbackUrl leaves a present ?callbackUrl= query to answer, un-prefixed', async () => {
+  const { auth, lowdefy, assign } = setup({ signInResult: { token: 't', user: {} } });
+  lowdefy.basePath = '/app';
+  lowdefy._internal.globals.window.location.search = '?callbackUrl=%2Fapp%2Freports';
+  const { login } = createAuthMethods(lowdefy, auth);
+  await login({
+    email: 'user@example.com',
+    password: 'password123',
+    callbackUrl: '/app/reports',
+  });
+  expect(assign.mock.calls).toEqual([['/app/reports']]);
+});
+
+test('a non-object newUserCallbackUrl is omitted so BetterAuth defaults it to callbackUrl', async () => {
+  const { auth, lowdefy } = setup();
+  auth.authConfig.providers = [{ id: 'google', type: 'Google' }];
+  auth.signInSocial = jest.fn(() => Promise.resolve({ data: { url: 'x' }, error: null }));
+  const { login } = createAuthMethods(lowdefy, auth);
+  await login({ providerId: 'google', newUserCallbackUrl: '/welcome' });
+  expect(auth.signInSocial.mock.calls[0][0].newUserCallbackURL).toBeUndefined();
+});
+
+test('sendVerificationEmail reports a missing email before judging the callbackUrl', async () => {
+  const { auth, lowdefy } = setup();
+  const { sendVerificationEmail } = createAuthMethods(lowdefy, auth);
+  await expect(sendVerificationEmail({ callbackUrl: false })).rejects.toThrow(
+    'SendVerificationEmail requires an "email" param.'
+  );
 });

--- a/packages/docs/actions/Login.yaml
+++ b/packages/docs/actions/Login.yaml
@@ -29,7 +29,7 @@ _ref:
           pageId?: string
           url?: string
           urlQuery?: object
-        }
+        } | false
         providerId?: string,
       }): void
       ```
@@ -38,24 +38,40 @@ _ref:
 
       The authorization url usually hosts a page where the user can input their credentials. After the user has logged in successfully, the user is redirected to the `api/auth/callback/[provider_id]` route in the Lowdefy app, where the rest of the authorization code flow is completed.
 
-      The `callbackUrl` parameters of the Login action specify where the user is redirected after login is complete. If `callbackUrl` parameters not set, the user will return to the page from which the action was called.
+      The `callbackUrl` parameter of the Login action specifies where the user lands after login is complete. Three sources are consulted, in order:
+
+      1. The `callbackUrl` param, if given.
+      2. The `?callbackUrl=` query parameter, which Lowdefy sets when it redirects an unauthenticated user to the sign-in page - so a user who was bounced there returns to the page they asked for.
+      3. The app's home page.
+
+      If none of the three resolves - an app with no `homePageId` whose menu offers the signed-out user no page to fall back on - the action throws rather than staying silently on the sign-in page.
+
+      To sign in without navigating at all, set `callbackUrl: false`. This is for a login form in a modal or an embedded panel, where the session store re-renders the page with the new user in place. It is not valid for magic-link or social/OAuth sign-in, which redirect through a hop Lowdefy does not control.
 
     params: |
       ###### object
       - `authUrl: object`:
         - `urlQuery: object`: Query parameters to set for the authorization URL.
-      - `callbackUrl: object`:
+      - `callbackUrl: object | false`: Set to `false` to sign in without navigating. As an object:
         - `home: boolean`: Redirect to the home page after the login flow is complete.
         - `pageId: string`: The pageId of the page to redirect to after the login flow is complete.
-        - `url: string`: The URL to redirect to after the login flow is complete.
+        - `url: string`: The URL to redirect to after the login flow is complete. An absolute URL is not `basePath`-prefixed, so it can be an external landing page.
         - `urlQuery: object`: The urlQuery to set for the page the user is redirected to after login.
       - `providerId: string`: The ID of the provider that should be used for login. If not set and only one provider is configured the configured provider will be used. Else the user will be redirected to a sign in page where they can choose a provider.
 
     examples: |
-      ###### Login and return to the same page:
+      ###### Login and land on the home page (or the page the user was bounced from):
       ```yaml
       - id: login
         type: Login
+      ```
+
+      ###### Login in a modal, without navigating:
+      ```yaml
+      - id: login
+        type: Login
+        params:
+          callbackUrl: false
       ```
 
       ###### Login with the google provider:

--- a/packages/docs/actions/Logout.yaml
+++ b/packages/docs/actions/Logout.yaml
@@ -33,15 +33,15 @@ _ref:
     description: |
       When the `Logout` action is called, the user data and authorization cookies are cleared by the app.
 
-      The `callbackUrl` parameters of the Logout action specify where the user is redirected after logout is complete. If `callbackUrl` parameters not set, the user will return to the page from which the action was called.
+      The `callbackUrl` parameter of the Logout action specifies where the user lands after logout is complete. Unlike the `Login` action it has no default and does not read the `?callbackUrl=` query: with no `callbackUrl` the page is reloaded and the server re-applies the page's auth rules, which sends a signed-out user off a protected page to the sign-in page. Defaulting to the home page instead could land them on a page they may no longer see.
 
     params: |
       ###### object
       - `callbackUrl: object`:
-        - `home: boolean`: Redirect to the home page after the login flow is complete.
-        - `pageId: string`: The pageId of the page to redirect to after the login flow is complete.
-        - `url: string`: The URL to redirect to after the login flow is complete.
-        - `urlQuery: object`: The urlQuery to set for the page the user is redirected to after login.
+        - `home: boolean`: Redirect to the home page after the logout flow is complete.
+        - `pageId: string`: The pageId of the page to redirect to after the logout flow is complete.
+        - `url: string`: The URL to redirect to after the logout flow is complete. An absolute URL is not `basePath`-prefixed, so it can be an external logout landing page.
+        - `urlQuery: object`: The urlQuery to set for the page the user is redirected to after logout.
       - `redirect: boolean`: If set to `false` the user session will be cleared, but the page will not be reloaded.
     examples: |
       ###### A logout button:

--- a/packages/docs/users/login-and-logout.yaml
+++ b/packages/docs/users/login-and-logout.yaml
@@ -32,15 +32,17 @@ _ref:
 
             The authorization url usually hosts a page where the user can input their credentials. After the user has logged in successfully, the user is redirected to the `/api/auth/callback/<provider_id>` route in the Lowdefy app, where the rest of the authorization code flow is completed. This URL usually needs to be configured in the identity provider's settings.
 
-            The `callbackUrl` parameters of the Login action specify where the user is redirected after login is complete. If `callbackUrl` parameters not set, the user will return to the page from which the action was called.
+            The `callbackUrl` parameter of the Login action specifies where the user lands after login is complete. Three sources are consulted, in order: the `callbackUrl` param, then the `?callbackUrl=` query parameter Lowdefy sets when it redirects an unauthenticated user to the sign-in page, then the app's home page. If none resolves the action throws, rather than staying silently on the sign-in page.
+
+            To sign in without navigating at all - a login form in a modal, or an embedded panel - set `callbackUrl: false`. This is not valid for magic-link or social/OAuth sign-in, which redirect through a hop Lowdefy does not control.
 
             The parameters are:
             - `authUrl: object`:
               - `urlQuery: object`: Query parameters to set for the authorization URL.
-            - `callbackUrl: object`:
+            - `callbackUrl: object | false`: Set to `false` to sign in without navigating. As an object:
               - `home: boolean`: Redirect to the home page after the login flow is complete.
               - `pageId: string`: The pageId of the page to redirect to after the login flow is complete.
-              - `url: string`: The URL to redirect to after the login flow is complete.
+              - `url: string`: The URL to redirect to after the login flow is complete. An absolute URL is not `basePath`-prefixed, so it can be an external landing page.
               - `urlQuery: object`: The urlQuery to set for the page the user is redirected to after login.
             - `providerId: string`: The ID of the provider that should be used for login. If not set and only one provider is configured the configured provider will be used. Else the user will be redirected to a sign in page where they can choose a provider.
 
@@ -119,14 +121,14 @@ _ref:
 
             When the `Logout` action is called, the user data and authorization cookies are cleared by the app.
 
-            The `callbackUrl` parameters of the Logout action specify where the user is redirected after logout is complete. If `callbackUrl` parameters are not set, the user will return to the page from which the action was called.
+            The `callbackUrl` parameter of the Logout action specifies where the user lands after logout is complete. Unlike the `Login` action it has no default and does not read the `?callbackUrl=` query: with no `callbackUrl` the page is reloaded and the server re-applies the page's auth rules, which sends a signed-out user off a protected page to the sign-in page.
 
             The parameters are:
             - `callbackUrl: object`:
-              - `home: boolean`: Redirect to the home page after the login flow is complete.
-              - `pageId: string`: The pageId of the page to redirect to after the login flow is complete.
-              - `url: string`: The URL to redirect to after the login flow is complete.
-              - `urlQuery: object`: The urlQuery to set for the page the user is redirected to after login.
+              - `home: boolean`: Redirect to the home page after the logout flow is complete.
+              - `pageId: string`: The pageId of the page to redirect to after the logout flow is complete.
+              - `url: string`: The URL to redirect to after the logout flow is complete. An absolute URL is not `basePath`-prefixed, so it can be an external logout landing page.
+              - `urlQuery: object`: The urlQuery to set for the page the user is redirected to after logout.
             - `redirect: boolean`: If set to `false` the user session will be cleared, but the page will not be reloaded.
 
 

--- a/packages/engine/src/createLink.js
+++ b/packages/engine/src/createLink.js
@@ -16,6 +16,8 @@
 
 import { type, urlQuery as urlQueryFn } from '@lowdefy/helpers';
 
+import getHomePathname from './getHomePathname.js';
+
 function createLink({ backLink, disabledLink, lowdefy, newOriginLink, noLink, sameOriginLink }) {
   function link(props) {
     if (props.disabled === true) {
@@ -35,13 +37,13 @@ function createLink({ backLink, disabledLink, lowdefy, newOriginLink, noLink, sa
     }
     const query = type.isNone(props.urlQuery) ? '' : `${urlQueryFn.stringify(props.urlQuery)}`;
     if (props.home === true) {
+      const pathname = getHomePathname({ lowdefy });
       // An app whose home config names no page has no resolvable home - fall
       // through to noLink's `Invalid Link.` rather than pushing "/undefined"
       // into history and writing inputs['page:undefined'] on the way.
-      if (lowdefy.home?.configured !== true && !type.isString(lowdefy.home?.pageId)) {
+      if (type.isNone(pathname)) {
         return noLink(props);
       }
-      const pathname = `/${lowdefy.home.configured ? '' : lowdefy.home.pageId}`;
       return sameOriginLink({
         ...props,
         pathname,

--- a/packages/engine/src/createLink.js
+++ b/packages/engine/src/createLink.js
@@ -35,6 +35,12 @@ function createLink({ backLink, disabledLink, lowdefy, newOriginLink, noLink, sa
     }
     const query = type.isNone(props.urlQuery) ? '' : `${urlQueryFn.stringify(props.urlQuery)}`;
     if (props.home === true) {
+      // An app whose home config names no page has no resolvable home - fall
+      // through to noLink's `Invalid Link.` rather than pushing "/undefined"
+      // into history and writing inputs['page:undefined'] on the way.
+      if (lowdefy.home?.configured !== true && !type.isString(lowdefy.home?.pageId)) {
+        return noLink(props);
+      }
       const pathname = `/${lowdefy.home.configured ? '' : lowdefy.home.pageId}`;
       return sameOriginLink({
         ...props,

--- a/packages/engine/src/getHomePathname.js
+++ b/packages/engine/src/getHomePathname.js
@@ -1,0 +1,38 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { type } from '@lowdefy/helpers';
+
+// The single reading of `lowdefy.home` for every 'home' target - the Link
+// grammar in createLink and the post-auth callbackUrl ladder in the client both
+// resolve through here. Returns undefined when the app names no home page:
+// getHomeAndMenus resolves pageId to null for an app with no homePageId whose
+// authorized menu yields no link, and each caller decides what no-home means
+// for it (an invalid link, no callback target) rather than interpolating the
+// missing value into a path.
+function getHomePathname({ lowdefy }) {
+  // A configured homePageId is served at the app root - the server resolves `/`
+  // to that page, so the pageId is deliberately not in the path.
+  if (lowdefy.home?.configured === true) {
+    return '/';
+  }
+  if (type.isString(lowdefy.home?.pageId)) {
+    return `/${lowdefy.home.pageId}`;
+  }
+  return undefined;
+}
+
+export default getHomePathname;

--- a/packages/engine/src/index.js
+++ b/packages/engine/src/index.js
@@ -19,9 +19,10 @@ import Slots from './Slots.js';
 import createLink from './createLink.js';
 import Events from './Events.js';
 import getContext from './getContext.js';
+import getHomePathname from './getHomePathname.js';
 import Requests from './Requests.js';
 import State from './State.js';
 
-export { Actions, Slots, createLink, Events, Requests, State };
+export { Actions, Slots, createLink, Events, getHomePathname, Requests, State };
 
 export default getContext;

--- a/packages/engine/test/createLink.test.js
+++ b/packages/engine/test/createLink.test.js
@@ -461,6 +461,43 @@ test('createLink, link with home with inputs, not configured', () => {
   });
 });
 
+test('createLink, link with home calls noLink when the home config names no page', () => {
+  // What getHomeAndMenus returns for an app with no homePageId and no menu link
+  // to fall back on. Unguarded this pushed "/undefined" into history.
+  const lowdefy = { inputs: {}, home: { configured: false, pageId: null } };
+  const link = createLink({
+    backLink: mockBackLink,
+    disabledLink: mockDisabledLink,
+    lowdefy,
+    newOriginLink: mockNewOriginLink,
+    noLink: mockNoLink,
+    sameOriginLink: mockSameOriginLink,
+  });
+  link({ home: true });
+  expect(mockBackLink.mock.calls).toEqual([]);
+  expect(mockDisabledLink.mock.calls).toEqual([]);
+  expect(mockNewOriginLink.mock.calls).toEqual([]);
+  expect(mockSameOriginLink.mock.calls).toEqual([]);
+  expect(mockNoLink.mock.calls).toEqual([[{ home: true }]]);
+  expect(lowdefy.inputs).toEqual({});
+});
+
+test('createLink, link with home calls noLink when there is no home config at all', () => {
+  const lowdefy = { inputs: {} };
+  const link = createLink({
+    backLink: mockBackLink,
+    disabledLink: mockDisabledLink,
+    lowdefy,
+    newOriginLink: mockNewOriginLink,
+    noLink: mockNoLink,
+    sameOriginLink: mockSameOriginLink,
+  });
+  link({ home: true, input: { a: 1 } });
+  expect(mockSameOriginLink.mock.calls).toEqual([]);
+  expect(mockNoLink.mock.calls).toEqual([[{ home: true, input: { a: 1 } }]]);
+  expect(lowdefy.inputs).toEqual({});
+});
+
 test('createLink, no params calls noLink', () => {
   const lowdefy = { inputs: {}, home: { pageId: 'home' } };
   const link = createLink({

--- a/packages/engine/test/getHomePathname.test.js
+++ b/packages/engine/test/getHomePathname.test.js
@@ -1,0 +1,45 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import getHomePathname from '../src/getHomePathname.js';
+
+test('getHomePathname returns the app root when a homePageId is configured', () => {
+  expect(getHomePathname({ lowdefy: { home: { configured: true, pageId: 'dashboard' } } })).toEqual(
+    '/'
+  );
+});
+
+test('getHomePathname returns the menu-derived pageId when no homePageId is configured', () => {
+  expect(
+    getHomePathname({ lowdefy: { home: { configured: false, pageId: 'first-page' } } })
+  ).toEqual('/first-page');
+});
+
+test('getHomePathname returns undefined when the home config names no page', () => {
+  // What getHomeAndMenus returns for an app with no homePageId whose authorized
+  // menu yields no link - the input that built the literal "/null".
+  expect(
+    getHomePathname({ lowdefy: { home: { configured: false, pageId: null } } })
+  ).toBeUndefined();
+});
+
+test('getHomePathname returns undefined when there is no home config at all', () => {
+  expect(getHomePathname({ lowdefy: {} })).toBeUndefined();
+});
+
+test('getHomePathname ignores a non-string pageId', () => {
+  expect(getHomePathname({ lowdefy: { home: { configured: false, pageId: 42 } } })).toBeUndefined();
+});

--- a/packages/plugins/actions/actions-core/src/actions/Login/schema.js
+++ b/packages/plugins/actions/actions-core/src/actions/Login/schema.js
@@ -26,18 +26,85 @@ export default {
         description: 'Send a magic sign-in link to the email address instead of using a password.',
       },
       callbackUrl: {
-        type: 'string',
-        description: 'URL to redirect to after login.',
+        oneOf: [
+          {
+            type: 'object',
+            description:
+              "Structured callback target for where a successful sign-in lands, basePath-prefixed. Defaults to the app's home page when omitted and no ?callbackUrl= query is present; a ?callbackUrl= query set by the unauthenticated-page redirect wins over that default, and this param wins over both.",
+            properties: {
+              home: {
+                type: 'boolean',
+                description: "Land on the app's home page.",
+              },
+              pageId: {
+                type: 'string',
+                description: 'The pageId to land on.',
+              },
+              url: {
+                type: 'string',
+                description:
+                  'The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external landing page.',
+              },
+              urlQuery: {
+                type: 'object',
+                description: 'The urlQuery to set on the destination.',
+              },
+            },
+          },
+          {
+            enum: [false],
+            description:
+              'Do not navigate - the session store re-renders the page with the new user in place, for a login form in a modal or an embedded panel. Not valid for magic-link or social/OAuth sign-in, which redirect through an external hop.',
+          },
+        ],
       },
       newUserCallbackUrl: {
-        type: 'string',
+        type: 'object',
         description:
           'Structured callback target for where a first-time user lands after a magic link (or social/OAuth sign-in) creates their account. Resolved like callbackUrl - basePath-prefixed. When omitted, BetterAuth defaults it to callbackUrl. Ignored by email and phone sign-in.',
+        properties: {
+          home: {
+            type: 'boolean',
+            description: "Land on the app's home page.",
+          },
+          pageId: {
+            type: 'string',
+            description: 'The pageId to land on.',
+          },
+          url: {
+            type: 'string',
+            description:
+              'The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external landing page.',
+          },
+          urlQuery: {
+            type: 'object',
+            description: 'The urlQuery to set on the destination.',
+          },
+        },
       },
       errorCallbackUrl: {
-        type: 'string',
+        type: 'object',
         description:
           "Structured callback target for where a failed or expired magic link (or social/OAuth sign-in) lands, carrying the ?error= reason. Resolved like callbackUrl - basePath-prefixed. When omitted, defaults to the app's authPages.error page (basePath-prefixed); if authPages.error is unset, BetterAuth's own fallback stands. Ignored by email and phone sign-in.",
+        properties: {
+          home: {
+            type: 'boolean',
+            description: "Land on the app's home page.",
+          },
+          pageId: {
+            type: 'string',
+            description: 'The pageId to land on.',
+          },
+          url: {
+            type: 'string',
+            description:
+              'The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external landing page.',
+          },
+          urlQuery: {
+            type: 'object',
+            description: 'The urlQuery to set on the destination.',
+          },
+        },
       },
       captchaToken: {
         type: 'string',

--- a/packages/plugins/actions/actions-core/src/actions/Logout/schema.js
+++ b/packages/plugins/actions/actions-core/src/actions/Logout/schema.js
@@ -1,6 +1,33 @@
 export default {
   type: 'object',
   params: {
+    type: 'object',
     description: 'Parameters passed to the logout method.',
+    properties: {
+      callbackUrl: {
+        type: 'object',
+        description:
+          'Structured callback target for where a signed-out user lands, basePath-prefixed. Unlike the sign-in actions this has no default and does not read the ?callbackUrl= query: with no target the session provider reloads the page and the server re-applies the page auth fork, which sends a protected page to the sign-in page.',
+        properties: {
+          home: {
+            type: 'boolean',
+            description: "Land on the app's home page.",
+          },
+          pageId: {
+            type: 'string',
+            description: 'The pageId to land on.',
+          },
+          url: {
+            type: 'string',
+            description:
+              'The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external logout landing page.',
+          },
+          urlQuery: {
+            type: 'object',
+            description: 'The urlQuery to set on the destination.',
+          },
+        },
+      },
+    },
   },
 };

--- a/packages/plugins/actions/actions-core/src/actions/PasskeySignIn/schema.js
+++ b/packages/plugins/actions/actions-core/src/actions/PasskeySignIn/schema.js
@@ -5,8 +5,37 @@ export default {
     description: 'Parameters passed to the passkey sign-in method.',
     properties: {
       callbackUrl: {
-        type: 'string',
-        description: 'URL to navigate to after a successful passkey sign-in.',
+        oneOf: [
+          {
+            type: 'object',
+            description:
+              "Structured callback target for where a successful passkey sign-in lands, basePath-prefixed. Defaults to the app's home page when omitted and no ?callbackUrl= query is present; a ?callbackUrl= query set by the unauthenticated-page redirect wins over that default, and this param wins over both.",
+            properties: {
+              home: {
+                type: 'boolean',
+                description: "Land on the app's home page.",
+              },
+              pageId: {
+                type: 'string',
+                description: 'The pageId to land on.',
+              },
+              url: {
+                type: 'string',
+                description:
+                  'The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external landing page.',
+              },
+              urlQuery: {
+                type: 'object',
+                description: 'The urlQuery to set on the destination.',
+              },
+            },
+          },
+          {
+            enum: [false],
+            description:
+              'Do not navigate - the session store re-renders the page with the new user in place, for a re-authentication prompt in a modal or an embedded panel.',
+          },
+        ],
       },
     },
   },

--- a/packages/plugins/actions/actions-core/src/actions/SendVerificationEmail/schema.js
+++ b/packages/plugins/actions/actions-core/src/actions/SendVerificationEmail/schema.js
@@ -10,8 +10,28 @@ export default {
         description: 'Email address of the unverified account to send the verification email to.',
       },
       callbackUrl: {
-        type: 'string',
-        description: 'URL to redirect to after email verification.',
+        type: 'object',
+        description:
+          'Structured callback target for where the emailed verification link lands after verifying, basePath-prefixed. Defaults to the home page when omitted and no ?callbackUrl= query is present. A false value is not valid here: the destination belongs to a redirect hop this action cannot suppress.',
+        properties: {
+          home: {
+            type: 'boolean',
+            description: "Land on the app's home page.",
+          },
+          pageId: {
+            type: 'string',
+            description: 'The pageId to land on.',
+          },
+          url: {
+            type: 'string',
+            description:
+              'The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external landing page.',
+          },
+          urlQuery: {
+            type: 'object',
+            description: 'The urlQuery to set on the destination.',
+          },
+        },
       },
       captchaToken: {
         type: 'string',

--- a/packages/plugins/actions/actions-core/src/actions/SignUp/schema.js
+++ b/packages/plugins/actions/actions-core/src/actions/SignUp/schema.js
@@ -17,8 +17,28 @@ export default {
         description: 'Name of the user.',
       },
       callbackUrl: {
-        type: 'string',
-        description: 'URL to redirect to after email verification.',
+        type: 'object',
+        description:
+          'Structured callback target for where the new account lands - both where the emailed verification link goes and, when the response carries a session, where the browser navigates. basePath-prefixed. Defaults to the home page when omitted and no ?callbackUrl= query is present. A false value is not valid here: the same value is the emailed link destination, which SignUp cannot suppress.',
+        properties: {
+          home: {
+            type: 'boolean',
+            description: "Land on the app's home page.",
+          },
+          pageId: {
+            type: 'string',
+            description: 'The pageId to land on.',
+          },
+          url: {
+            type: 'string',
+            description:
+              'The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external landing page.',
+          },
+          urlQuery: {
+            type: 'object',
+            description: 'The urlQuery to set on the destination.',
+          },
+        },
       },
       captchaToken: {
         type: 'string',


### PR DESCRIPTION
## Summary

A successful sign-in with no `callbackUrl` and no `?callbackUrl=` query navigated **nowhere**: `resolveCallbackURL` was a two-rung ladder with nothing at the bottom, and all four navigation sites were written to shrug at `undefined`. The session was minted, the action chain reported success, and the user was left sitting on a live sign-in form with no error anywhere. Reaching a sign-in page without the query param is ordinary rather than exotic — both producers of that param fire only when the user was *bounced* there, so a bookmark, a typed URL, or a link from the signup page produces no destination.

This adds `home: true` as the ladder's bottom rung, adds `callbackUrl: false` so deliberately staying put stays expressible once absence means "go home", and makes an unresolvable destination a legible error instead of a silent return. Implements the `callback-url-default` design (auth-upgrade), the success-path mirror of `error-callback-default`.

It also closes a post-authentication **open redirect** in the query rung the ladder now promotes to a documented feature.

## Changes

- **@lowdefy/client** — `getCallbackUrl`'s `home: true` branch now returns no target when the home config names no page, instead of interpolating the missing value into a URL. `resolveCallbackURL` gains a `callbackUrl === false` short-circuit above the ladder, a `{ home: true }` rung below the query rung, and a throw when nothing resolves. A new `assertCallbackUrlNavigable` rejects `false` on the four paths that forward the value to BetterAuth. `logout` moves onto `resolveTargetURL`, dropping its hand-rolled basePath prefix.
- **@lowdefy/client (security)** — the `?callbackUrl=` rung was guarded by `startsWith('/')`, which accepts `//evil.com` and `/\evil.com`: protocol-relative URLs that navigate off-site. That value never reaches BetterAuth on the email, phone and passkey paths — it goes straight into `window.location.assign` — so `originCheck` / `trustedOrigins` never saw it, and a crafted sign-in link was a post-authentication open redirect with a freshly minted session. Now guarded by `isAppRelativePath`. Pre-existing, fixed here because this PR promotes that rung to a documented ladder rung and rewrites the comment that claimed the protection.
- **@lowdefy/engine** — `createLink` carried the identical unguarded home expression, so the same broken config made a `Link` with `home: true` push `/undefined` into history and write `inputs['page:undefined']`. It now falls through to `noLink`'s `Invalid Link.`. The rule itself moves into a new `getHomePathname`, exported from `@lowdefy/engine` and consumed by the client ladder, so `lowdefy.home` is read in exactly one place instead of being duplicated across two packages.
- **@lowdefy/actions-core** — `callbackUrl` was declared `type: 'string'` on `Login`, `SignUp`, `PasskeySignIn` and `SendVerificationEmail`, which was already wrong: it is a structured `{ home, pageId, url, urlQuery }` target. Corrected to the real shape plus the `false` variant where it is honoured. `newUserCallbackUrl` and `errorCallbackUrl` were mis-typed the same way. `Logout` gained a `params` surface it never had.
- **@lowdefy/build** — three auth fixture snapshots regenerated.
- **@lowdefy/docs** — `actions/Login.yaml`, `actions/Logout.yaml` and `users/login-and-logout.yaml` all stated that an unset `callbackUrl` returns the user to the page the action was called from, which was never true and is now the opposite of the default. Rewritten to document the three-rung precedence and `callbackUrl: false`.

## Key Files

- `packages/client/src/auth/createAuthMethods.js` — the ladder, the `false` opt-out, the throw, the open-redirect guard, and the `logout` fold
- `packages/engine/src/getHomePathname.js` — new; the single reading of `lowdefy.home`
- `packages/engine/src/createLink.js` — the second consumer of that rule
- `packages/client/src/auth/createAuthMethods.test.js` — 92 → 128 tests
- `packages/plugins/actions/actions-core/src/actions/Login/schema.js` — the structured `callbackUrl` shape

## Breaking Changes

- **A sign-in that resolved no destination now navigates to the app's home page** instead of staying put. An app relying on the old no-navigation behaviour — a login form in a modal, an embedded panel, a re-authentication prompt — must now pass `callbackUrl: false`. The previously-only spelling for this was an accident (`callbackUrl: {url: ''}`, which survives as a resolved-but-falsy target); `false` replaces it as the documented surface.
- **`callbackUrl: false` throws** on magic-link, social/OAuth, `SignUp` and `SendVerificationEmail`. There the value is the destination of a hop Lowdefy does not control, so "do not navigate" is unachievable once the browser has left. Both alternatives are worse than an error: omitting the param lands the user on BetterAuth's `"/"` fallback, and silently substituting the home default contradicts an explicit instruction.
- **Magic-link, social and `sendVerificationEmail` under a `basePath` are fixed, not merely reinforced.** BetterAuth resolves its own fallback as `new URL("/", baseURL)` with `baseURL` of `${origin}${basePath}/api/auth`, and a root-relative `/` discards the path — so a subpath-hosted app was dropping those users on the **origin root, outside the app**. They now land on `${basePath}/`.
- **An unresolvable home config now throws** where it previously navigated to `/undefined` (or `/null`) — a 404 with no symptom anywhere.
- **A protocol-relative `?callbackUrl=` is no longer honoured.** Any app that relied on `//host/path` in that query to leave the origin after sign-in must pass an explicit absolute `callbackUrl: {url: ...}` instead, where BetterAuth's origin checks apply.
- **Not a break, deliberately:** a `callbackUrl` that resolves to `null` or to a bare string is treated as absence and falls through the ladder. `null` (an `_if` with no matching branch) previously threw a TypeError. A bare string is the spelling these params were *wrongly declared as* until this PR, so it is common in existing apps: throwing would fail sign-ins that work today, and reading a string as `{ url }` would double-prefix `basePath` on the commonest case of all — a string carrying the already-prefixed query value.

## Notes

- **The throw is reachable, not defensive.** `getHomeAndMenus` genuinely returns `{ configured: false, pageId: null }` for an app with no `homePageId` and no menu link to fall back on, so `home: true` built the literal `"/null"` today. Without the guard in `getCallbackUrl` the new throw would have been dead code.
- **The home default is resolved for the *unauthenticated* caller when `homePageId` is unset.** `getHomeAndMenus` derives `home.pageId` from the menu, and `filterMenuList` filters every `MenuLink` through `authorize` — so on a public sign-in page the fallback is computed from what a signed-out visitor can see. An app whose menu is entirely protected therefore resolves no home and throws, and one with a single public link resolves to that page rather than the user's real home. Setting `homePageId` sidesteps both: the ladder then yields `/` and the server resolves the destination after authentication, when it knows the caller. Worth knowing before relying on the menu fallback.
- **The throw is pre-flight, so "sign-in failed" is the truth.** Every site resolves the destination before its BetterAuth call, so a throw mints no session — a login page mapping the failure to authentication messaging is not lying. A test pins this (`expect(auth.signInEmail).not.toHaveBeenCalled()`); reordering the resolve below the call would turn that message into a lie.
- **`renderPage.js:41` carries a third copy of the same expression** and sends `/` to `${basePath}/null`, which lands on `/404` after a second redirect, logged as `redirect_to_homepage pageId: null`. Left unfixed here — choosing the right status and log line for a home-less app is its own change.
- **Do not "tidy" the query rung through `resolveTargetURL`** for uniformity's sake. Both of its producers (`renderPage.js`, `apiPage.js`) already bake `basePath` into the value they emit, so prefixing there double-prefixes a bounced sign-in to `/app/app/reports`. There is a test pinning this. The same reasoning is why a bare-string `callbackUrl` is not read as `{ url }`.
- **The three regenerated build snapshots were already failing on `auth-upgrade`** before this branch — `newUserCallbackUrl`/`errorCallbackUrl` were added to the Login schema without regenerating them. This clears that backlog alongside the new shape, which is why the snapshot diff is larger than this change alone would produce.
- **`logout` deliberately gains no default** and still reads neither the query nor the home rung; the post-sign-out reload plus the server's page auth fork is the correct landing for a sign-out. It does inherit the `/undefined` correctness fix. The `resolveTargetURL` fold is behaviour-neutral on every input, including the empty-string case where `willNavigate` must stay `false`.
- **No changeset**, matching the sibling `error-callback-default` implementation (`ed27ae72b`) — auth-upgrade features are being rolled up rather than versioned individually.
- **Pre-existing test failures unrelated to this change:** `connection-google-sheets` and `plugin-gcp` fail to load on a patched `buffer-equal-constant-time` via `jwa`. Verified present without these commits. All other packages pass — client 187, engine 384, build 1972, api 782, actions-core 188, server-dev 155.
