### PR TITLE
UpdateSession must actually refresh the BetterAuth client session store

### DIFF
--- a/packages/client/src/auth/createAuthMethods.js
+++ b/packages/client/src/auth/createAuthMethods.js
@@ -399,13 +399,20 @@ function createAuthMethods(lowdefy, auth) {
     return unwrap(auth.stopImpersonating());
   }
 
-  // Bypasses the cookie cache (a live re-resolve), so role, attribute or
-  // session changes surface immediately instead of after cookieCache.maxAge.
-  // Roles and merged attributes come from the server-resolved caller - the
-  // active member row read the base session does not carry.
+  // Refreshes the BetterAuth client session store through an awaited
+  // store refetch, bypassing the cookie cache (a live re-resolve) so role,
+  // attribute or session changes surface immediately instead of after
+  // cookieCache.maxAge. The store holds a fresh session user before this
+  // resolves. Roles and merged attributes come from the server-resolved
+  // caller - the active member row read the base session does not carry.
   async function updateSession() {
-    await unwrap(auth.getSession({ disableCookieCache: true }));
+    const session = await unwrap(auth.refreshSession({ disableCookieCache: true }));
     const { user } = await auth.getResolvedUser();
+    if (session && type.isNone(user)) {
+      // A session with no resolved caller is the admission wall rejecting a
+      // real session, not a logout - surface it instead of nulling the caller.
+      throw new Error('UpdateSession failed: a session is active but the server resolved no user.');
+    }
     if (auth.updateResolvedUser) {
       auth.updateResolvedUser(user ?? null);
     }

--- a/packages/client/src/auth/createAuthMethods.test.js
+++ b/packages/client/src/auth/createAuthMethods.test.js
@@ -34,6 +34,9 @@ function setup({ signInResult, signUpResult } = {}) {
       Promise.resolve({ data: { token: null, user: {} }, error: null })
     ),
     deletePasskey: jest.fn(() => Promise.resolve({ data: { status: true }, error: null })),
+    getResolvedUser: jest.fn(() =>
+      Promise.resolve({ user: { id: 'user-1', roles: ['admin'], attributes: {} } })
+    ),
     getSession: jest.fn(() =>
       Promise.resolve({
         data: { session: { activeOrganizationId: 'org-1' }, user: {} },
@@ -52,6 +55,9 @@ function setup({ signInResult, signUpResult } = {}) {
     phoneNumberSendOtp: jest.fn(() => Promise.resolve({ data: { status: true }, error: null })),
     phoneNumberVerify: jest.fn(() =>
       Promise.resolve({ data: { token: 't', user: {} }, error: null })
+    ),
+    refreshSession: jest.fn(() =>
+      Promise.resolve({ data: { session: {}, user: { id: 'user-1' } }, error: null })
     ),
     removeMember: jest.fn(() => Promise.resolve({ data: { member: {} }, error: null })),
     requestPasswordReset: jest.fn(() => Promise.resolve({ data: { status: true }, error: null })),
@@ -88,6 +94,7 @@ function setup({ signInResult, signUpResult } = {}) {
     updateOrganization: jest.fn(() =>
       Promise.resolve({ data: { id: 'org-1', name: 'Acme Inc' }, error: null })
     ),
+    updateResolvedUser: jest.fn(),
   };
   return { auth, lowdefy, assign };
 }
@@ -1422,4 +1429,71 @@ test('sendVerificationEmail reports a missing email before judging the callbackU
   await expect(sendVerificationEmail({ callbackUrl: false })).rejects.toThrow(
     'SendVerificationEmail requires an "email" param.'
   );
+});
+
+test('updateSession awaits the store refetch, with disableCookieCache, before resolving the user', async () => {
+  const { auth, lowdefy } = setup();
+  const order = [];
+  auth.refreshSession = jest.fn(
+    () =>
+      new Promise((resolve) => {
+        setTimeout(() => {
+          order.push('refreshSession resolved');
+          resolve({ data: { session: {}, user: { id: 'user-1' } }, error: null });
+        }, 0);
+      })
+  );
+  auth.getResolvedUser = jest.fn(() => {
+    order.push('getResolvedUser called');
+    return Promise.resolve({ user: { id: 'user-1', roles: ['admin'], attributes: {} } });
+  });
+  const { updateSession } = createAuthMethods(lowdefy, auth);
+  await updateSession();
+  expect(auth.refreshSession.mock.calls).toEqual([[{ disableCookieCache: true }]]);
+  expect(order).toEqual(['refreshSession resolved', 'getResolvedUser called']);
+});
+
+test('updateSession updates the resolved user ref and lowdefy.user from /api/user', async () => {
+  const { auth, lowdefy } = setup();
+  const resolved = { id: 'user-1', roles: ['admin'], attributes: { plan: 'pro' } };
+  auth.getResolvedUser = jest.fn(() => Promise.resolve({ user: resolved }));
+  const { updateSession } = createAuthMethods(lowdefy, auth);
+  await updateSession();
+  expect(auth.updateResolvedUser.mock.calls).toEqual([[resolved]]);
+  expect(lowdefy.user).toEqual(resolved);
+});
+
+test('updateSession throws when the session refresh fails and never reaches /api/user', async () => {
+  const { auth, lowdefy } = setup();
+  auth.refreshSession = jest.fn(() =>
+    Promise.resolve({ data: null, error: { message: 'Failed to fetch the session.', status: 500 } })
+  );
+  lowdefy.user = { id: 'user-1' };
+  const { updateSession } = createAuthMethods(lowdefy, auth);
+  await expect(updateSession()).rejects.toThrow('Failed to fetch the session.');
+  expect(auth.getResolvedUser).not.toHaveBeenCalled();
+  expect(lowdefy.user).toEqual({ id: 'user-1' });
+});
+
+test('updateSession throws when a session is present but no user resolves, instead of nulling', async () => {
+  const { auth, lowdefy } = setup();
+  auth.getResolvedUser = jest.fn(() => Promise.resolve({ user: null }));
+  lowdefy.user = { id: 'user-1' };
+  const { updateSession } = createAuthMethods(lowdefy, auth);
+  await expect(updateSession()).rejects.toThrow(
+    'UpdateSession failed: a session is active but the server resolved no user.'
+  );
+  expect(auth.updateResolvedUser).not.toHaveBeenCalled();
+  expect(lowdefy.user).toEqual({ id: 'user-1' });
+});
+
+test('updateSession nulls the user when the session is genuinely absent', async () => {
+  const { auth, lowdefy } = setup();
+  auth.refreshSession = jest.fn(() => Promise.resolve({ data: null, error: null }));
+  auth.getResolvedUser = jest.fn(() => Promise.resolve({ user: null }));
+  lowdefy.user = { id: 'user-1' };
+  const { updateSession } = createAuthMethods(lowdefy, auth);
+  await updateSession();
+  expect(auth.updateResolvedUser.mock.calls).toEqual([[null]]);
+  expect(lowdefy.user).toBe(null);
 });

--- a/packages/servers/server-dev/lib/client/auth/AuthConfigured.jsx
+++ b/packages/servers/server-dev/lib/client/auth/AuthConfigured.jsx
@@ -45,15 +45,23 @@ const authClient = createAuthClient({
   ],
 });
 
+// UpdateSession owns session freshness - suppress BetterAuth's own
+// signal-driven refetch on the calls that would otherwise fire one, so
+// nothing competes with (and aborts) the refetch UpdateSession awaits.
+// disableSignal silences all atomListeners for the call, including the
+// organization plugin's org atoms - none are exposed to app config, so a
+// future design exposing one must refresh it through its own action.
+const sessionScoped = (params) => ({ ...params, fetchOptions: { disableSignal: true } });
+
 // The server resolves the caller per request and embeds it in the page
 // config, so the first render never flashes unauthenticated. The BetterAuth
 // client store takes over once its session fetch settles.
 //
 // Roles and merged attributes resolve server-side from the active member row
 // - the base session carries neither. The last server-resolved caller is
-// kept in a ref: while the session user is unchanged its roles and
-// attributes stay authoritative, and UpdateSession refreshes the ref from
-// /api/user after a change (e.g. SetActiveOrganization).
+// kept in a ref: while the session user is unchanged it stays authoritative
+// for the fields the session does not carry, and UpdateSession refreshes the
+// ref from /api/user after a change (e.g. SetActiveOrganization).
 function Session({ children, reloadSuppressedRef, serverUser }) {
   const { data: session, isPending } = authClient.useSession();
   const resolvedUserRef = useRef(serverUser);
@@ -79,10 +87,29 @@ function Session({ children, reloadSuppressedRef, serverUser }) {
     return children(null, resolvedUserRef);
   }
   const resolved = resolvedUserRef.current;
-  const user =
-    resolved && resolved.id === session.user.id
-      ? { ...session.user, roles: resolved.roles, attributes: resolved.attributes }
-      : { roles: [], ...session.user };
+  if (!resolved) {
+    return children({ roles: [], ...session.user }, resolvedUserRef);
+  }
+  if (resolved.id !== session.user.id) {
+    // The ref has not caught up with a changed session user (an impersonation
+    // switch between the session refetch and the /api/user result). Render
+    // the last resolved caller rather than a caller with no roles - blocks
+    // re-evaluate operators on render, so a role-guarded page would act on
+    // roles: [].
+    return children(resolved, resolvedUserRef);
+  }
+  // The resolved caller contributes every field the session user lacks: roles
+  // (the active member row), attributes (the merged bag), and
+  // activeOrganizationId / impersonatedBy (session row, not session user).
+  // impersonatedBy is carried only when present, matching the server, which
+  // omits it rather than setting it to undefined.
+  const user = {
+    ...session.user,
+    roles: resolved.roles,
+    attributes: resolved.attributes,
+    activeOrganizationId: resolved.activeOrganizationId,
+    ...('impersonatedBy' in resolved ? { impersonatedBy: resolved.impersonatedBy } : {}),
+  };
   return children(user, resolvedUserRef);
 }
 
@@ -92,6 +119,19 @@ function AuthConfigured({ authConfig, children, serverUser }) {
     authConfig,
     getSession: ({ disableCookieCache } = {}) =>
       authClient.getSession(disableCookieCache ? { query: { disableCookieCache: true } } : {}),
+    // Refetches the session through the session atom - the store's only
+    // writer - and resolves only after the store is written. fetchSession
+    // returns undefined and never rejects (failures are written into the
+    // atom), so the atom's own { data, error } is read back and returned,
+    // keeping unwrap working and surfacing a failed refresh to the action.
+    refreshSession: async ({ disableCookieCache } = {}) => {
+      const sessionAtom = authClient.$store.atoms.session;
+      await sessionAtom
+        .get()
+        .refetch(disableCookieCache ? { query: { disableCookieCache: true } } : undefined);
+      const { data, error } = sessionAtom.get();
+      return { data, error };
+    },
     // The server-resolved caller - roles from the active member row and the
     // merged attributes bag - for re-syncing after session changes.
     getResolvedUser: async () => {
@@ -99,8 +139,10 @@ function AuthConfigured({ authConfig, children, serverUser }) {
         credentials: 'same-origin',
       });
       if (!response.ok) {
-        // Throw instead of parsing an error page - a silent { user: undefined }
-        // would read as a client-side logout in updateSession.
+        // /api/user itself always answers 200 { user } - user: null when no
+        // caller is admitted, which updateSession branches on. A non-OK
+        // response is a transport failure (gateway error page, 5xx) with no
+        // parsable body.
         throw new Error(`Failed to fetch the resolved user (HTTP ${response.status}).`);
       }
       return response.json();
@@ -108,27 +150,27 @@ function AuthConfigured({ authConfig, children, serverUser }) {
     suppressSignOutReload: () => {
       reloadSuppressedRef.current = true;
     },
-    acceptInvitation: (params) => authClient.organization.acceptInvitation(params),
+    acceptInvitation: (params) => authClient.organization.acceptInvitation(sessionScoped(params)),
     // addPasskey runs the WebAuthn browser ceremony itself - options fetch,
     // authenticator prompt, verification.
     addPasskey: (params) => authClient.passkey.addPasskey(params),
     cancelInvitation: (params) => authClient.organization.cancelInvitation(params),
-    changePassword: (params) => authClient.changePassword(params),
+    changePassword: (params) => authClient.changePassword(sessionScoped(params)),
     deletePasskey: (params) => authClient.passkey.deletePasskey(params),
-    impersonateUser: (params) => authClient.admin.impersonateUser(params),
+    impersonateUser: (params) => authClient.admin.impersonateUser(sessionScoped(params)),
     inviteMember: (params) => authClient.organization.inviteMember(params),
-    leaveOrganization: (params) => authClient.organization.leave(params),
+    leaveOrganization: (params) => authClient.organization.leave(sessionScoped(params)),
     phoneNumberRequestPasswordReset: (params) =>
       authClient.phoneNumber.requestPasswordReset(params),
     phoneNumberResetPassword: (params) => authClient.phoneNumber.resetPassword(params),
     phoneNumberSendOtp: (params) => authClient.phoneNumber.sendOtp(params),
     phoneNumberVerify: (params) => authClient.phoneNumber.verify(params),
-    removeMember: (params) => authClient.organization.removeMember(params),
+    removeMember: (params) => authClient.organization.removeMember(sessionScoped(params)),
     requestPasswordReset: (params) => authClient.requestPasswordReset(params),
     resetPassword: (params) => authClient.resetPassword(params),
-    revokeOtherSessions: () => authClient.revokeOtherSessions(),
+    revokeOtherSessions: () => authClient.revokeOtherSessions(sessionScoped()),
     sendVerificationEmail: (params) => authClient.sendVerificationEmail(params),
-    setActiveOrganization: (params) => authClient.organization.setActive(params),
+    setActiveOrganization: (params) => authClient.organization.setActive(sessionScoped(params)),
     signInEmail: (params) => authClient.signIn.email(params),
     signInMagicLink: (params) => authClient.signIn.magicLink(params),
     signInOauth2: (params) => authClient.signIn.oauth2(params),
@@ -137,7 +179,7 @@ function AuthConfigured({ authConfig, children, serverUser }) {
     signInSocial: (params) => authClient.signIn.social(params),
     signOut: () => authClient.signOut(),
     signUpEmail: (params) => authClient.signUp.email(params),
-    stopImpersonating: () => authClient.admin.stopImpersonating(),
+    stopImpersonating: () => authClient.admin.stopImpersonating(sessionScoped()),
     twoFactorDisable: (params) => authClient.twoFactor.disable(params),
     twoFactorEnable: (params) => authClient.twoFactor.enable(params),
     twoFactorVerifyBackupCode: (params) => authClient.twoFactor.verifyBackupCode(params),

--- a/packages/servers/server-dev/lib/client/auth/AuthConfigured.jsx
+++ b/packages/servers/server-dev/lib/client/auth/AuthConfigured.jsx
@@ -48,10 +48,17 @@ const authClient = createAuthClient({
 // UpdateSession owns session freshness - suppress BetterAuth's own
 // signal-driven refetch on the calls that would otherwise fire one, so
 // nothing competes with (and aborts) the refetch UpdateSession awaits.
+// Only calls that mutate an existing session are suppressed - calls that
+// can establish one (the sign-ins, and the two-factor, phone-number and
+// passkey verifies) keep their signal: its refetch is what makes the store
+// notice a login when no navigation follows.
 // disableSignal silences all atomListeners for the call, including the
 // organization plugin's org atoms - none are exposed to app config, so a
 // future design exposing one must refresh it through its own action.
-const sessionScoped = (params) => ({ ...params, fetchOptions: { disableSignal: true } });
+const sessionScoped = (params) => ({
+  ...params,
+  fetchOptions: { ...params?.fetchOptions, disableSignal: true },
+});
 
 // The server resolves the caller per request and embeds it in the page
 // config, so the first render never flashes unauthenticated. The BetterAuth
@@ -95,7 +102,9 @@ function Session({ children, reloadSuppressedRef, serverUser }) {
     // switch between the session refetch and the /api/user result). Render
     // the last resolved caller rather than a caller with no roles - blocks
     // re-evaluate operators on render, so a role-guarded page would act on
-    // roles: [].
+    // roles: []. UpdateSession closes the window when it lands the new
+    // caller; a flow that swaps the session user without chaining it leaves
+    // the previous caller rendered until the next page load.
     return children(resolved, resolvedUserRef);
   }
   // The resolved caller contributes every field the session user lacks: roles
@@ -180,8 +189,8 @@ function AuthConfigured({ authConfig, children, serverUser }) {
     signOut: () => authClient.signOut(),
     signUpEmail: (params) => authClient.signUp.email(params),
     stopImpersonating: () => authClient.admin.stopImpersonating(sessionScoped()),
-    twoFactorDisable: (params) => authClient.twoFactor.disable(params),
-    twoFactorEnable: (params) => authClient.twoFactor.enable(params),
+    twoFactorDisable: (params) => authClient.twoFactor.disable(sessionScoped(params)),
+    twoFactorEnable: (params) => authClient.twoFactor.enable(sessionScoped(params)),
     twoFactorVerifyBackupCode: (params) => authClient.twoFactor.verifyBackupCode(params),
     twoFactorVerifyTotp: (params) => authClient.twoFactor.verifyTotp(params),
     updateMemberRole: (params) => authClient.organization.updateMemberRole(params),

--- a/packages/servers/server-dev/lib/client/auth/authTemplateSync.test.mjs
+++ b/packages/servers/server-dev/lib/client/auth/authTemplateSync.test.mjs
@@ -1,0 +1,40 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const devAuthDir = path.dirname(fileURLToPath(import.meta.url));
+const prodAuthDir = path.resolve(devAuthDir, '../../../../server/lib/client/auth');
+
+// The dev and prod server templates each carry their own copy of the auth
+// components, kept in sync by hand. A change applied to one and not the
+// other ships dev-only or prod-only - the app then behaves differently
+// between lowdefy dev and a production build, which no unit test of either
+// copy can catch.
+test('the auth client templates are byte-identical between server and server-dev', async () => {
+  const isTemplate = (file) => !file.includes('.test.');
+  const devFiles = (await readdir(devAuthDir)).filter(isTemplate).sort();
+  const prodFiles = (await readdir(prodAuthDir)).filter(isTemplate).sort();
+  expect(prodFiles).toEqual(devFiles);
+  for (const file of devFiles) {
+    const dev = await readFile(path.join(devAuthDir, file), 'utf8');
+    const prod = await readFile(path.join(prodAuthDir, file), 'utf8');
+    // Compared per file so a failure names the file that diverged.
+    expect({ file, content: prod }).toEqual({ file, content: dev });
+  }
+});

--- a/packages/servers/server-dev/lib/client/auth/betterAuthSessionContract.test.mjs
+++ b/packages/servers/server-dev/lib/client/auth/betterAuthSessionContract.test.mjs
@@ -1,0 +1,175 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { createAuthClient } from 'better-auth/client';
+
+// AuthConfigured.jsx depends on behaviours of better-auth's client internals
+// that no public API documents:
+//   1. authClient.$store.atoms.session is the real session store, and its
+//      value exposes an awaitable refetch - the store's only writer.
+//   2. A getSession path call never writes the store (/get-session is not in
+//      the atomListeners matcher) - the defect refreshSession exists to work
+//      around.
+//   3. A failed refetch resolves normally (it never rejects) and writes the
+//      error into the atom - why refreshSession reads { data, error } back
+//      instead of using the refetch's return value.
+//   4. The proxy fires a signal-driven background session fetch shortly
+//      after a matched endpoint succeeds, aborting any refetch already in
+//      flight, and fetchOptions.disableSignal suppresses it - the
+//      sessionScoped mechanism, and why it is required rather than merely
+//      awaiting the refetch.
+// A better-auth upgrade that changes any of these breaks UpdateSession the
+// way the original defect did - visibly only in a running app. These tests
+// pin the contract so the break surfaces here instead.
+
+const USER_1 = { id: 'user-1', email: 'user-1@example.com' };
+const USER_2 = { id: 'user-2', email: 'user-2@example.com' };
+
+function jsonResponse(payload, { status = 200 } = {}) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function sessionPayload(user) {
+  return { session: { id: 'session-1', userId: user.id }, user };
+}
+
+function createClient(handleGetSession) {
+  const requests = [];
+  const client = createAuthClient({
+    baseURL: 'http://localhost:3000/api/auth',
+    fetchOptions: {
+      customFetchImpl: async (input, init) => {
+        const url = String(input);
+        requests.push({ url, init });
+        if (url.includes('/get-session')) {
+          if (handleGetSession) {
+            return handleGetSession(url, init);
+          }
+          return jsonResponse(sessionPayload(USER_1));
+        }
+        return jsonResponse({ status: true });
+      },
+    },
+  });
+  // Mount the session atom with a never-removed subscription, mirroring the
+  // app - Session's useSession() keeps it mounted, and mounting is what
+  // makes the signal subscription live. It also keeps the store mounted for
+  // bare .get() calls: on an unmounted onMount store, .get() temporarily
+  // mounts it and schedules nanostores' delayed unmount on a timer that
+  // outlives the jest worker. The mount's own initial fetch is skipped in
+  // node (isServer), so no request is recorded here.
+  client.$store.atoms.session.subscribe(() => {});
+  const getSessionRequests = () => requests.filter((r) => r.url.includes('/get-session'));
+  return { client, getSessionRequests };
+}
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test('the session store is reachable at $store.atoms.session and exposes an awaitable refetch', () => {
+  const { client } = createClient();
+  const value = client.$store.atoms.session.get();
+  expect(value).toMatchObject({ data: null, error: null, isPending: true });
+  expect(typeof value.refetch).toBe('function');
+});
+
+test('a getSession path call resolves the session without ever writing the store', async () => {
+  const { client } = createClient();
+  const sessionAtom = client.$store.atoms.session;
+  const { data } = await client.getSession({ query: { disableCookieCache: true } });
+  expect(data.user).toEqual(USER_1);
+  expect(sessionAtom.get().data).toBe(null);
+});
+
+test('an awaited refetch writes the store before resolving, carrying the disableCookieCache query', async () => {
+  const { client, getSessionRequests } = createClient();
+  const sessionAtom = client.$store.atoms.session;
+  const result = await sessionAtom.get().refetch({ query: { disableCookieCache: true } });
+  // The refetch resolves to undefined - its outcome is only readable from
+  // the atom, which is why refreshSession returns the atom's { data, error }.
+  expect(result).toBeUndefined();
+  const { data, error, isPending } = sessionAtom.get();
+  expect(data.user).toEqual(USER_1);
+  expect(error).toBe(null);
+  expect(isPending).toBe(false);
+  expect(getSessionRequests()).toHaveLength(1);
+  expect(getSessionRequests()[0].url).toContain('disableCookieCache=true');
+});
+
+test('a failed refetch resolves normally and writes the error into the atom', async () => {
+  const { client } = createClient(() =>
+    jsonResponse({ message: 'Internal error.' }, { status: 500 })
+  );
+  const sessionAtom = client.$store.atoms.session;
+  await expect(sessionAtom.get().refetch()).resolves.toBeUndefined();
+  const { error } = sessionAtom.get();
+  expect(error).not.toBe(null);
+  expect(error.status).toBe(500);
+});
+
+test('a matched endpoint fires one background session refetch shortly after success', async () => {
+  const { client, getSessionRequests } = createClient();
+  await client.changePassword({ currentPassword: 'old', newPassword: 'new' });
+  expect(getSessionRequests()).toHaveLength(0);
+  // The proxy flips $sessionSignal on a 10ms setTimeout after success.
+  await wait(100);
+  expect(getSessionRequests()).toHaveLength(1);
+});
+
+test('fetchOptions.disableSignal suppresses the background refetch - the sessionScoped mechanism', async () => {
+  const { client, getSessionRequests } = createClient();
+  await client.changePassword({
+    currentPassword: 'old',
+    newPassword: 'new',
+    fetchOptions: { disableSignal: true },
+  });
+  await wait(100);
+  expect(getSessionRequests()).toHaveLength(0);
+});
+
+test('a competing session fetch aborts an in-flight refetch, which resolves having written nothing', async () => {
+  let getSessionCalls = 0;
+  const { client } = createClient((url, init) => {
+    getSessionCalls += 1;
+    if (getSessionCalls === 1) {
+      // The first refetch's request: rejects on abort like a real fetch,
+      // with a slow success fallback so the test stays deterministic even
+      // if the abort signal is not forwarded - the aborted-controller check
+      // must prevent the write either way.
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => resolve(jsonResponse(sessionPayload(USER_1))), 80);
+        init?.signal?.addEventListener('abort', () => {
+          clearTimeout(timer);
+          reject(new Error('aborted'));
+        });
+      });
+    }
+    return jsonResponse(sessionPayload(USER_2));
+  });
+  const sessionAtom = client.$store.atoms.session;
+  const first = sessionAtom.get().refetch({ query: { disableCookieCache: true } });
+  const second = sessionAtom.get().refetch();
+  await expect(first).resolves.toBeUndefined();
+  await second;
+  // Only the second fetch's write landed - the first was aborted mid-flight
+  // and wrote nothing, which is why UpdateSession must be the only session
+  // refresher for its awaited refetch to mean anything.
+  expect(sessionAtom.get().data.user).toEqual(USER_2);
+});

--- a/packages/servers/server/lib/client/auth/AuthConfigured.jsx
+++ b/packages/servers/server/lib/client/auth/AuthConfigured.jsx
@@ -45,15 +45,23 @@ const authClient = createAuthClient({
   ],
 });
 
+// UpdateSession owns session freshness - suppress BetterAuth's own
+// signal-driven refetch on the calls that would otherwise fire one, so
+// nothing competes with (and aborts) the refetch UpdateSession awaits.
+// disableSignal silences all atomListeners for the call, including the
+// organization plugin's org atoms - none are exposed to app config, so a
+// future design exposing one must refresh it through its own action.
+const sessionScoped = (params) => ({ ...params, fetchOptions: { disableSignal: true } });
+
 // The server resolves the caller per request and embeds it in the page
 // config, so the first render never flashes unauthenticated. The BetterAuth
 // client store takes over once its session fetch settles.
 //
 // Roles and merged attributes resolve server-side from the active member row
 // - the base session carries neither. The last server-resolved caller is
-// kept in a ref: while the session user is unchanged its roles and
-// attributes stay authoritative, and UpdateSession refreshes the ref from
-// /api/user after a change (e.g. SetActiveOrganization).
+// kept in a ref: while the session user is unchanged it stays authoritative
+// for the fields the session does not carry, and UpdateSession refreshes the
+// ref from /api/user after a change (e.g. SetActiveOrganization).
 function Session({ children, reloadSuppressedRef, serverUser }) {
   const { data: session, isPending } = authClient.useSession();
   const resolvedUserRef = useRef(serverUser);
@@ -79,10 +87,29 @@ function Session({ children, reloadSuppressedRef, serverUser }) {
     return children(null, resolvedUserRef);
   }
   const resolved = resolvedUserRef.current;
-  const user =
-    resolved && resolved.id === session.user.id
-      ? { ...session.user, roles: resolved.roles, attributes: resolved.attributes }
-      : { roles: [], ...session.user };
+  if (!resolved) {
+    return children({ roles: [], ...session.user }, resolvedUserRef);
+  }
+  if (resolved.id !== session.user.id) {
+    // The ref has not caught up with a changed session user (an impersonation
+    // switch between the session refetch and the /api/user result). Render
+    // the last resolved caller rather than a caller with no roles - blocks
+    // re-evaluate operators on render, so a role-guarded page would act on
+    // roles: [].
+    return children(resolved, resolvedUserRef);
+  }
+  // The resolved caller contributes every field the session user lacks: roles
+  // (the active member row), attributes (the merged bag), and
+  // activeOrganizationId / impersonatedBy (session row, not session user).
+  // impersonatedBy is carried only when present, matching the server, which
+  // omits it rather than setting it to undefined.
+  const user = {
+    ...session.user,
+    roles: resolved.roles,
+    attributes: resolved.attributes,
+    activeOrganizationId: resolved.activeOrganizationId,
+    ...('impersonatedBy' in resolved ? { impersonatedBy: resolved.impersonatedBy } : {}),
+  };
   return children(user, resolvedUserRef);
 }
 
@@ -92,6 +119,19 @@ function AuthConfigured({ authConfig, children, serverUser }) {
     authConfig,
     getSession: ({ disableCookieCache } = {}) =>
       authClient.getSession(disableCookieCache ? { query: { disableCookieCache: true } } : {}),
+    // Refetches the session through the session atom - the store's only
+    // writer - and resolves only after the store is written. fetchSession
+    // returns undefined and never rejects (failures are written into the
+    // atom), so the atom's own { data, error } is read back and returned,
+    // keeping unwrap working and surfacing a failed refresh to the action.
+    refreshSession: async ({ disableCookieCache } = {}) => {
+      const sessionAtom = authClient.$store.atoms.session;
+      await sessionAtom
+        .get()
+        .refetch(disableCookieCache ? { query: { disableCookieCache: true } } : undefined);
+      const { data, error } = sessionAtom.get();
+      return { data, error };
+    },
     // The server-resolved caller - roles from the active member row and the
     // merged attributes bag - for re-syncing after session changes.
     getResolvedUser: async () => {
@@ -99,8 +139,10 @@ function AuthConfigured({ authConfig, children, serverUser }) {
         credentials: 'same-origin',
       });
       if (!response.ok) {
-        // Throw instead of parsing an error page - a silent { user: undefined }
-        // would read as a client-side logout in updateSession.
+        // /api/user itself always answers 200 { user } - user: null when no
+        // caller is admitted, which updateSession branches on. A non-OK
+        // response is a transport failure (gateway error page, 5xx) with no
+        // parsable body.
         throw new Error(`Failed to fetch the resolved user (HTTP ${response.status}).`);
       }
       return response.json();
@@ -108,27 +150,27 @@ function AuthConfigured({ authConfig, children, serverUser }) {
     suppressSignOutReload: () => {
       reloadSuppressedRef.current = true;
     },
-    acceptInvitation: (params) => authClient.organization.acceptInvitation(params),
+    acceptInvitation: (params) => authClient.organization.acceptInvitation(sessionScoped(params)),
     // addPasskey runs the WebAuthn browser ceremony itself - options fetch,
     // authenticator prompt, verification.
     addPasskey: (params) => authClient.passkey.addPasskey(params),
     cancelInvitation: (params) => authClient.organization.cancelInvitation(params),
-    changePassword: (params) => authClient.changePassword(params),
+    changePassword: (params) => authClient.changePassword(sessionScoped(params)),
     deletePasskey: (params) => authClient.passkey.deletePasskey(params),
-    impersonateUser: (params) => authClient.admin.impersonateUser(params),
+    impersonateUser: (params) => authClient.admin.impersonateUser(sessionScoped(params)),
     inviteMember: (params) => authClient.organization.inviteMember(params),
-    leaveOrganization: (params) => authClient.organization.leave(params),
+    leaveOrganization: (params) => authClient.organization.leave(sessionScoped(params)),
     phoneNumberRequestPasswordReset: (params) =>
       authClient.phoneNumber.requestPasswordReset(params),
     phoneNumberResetPassword: (params) => authClient.phoneNumber.resetPassword(params),
     phoneNumberSendOtp: (params) => authClient.phoneNumber.sendOtp(params),
     phoneNumberVerify: (params) => authClient.phoneNumber.verify(params),
-    removeMember: (params) => authClient.organization.removeMember(params),
+    removeMember: (params) => authClient.organization.removeMember(sessionScoped(params)),
     requestPasswordReset: (params) => authClient.requestPasswordReset(params),
     resetPassword: (params) => authClient.resetPassword(params),
-    revokeOtherSessions: () => authClient.revokeOtherSessions(),
+    revokeOtherSessions: () => authClient.revokeOtherSessions(sessionScoped()),
     sendVerificationEmail: (params) => authClient.sendVerificationEmail(params),
-    setActiveOrganization: (params) => authClient.organization.setActive(params),
+    setActiveOrganization: (params) => authClient.organization.setActive(sessionScoped(params)),
     signInEmail: (params) => authClient.signIn.email(params),
     signInMagicLink: (params) => authClient.signIn.magicLink(params),
     signInOauth2: (params) => authClient.signIn.oauth2(params),
@@ -137,7 +179,7 @@ function AuthConfigured({ authConfig, children, serverUser }) {
     signInSocial: (params) => authClient.signIn.social(params),
     signOut: () => authClient.signOut(),
     signUpEmail: (params) => authClient.signUp.email(params),
-    stopImpersonating: () => authClient.admin.stopImpersonating(),
+    stopImpersonating: () => authClient.admin.stopImpersonating(sessionScoped()),
     twoFactorDisable: (params) => authClient.twoFactor.disable(params),
     twoFactorEnable: (params) => authClient.twoFactor.enable(params),
     twoFactorVerifyBackupCode: (params) => authClient.twoFactor.verifyBackupCode(params),

--- a/packages/servers/server/lib/client/auth/AuthConfigured.jsx
+++ b/packages/servers/server/lib/client/auth/AuthConfigured.jsx
@@ -48,10 +48,17 @@ const authClient = createAuthClient({
 // UpdateSession owns session freshness - suppress BetterAuth's own
 // signal-driven refetch on the calls that would otherwise fire one, so
 // nothing competes with (and aborts) the refetch UpdateSession awaits.
+// Only calls that mutate an existing session are suppressed - calls that
+// can establish one (the sign-ins, and the two-factor, phone-number and
+// passkey verifies) keep their signal: its refetch is what makes the store
+// notice a login when no navigation follows.
 // disableSignal silences all atomListeners for the call, including the
 // organization plugin's org atoms - none are exposed to app config, so a
 // future design exposing one must refresh it through its own action.
-const sessionScoped = (params) => ({ ...params, fetchOptions: { disableSignal: true } });
+const sessionScoped = (params) => ({
+  ...params,
+  fetchOptions: { ...params?.fetchOptions, disableSignal: true },
+});
 
 // The server resolves the caller per request and embeds it in the page
 // config, so the first render never flashes unauthenticated. The BetterAuth
@@ -95,7 +102,9 @@ function Session({ children, reloadSuppressedRef, serverUser }) {
     // switch between the session refetch and the /api/user result). Render
     // the last resolved caller rather than a caller with no roles - blocks
     // re-evaluate operators on render, so a role-guarded page would act on
-    // roles: [].
+    // roles: []. UpdateSession closes the window when it lands the new
+    // caller; a flow that swaps the session user without chaining it leaves
+    // the previous caller rendered until the next page load.
     return children(resolved, resolvedUserRef);
   }
   // The resolved caller contributes every field the session user lacks: roles
@@ -180,8 +189,8 @@ function AuthConfigured({ authConfig, children, serverUser }) {
     signOut: () => authClient.signOut(),
     signUpEmail: (params) => authClient.signUp.email(params),
     stopImpersonating: () => authClient.admin.stopImpersonating(sessionScoped()),
-    twoFactorDisable: (params) => authClient.twoFactor.disable(params),
-    twoFactorEnable: (params) => authClient.twoFactor.enable(params),
+    twoFactorDisable: (params) => authClient.twoFactor.disable(sessionScoped(params)),
+    twoFactorEnable: (params) => authClient.twoFactor.enable(sessionScoped(params)),
     twoFactorVerifyBackupCode: (params) => authClient.twoFactor.verifyBackupCode(params),
     twoFactorVerifyTotp: (params) => authClient.twoFactor.verifyTotp(params),
     updateMemberRole: (params) => authClient.organization.updateMemberRole(params),


### PR DESCRIPTION
## Summary

`UpdateSession` is documented to refresh two things: the BetterAuth client session store, and `_user`'s roles and attributes. It only did the second. Its `getSession` call was a plain path request that never reached the session atom (`/get-session` is not in BetterAuth's `atomListeners` matcher), and its result was discarded — so every session-user field (`profile`, `name`, `emailVerified`, deployment `additionalFields`) stayed stale on the client until a full page load. Reproduced as an onboarding page that saves a profile, fires `UpdateSession`, then links to a router page — which read the stale marker and bounced the user straight back to the form they had just submitted.

Implements the `update-session-store-refresh` design (auth-upgrade). Three further defects surfaced in the same code ship alongside: `UpdateSession` could silently null the caller, an impersonation switch could publish a caller with no roles, and the client merge dropped two fields the server-resolved caller carries.

## Changes

- **@lowdefy/client**: `updateSession` replaces the discarded `getSession` call with an awaited `auth.refreshSession({ disableCookieCache: true })` — the session atom's own refetch, which is the store's only writer and resolves only after the store is written. A failed refresh now throws to the action's `catch` instead of reporting success over a stale store, and a session that is present while `/api/user` resolves no user throws instead of silently nulling `lowdefy.user` (that is the admission wall rejecting a real session, not a logout).
- **@lowdefy/server, @lowdefy/server-dev** (templates kept byte-identical): the auth wrapper gains `refreshSession`, returning the session atom's `{ data, error }` so `unwrap` works and failures surface. A `sessionScoped` helper merges `fetchOptions: { disableSignal: true }` into the ten methods whose endpoints flip `$sessionSignal` while mutating an existing session (`setActiveOrganization`, `acceptInvitation`, `leaveOrganization`, `removeMember`, `impersonateUser`, `stopImpersonating`, `changePassword`, `revokeOtherSessions`, `twoFactorEnable`, `twoFactorDisable`) — BetterAuth's own signal-driven refetch fires 10ms after those endpoints and aborts the refetch `UpdateSession` awaits, leaving it resolved with nothing written. Calls that can *establish* a session (the sign-ins, and the two-factor, phone-number and passkey verifies) keep their signal: its refetch is what makes the store notice a login when no navigation follows. `UpdateSession` is now the only refresher of an established session. The `Session` merge renders the last resolved caller on an id mismatch (an impersonation switch mid-refresh no longer publishes `roles: []` to role-guarded pages) and carries `activeOrganizationId` and `impersonatedBy` from the resolved caller — both live on the session row, not the session user, so the client dropped them the moment the first session fetch settled.

## Breaking Changes

- **`UpdateSession` now surfaces failures it previously swallowed.** A failed session refresh, or a session that exists while the server resolves no user, throws to the action's `catch`/`onError` — previously the first proceeded silently over a stale store and the second silently nulled `_user` (a phantom client-side logout).
- **BetterAuth's background session refetch no longer fires after the ten session-changing actions above.** Chain `UpdateSession` after them — which is already the documented convention, and now actually guarantees a fresh `_user` when the next action runs.

## Notes

- Stacked on #2296 (`feat/callback-url-default`) — same two client files; retarget to `auth-upgrade` when it merges.
- Two test suites in `server-dev/lib/client/auth/` guard the templates: `authTemplateSync.test.mjs` keeps the server and server-dev copies byte-identical (a divergence names the file), and `betterAuthSessionContract.test.mjs` pins the four undocumented better-auth behaviours this PR relies on — the session atom's awaitable `refetch`, the non-writing `getSession` path call, the never-rejecting failed refetch, and the signal-driven background refetch that `disableSignal` suppresses, including the competing-fetch abort race. A better-auth upgrade that changes any of these now fails in CI instead of visibly only in a running app.
- The end-to-end behaviours remain the design's Gate, run in a live app against **both** templates: exactly one `/get-session` (carrying `disableCookieCache`) after `SetActiveOrganization`/`ImpersonateUser`/`StopImpersonating`; `_user.activeOrganizationId` surviving the first session fetch; `_user.roles` never transiently emptying during an impersonation switch; the onboarding-bounce reproduction closing.
- Verified against installed `better-auth@1.6.23`: `proxy.mjs:49` honours `options.disableSignal`, the session atom's value exposes awaitable `refetch`, and `authClient.$store.atoms.session` is the real atom.
- `disableSignal` also silences the organization plugin's org atoms for those calls — none are exposed to app config today; a future design exposing an org hook must refresh it through its own action (recorded in design Decision 6).
- No changeset, matching the sibling auth-upgrade features (rolled up rather than versioned individually).
- No docs change needed: the docs already describe the behaviour this PR makes true.
- Design: `lowdefy-design/designs/auth-upgrade/features/update-session-store-refresh/design.md` (twice-reviewed, all findings resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
