### PR TITLE
fix(layout): stop grid layout custom properties from inheriting into nested blocks

### DIFF
--- a/.changeset/fix-grid-var-inheritance-leak.md
+++ b/.changeset/fix-grid-var-inheritance-leak.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/layout': patch
+---
+
+fix(layout): Stop grid layout custom properties from inheriting into nested blocks.
+
+The grid emitted column-span, gap, offset, order, push/pull and display values as plain CSS custom properties, which inherit by default. A nested row or column with no value of its own therefore picked up an ancestor's value instead of falling through its `var(…, fallback)` chain — so a box's `gap` leaked as row-gap into every nested box (inflating stacked content), and a column's breakpoint span leaked into nested columns. Registered these properties with `inherits: false` (universal syntax, no initial value) so each block resolves its own value while the existing fallback chains and `calc()` usage are unchanged.

--- a/packages/layout/src/grid.css
+++ b/packages/layout/src/grid.css
@@ -14,6 +14,75 @@
   limitations under the License.
 */
 
+/*
+  Layout inputs must NOT inherit.
+
+  grid.css reads each of these custom properties through a var(…, fallback) chain
+  so a block falls through to its own less-specific value — e.g.
+  --lf-span-lg → --lf-span-md → --lf-span, and --lf-gap-x-md → … → --lf-gap-x → 0.
+  Left unregistered, custom properties inherit by default, so a nested row/column
+  with no value of its own picks up an ANCESTOR's value instead of falling through:
+  a row's gap leaks as row-gap into every nested row, and a column's breakpoint
+  span leaks into nested columns.
+
+  Registering them with inherits:false stops the cascade. The universal syntax
+  ("*") with no initial-value preserves the "guaranteed-invalid when unset"
+  behaviour, so the existing var() fallback chains still resolve exactly as before
+  (universal syntax is not type-checked, so calc() usage is unchanged too).
+
+  --_gap is intentionally left unregistered: it is derived per-row and must inherit
+  from the row down to its columns for the flex-basis gap math.
+*/
+@property --lf-span { syntax: "*"; inherits: false; }
+@property --lf-span-sm { syntax: "*"; inherits: false; }
+@property --lf-span-md { syntax: "*"; inherits: false; }
+@property --lf-span-lg { syntax: "*"; inherits: false; }
+@property --lf-span-xl { syntax: "*"; inherits: false; }
+@property --lf-span-2xl { syntax: "*"; inherits: false; }
+@property --lf-display { syntax: "*"; inherits: false; }
+@property --lf-display-sm { syntax: "*"; inherits: false; }
+@property --lf-display-md { syntax: "*"; inherits: false; }
+@property --lf-display-lg { syntax: "*"; inherits: false; }
+@property --lf-display-xl { syntax: "*"; inherits: false; }
+@property --lf-display-2xl { syntax: "*"; inherits: false; }
+@property --lf-offset { syntax: "*"; inherits: false; }
+@property --lf-offset-sm { syntax: "*"; inherits: false; }
+@property --lf-offset-md { syntax: "*"; inherits: false; }
+@property --lf-offset-lg { syntax: "*"; inherits: false; }
+@property --lf-offset-xl { syntax: "*"; inherits: false; }
+@property --lf-offset-2xl { syntax: "*"; inherits: false; }
+@property --lf-order { syntax: "*"; inherits: false; }
+@property --lf-order-sm { syntax: "*"; inherits: false; }
+@property --lf-order-md { syntax: "*"; inherits: false; }
+@property --lf-order-lg { syntax: "*"; inherits: false; }
+@property --lf-order-xl { syntax: "*"; inherits: false; }
+@property --lf-order-2xl { syntax: "*"; inherits: false; }
+@property --lf-push { syntax: "*"; inherits: false; }
+@property --lf-push-sm { syntax: "*"; inherits: false; }
+@property --lf-push-md { syntax: "*"; inherits: false; }
+@property --lf-push-lg { syntax: "*"; inherits: false; }
+@property --lf-push-xl { syntax: "*"; inherits: false; }
+@property --lf-push-2xl { syntax: "*"; inherits: false; }
+@property --lf-pull { syntax: "*"; inherits: false; }
+@property --lf-pull-sm { syntax: "*"; inherits: false; }
+@property --lf-pull-md { syntax: "*"; inherits: false; }
+@property --lf-pull-lg { syntax: "*"; inherits: false; }
+@property --lf-pull-xl { syntax: "*"; inherits: false; }
+@property --lf-pull-2xl { syntax: "*"; inherits: false; }
+@property --lf-gap-x { syntax: "*"; inherits: false; }
+@property --lf-gap-x-sm { syntax: "*"; inherits: false; }
+@property --lf-gap-x-md { syntax: "*"; inherits: false; }
+@property --lf-gap-x-lg { syntax: "*"; inherits: false; }
+@property --lf-gap-x-xl { syntax: "*"; inherits: false; }
+@property --lf-gap-x-2xl { syntax: "*"; inherits: false; }
+@property --lf-gap-y { syntax: "*"; inherits: false; }
+@property --lf-gap-y-sm { syntax: "*"; inherits: false; }
+@property --lf-gap-y-md { syntax: "*"; inherits: false; }
+@property --lf-gap-y-lg { syntax: "*"; inherits: false; }
+@property --lf-gap-y-xl { syntax: "*"; inherits: false; }
+@property --lf-gap-y-2xl { syntax: "*"; inherits: false; }
+
+
 @layer components {
   /* =====================================================
      Row (Area)


### PR DESCRIPTION
## Problem

The grid emits its layout inputs — column span, gap, offset, order, push/pull and display — as plain CSS custom properties (`--lf-span-*`, `--lf-gap-x/-y*`, `--lf-offset-*`, etc.) and reads them back through `var(…, fallback)` chains so each block can fall through to its own less-specific value (e.g. `--lf-span-lg → --lf-span-md → --lf-span`, `--lf-gap-x → 0`).

Plain custom properties **inherit by default**, so a nested `.lf-row`/`.lf-col` that doesn't set a value picks up an **ancestor's** value instead of falling through its own chain:

- A box's `gap` leaks as **row-gap** into every nested box, opening extra vertical space between stacked content (e.g. inflating summary cards and pushing chart tiles out of alignment).
- A column's breakpoint span leaks into nested columns, compounding widths down the tree at ≥ that breakpoint.

## Fix

Register the layout inputs with `@property { syntax: "*"; inherits: false; }`.

- `inherits: false` stops the cascade, so each block resolves its own value.
- **Universal syntax (`"*"`) with no `initial-value`** preserves the “guaranteed-invalid when unset” behaviour, so the existing `var(…, fallback)` chains still resolve exactly as before — and because universal syntax isn't type-checked, the values behave the same inside `calc()`.
- `--_gap` is intentionally **not** registered: it's derived per-row and must keep inheriting from the row down to its columns for the flex-basis gap math.

No behavioural change for blocks that set their own values; only the unintended inheritance into nested blocks is removed.

## Notes

- Consumers currently work around this with app-level resets (`.lf-row { --lf-gap-*: initial }`, `.lf-col { --lf-span-*: initial }`); those can be dropped once this lands.
- Changeset included (`@lowdefy/layout`: patch).
- A matching PR targets `develop` (#2306).