### PR TITLE
Point the blocks-antd e2e app at the renamed TreeInput test page

### DIFF
--- a/packages/plugins/blocks/blocks-antd/e2e/app/lowdefy.yaml
+++ b/packages/plugins/blocks/blocks-antd/e2e/app/lowdefy.yaml
@@ -29,7 +29,7 @@ pages:
   - _ref: ../../src/blocks/MultipleSelector/tests/MultipleSelector.e2e.yaml
   - _ref: ../../src/blocks/CheckboxSelector/tests/CheckboxSelector.e2e.yaml
   - _ref: ../../src/blocks/RadioSelector/tests/RadioSelector.e2e.yaml
-  - _ref: ../../src/blocks/TreeSelector/tests/TreeSelector.e2e.yaml
+  - _ref: ../../src/blocks/TreeInput/tests/TreeInput.e2e.yaml
   - _ref: ../../src/blocks/AutoComplete/tests/AutoComplete.e2e.yaml
   - _ref: ../../src/blocks/ButtonSelector/tests/ButtonSelector.e2e.yaml
   # Step 1.3: Date/Time Inputs


### PR DESCRIPTION
## Summary

The blocks-antd e2e app cannot build. `e2e/app/lowdefy.yaml` references `src/blocks/TreeSelector/tests/TreeSelector.e2e.yaml`, which does not exist — and a missing `_ref` target is a fatal build error, so the **entire suite is unrunnable** unless that line is commented out locally.

Commit 2aaf365a4 ("Tree selectors — rename to TreeInput, add TreeSelect dropdowns") renamed the inline tree block `TreeSelector` → `TreeInput`: it moved `TreeSelector.e2e.spec.js` to `TreeInput/tests/TreeInput.e2e.spec.js`, deleted `TreeSelector/tests/TreeSelector.e2e.yaml` and added `TreeInput/tests/TreeInput.e2e.yaml` — but never touched the e2e app config, leaving the `_ref` on the deleted path.

The stale path looks plausible because `src/blocks/TreeSelector/` still exists — it is just a different block now (the new antd `TreeSelect` dropdown), with no `tests/` directory.

## Changes

- **@lowdefy/blocks-antd**: `e2e/app/lowdefy.yaml` now refs `TreeInput/tests/TreeInput.e2e.yaml`. Repointed rather than removed, because `TreeInput.e2e.spec.js` navigates to `treeinput` and that page config exists — the spec was orphaned, testing a page that was never built.

## Notes

No changeset: this is test infrastructure only, with no change to any published source.

**Verified:**

- The app builds with no local edits.
- The 8 previously orphaned `TreeInput` tests pass.
- The full suite runs: **1025 passed, 12 failed**. All 12 are pre-existing and unrelated to this change — 4 are the antd v6 default-placeholder casing mismatches (`Select date` vs the expected `Select Date`), and 8 are keyboard-driven tests (`AutoComplete`, `Button`, `DropdownButton`, `DropdownMenu`, `Menu`, `Tabs`, `Tag`) which may partly be artifacts of my local run: the bundled chromium install for this Playwright version is broken here, so the suite ran against installed Google Chrome. Worth reading the CI numbers as the real baseline.

The two new tree blocks (`TreeSelector`, `TreeMultipleSelector`) have no e2e yaml or spec yet, so nothing is missing for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)