### PR TITLE
feat(blocks-antd-x, ai-utils): AgentChat welcome tracks, setInput method, and ids on persisted messages

### DIFF
--- a/.changeset/feat-agentchat-welcome-tracks-set-input.md
+++ b/.changeset/feat-agentchat-welcome-tracks-set-input.md
@@ -1,0 +1,9 @@
+---
+'@lowdefy/blocks-antd-x': minor
+---
+
+feat: AgentChat welcome supports in-flow teaching tracks and a setInput method
+
+AgentChat's `welcome` config gains a `tracks` shape: labelled cards, each a column of starter prompts. Unlike the flat `prompts` welcome — which sends on click and is swapped out on the first message — a tracks welcome renders in-flow as the leading item of the message list, so it scrolls up with the conversation and stays reachable by scrolling back. A track starter fills the composer instead of sending, so a shipped default becomes an editable first draft rather than a message the user never meant to send.
+
+The composer is now controlled, and a new `setInput` CallMethod method sets its text — so app config can seed or clear the input. Clearing after a send moved to the tail of the send handler (downstream of the `onBeforeSend` cancellation and the upload await), so a rejected or failed send leaves the user's typed text in place instead of discarding it.

--- a/.changeset/fix-agent-chat-persisted-message-ids.md
+++ b/.changeset/fix-agent-chat-persisted-message-ids.md
@@ -1,0 +1,14 @@
+---
+'@lowdefy/ai-utils': patch
+---
+
+fix(ai-utils): Give the assistant message an id so persisted transcripts render correctly.
+
+`handleAgentChat` passed no `generateMessageId` to the AI SDK, so the assistant message delivered to
+the stream-level `onFinish` arrived with an empty id. An `onFinish` hook that saves the conversation
+therefore stored every assistant message under the same id, and reloading that conversation collapsed
+the transcript: `AgentChat` keys its bubbles by message id and looks each bubble's parts up by that id,
+so every assistant bubble rendered the last reply. User messages were unaffected, and a live turn
+looked correct because the client generates its own id while streaming — the damage only appeared once
+the conversation was reopened. Both stream paths (with and without `prune`) now pass the SDK's
+`generateId`.

--- a/packages/docs-content/content/agents/agentchat.md
+++ b/packages/docs-content/content/agents/agentchat.md
@@ -87,6 +87,31 @@ Shown when the chat has no messages. Clicking a prompt sends the `label` as a me
     - `label: string`: Button label (sent as message when clicked).
     - `description: string`: Button description.
     - `icon`: Button icon.
+  - `tracks: object[]`: An alternative to `prompts` for a teaching empty state — two or more labelled columns of starters, e.g. one track to ask a question and another to build a report. A `tracks` welcome renders **in-flow** as the leading item of the transcript (rather than centred and swapped out on the first send), so it scrolls up with the conversation and stays reachable by scrolling back. A track starter **fills the composer** instead of sending, so a suggested prompt becomes an editable first draft rather than a message the user never meant to send. Each track:
+    - `label: string`: Track heading.
+    - `prompts: (string | object)[]`: Starters — a plain string, or `{ label }`. The text fills the composer on click.
+
+When `tracks` is set, `prompts` is ignored.
+
+###### Two-track welcome (ask a question / build a report):
+```yaml
+- id: chat
+  type: AgentChat
+  properties:
+    agentId: assistant
+    welcome:
+      title: Ask about your data
+      description: I can see your orders, customers, and activity.
+      tracks:
+        - label: Get a quick answer
+          prompts:
+            - Which region has the highest total sales?
+            - How many activities were logged last month?
+        - label: Build a report
+          prompts:
+            - Build a report showing trends over time.
+            - Build a report comparing categories side by side.
+```
 
 ### Suggestions
 
@@ -358,6 +383,7 @@ Control the chat programmatically using [`CallMethod`](/CallMethod):
 | Method | Arguments | Description |
 | --- | --- | --- |
 | `sendMessage` | `{ text, files?, metadata? }` | Send a message programmatically. |
+| `setInput` | `{ text }` | Set the composer's text without sending — seed or clear the input box. Omit `text` to clear. |
 | `regenerate` | `{ messageId? }` | Regenerate the last (or a specific) assistant message. |
 | `setMessages` | `{ messages }` | Replace all messages with a new array. |
 | `clearMessages` | | Clear all messages. |
@@ -381,6 +407,23 @@ Control the chat programmatically using [`CallMethod`](/CallMethod):
           method: sendMessage
           args:
             - text: Please summarize the current page content.
+```
+
+###### Prefill the composer without sending:
+```yaml
+- id: draft_reply
+  type: Button
+  properties:
+    title: Draft a reply
+  events:
+    onClick:
+      - id: prefill
+        type: CallMethod
+        params:
+          blockId: chat
+          method: setInput
+          args:
+            - text: Please draft a polite reply to the last message.
 ```
 
 ###### New conversation button:

--- a/packages/docs/agents/AgentChat.yaml
+++ b/packages/docs/agents/AgentChat.yaml
@@ -111,6 +111,31 @@ _ref:
                 - `label: string`: Button label (sent as message when clicked).
                 - `description: string`: Button description.
                 - `icon`: Button icon.
+              - `tracks: object[]`: An alternative to `prompts` for a teaching empty state — two or more labelled columns of starters, e.g. one track to ask a question and another to build a report. A `tracks` welcome renders **in-flow** as the leading item of the transcript (rather than centred and swapped out on the first send), so it scrolls up with the conversation and stays reachable by scrolling back. A track starter **fills the composer** instead of sending, so a suggested prompt becomes an editable first draft rather than a message the user never meant to send. Each track:
+                - `label: string`: Track heading.
+                - `prompts: (string | object)[]`: Starters — a plain string, or `{ label }`. The text fills the composer on click.
+
+            When `tracks` is set, `prompts` is ignored.
+
+            ###### Two-track welcome (ask a question / build a report):
+            ```yaml
+            - id: chat
+              type: AgentChat
+              properties:
+                agentId: assistant
+                welcome:
+                  title: Ask about your data
+                  description: I can see your orders, customers, and activity.
+                  tracks:
+                    - label: Get a quick answer
+                      prompts:
+                        - Which region has the highest total sales?
+                        - How many activities were logged last month?
+                    - label: Build a report
+                      prompts:
+                        - Build a report showing trends over time.
+                        - Build a report comparing categories side by side.
+            ```
 
             ### Suggestions
 
@@ -382,6 +407,7 @@ _ref:
             | Method | Arguments | Description |
             | --- | --- | --- |
             | `sendMessage` | `{ text, files?, metadata? }` | Send a message programmatically. |
+            | `setInput` | `{ text }` | Set the composer's text without sending — seed or clear the input box. Omit `text` to clear. |
             | `regenerate` | `{ messageId? }` | Regenerate the last (or a specific) assistant message. |
             | `setMessages` | `{ messages }` | Replace all messages with a new array. |
             | `clearMessages` | | Clear all messages. |
@@ -405,6 +431,23 @@ _ref:
                       method: sendMessage
                       args:
                         - text: Please summarize the current page content.
+            ```
+
+            ###### Prefill the composer without sending:
+            ```yaml
+            - id: draft_reply
+              type: Button
+              properties:
+                title: Draft a reply
+              events:
+                onClick:
+                  - id: prefill
+                    type: CallMethod
+                    params:
+                      blockId: chat
+                      method: setInput
+                      args:
+                        - text: Please draft a polite reply to the last message.
             ```
 
             ###### New conversation button:

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
@@ -55,6 +55,9 @@ function AgentChat({ blockId, components: { Icon }, methods, pageId, properties 
   const finishMetaRef = useRef(null);
   const fileInputRef = useRef(null);
   const [attachedFiles, setAttachedFiles] = useState([]);
+  // Controlled composer value, so a starter prompt (or the setInput method) can
+  // fill the box, and a send can leave typed text in place when it is rejected.
+  const [inputValue, setInputValue] = useState('');
   // Mirror the operator-evaluated sharedState object into a ref so transport.body()
   // sees the freshest value at send time without re-constructing the transport.
   const sharedStateRef = useRef(null);
@@ -233,6 +236,9 @@ function AgentChat({ blockId, components: { Icon }, methods, pageId, properties 
         });
       }
     });
+    methods.registerMethod('setInput', (args) => {
+      setInputValue(typeof args?.text === 'string' ? args.text : '');
+    });
     methods.registerMethod('clearMessages', () => {
       setMessages([]);
     });
@@ -385,7 +391,12 @@ function AgentChat({ blockId, components: { Icon }, methods, pageId, properties 
     } else {
       sendMessage({ text });
     }
-    senderRef.current?.clear();
+    // Empty the composer here, after the sends and downstream of both the
+    // onBeforeSend cancellation return and the upload await, so a send that was
+    // rejected or failed to upload leaves the user's text in the box. Resetting
+    // from the Sender's onSubmit handler instead would silently lose typed input
+    // on every rejected send.
+    setInputValue('');
   }
 
   function handleStop() {
@@ -398,6 +409,13 @@ function AgentChat({ blockId, components: { Icon }, methods, pageId, properties 
 
   function handlePromptClick(prompt) {
     sendMessage({ text: prompt.label });
+  }
+
+  // A two-track welcome starter fills the composer instead of sending, so a
+  // generic shipped default is an editable first draft rather than a message the
+  // user never meant to send. Reuses the controlled Sender value.
+  function handleWelcomePromptFill(text) {
+    setInputValue(typeof text === 'string' ? text : '');
   }
 
   function handleSuggestionClick(suggestion) {
@@ -487,7 +505,7 @@ function AgentChat({ blockId, components: { Icon }, methods, pageId, properties 
       }}
     >
       <div style={{ flex: 1, minHeight: 0, padding: '16px 0' }}>
-        {isEmpty ? (
+        {isEmpty && !welcome?.tracks ? (
           <WelcomeScreen config={welcome} onPromptClick={handlePromptClick} />
         ) : (
           <MessageList
@@ -495,6 +513,8 @@ function AgentChat({ blockId, components: { Icon }, methods, pageId, properties 
             messages={messages}
             isStreaming={isBusy}
             config={messageDisplay}
+            welcome={welcome}
+            onWelcomePromptFill={handleWelcomePromptFill}
             addToolApprovalResponse={addToolApprovalResponse}
             onFeedback={handleFeedback}
             onRegenerate={handleRegenerate}
@@ -562,6 +582,8 @@ function AgentChat({ blockId, components: { Icon }, methods, pageId, properties 
         )}
         <Sender
           ref={senderRef}
+          value={inputValue}
+          onChange={setInputValue}
           placeholder={sender?.placeholder ?? methods.translate('agent.sender.placeholder')}
           submitType={sender?.submitType ?? 'enter'}
           allowSpeech={sender?.allowSpeech ?? false}

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageList.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageList.js
@@ -24,6 +24,7 @@ import { hasVisibleContent } from './messageParts.js';
 import MessageBubble from './MessageBubble.js';
 import ThinkingIndicator from './ThinkingIndicator.js';
 import useThinkingMessage from './useThinkingMessage.js';
+import WelcomeScreen from './WelcomeScreen.js';
 
 function roleAvatar(roleConfig, fallbackIcon) {
   if (roleConfig?.avatar) {
@@ -57,6 +58,8 @@ const MessageList = React.forwardRef(function MessageList(
     messages,
     isStreaming,
     config,
+    welcome,
+    onWelcomePromptFill,
     addToolApprovalResponse,
     onFeedback,
     onRegenerate,
@@ -97,8 +100,7 @@ const MessageList = React.forwardRef(function MessageList(
     // Show loading dots while the agent is working on the last assistant bubble and
     // nothing visible has rendered yet. `hasVisibleContent` mirrors what MessageBubble
     // paints, so tool-only messages with showThoughtChain: false also keep dots.
-    const showLoading =
-      isStreaming && isLastAssistant && !hasVisibleContent(msg, config);
+    const showLoading = isStreaming && isLastAssistant && !hasVisibleContent(msg, config);
 
     items.push({
       key: msg.id,
@@ -133,11 +135,27 @@ const MessageList = React.forwardRef(function MessageList(
     });
   }
 
+  // The welcome renders as a leading item so it scrolls up with the transcript
+  // and stays reachable by scrolling back, rather than being swapped out on the
+  // first send. With no messages yet it is simply the only item in the list.
+  if (welcome?.tracks) {
+    items.unshift({ key: '__welcome__', role: 'welcome' });
+  }
+
   return (
     <Bubble.List
       ref={ref}
       items={items}
       role={{
+        welcome: {
+          placement: 'start',
+          variant: 'borderless',
+          style: { maxWidth: '100%' },
+          styles: { content: { width: '100%' } },
+          contentRender: () => (
+            <WelcomeScreen config={welcome} onFill={onWelcomePromptFill} inFlow />
+          ),
+        },
         user: {
           placement: 'end',
           variant: config?.roles?.user?.variant ?? 'filled',

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/WelcomeScreen.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/WelcomeScreen.js
@@ -16,9 +16,117 @@
 
 import React from 'react';
 import { Welcome, Prompts } from '@ant-design/x';
+import { Button } from 'antd';
 
-function WelcomeScreen({ config, onPromptClick }) {
+// One track: a bordered card holding a heading and a column of starter chips.
+// A chip fills the composer (onFill) rather than sending — a near-miss starter
+// becomes an editable first draft, not a message the user never meant to send.
+function TrackCard({ track, onFill }) {
+  const prompts = track.prompts ?? [];
+  return (
+    <div
+      style={{
+        flex: '1 1 240px',
+        border: '1px solid var(--ant-color-border)',
+        borderRadius: 'var(--ant-border-radius-lg)',
+        padding: 16,
+        backgroundColor: 'var(--ant-color-bg-container)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      {track.label && (
+        <h5
+          style={{
+            margin: '0 0 4px',
+            fontSize: 'var(--ant-font-size-heading-5)',
+            fontWeight: 'var(--ant-font-weight-strong, 600)',
+            lineHeight: 'var(--ant-line-height-heading-5)',
+          }}
+        >
+          {track.label}
+        </h5>
+      )}
+      {prompts.map((prompt, index) => {
+        const text = typeof prompt === 'string' ? prompt : prompt.label;
+        return (
+          <Button
+            key={index}
+            block
+            // antd buttons are nowrap and size to their longest line; height auto
+            // plus whiteSpace normal lets a sentence-length starter wrap left.
+            style={{
+              height: 'auto',
+              whiteSpace: 'normal',
+              textAlign: 'left',
+              paddingTop: 6,
+              paddingBottom: 6,
+            }}
+            onClick={() => onFill?.(text)}
+          >
+            {text}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}
+
+// The chat empty state. Two modes:
+//   - `config.tracks` present → a two-track teaching panel (ask a question /
+//     build a report), each track a card of fill-the-composer starters. When
+//     `inFlow` it renders top-aligned as a leading item inside the message
+//     scroll area, so it scrolls up with the conversation and stays reachable
+//     by scrolling back rather than being swapped out on the first send.
+//   - otherwise → the flat Welcome + Prompts row, centred, sending on click.
+function WelcomeScreen({ config, onPromptClick, onFill, inFlow }) {
   if (!config) return null;
+
+  if (config.tracks) {
+    return (
+      <div
+        style={
+          inFlow
+            ? {
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 16,
+                width: '100%',
+              }
+            : {
+                flex: 1,
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 16,
+              }
+        }
+      >
+        {config.title && (
+          <h3
+            style={{
+              margin: 0,
+              fontSize: 'var(--ant-font-size-heading-3)',
+              fontWeight: 'var(--ant-font-weight-strong, 600)',
+              lineHeight: 'var(--ant-line-height-heading-3)',
+            }}
+          >
+            {config.title}
+          </h3>
+        )}
+        {config.description && (
+          <div style={{ color: 'var(--ant-color-text-secondary)' }}>{config.description}</div>
+        )}
+        <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+          {config.tracks.map((track, index) => (
+            <TrackCard key={index} track={track} onFill={onFill} />
+          ))}
+        </div>
+      </div>
+    );
+  }
 
   const promptItems = (config.prompts ?? []).map((prompt, index) => ({
     key: prompt.key ?? `prompt-${index}`,
@@ -44,11 +152,7 @@ function WelcomeScreen({ config, onPromptClick }) {
         variant={config.variant}
       />
       {promptItems.length > 0 && (
-        <Prompts
-          items={promptItems}
-          onItemClick={({ data }) => onPromptClick(data)}
-          wrap
-        />
+        <Prompts items={promptItems} onItemClick={({ data }) => onPromptClick(data)} wrap />
       )}
     </div>
   );

--- a/packages/utils/ai-utils/src/handleAgentChat.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.js
@@ -19,6 +19,7 @@ import {
   createAgentUIStream,
   createUIMessageStream,
   createUIMessageStreamResponse,
+  generateId,
   generateText,
   pruneMessages,
   validateUIMessages,
@@ -155,6 +156,9 @@ async function handleAgentChat({ connection, properties, context }) {
         });
         agentStream = result.toUIMessageStream({
           originalMessages: validatedMessages,
+          // Without a generator the assistant message reaches onFinish with
+          // id: '' — see the createAgentUIStream call below.
+          generateMessageId: generateId,
           onFinish: captureMessages,
         });
       } else {
@@ -165,6 +169,18 @@ async function handleAgentChat({ connection, properties, context }) {
           agent: agentInstance,
           uiMessages: messages,
           ...timeoutConfig,
+          // The AI SDK only ids the assistant message it builds when the caller
+          // supplies a generator: toUIMessageStream derives responseMessageId
+          // only if generateMessageId != null, and handleUIMessageStreamFinish
+          // then seeds the streaming state with `messageId ?? ''`, with no
+          // messageId on the start chunk to override it. Without this every
+          // assistant message an onFinish hook persists carries id: '', so a
+          // saved transcript has them all sharing one id — and a UI that keys
+          // its bubbles by message id (AgentChat does) renders the last reply in
+          // every assistant bubble when the conversation is reloaded. The client
+          // generates its own id while streaming, so the damage only shows up
+          // after a reload.
+          generateMessageId: generateId,
           onStepFinish: collectStep,
           onFinish: captureMessages,
         });

--- a/packages/utils/ai-utils/src/handleAgentChat.test.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.test.js
@@ -61,6 +61,7 @@ const mockCreateUIMessageStream = jest.fn().mockImplementation(({ execute }) => 
 });
 const mockCreateUIMessageStreamResponse = jest.fn().mockReturnValue({ type: 'web-response' });
 const mockGenerateText = jest.fn().mockResolvedValue({ text: 'Generated Title' });
+const mockGenerateId = jest.fn(() => 'generated-id');
 
 let lastAgentConfig = null;
 let lastAgentInstance = null;
@@ -93,6 +94,7 @@ jest.unstable_mockModule('ai', () => ({
   createAgentUIStream: mockCreateAgentUIStream,
   createUIMessageStream: mockCreateUIMessageStream,
   createUIMessageStreamResponse: mockCreateUIMessageStreamResponse,
+  generateId: mockGenerateId,
   generateText: mockGenerateText,
   pruneMessages: mockPruneMessages,
   tool: mockTool,
@@ -2090,9 +2092,52 @@ test('prune config triggers decomposed stream pipeline instead of createAgentUIS
   });
   expect(mockToUIMessageStream).toHaveBeenCalledWith({
     originalMessages: mockValidated,
+    generateMessageId: mockGenerateId,
     onFinish: expect.any(Function),
   });
   expect(mockCreateAgentUIStream).not.toHaveBeenCalled();
+});
+
+// The AI SDK ids the assistant message it builds only when the caller passes a
+// generator; without one it reaches onFinish with id: '', so every assistant
+// message an onFinish hook persists shares the empty id and a reloaded
+// transcript collapses onto its last reply in any UI that keys bubbles by
+// message id. Asserted on both stream constructions because only one of them
+// runs per turn, and the prune branch is the one that is easy to forget.
+test('the assistant message is given an id on both stream paths', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
+  mockCreateAgentUIStream.mockClear();
+  mockToUIMessageStream.mockClear();
+  mockValidateUIMessages.mockResolvedValue([]);
+  mockConvertToModelMessages.mockResolvedValue([]);
+  mockPruneMessages.mockReturnValue([]);
+
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+
+  async function run(properties) {
+    await handleAgentChat({
+      connection: { provider: jest.fn().mockReturnValue({}) },
+      properties,
+      context: { callEndpoint: jest.fn(), getEndpointConfig: jest.fn() },
+    });
+    await mockCreateUIMessageStream._lastExecute({ writer: { write: jest.fn() } });
+  }
+
+  const messages = [{ role: 'user', parts: [{ type: 'text', text: 'hi' }] }];
+
+  await run({ agent: { tools: [], properties: { model: 'gpt-4o' } }, messages });
+  expect(mockCreateAgentUIStream).toHaveBeenCalledWith(
+    expect.objectContaining({ generateMessageId: mockGenerateId })
+  );
+
+  await run({
+    agent: { tools: [], properties: { model: 'gpt-4o', prune: { reasoning: 'all' } } },
+    messages,
+  });
+  expect(mockToUIMessageStream).toHaveBeenCalledWith(
+    expect.objectContaining({ generateMessageId: mockGenerateId })
+  );
 });
 
 test('without prune config, createAgentUIStream is used and prune functions are not called', async () => {


### PR DESCRIPTION
## Summary

Two additions to `AgentChat` and one fix to the agent runtime behind it, all extracted from running the block as the surface of a reporting chat page where the empty state has to teach two distinct jobs (ask a question / build a report), offer editable starters, and reload a saved conversation faithfully.

**In-flow welcome tracks.** The `welcome` config gains a `tracks` shape — labelled cards, each a column of starter prompts. The existing flat `prompts` welcome is centred in the empty pane and swapped out the moment the first message arrives, so anything it taught is gone and unreachable. A `tracks` welcome instead renders **in-flow** as the leading item of the message list: it scrolls up with the conversation and stays reachable by scrolling back. A track starter **fills the composer** rather than sending, so a shipped default becomes an editable first draft instead of a message the user never meant to send.

**Controlled composer + `setInput` method.** The composer is now controlled by an `inputValue` state, and a new `setInput` CallMethod method sets its text — so app config can seed or clear the input (the track starters use it). The post-send clear moved from `senderRef.current.clear()` to `setInputValue('')` at the tail of `handleSend`, downstream of the `onBeforeSend` cancellation return and the upload await — so a send that is **rejected or fails to upload leaves the user's typed text in place** instead of silently discarding it.

**Persisted messages get an id (`@lowdefy/ai-utils`).** `handleAgentChat` passed no `generateMessageId` to the AI SDK, so the assistant message delivered to the stream-level `onFinish` arrived with an **empty id**. The SDK derives a `responseMessageId` only when the caller supplies a generator (`toUIMessageStream`), and `handleUIMessageStreamFinish` then seeds the streaming state with `messageId ?? ''`, with no `messageId` on the `start` chunk to override it.

An `onFinish` hook that saves the conversation therefore stored **every** assistant message under the same empty id, and reopening that conversation collapsed the transcript: `AgentChat` keys its bubbles by message id and looks each bubble's parts up in an `id -> parts` map, so every assistant bubble rendered the **last** reply. User bubbles were unaffected (they render the item's own `content`), and a live turn looked correct throughout because the client generates its own id while streaming — the damage only appeared after a reload, which is what made it read as "the conversation is doing something weird" rather than as an obvious break. The same collision also aimed `deleteMessage` and `regenerate` at every assistant message at once.

The block additions are additive: the flat `prompts` welcome, the uncontrolled-feeling API, and every existing method are unchanged. When `welcome.tracks` is absent the block behaves exactly as before.

## Changes

- **`WelcomeScreen.js`** — new `TrackCard` component and a `tracks` branch on `WelcomeScreen` (with `onFill`/`inFlow` props). Cards use antd CSS-variable tokens so they track the active theme. The flat `Welcome` + `Prompts` path is untouched.
- **`MessageList.js`** — when `welcome.tracks` is set, unshifts a `welcome`-role leading item whose `contentRender` is `WelcomeScreen` in `inFlow` mode (borderless, full-width bubble).
- **`AgentChat.js`** — `inputValue` state on a controlled `Sender`; `setInput` method; `handleWelcomePromptFill`; the empty-state render skips the standalone centred `WelcomeScreen` when `welcome.tracks` is present (the in-flow one takes over); post-send clear via `setInputValue('')`.
- **`handleAgentChat.js`** — passes the SDK's `generateId` as `generateMessageId` on **both** stream constructions: `createAgentUIStream` on the default path and `toUIMessageStream` on the `prune` path.

## Test plan

- **swc** compiles the three block files clean under the repo's `.swcrc` (`jsx: true`, classic runtime).
- **prettier 3.1.0** (the repo's pinned version) reports every touched file formatted.
- **`@lowdefy/ai-utils` jest suite: 71 passed, 71 total**, including a new test asserting `generateMessageId` reaches both stream paths (only one runs per turn, and the `prune` branch is the easy one to miss). The existing prune-path assertion was updated, since it pins the options object exactly.
- The SDK behaviour itself was probed directly against `ai@6.0.176` rather than assumed: with no generator, two turns yield `assistant ids: ["", ""]`; with `generateMessageId: generateId` the new message gets a real id.
- The compiled equivalent of the block change has been running in a production reporting chat app (delivered there as a pnpm patch): the two-track empty state, fill-don't-send starters, and the leave-text-on-rejected-send behaviour are all exercised in a browser. The message-id fix is verified there end to end by a Playwright spec that seeds a two-turn transcript with empty assistant ids: before the fix the first answer bubble renders the *last* answer, after it each answer stays in its own bubble.
- Not run locally: the block package's own build/e2e (that clone has no `node_modules` for it); CI covers these.

## Notes

Builds on #2289 (`id: effectiveConversationId` keying), already merged into `vite-hono` — this branch forks from that state.

The message-id fix lands here rather than in its own PR because it is the same defect surface: #2289 keyed the chat so a continued conversation saves under the right id, and this makes the transcript that gets saved render correctly when it is reopened. Happy to split it out if you would rather keep the PR to one package.
