### PR TITLE
fix(blocks-markdown): restore list markers on top-level lists

### DIFF
--- a/.changeset/fix-markdown-list-markers.md
+++ b/.changeset/fix-markdown-list-markers.md
@@ -2,9 +2,9 @@
 '@lowdefy/blocks-markdown': patch
 ---
 
-fix(blocks-markdown): Restore list markers and indentation on top-level lists.
+fix(blocks-markdown): Restore list markers on top-level lists.
 
-Numbered and bulleted lists rendered without their `1.`/`•` markers and with no indent. The block's
-stylesheet set `padding-left: 0` and only assigned a `list-style-type` to nested lists, so top-level
-`ol`/`ul` fell through to the Tailwind preflight reset (`list-style: none`). Restored `padding-left`
-and gave top-level `ol`/`ul` an explicit `decimal`/`disc` marker.
+Numbered and bulleted lists rendered without their `1.`/`•` markers. The block's stylesheet only
+assigned a `list-style-type` to nested lists, so top-level `ol`/`ul` fell through to the Tailwind
+preflight reset (`list-style: none`) and showed no marker. Gave top-level `ol`/`ul` an explicit
+`decimal`/`disc` marker.

--- a/.changeset/fix-markdown-list-markers.md
+++ b/.changeset/fix-markdown-list-markers.md
@@ -1,0 +1,10 @@
+---
+'@lowdefy/blocks-markdown': patch
+---
+
+fix(blocks-markdown): Restore list markers and indentation on top-level lists.
+
+Numbered and bulleted lists rendered without their `1.`/`•` markers and with no indent. The block's
+stylesheet set `padding-left: 0` and only assigned a `list-style-type` to nested lists, so top-level
+`ol`/`ul` fell through to the Tailwind preflight reset (`list-style: none`). Restored `padding-left`
+and gave top-level `ol`/`ul` an explicit `decimal`/`disc` marker.

--- a/packages/plugins/blocks/blocks-markdown/src/style.module.css
+++ b/packages/plugins/blocks/blocks-markdown/src/style.module.css
@@ -113,12 +113,13 @@
   .markdown-body ul {
     margin-bottom: 0;
     margin-top: 0;
-    padding-left: 2em;
+    padding-left: 0;
   }
 
   /* Restore top-level markers. The Tailwind preflight (base layer) resets
      `list-style: none`; without an explicit type here the markers vanish, since
-     only the nested rules below set a type. */
+     only the nested rules below set a type. (Indentation comes from the
+     `padding-left` rule lower in this file.) */
   .markdown-body ol {
     list-style-type: decimal;
   }

--- a/packages/plugins/blocks/blocks-markdown/src/style.module.css
+++ b/packages/plugins/blocks/blocks-markdown/src/style.module.css
@@ -113,7 +113,18 @@
   .markdown-body ul {
     margin-bottom: 0;
     margin-top: 0;
-    padding-left: 0;
+    padding-left: 2em;
+  }
+
+  /* Restore top-level markers. The Tailwind preflight (base layer) resets
+     `list-style: none`; without an explicit type here the markers vanish, since
+     only the nested rules below set a type. */
+  .markdown-body ol {
+    list-style-type: decimal;
+  }
+
+  .markdown-body ul {
+    list-style-type: disc;
   }
 
   .markdown-body ol ol,


### PR DESCRIPTION
## Problem

In the `Markdown` block, numbered and bulleted lists render **without** their `1.`/`•` markers on top-level items. The block's stylesheet sets `padding-left: 0` and only assigns a `list-style-type` to *nested* lists, so top-level `ol`/`ul` fall through to the Tailwind preflight reset (`list-style: none`, in the `base` layer) and lose their markers entirely.

This is the same class of issue that was fixed for the tiptap/`.x-markdown` blocks in #2202, but the plain `Markdown` block was never patched.

## Fix

Give top-level `.markdown-body ol`/`ul` an explicit `decimal`/`disc` marker (the `padding-left` indent already exists lower in the file). Nested-list numbering is unaffected.

```css
.markdown-body ol { list-style-type: decimal; }
.markdown-body ul { list-style-type: disc; }
```

## Notes

- This ports the fix already present on `vite-hono` (authored by Gerrie van Wyk) to `develop`, cherry-picked to preserve authorship.
- Changeset included (`@lowdefy/blocks-markdown`: patch).