### PR TITLE
Add columns and gutter to the checkbox and radio selector blocks

### DIFF
--- a/.changeset/feat-selector-blocks-columns.md
+++ b/.changeset/feat-selector-blocks-columns.md
@@ -1,0 +1,13 @@
+---
+'@lowdefy/blocks-antd': minor
+---
+
+feat(blocks-antd): Add `columns` and `gutter` to `CheckboxSelector` and `RadioSelector`.
+
+A long list of options flowed across the row and wrapped wherever the labels happened to run out of room, so it could not be read down a column. The only even alternative was `direction: vertical` — one option per line — which does not scale past a handful of options.
+
+Set `columns` to lay the options out in an even grid instead: `columns: 2` gives two equal-width columns. Use a count that divides 24 evenly (1, 2, 3, 4, 6, 8 or 12), or a responsive breakpoint object such as `{ xs: 1, md: 3 }`. `gutter` sets the spacing between options, as a number or a `[horizontal, vertical]` pair, and defaults to matching the spacing the flowed layout produced.
+
+`align`, `direction` and `wrap` describe the flowed layout and are ignored while `columns` is set. With `columns` unset, both blocks render exactly as before.
+
+The `theme.marginXS` description on `CheckboxSelector` is also corrected — it claimed to be the horizontal gap between checkboxes, which was never what that token affected.

--- a/packages/plugins/blocks/blocks-antd/e2e/app/lowdefy.yaml
+++ b/packages/plugins/blocks/blocks-antd/e2e/app/lowdefy.yaml
@@ -29,7 +29,7 @@ pages:
   - _ref: ../../src/blocks/MultipleSelector/tests/MultipleSelector.e2e.yaml
   - _ref: ../../src/blocks/CheckboxSelector/tests/CheckboxSelector.e2e.yaml
   - _ref: ../../src/blocks/RadioSelector/tests/RadioSelector.e2e.yaml
-  - _ref: ../../src/blocks/TreeSelector/tests/TreeSelector.e2e.yaml
+  - _ref: ../../src/blocks/TreeInput/tests/TreeInput.e2e.yaml
   - _ref: ../../src/blocks/AutoComplete/tests/AutoComplete.e2e.yaml
   - _ref: ../../src/blocks/ButtonSelector/tests/ButtonSelector.e2e.yaml
   # Step 1.3: Date/Time Inputs

--- a/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/CheckboxSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/CheckboxSelector.js
@@ -15,7 +15,7 @@
 */
 
 import React from 'react';
-import { Checkbox, ConfigProvider, Space } from 'antd';
+import { Checkbox, Col, ConfigProvider, Row, Space, theme } from 'antd';
 import { type } from '@lowdefy/helpers';
 import { renderHtml, withBlockDefaults } from '@lowdefy/block-utils';
 
@@ -37,16 +37,59 @@ const CheckboxSelector = ({
   value,
   methods,
 }) => {
+  const { token } = theme.useToken();
   const uniqueValueOptions = useSelectorOptions({ properties, methods });
   const selectedIndexes = new Set(
     type.isNone(value) ? [] : getSelectedIndex(value, uniqueValueOptions, { properties, multiple: true })
   );
+  const grid = !type.isNone(properties.columns);
+  // Col takes spans, not counts, so a breakpoint map of counts converts per key.
+  const colProps = type.isObject(properties.columns)
+    ? Object.fromEntries(
+        Object.entries(properties.columns).map(([breakpoint, columns]) => [
+          breakpoint,
+          { span: 24 / columns },
+        ])
+      )
+    : { span: 24 / properties.columns };
+  const renderOption = (opt, i) => {
+    if (type.isPrimitive(opt)) {
+      return (
+        <Checkbox id={`${blockId}_${i}`} key={i} value={`${i}`}>
+          {renderHtml({ html: `${opt}`, methods })}
+        </Checkbox>
+      );
+    }
+    const isSelected = selectedIndexes.has(`${i}`);
+    const checkbox = (
+      <Checkbox
+        id={`${blockId}_${i}`}
+        key={i}
+        value={`${i}`}
+        disabled={opt.disabled}
+        style={{ ...opt.style, ...(isSelected && opt.color ? { color: opt.color } : {}) }}
+      >
+        {type.isNone(opt.label)
+          ? renderHtml({ html: `${opt.value}`, methods })
+          : renderHtml({ html: opt.label, methods })}
+      </Checkbox>
+    );
+    if (type.isNone(opt.color)) return checkbox;
+    // Per-option color: token override colors this checkbox's checked tick.
+    return (
+      <ConfigProvider key={i} theme={{ token: { colorPrimary: opt.color } }}>
+        {checkbox}
+      </ConfigProvider>
+    );
+  };
   const checkboxGroup = (
     <Checkbox.Group
       id={`${blockId}_input`}
       className={classNames.element}
       disabled={properties.disabled || loading}
-      style={styles.element}
+      // Checkbox.Group is inline-flex and shrink-wraps, so the Row inside it can
+      // only fill a group that has been given a width.
+      style={grid ? { width: '100%', ...styles.element } : styles.element}
       onChange={(newVal) => {
         const val = [];
         newVal.forEach((nv) => {
@@ -61,42 +104,23 @@ const CheckboxSelector = ({
       }}
       value={getSelectedIndex(value, uniqueValueOptions, { properties, multiple: true })}
     >
-      <Space
-        direction={properties.direction}
-        wrap={type.isNone(properties.wrap) ? true : properties.wrap}
-        align={type.isNone(properties.align) ? 'start' : properties.align}
-      >
-        {uniqueValueOptions.map((opt, i) => {
-          if (type.isPrimitive(opt)) {
-            return (
-              <Checkbox id={`${blockId}_${i}`} key={i} value={`${i}`}>
-                {renderHtml({ html: `${opt}`, methods })}
-              </Checkbox>
-            );
-          }
-          const isSelected = selectedIndexes.has(`${i}`);
-          const checkbox = (
-            <Checkbox
-              id={`${blockId}_${i}`}
-              key={i}
-              value={`${i}`}
-              disabled={opt.disabled}
-              style={{ ...opt.style, ...(isSelected && opt.color ? { color: opt.color } : {}) }}
-            >
-              {type.isNone(opt.label)
-                ? renderHtml({ html: `${opt.value}`, methods })
-                : renderHtml({ html: opt.label, methods })}
-            </Checkbox>
-          );
-          if (type.isNone(opt.color)) return checkbox;
-          // Per-option color: token override colors this checkbox's checked tick.
-          return (
-            <ConfigProvider key={i} theme={{ token: { colorPrimary: opt.color } }}>
-              {checkbox}
-            </ConfigProvider>
-          );
-        })}
-      </Space>
+      {grid ? (
+        <Row gutter={type.isNone(properties.gutter) ? [token.paddingXS, 0] : properties.gutter}>
+          {uniqueValueOptions.map((opt, i) => (
+            <Col key={i} {...colProps}>
+              {renderOption(opt, i)}
+            </Col>
+          ))}
+        </Row>
+      ) : (
+        <Space
+          direction={properties.direction}
+          wrap={type.isNone(properties.wrap) ? true : properties.wrap}
+          align={type.isNone(properties.align) ? 'start' : properties.align}
+        >
+          {uniqueValueOptions.map(renderOption)}
+        </Space>
+      )}
     </Checkbox.Group>
   );
   return (

--- a/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/gallery.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/gallery.yaml
@@ -708,3 +708,74 @@
           - { id: 3, name: Admin }
         html: '{{ item.name }}'
         valueKey: id
+- title: Columns
+  blocks:
+    - id: columns_two
+      type: CheckboxSelector
+      properties:
+        title: Two columns
+        columns: 2
+        options:
+          - Weekday mornings
+          - Weekday afternoons
+          - Weekday evenings
+          - Weekend mornings
+          - Weekend afternoons
+          - Weekend evenings
+    - id: columns_four
+      type: CheckboxSelector
+      properties:
+        title: Four columns
+        columns: 4
+        options:
+          - January
+          - February
+          - March
+          - April
+          - May
+          - June
+          - July
+          - August
+    - id: columns_responsive
+      type: CheckboxSelector
+      properties:
+        title: One column below md, three from md up
+        columns:
+          xs: 1
+          md: 3
+        options:
+          - Email
+          - SMS
+          - Push notification
+          - Webhook
+          - In-app message
+          - Weekly digest
+    - id: columns_gutter
+      type: CheckboxSelector
+      properties:
+        title: Wider gutter
+        columns: 2
+        gutter: [24, 12]
+        options:
+          - Read
+          - Write
+          - Delete
+          - Administer
+    - id: columns_per_option_color
+      type: CheckboxSelector
+      properties:
+        title: Coloured options in a grid
+        columns: 2
+        options:
+          - label: Low
+            value: low
+            color: '#16a34a'
+          - label: Medium
+            value: medium
+            color: '#d97706'
+          - label: High
+            value: high
+            color: '#dc2626'
+          - label: Critical
+            value: critical
+            color: '#7e22ce'

--- a/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/meta.js
@@ -45,7 +45,7 @@ export default {
         type: 'string',
         enum: ['start', 'end', 'center', 'baseline'],
         default: 'start',
-        description: 'Align options.',
+        description: "Align options. Ignored when 'columns' is set.",
       },
       color: {
         type: 'string',
@@ -54,17 +54,34 @@ export default {
           displayType: 'color',
         },
       },
+      columns: {
+        type: ['integer', 'object'],
+        description:
+          'Number of columns to lay the options out in, or a responsive breakpoint object. Use a count that divides 24 evenly.',
+        docs: {
+          displayType: 'yaml',
+        },
+      },
       disabled,
       direction: {
         type: 'string',
         enum: ['horizontal', 'vertical'],
         default: 'horizontal',
-        description: 'List options horizontally or vertical.',
+        description: "List options horizontally or vertical. Ignored when 'columns' is set.",
+      },
+      gutter: {
+        type: ['number', 'array'],
+        description:
+          "Gap between options in the grid. Number or [horizontal, vertical] array. Applies when 'columns' is set.",
+        docs: {
+          displayType: 'yaml',
+        },
       },
       wrap: {
         type: 'boolean',
         default: true,
-        description: "Specifies wrapping of options. Applies when 'direction' is 'horizontal'.",
+        description:
+          "Specifies wrapping of options. Applies when 'direction' is 'horizontal'. Ignored when 'columns' is set.",
       },
       options,
       data,
@@ -134,7 +151,8 @@ export default {
           marginXS: {
             type: 'number',
             default: 8,
-            description: 'Horizontal gap between checkboxes in a group.',
+            description:
+              "Column gap on the checkbox group element. Does not space the options apart; set 'gutter' for a grid.",
           },
           paddingXS: {
             type: 'number',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/tests.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/tests.yaml
@@ -235,3 +235,91 @@
       - '<div>Some main text</div><div style="font-size: 6px;">Some small subtext</div>'
       - '<div style="color: green;">Option green</div>'
       - Option 3
+- id: 'properties.columns: 2'
+  type: CheckboxSelector
+  properties:
+    columns: 2
+    options:
+      - Option 1
+      - Option 2
+      - Option 3
+      - Option 4
+      - Option 5
+- id: 'properties.columns: 3'
+  type: CheckboxSelector
+  properties:
+    columns: 3
+    options:
+      - A much longer option label than the others
+      - Short
+      - Option 3
+      - Option 4
+      - Option 5
+      - Option 6
+- id: 'properties.columns: responsive'
+  type: CheckboxSelector
+  properties:
+    columns:
+      xs: 1
+      md: 3
+    options:
+      - Option 1
+      - Option 2
+      - Option 3
+      - Option 4
+      - Option 5
+      - Option 6
+- id: 'properties.columns: two short options'
+  type: CheckboxSelector
+  properties:
+    columns: 2
+    options:
+      - 'Yes'
+      - 'No'
+- id: 'properties.columns: unsupported count'
+  type: CheckboxSelector
+  properties:
+    columns: 5
+    options:
+      - Option 1
+      - Option 2
+      - Option 3
+      - Option 4
+      - Option 5
+- id: 'properties.gutter'
+  type: CheckboxSelector
+  properties:
+    columns: 2
+    gutter: [24, 12]
+    options:
+      - Option 1
+      - Option 2
+      - Option 3
+      - Option 4
+- id: 'properties.columns: per-option color'
+  type: CheckboxSelector
+  properties:
+    columns: 2
+    options:
+      - label: Low
+        value: low
+        color: '#16a34a'
+      - label: Medium
+        value: medium
+        color: '#d97706'
+      - label: High
+        value: high
+        color: '#dc2626'
+      - label: Critical
+        value: critical
+        color: '#7e22ce'
+- id: 'properties.columns: with direction vertical'
+  type: CheckboxSelector
+  properties:
+    columns: 2
+    direction: vertical
+    options:
+      - Option 1
+      - Option 2
+      - Option 3
+      - Option 4

--- a/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/tests/CheckboxSelector.e2e.spec.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/tests/CheckboxSelector.e2e.spec.js
@@ -91,6 +91,86 @@ test.describe('CheckboxSelector Block', () => {
     await expect(space).toHaveClass(/ant-space-horizontal/);
   });
 
+  // ============================================
+  // COLUMNS (GRID LAYOUT) TESTS
+  // ============================================
+
+  test('renders a grid instead of the flow layout when columns is set', async ({ page }) => {
+    const group = getCheckboxGroup(page, 'cs_columns_2');
+    await expect(group.locator('.ant-row')).toHaveCount(1);
+    await expect(group.locator('.ant-space')).toHaveCount(0);
+  });
+
+  test('keeps the flow layout when columns is not set', async ({ page }) => {
+    const group = getCheckboxGroup(page, 'cs_basic');
+    await expect(group.locator('.ant-space')).toHaveCount(1);
+    await expect(group.locator('.ant-row')).toHaveCount(0);
+  });
+
+  test('stretches the group to full width in grid mode', async ({ page }) => {
+    // The group is inline-flex, so without an explicit width the row inside it
+    // sizes to its content instead of filling the container.
+    const group = getCheckboxGroup(page, 'cs_columns_2');
+    const [groupWidth, parentWidth] = await group.evaluate((el) => [
+      el.getBoundingClientRect().width,
+      el.parentElement.getBoundingClientRect().width,
+    ]);
+    expect(Math.round(groupWidth)).toBe(Math.round(parentWidth));
+  });
+
+  test('renders two even columns as span 12', async ({ page }) => {
+    const group = getCheckboxGroup(page, 'cs_columns_2');
+    const cols = group.locator('.ant-row > .ant-col');
+    await expect(cols).toHaveCount(4);
+    for (let i = 0; i < 4; i += 1) {
+      await expect(cols.nth(i)).toHaveClass(/ant-col-12/);
+    }
+  });
+
+  test('renders three even columns as span 8', async ({ page }) => {
+    const group = getCheckboxGroup(page, 'cs_columns_3');
+    const cols = group.locator('.ant-row > .ant-col');
+    await expect(cols).toHaveCount(6);
+    await expect(cols.first()).toHaveClass(/ant-col-8/);
+  });
+
+  test('renders a responsive column count per breakpoint', async ({ page }) => {
+    const col = getCheckboxGroup(page, 'cs_columns_responsive')
+      .locator('.ant-row > .ant-col')
+      .first();
+    await expect(col).toHaveClass(/ant-col-xs-24/);
+    await expect(col).toHaveClass(/ant-col-md-8/);
+  });
+
+  test('applies an explicit gutter to the grid', async ({ page }) => {
+    const col = getCheckboxGroup(page, 'cs_columns_gutter').locator('.ant-row > .ant-col').first();
+    await expect(col).toHaveCSS('padding-left', '12px');
+    await expect(col).toHaveCSS('padding-right', '12px');
+  });
+
+  test('falls back to content width for a column count that does not divide 24', async ({
+    page,
+  }) => {
+    // 24/5 is 4.8, so the class name carries a decimal and antd has no rule for it —
+    // the column gets no flex-basis and keeps its content width. A supported count
+    // resolves to a percentage, which is the contrast being asserted here.
+    const unsupported = getCheckboxGroup(page, 'cs_columns_unsupported')
+      .locator('.ant-row > .ant-col')
+      .first();
+    await expect(unsupported).toHaveCSS('flex-basis', 'auto');
+
+    const supported = getCheckboxGroup(page, 'cs_columns_2').locator('.ant-row > .ant-col').first();
+    await expect(supported).toHaveCSS('flex-basis', '50%');
+  });
+
+  test('nests the column outside a per-option color provider', async ({ page }) => {
+    // Col -> ConfigProvider -> Checkbox. Inverting this drops the column out of
+    // the row's gutter.
+    const cols = getCheckboxGroup(page, 'cs_columns_color').locator('.ant-row > .ant-col');
+    await expect(cols).toHaveCount(2);
+    await expect(cols.nth(1).locator('.ant-checkbox-wrapper')).toHaveCount(1);
+  });
+
   test('renders with title', async ({ page }) => {
     const block = getBlock(page, 'cs_with_title');
     const label = block.locator('.ant-form-item-label');

--- a/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/tests/CheckboxSelector.e2e.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/CheckboxSelector/tests/CheckboxSelector.e2e.yaml
@@ -189,6 +189,76 @@ blocks:
           else: ''
 
   # ============================================
+  # COLUMNS (GRID LAYOUT)
+  # ============================================
+
+  - id: cs_columns_2
+    type: CheckboxSelector
+    properties:
+      columns: 2
+      options:
+        - A
+        - B
+        - C
+        - D
+
+  - id: cs_columns_3
+    type: CheckboxSelector
+    properties:
+      columns: 3
+      options:
+        - A
+        - B
+        - C
+        - D
+        - E
+        - F
+
+  - id: cs_columns_responsive
+    type: CheckboxSelector
+    properties:
+      columns:
+        xs: 1
+        md: 3
+      options:
+        - A
+        - B
+        - C
+
+  - id: cs_columns_gutter
+    type: CheckboxSelector
+    properties:
+      columns: 2
+      gutter:
+        - 24
+        - 12
+      options:
+        - A
+        - B
+        - C
+        - D
+
+  - id: cs_columns_unsupported
+    type: CheckboxSelector
+    properties:
+      columns: 5
+      options:
+        - A
+        - B
+        - C
+
+  - id: cs_columns_color
+    type: CheckboxSelector
+    properties:
+      columns: 2
+      options:
+        - label: Plain
+          value: plain
+        - label: Tinted
+          value: tinted
+          color: '#722ed1'
+
+  # ============================================
   # INTERACTION TESTS
   # ============================================
 

--- a/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/RadioSelector.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/RadioSelector.js
@@ -15,7 +15,7 @@
 */
 
 import React from 'react';
-import { ConfigProvider, Radio, Space } from 'antd';
+import { Col, ConfigProvider, Radio, Row, Space, theme } from 'antd';
 import { renderHtml, withBlockDefaults } from '@lowdefy/block-utils';
 import { type } from '@lowdefy/helpers';
 
@@ -39,14 +39,57 @@ const RadioSelector = ({
   value,
   methods,
 }) => {
+  const { token } = theme.useToken();
   const uniqueValueOptions = useSelectorOptions({ properties, methods });
   const selectedIndex = getSelectedIndex(value, uniqueValueOptions, { properties });
+  const grid = !type.isNone(properties.columns);
+  // Col takes spans, not counts, so a breakpoint map of counts converts per key.
+  const colProps = type.isObject(properties.columns)
+    ? Object.fromEntries(
+        Object.entries(properties.columns).map(([breakpoint, columns]) => [
+          breakpoint,
+          { span: 24 / columns },
+        ])
+      )
+    : { span: 24 / properties.columns };
+  const renderOption = (opt, i) => {
+    if (type.isPrimitive(opt)) {
+      return (
+        <Radio id={`${blockId}_${opt}`} key={i} value={`${i}`}>
+          {renderHtml({ html: `${opt}`, methods })}
+        </Radio>
+      );
+    }
+    const isSelected = `${i}` === selectedIndex;
+    const radio = (
+      <Radio
+        id={`${blockId}_${i}`}
+        key={i}
+        value={`${i}`}
+        disabled={opt.disabled}
+        style={{ ...opt.style, ...(isSelected && opt.color ? { color: opt.color } : {}) }}
+      >
+        {type.isNone(opt.label)
+          ? renderHtml({ html: `${opt.value}`, methods })
+          : renderHtml({ html: opt.label, methods })}
+      </Radio>
+    );
+    if (type.isNone(opt.color)) return radio;
+    // Per-option color: token override colors this radio's selected dot.
+    return (
+      <ConfigProvider key={i} theme={{ token: { colorPrimary: opt.color } }}>
+        {radio}
+      </ConfigProvider>
+    );
+  };
   const radioGroup = (
     <RadioGroup
       id={`${blockId}_input`}
       className={classNames.element}
       disabled={properties.disabled || loading}
-      style={styles.element}
+      // Radio.Group is inline-block and shrink-wraps, so the Row inside it can
+      // only fill a group that has been given a width.
+      style={grid ? { width: '100%', ...styles.element } : styles.element}
       onChange={(event) => {
         const val = type.isPrimitive(uniqueValueOptions[event.target.value])
           ? uniqueValueOptions[event.target.value]
@@ -56,42 +99,23 @@ const RadioSelector = ({
       }}
       value={`${getSelectedIndex(value, uniqueValueOptions, { properties })}`}
     >
-      <Space
-        direction={properties.direction}
-        wrap={type.isNone(properties.wrap) ? true : properties.wrap}
-        align={type.isNone(properties.align) ? 'start' : properties.align}
-      >
-        {uniqueValueOptions.map((opt, i) => {
-          if (type.isPrimitive(opt)) {
-            return (
-              <Radio id={`${blockId}_${opt}`} key={i} value={`${i}`}>
-                {renderHtml({ html: `${opt}`, methods })}
-              </Radio>
-            );
-          }
-          const isSelected = `${i}` === selectedIndex;
-          const radio = (
-            <Radio
-              id={`${blockId}_${i}`}
-              key={i}
-              value={`${i}`}
-              disabled={opt.disabled}
-              style={{ ...opt.style, ...(isSelected && opt.color ? { color: opt.color } : {}) }}
-            >
-              {type.isNone(opt.label)
-                ? renderHtml({ html: `${opt.value}`, methods })
-                : renderHtml({ html: opt.label, methods })}
-            </Radio>
-          );
-          if (type.isNone(opt.color)) return radio;
-          // Per-option color: token override colors this radio's selected dot.
-          return (
-            <ConfigProvider key={i} theme={{ token: { colorPrimary: opt.color } }}>
-              {radio}
-            </ConfigProvider>
-          );
-        })}
-      </Space>
+      {grid ? (
+        <Row gutter={type.isNone(properties.gutter) ? [token.paddingXS, 0] : properties.gutter}>
+          {uniqueValueOptions.map((opt, i) => (
+            <Col key={i} {...colProps}>
+              {renderOption(opt, i)}
+            </Col>
+          ))}
+        </Row>
+      ) : (
+        <Space
+          direction={properties.direction}
+          wrap={type.isNone(properties.wrap) ? true : properties.wrap}
+          align={type.isNone(properties.align) ? 'start' : properties.align}
+        >
+          {uniqueValueOptions.map(renderOption)}
+        </Space>
+      )}
     </RadioGroup>
   );
   return (

--- a/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/gallery.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/gallery.yaml
@@ -757,3 +757,60 @@
           - { id: 3, name: Push }
         html: '{{ item.name }}'
         valueKey: id
+- title: Columns
+  blocks:
+    - id: radio_columns_two
+      type: RadioSelector
+      properties:
+        title: Two columns
+        columns: 2
+        options:
+          - Weekday mornings
+          - Weekday afternoons
+          - Weekday evenings
+          - Weekend mornings
+          - Weekend afternoons
+          - Weekend evenings
+    - id: radio_columns_responsive
+      type: RadioSelector
+      properties:
+        title: One column below md, three from md up
+        columns:
+          xs: 1
+          md: 3
+        options:
+          - Email
+          - SMS
+          - Push notification
+          - Webhook
+          - In-app message
+          - Weekly digest
+    - id: radio_columns_gutter
+      type: RadioSelector
+      properties:
+        title: Wider gutter
+        columns: 2
+        gutter: [24, 12]
+        options:
+          - Read only
+          - Read and write
+          - Administer
+          - No access
+    - id: radio_columns_per_option_color
+      type: RadioSelector
+      properties:
+        title: Coloured options in a grid
+        columns: 2
+        options:
+          - label: Low
+            value: low
+            color: '#16a34a'
+          - label: Medium
+            value: medium
+            color: '#d97706'
+          - label: High
+            value: high
+            color: '#dc2626'
+          - label: Critical
+            value: critical
+            color: '#7e22ce'

--- a/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/meta.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/meta.js
@@ -45,7 +45,7 @@ export default {
         type: 'string',
         enum: ['start', 'end', 'center', 'baseline'],
         default: 'start',
-        description: 'Align options.',
+        description: "Align options. Ignored when 'columns' is set.",
       },
       color: {
         type: 'string',
@@ -54,17 +54,34 @@ export default {
           displayType: 'color',
         },
       },
+      columns: {
+        type: ['integer', 'object'],
+        description:
+          'Number of columns to lay the options out in, or a responsive breakpoint object. Use a count that divides 24 evenly.',
+        docs: {
+          displayType: 'yaml',
+        },
+      },
       disabled,
       direction: {
         type: 'string',
         enum: ['horizontal', 'vertical'],
         default: 'horizontal',
-        description: 'List options horizontally or vertical.',
+        description: "List options horizontally or vertical. Ignored when 'columns' is set.",
+      },
+      gutter: {
+        type: ['number', 'array'],
+        description:
+          "Gap between options in the grid. Number or [horizontal, vertical] array. Applies when 'columns' is set.",
+        docs: {
+          displayType: 'yaml',
+        },
       },
       wrap: {
         type: 'boolean',
         default: true,
-        description: "Specifies wrapping of options. Applies when 'direction' is 'horizontal'.",
+        description:
+          "Specifies wrapping of options. Applies when 'direction' is 'horizontal'. Ignored when 'columns' is set.",
       },
       label,
       options,

--- a/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/tests.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/tests.yaml
@@ -249,3 +249,91 @@
       - '<div>Some main text</div><div style="font-size: 6px;">Some small subtext</div>'
       - '<div style="color: green;">Option green</div>'
       - Option 3
+- id: 'properties.columns: 2'
+  type: RadioSelector
+  properties:
+    columns: 2
+    options:
+      - Option 1
+      - Option 2
+      - Option 3
+      - Option 4
+      - Option 5
+- id: 'properties.columns: 3'
+  type: RadioSelector
+  properties:
+    columns: 3
+    options:
+      - A much longer option label than the others
+      - Short
+      - Option 3
+      - Option 4
+      - Option 5
+      - Option 6
+- id: 'properties.columns: responsive'
+  type: RadioSelector
+  properties:
+    columns:
+      xs: 1
+      md: 3
+    options:
+      - Option 1
+      - Option 2
+      - Option 3
+      - Option 4
+      - Option 5
+      - Option 6
+- id: 'properties.columns: two short options'
+  type: RadioSelector
+  properties:
+    columns: 2
+    options:
+      - 'Yes'
+      - 'No'
+- id: 'properties.columns: unsupported count'
+  type: RadioSelector
+  properties:
+    columns: 5
+    options:
+      - Option 1
+      - Option 2
+      - Option 3
+      - Option 4
+      - Option 5
+- id: 'properties.gutter'
+  type: RadioSelector
+  properties:
+    columns: 2
+    gutter: [24, 12]
+    options:
+      - Option 1
+      - Option 2
+      - Option 3
+      - Option 4
+- id: 'properties.columns: per-option color'
+  type: RadioSelector
+  properties:
+    columns: 2
+    options:
+      - label: Low
+        value: low
+        color: '#16a34a'
+      - label: Medium
+        value: medium
+        color: '#d97706'
+      - label: High
+        value: high
+        color: '#dc2626'
+      - label: Critical
+        value: critical
+        color: '#7e22ce'
+- id: 'properties.columns: with direction vertical'
+  type: RadioSelector
+  properties:
+    columns: 2
+    direction: vertical
+    options:
+      - Option 1
+      - Option 2
+      - Option 3
+      - Option 4

--- a/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/tests/RadioSelector.e2e.spec.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/tests/RadioSelector.e2e.spec.js
@@ -91,6 +91,90 @@ test.describe('RadioSelector Block', () => {
     await expect(space).toHaveClass(/ant-space-horizontal/);
   });
 
+  // ============================================
+  // COLUMNS (GRID LAYOUT) TESTS
+  // ============================================
+
+  test('renders a grid instead of the flow layout when columns is set', async ({ page }) => {
+    const group = getRadioGroup(page, 'rs_columns_2');
+    await expect(group.locator('.ant-row')).toHaveCount(1);
+    await expect(group.locator('.ant-space')).toHaveCount(0);
+  });
+
+  test('keeps the flow layout when columns is not set', async ({ page }) => {
+    const group = getRadioGroup(page, 'rs_basic');
+    await expect(group.locator('.ant-space')).toHaveCount(1);
+    await expect(group.locator('.ant-row')).toHaveCount(0);
+  });
+
+  test('stretches the group to full width in grid mode', async ({ page }) => {
+    // The group is inline-block, so without an explicit width the row inside it
+    // sizes to its content instead of filling the container.
+    const group = getRadioGroup(page, 'rs_columns_2');
+    const [groupWidth, parentWidth] = await group.evaluate((el) => [
+      el.getBoundingClientRect().width,
+      el.parentElement.getBoundingClientRect().width,
+    ]);
+    expect(Math.round(groupWidth)).toBe(Math.round(parentWidth));
+  });
+
+  test('renders two even columns as span 12', async ({ page }) => {
+    const group = getRadioGroup(page, 'rs_columns_2');
+    const cols = group.locator('.ant-row > .ant-col');
+    await expect(cols).toHaveCount(4);
+    for (let i = 0; i < 4; i += 1) {
+      await expect(cols.nth(i)).toHaveClass(/ant-col-12/);
+    }
+  });
+
+  test('renders three even columns as span 8', async ({ page }) => {
+    const group = getRadioGroup(page, 'rs_columns_3');
+    const cols = group.locator('.ant-row > .ant-col');
+    await expect(cols).toHaveCount(6);
+    await expect(cols.first()).toHaveClass(/ant-col-8/);
+  });
+
+  test('renders a responsive column count per breakpoint', async ({ page }) => {
+    const col = getRadioGroup(page, 'rs_columns_responsive').locator('.ant-row > .ant-col').first();
+    await expect(col).toHaveClass(/ant-col-xs-24/);
+    await expect(col).toHaveClass(/ant-col-md-8/);
+  });
+
+  test('applies an explicit gutter to the grid', async ({ page }) => {
+    const col = getRadioGroup(page, 'rs_columns_gutter').locator('.ant-row > .ant-col').first();
+    await expect(col).toHaveCSS('padding-left', '12px');
+    await expect(col).toHaveCSS('padding-right', '12px');
+  });
+
+  test('falls back to content width for a column count that does not divide 24', async ({
+    page,
+  }) => {
+    // 24/5 is 4.8, so the class name carries a decimal and antd has no rule for it —
+    // the column gets no flex-basis and keeps its content width. A supported count
+    // resolves to a percentage, which is the contrast being asserted here.
+    const unsupported = getRadioGroup(page, 'rs_columns_unsupported')
+      .locator('.ant-row > .ant-col')
+      .first();
+    await expect(unsupported).toHaveCSS('flex-basis', 'auto');
+
+    const supported = getRadioGroup(page, 'rs_columns_2').locator('.ant-row > .ant-col').first();
+    await expect(supported).toHaveCSS('flex-basis', '50%');
+  });
+
+  test('renders option labels at normal size inside the grid', async ({ page }) => {
+    // The radio group sets font-size 0 as an inline-block whitespace trick; an
+    // intervening column must not leave the labels at that size.
+    const label = getRadioGroup(page, 'rs_columns_2').locator('.ant-radio-wrapper').first();
+    const fontSize = await label.evaluate((el) => parseFloat(getComputedStyle(el).fontSize));
+    expect(fontSize).toBeGreaterThan(0);
+  });
+
+  test('nests the column outside a per-option color provider', async ({ page }) => {
+    const cols = getRadioGroup(page, 'rs_columns_color').locator('.ant-row > .ant-col');
+    await expect(cols).toHaveCount(2);
+    await expect(cols.nth(1).locator('.ant-radio-wrapper')).toHaveCount(1);
+  });
+
   test('renders with title', async ({ page }) => {
     const block = getBlock(page, 'rs_with_title');
     const label = block.locator('.ant-form-item-label');

--- a/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/tests/RadioSelector.e2e.yaml
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/RadioSelector/tests/RadioSelector.e2e.yaml
@@ -186,6 +186,76 @@ blocks:
           else: ''
 
   # ============================================
+  # COLUMNS (GRID LAYOUT)
+  # ============================================
+
+  - id: rs_columns_2
+    type: RadioSelector
+    properties:
+      columns: 2
+      options:
+        - A
+        - B
+        - C
+        - D
+
+  - id: rs_columns_3
+    type: RadioSelector
+    properties:
+      columns: 3
+      options:
+        - A
+        - B
+        - C
+        - D
+        - E
+        - F
+
+  - id: rs_columns_responsive
+    type: RadioSelector
+    properties:
+      columns:
+        xs: 1
+        md: 3
+      options:
+        - A
+        - B
+        - C
+
+  - id: rs_columns_gutter
+    type: RadioSelector
+    properties:
+      columns: 2
+      gutter:
+        - 24
+        - 12
+      options:
+        - A
+        - B
+        - C
+        - D
+
+  - id: rs_columns_unsupported
+    type: RadioSelector
+    properties:
+      columns: 5
+      options:
+        - A
+        - B
+        - C
+
+  - id: rs_columns_color
+    type: RadioSelector
+    properties:
+      columns: 2
+      options:
+        - label: Plain
+          value: plain
+        - label: Tinted
+          value: tinted
+          color: '#722ed1'
+
+  # ============================================
   # INTERACTION TESTS
   # ============================================
 


### PR DESCRIPTION
## Summary

`CheckboxSelector` and `RadioSelector` laid their options out in a `Space`, which sizes every item to its own content — so a long option list wrapped wherever the labels happened to run out of room and could not be read down a column. `align`, `direction` and `wrap` control that flow but never the cell width, leaving `direction: vertical` (one option per line) as the only even layout, which does not scale past a handful of options.

`Checkbox.Group` has no layout prop of its own; antd's [Use with Grid](https://ant.design/components/checkbox#checkbox-demo-layout) demo gets even columns by composing `Row` / `Col` around the checkbox children. This adds that behind an opt-in `columns` property, with a `gutter` beside it. With `columns` unset, both blocks render exactly as before.

## Changes

- **@lowdefy/blocks-antd**: `columns` on `CheckboxSelector` and `RadioSelector` renders the options as a `Row` of equal-width `Col`s instead of a `Space`. It takes an integer or a responsive breakpoint object, matching the shape `Masonry`, `MasonryList` and `Descriptions` already use for "how many across". `gutter` sets the grid's spacing as a number or `[horizontal, vertical]` array, defaulting to the `paddingXS` token horizontally with no vertical gap so unset spacing matches what `Space` produced. `align`, `direction` and `wrap` are `Space` properties with no `Row`/`Col` equivalent and are ignored while `columns` is set — their descriptions now say so. Also corrects the `theme.marginXS` description on `CheckboxSelector`, and repoints the e2e app at the renamed Tree block.

## Key Files

- `src/blocks/CheckboxSelector/CheckboxSelector.js` — the `Row`/`Col` branch, a shared per-option helper used by both layouts, and `width: 100%` on the group in grid mode
- `src/blocks/RadioSelector/RadioSelector.js` — the same, allowing for the radio group being `inline-block` rather than `inline-flex`
- `src/blocks/*/meta.js` — the two new properties, the grid-mode notes, and the `marginXS` correction
- `e2e/app/lowdefy.yaml` — one-line fix, see Notes

## Notes

**Three decisions worth a reviewer's eye.**

`Row`/`Col` over a CSS-grid override on the existing container: it is what antd documents and keeps the block built from public antd components. The cost is that a `Col` span must be an integer, so only counts dividing 24 evenly are supported.

**An unsupported count has no fallback code.** antd emits width classes for integer spans 1–24 only, so `columns: 5` yields span 4.8, names a class that was never generated, and the column keeps its content width — a ragged wrap, close to what `Space` gives. Rounding to the nearest supported count was considered and rejected: an author who writes 5 and sees ragged columns learns 5 is unsupported, one who silently gets 4 does not. There is an e2e test asserting `flex-basis: auto` for the unsupported count against `50%` for a supported one.

**`width: 100%` on the group is load-bearing, not decoration.** antd carries `> .ant-row { flex: 1 }` on `.ant-checkbox-group` for this composition, but the same rule sets `display: inline-flex`, so the group is an inline-level box sized shrink-to-fit and the row inside it cannot fill the container. antd's own grid demo sets the width for this reason. It is easy to miss because with enough options the content overflows and the layout looks correct anyway — a two-option field with `columns: 2` is where it shows.

**One unrelated fix rides along.** The last commit repoints `e2e/app/lowdefy.yaml` from `TreeSelector/tests/TreeSelector.e2e.yaml`, which no longer exists after the Tree rename, to `TreeInput/tests/TreeInput.e2e.yaml`, which does. A dead `_ref` fails the app build, and because every block's page comes from one app config that failed the **entire** blocks-antd e2e suite, not just one block's tests. Nothing in CI runs `pnpm e2e`, so it had gone unnoticed. Repointing it is what made verifying this PR possible.

**Verification.** `pnpm e2e` for both blocks: 55 passed, 0 failed — 19 new tests plus the 36 pre-existing ones. Note that this requires node 22 or 24; playwright 1.50.1 stalls silently on node 26, both when downloading browsers and during test collection, which is consistent with the node-26 compatibility work not yet being on `develop`.
