### PR TITLE
Reject anonymous agent calls on protected apps

### DIFF
--- a/.changeset/fix-agent-route-auth.md
+++ b/.changeset/fix-agent-route-auth.md
@@ -5,6 +5,6 @@
 
 fix: Anonymous calls to protected agents are rejected.
 
-The `/api/agent` route ran agents without checking the session: on an app with `auth.api.protected: true`, a session-less caller could still execute any agent — tool calls failed endpoint auth, but the model call ran on the app's provider account. Agents now follow the `auth.api` config exactly like endpoints: `public`, `protected`, and `roles` patterns match agent ids, and unauthorized calls fail with the same error as an unknown agent id.
+The `/api/agent` route ran agents without checking the session: on an app with `auth.api.protected: true`, a session-less caller could still execute any agent — tool calls failed endpoint auth, but the model call ran on the app's provider account. Agents now follow the `auth.api` config exactly like endpoints: `public`, `protected`, and `roles` patterns match agent ids, and unauthorized calls fail with the same error as an unknown agent id. Sub-agent invocations are authorized against the same session per call, matching how in-run endpoint tool calls are authorized.
 
 Note for apps using wildcard patterns in `auth.api.public` or `auth.api.roles`: those patterns now also match agent ids.

--- a/.changeset/fix-agent-route-auth.md
+++ b/.changeset/fix-agent-route-auth.md
@@ -1,0 +1,10 @@
+---
+'@lowdefy/build': patch
+'@lowdefy/api': patch
+---
+
+fix: Anonymous calls to protected agents are rejected.
+
+The `/api/agent` route ran agents without checking the session: on an app with `auth.api.protected: true`, a session-less caller could still execute any agent — tool calls failed endpoint auth, but the model call ran on the app's provider account. Agents now follow the `auth.api` config exactly like endpoints: `public`, `protected`, and `roles` patterns match agent ids, and unauthorized calls fail with the same error as an unknown agent id.
+
+Note for apps using wildcard patterns in `auth.api.public` or `auth.api.roles`: those patterns now also match agent ids.

--- a/packages/api/src/routes/agent/authorizeAgent.js
+++ b/packages/api/src/routes/agent/authorizeAgent.js
@@ -1,0 +1,43 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ConfigError } from '@lowdefy/errors';
+import { translate } from '@lowdefy/helpers';
+
+function authorizeAgent({ authorize, i18n, logger }, { agentConfig }) {
+  if (!authorize(agentConfig)) {
+    logger.debug({
+      event: 'debug_agent_authorize',
+      authorized: false,
+      auth_config: agentConfig.auth,
+    });
+    // Same message as an unknown agentId so responses do not reveal which agents exist.
+    throw new ConfigError(
+      translate({
+        key: 'agent.runtime.agentNotFound',
+        values: { agentId: agentConfig.agentId },
+        i18n,
+      })
+    );
+  }
+  logger.debug({
+    event: 'debug_agent_authorize',
+    authorized: true,
+    auth_config: agentConfig.auth,
+  });
+}
+
+export default authorizeAgent;

--- a/packages/api/src/routes/agent/authorizeAgent.test.js
+++ b/packages/api/src/routes/agent/authorizeAgent.test.js
@@ -1,0 +1,71 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+
+import authorizeAgent from './authorizeAgent.js';
+import testContext from '../../test/testContext.js';
+
+const logger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('authorizeAgent allows a public agent without a session', () => {
+  const context = testContext({ logger });
+  const agentConfig = { agentId: 'my-agent', auth: { public: true } };
+  expect(() => authorizeAgent(context, { agentConfig })).not.toThrow();
+});
+
+test('authorizeAgent rejects a protected agent without a session', () => {
+  const context = testContext({ logger });
+  const agentConfig = { agentId: 'my-agent', auth: { public: false } };
+  expect(() => authorizeAgent(context, { agentConfig })).toThrow(
+    'Agent "my-agent" does not exist.'
+  );
+});
+
+test('authorizeAgent allows a protected agent with a session', () => {
+  const context = testContext({ logger, session: { user: { id: 'user_1' } } });
+  const agentConfig = { agentId: 'my-agent', auth: { public: false } };
+  expect(() => authorizeAgent(context, { agentConfig })).not.toThrow();
+});
+
+test('authorizeAgent rejects a role-protected agent when the user lacks the role', () => {
+  const context = testContext({
+    logger,
+    session: { user: { id: 'user_1', roles: ['user'] } },
+  });
+  const agentConfig = { agentId: 'my-agent', auth: { public: false, roles: ['admin'] } };
+  expect(() => authorizeAgent(context, { agentConfig })).toThrow(
+    'Agent "my-agent" does not exist.'
+  );
+});
+
+test('authorizeAgent allows a role-protected agent when the user has the role', () => {
+  const context = testContext({
+    logger,
+    session: { user: { id: 'user_1', roles: ['admin'] } },
+  });
+  const agentConfig = { agentId: 'my-agent', auth: { public: false, roles: ['admin'] } };
+  expect(() => authorizeAgent(context, { agentConfig })).not.toThrow();
+});

--- a/packages/api/src/routes/agent/callAgent.js
+++ b/packages/api/src/routes/agent/callAgent.js
@@ -118,7 +118,9 @@ async function callAgent(
       return getEndpointConfig(context, { endpointId });
     },
     getAgentConfig: async ({ agentId }) => {
-      return getAgentConfig(context, { agentId });
+      const subAgentConfig = await getAgentConfig(context, { agentId });
+      authorizeAgent(context, { agentConfig: subAgentConfig });
+      return subAgentConfig;
     },
     getConnectionForAgent: async ({ agentConfig: subAgentConfig }) => {
       const subConnectionConfig = await getConnectionConfig(context, {

--- a/packages/api/src/routes/agent/callAgent.js
+++ b/packages/api/src/routes/agent/callAgent.js
@@ -17,6 +17,7 @@
 import { serializer, type } from '@lowdefy/helpers';
 
 import createEvaluateOperators from '../../context/createEvaluateOperators.js';
+import authorizeAgent from './authorizeAgent.js';
 import authorizeApiEndpoint from '../endpoints/authorizeApiEndpoint.js';
 import getEndpointConfig from '../endpoints/getEndpointConfig.js';
 import runRoutine from '../endpoints/runRoutine.js';
@@ -36,6 +37,7 @@ async function callAgent(
 
   logger.debug({ event: 'debug_agent', agentId, pageId });
   const agentConfig = await getAgentConfig(context, { agentId });
+  authorizeAgent(context, { agentConfig });
 
   const agentContext = {
     conversationId: conversationId ?? undefined,

--- a/packages/api/src/routes/agent/callAgent.test.js
+++ b/packages/api/src/routes/agent/callAgent.test.js
@@ -735,6 +735,7 @@ test('callAgent passes getAgentConfig in resolver context', async () => {
     properties: { model: 'claude-3-5-sonnet' },
   };
   const subAgentConfig = {
+    auth: { public: true },
     agentId: 'sub-agent',
     id: 'agent:sub-agent',
     type: 'ClaudeAgent',
@@ -1029,4 +1030,56 @@ test('callAgent runs a protected agent when a session exists', async () => {
 
   await callAgent(context, { agentId: 'my-agent', pageId: 'page1', messages: [] });
   expect(mockResolver).toHaveBeenCalled();
+});
+
+test('callAgent resolverContext.getAgentConfig authorizes sub-agents against the session', async () => {
+  const mockStream = { toUIMessageStreamResponse: jest.fn() };
+  const mockResolver = jest.fn().mockResolvedValue({ response: mockStream });
+  const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
+  const agentConfig = {
+    auth: { public: true },
+    agentId: 'parent-agent',
+    id: 'agent:parent-agent',
+    type: 'ClaudeAgent',
+    connectionId: 'my-anthropic',
+    tools: [],
+    properties: { model: 'claude-3-5-sonnet' },
+  };
+  const protectedSubAgentConfig = {
+    auth: { public: false },
+    agentId: 'protected-sub',
+    id: 'agent:protected-sub',
+    type: 'ClaudeAgent',
+    connectionId: 'my-anthropic',
+    tools: [],
+    properties: { model: 'claude-3-5-sonnet' },
+  };
+  const connectionConfig = {
+    connectionId: 'my-anthropic',
+    id: 'connection:my-anthropic',
+    type: 'Anthropic',
+    properties: { apiKey: 'sk-test' },
+  };
+  const readConfigFile = jest.fn((path) => {
+    if (path === 'agents/parent-agent.json') return agentConfig;
+    if (path === 'agents/protected-sub.json') return protectedSubAgentConfig;
+    if (path === 'connections/my-anthropic.json') return connectionConfig;
+    return null;
+  });
+  const context = testContext({
+    logger,
+    readConfigFile,
+    connections: { Anthropic: { create: mockCreate, requests: {} } },
+  });
+  context.agents = { ClaudeAgent: { resolver: mockResolver, schema: {} } };
+
+  await callAgent(context, { agentId: 'parent-agent', pageId: 'page1', messages: [] });
+  const resolverContext = mockResolver.mock.calls[0][0].context;
+
+  await expect(resolverContext.getAgentConfig({ agentId: 'protected-sub' })).rejects.toThrow(
+    'Agent "protected-sub" does not exist.'
+  );
+  await expect(resolverContext.getAgentConfig({ agentId: 'parent-agent' })).resolves.toEqual(
+    agentConfig
+  );
 });

--- a/packages/api/src/routes/agent/callAgent.test.js
+++ b/packages/api/src/routes/agent/callAgent.test.js
@@ -56,6 +56,7 @@ test('callAgent loads agent config, creates connection, and calls resolver', asy
   const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
 
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'ClaudeAgent',
@@ -129,6 +130,7 @@ test('callAgent throws ConfigError when agent does not exist', async () => {
 
 test('callAgent throws ConfigError when agent type not found in registry', async () => {
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'UnknownAgent',
@@ -171,6 +173,7 @@ test('callAgent throws ConfigError when agent type not found in registry', async
 
 test('callAgent throws when connection type not found in registry', async () => {
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'ClaudeAgent',
@@ -218,6 +221,7 @@ test('callAgent resolver context callEndpoint executes endpoint routine', async 
   const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
 
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'ClaudeAgent',
@@ -280,6 +284,7 @@ test('callAgent resolver context getEndpointConfig returns endpoint config', asy
   const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
 
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'ClaudeAgent',
@@ -343,6 +348,7 @@ test('callAgent resolver context callEndpoint allows InternalApi endpoints', asy
   const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
 
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'ClaudeAgent',
@@ -402,6 +408,7 @@ test('callAgent propagates error when connection.create throws', async () => {
   });
 
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'ClaudeAgent',
@@ -441,6 +448,7 @@ test('callAgent propagates error when resolver throws', async () => {
   const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
 
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'ClaudeAgent',
@@ -484,6 +492,7 @@ test('callAgent resolver context callEndpoint returns error when routine fails',
   const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
 
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'ClaudeAgent',
@@ -545,6 +554,7 @@ test('callAgent resolver context getEndpointConfig throws for missing endpoint',
   const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
 
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'ClaudeAgent',
@@ -586,6 +596,7 @@ test('callAgent passes agentContext with conversationId, pageId, urlQuery, userI
   const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
 
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'ClaudeAgent',
@@ -634,6 +645,7 @@ test('callAgent passes userId from context.user.id when sub is not present', asy
   const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
 
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'ClaudeAgent',
@@ -674,6 +686,7 @@ test('callAgent passes null userId when no user session', async () => {
   const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
 
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'ClaudeAgent',
@@ -713,6 +726,7 @@ test('callAgent passes getAgentConfig in resolver context', async () => {
   const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
 
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'ClaudeAgent',
@@ -766,6 +780,7 @@ test('callAgent passes getConnectionForAgent in resolver context', async () => {
   const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
 
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'ClaudeAgent',
@@ -814,6 +829,7 @@ test('callAgent evaluates operators in agent properties before passing to resolv
   const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
 
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'ClaudeAgent',
@@ -856,6 +872,7 @@ test('callAgent provides agentContext as payload for operator evaluation', async
   const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
 
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'ClaudeAgent',
@@ -916,6 +933,7 @@ test('callAgent passes resolveMcpSources in resolver context', async () => {
   const mockMcpCreate = jest.fn().mockReturnValue({ url: 'http://mcp.test', transport: 'http' });
 
   const agentConfig = {
+    auth: { public: true },
     agentId: 'my-agent',
     id: 'agent:my-agent',
     type: 'ClaudeAgent',
@@ -958,4 +976,57 @@ test('callAgent passes resolveMcpSources in resolver context', async () => {
 
   const resolverContext = mockResolver.mock.calls[0][0].context;
   expect(resolverContext.resolveMcpSources).toBeDefined();
+});
+
+test('callAgent rejects a protected agent when there is no session', async () => {
+  const mockResolver = jest.fn();
+  const agentConfig = {
+    auth: { public: false },
+    agentId: 'my-agent',
+    id: 'agent:my-agent',
+    type: 'ClaudeAgent',
+    connectionId: 'my-anthropic',
+    tools: [],
+    properties: { model: 'claude-3-5-sonnet' },
+  };
+  const readConfigFile = createMockReadConfigFile({ agentConfig });
+  const context = testContext({ logger, readConfigFile });
+  context.agents = { ClaudeAgent: { resolver: mockResolver, schema: {} } };
+
+  await expect(
+    callAgent(context, { agentId: 'my-agent', pageId: 'page1', messages: [] })
+  ).rejects.toThrow('Agent "my-agent" does not exist.');
+  expect(mockResolver).not.toHaveBeenCalled();
+});
+
+test('callAgent runs a protected agent when a session exists', async () => {
+  const mockStream = { toUIMessageStreamResponse: jest.fn() };
+  const mockResolver = jest.fn().mockResolvedValue({ response: mockStream });
+  const mockCreate = jest.fn().mockReturnValue({ provider: 'mock-provider' });
+  const agentConfig = {
+    auth: { public: false },
+    agentId: 'my-agent',
+    id: 'agent:my-agent',
+    type: 'ClaudeAgent',
+    connectionId: 'my-anthropic',
+    tools: [],
+    properties: { model: 'claude-3-5-sonnet' },
+  };
+  const connectionConfig = {
+    connectionId: 'my-anthropic',
+    id: 'connection:my-anthropic',
+    type: 'Anthropic',
+    properties: { apiKey: 'sk-test' },
+  };
+  const readConfigFile = createMockReadConfigFile({ agentConfig, connectionConfig });
+  const context = testContext({
+    logger,
+    readConfigFile,
+    connections: { Anthropic: { create: mockCreate, requests: {} } },
+    session: { user: { id: 'user_1' } },
+  });
+  context.agents = { ClaudeAgent: { resolver: mockResolver, schema: {} } };
+
+  await callAgent(context, { agentId: 'my-agent', pageId: 'page1', messages: [] });
+  expect(mockResolver).toHaveBeenCalled();
 });

--- a/packages/build/src/build/buildAuth/buildAgentAuth.js
+++ b/packages/build/src/build/buildAuth/buildAgentAuth.js
@@ -1,0 +1,60 @@
+/* eslint-disable no-param-reassign */
+
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { type } from '@lowdefy/helpers';
+import { ConfigError } from '@lowdefy/errors';
+import getAgentRoles from './getAgentRoles.js';
+import getProtectedAgents from './getProtectedAgents.js';
+import { isInPatternList } from './matchPattern.js';
+
+// Agents are served from the API surface, so auth.api patterns match agent ids too.
+function buildAgentAuth({ components, context }) {
+  const protectedAgents = getProtectedAgents({ components });
+  const agentRoles = getAgentRoles({ components });
+  let configPublicApi = [];
+  if (type.isArray(components.auth.api.public)) {
+    configPublicApi = components.auth.api.public;
+  }
+
+  (components.agents ?? []).forEach((agent) => {
+    if (agentRoles[agent.id]) {
+      if (isInPatternList(agent.id, configPublicApi)) {
+        throw new ConfigError(`Agent "${agent.id}" is both protected by roles and public.`, {
+          received: agentRoles[agent.id],
+          configKey: agent['~k'],
+        });
+      }
+      agent.auth = {
+        public: false,
+        roles: agentRoles[agent.id],
+      };
+    } else if (protectedAgents.includes(agent.id)) {
+      agent.auth = {
+        public: false,
+      };
+    } else {
+      agent.auth = {
+        public: true,
+      };
+    }
+  });
+
+  return components;
+}
+
+export default buildAgentAuth;

--- a/packages/build/src/build/buildAuth/buildAgentAuth.test.js
+++ b/packages/build/src/build/buildAuth/buildAgentAuth.test.js
@@ -1,0 +1,103 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import buildAgentAuth from './buildAgentAuth.js';
+import buildAuth from './buildAuth.js';
+import testContext from '../../test-utils/testContext.js';
+
+const context = testContext();
+
+test('buildAgentAuth agents are public when no auth config is set', () => {
+  const components = {
+    agents: [{ id: 'agent-a' }, { id: 'agent-b' }],
+    auth: { api: { roles: {} } },
+  };
+  const res = buildAgentAuth({ components, context });
+  expect(res.agents).toEqual([
+    { id: 'agent-a', auth: { public: true } },
+    { id: 'agent-b', auth: { public: true } },
+  ]);
+});
+
+test('buildAgentAuth all agents are protected when api.protected is true', () => {
+  const components = {
+    agents: [{ id: 'agent-a' }, { id: 'agent-b' }],
+    auth: { api: { protected: true, roles: {} } },
+  };
+  const res = buildAgentAuth({ components, context });
+  expect(res.agents).toEqual([
+    { id: 'agent-a', auth: { public: false } },
+    { id: 'agent-b', auth: { public: false } },
+  ]);
+});
+
+test('buildAgentAuth api.public list exempts matching agents from protection', () => {
+  const components = {
+    agents: [{ id: 'agent-a' }, { id: 'agent-b' }],
+    auth: { api: { public: ['agent-b'], roles: {} } },
+  };
+  const res = buildAgentAuth({ components, context });
+  expect(res.agents).toEqual([
+    { id: 'agent-a', auth: { public: false } },
+    { id: 'agent-b', auth: { public: true } },
+  ]);
+});
+
+test('buildAgentAuth api.protected list protects only matching agents', () => {
+  const components = {
+    agents: [{ id: 'agent-a' }, { id: 'agent-b' }],
+    auth: { api: { protected: ['agent-a'], roles: {} } },
+  };
+  const res = buildAgentAuth({ components, context });
+  expect(res.agents).toEqual([
+    { id: 'agent-a', auth: { public: false } },
+    { id: 'agent-b', auth: { public: true } },
+  ]);
+});
+
+test('buildAgentAuth api.roles patterns assign roles to matching agents', () => {
+  const components = {
+    agents: [{ id: 'admin-agent' }, { id: 'agent-b' }],
+    auth: { api: { protected: true, roles: { admin: ['admin-*'] } } },
+  };
+  const res = buildAgentAuth({ components, context });
+  expect(res.agents).toEqual([
+    { id: 'admin-agent', auth: { public: false, roles: ['admin'] } },
+    { id: 'agent-b', auth: { public: false } },
+  ]);
+});
+
+test('buildAgentAuth throws when an agent is both protected by roles and public', () => {
+  const components = {
+    agents: [{ id: 'admin-agent' }],
+    auth: { api: { public: ['admin-agent'], roles: { admin: ['admin-agent'] } } },
+  };
+  expect(() => buildAgentAuth({ components, context })).toThrow(
+    'Agent "admin-agent" is both protected by roles and public.'
+  );
+});
+
+test('buildAuth stamps agent auth alongside api and page auth', () => {
+  const components = {
+    agents: [{ id: 'agent-a' }],
+    api: [{ id: 'endpoint-a', type: 'Api' }],
+    pages: [{ id: 'page-a', type: 'Context' }],
+    auth: { api: { protected: true } },
+  };
+  const res = buildAuth({ components, context });
+  expect(res.agents).toEqual([{ id: 'agent-a', auth: { public: false } }]);
+  expect(res.api).toEqual([{ id: 'endpoint-a', type: 'Api', auth: { public: false } }]);
+});

--- a/packages/build/src/build/buildAuth/buildAuth.js
+++ b/packages/build/src/build/buildAuth/buildAuth.js
@@ -18,6 +18,7 @@
 
 import { type } from '@lowdefy/helpers';
 import buildAuthPlugins from './buildAuthPlugins.js';
+import buildAgentAuth from './buildAgentAuth.js';
 import buildApiAuth from './buildApiAuth.js';
 import buildPageAuth from './buildPageAuth.js';
 import validateAuthConfig from './validateAuthConfig.js';
@@ -27,6 +28,7 @@ function buildAuth({ components, context }) {
   validateAuthConfig({ components, context });
   components.auth.configured = configured;
   buildApiAuth({ components, context });
+  buildAgentAuth({ components, context });
   buildPageAuth({ components, context });
   buildAuthPlugins({ components, context });
 

--- a/packages/build/src/build/buildAuth/getAgentRoles.js
+++ b/packages/build/src/build/buildAuth/getAgentRoles.js
@@ -1,0 +1,41 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { matchesPattern } from './matchPattern.js';
+
+function getAgentRoles({ components }) {
+  const roles = components.auth.api.roles;
+  const agentIds = (components.agents ?? []).map((agent) => agent.id);
+  const agentRoles = {};
+  Object.keys(roles).forEach((roleName) => {
+    roles[roleName].forEach((pattern) => {
+      agentIds.forEach((agentId) => {
+        if (matchesPattern(agentId, pattern)) {
+          if (!agentRoles[agentId]) {
+            agentRoles[agentId] = new Set();
+          }
+          agentRoles[agentId].add(roleName);
+        }
+      });
+    });
+  });
+  Object.keys(agentRoles).forEach((agentId) => {
+    agentRoles[agentId] = [...agentRoles[agentId]];
+  });
+  return agentRoles;
+}
+
+export default getAgentRoles;

--- a/packages/build/src/build/buildAuth/getProtectedAgents.js
+++ b/packages/build/src/build/buildAuth/getProtectedAgents.js
@@ -1,0 +1,38 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { type } from '@lowdefy/helpers';
+import { isInPatternList } from './matchPattern.js';
+
+function getProtectedAgents({ components }) {
+  const agentIds = (components.agents ?? []).map((agent) => agent.id);
+  let protectedAgents = [];
+
+  if (type.isArray(components.auth.api.public)) {
+    protectedAgents = agentIds.filter(
+      (agentId) => !isInPatternList(agentId, components.auth.api.public)
+    );
+  } else if (components.auth.api.protected === true) {
+    protectedAgents = agentIds;
+  } else if (type.isArray(components.auth.api.protected)) {
+    protectedAgents = agentIds.filter((agentId) =>
+      isInPatternList(agentId, components.auth.api.protected)
+    );
+  }
+  return protectedAgents;
+}
+
+export default getProtectedAgents;

--- a/scripts/lib/createWorkspace.mjs
+++ b/scripts/lib/createWorkspace.mjs
@@ -18,7 +18,21 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 function createWorkspace({ targetDir }) {
-  fs.writeFileSync(path.join(targetDir, 'pnpm-workspace.yaml'), 'packages: []\n');
+  // pnpm 11 fails installs when build scripts are ignored — same fix as the root
+  // workspace, plus sharp, which enters the server copy via next.
+  fs.writeFileSync(
+    path.join(targetDir, 'pnpm-workspace.yaml'),
+    `packages: []
+onlyBuiltDependencies:
+  - '@swc/core'
+  - esbuild
+  - sharp
+allowBuilds:
+  '@swc/core': true
+  esbuild: true
+  sharp: true
+`
+  );
   if (!fs.existsSync(path.join(targetDir, '.npmrc'))) {
     fs.writeFileSync(path.join(targetDir, '.npmrc'), 'strict-peer-dependencies=false\n');
   }


### PR DESCRIPTION
## Summary

`POST /api/agent/{pageId}/{agentId}` performed no authorization: the session was attached to the request context but never checked, so on an app with `auth.api.protected: true` a session-less caller could still run any agent — tool calls failed endpoint auth, but the model call itself executed on the app's provider account, bounded only by `maxSteps` and provider spend limits. Found while verifying agent plumbing for a downstream app; both the Next.js and vite-hono servers route through the shared `callAgent`, so this closes the gap for both lines.

Agents now follow the `auth.api` config exactly like endpoints: build stamps `auth` onto each agent (`public`/`protected`/`roles` patterns match agent ids the way they match endpoint ids), and `callAgent` authorizes against the session before operator evaluation or any connection/model work. Unauthorized calls fail with the same `agentNotFound` error as an unknown agent id, so responses do not reveal which agents exist. Sub-agent invocations are authorized against the same session per call — mirroring how in-run endpoint tool calls go through `authorizeApiEndpoint` — so a public parent agent cannot front a protected sub-agent for an anonymous caller.

## Changes

- **@lowdefy/build**: `buildAgentAuth` (mirroring `buildApiAuth`) stamps `auth` per agent from the `auth.api` config during `buildAuth`; `writeAgents` already serializes the whole agent object, so the artifact carries it with no write-side change.
- **@lowdefy/api**: `authorizeAgent` (mirroring `authorizeApiEndpoint`) is called in `callAgent` immediately after the agent config loads.
- **scripts**: `createWorkspace` now writes the same `onlyBuiltDependencies`/`allowBuilds` pair as the root workspace (plus `sharp`, which enters the server copies via `next`) — the pnpm 11 fix from #2299's root-workspace change (00ebfc947) applied to the generated `_server/*` workspaces it missed. Fatal only on pnpm 11 (a warning on the pinned 10.29.2); found because `scripts/dev.mjs` could not boot to verify this PR.

## Key Files

- `packages/build/src/build/buildAuth/buildAgentAuth.js` — stamps agent auth from `auth.api`
- `packages/api/src/routes/agent/authorizeAgent.js` — the runtime check
- `packages/api/src/routes/agent/callAgent.js` — check wired in after config load
- `packages/build/src/build/buildAuth/buildAgentAuth.test.js` — build-side matrix (protected/public/roles/conflict)

## Breaking Changes

- A public agent on an app with `auth.api.protected: true` must now be listed in `auth.api.public` — previously all agents were reachable regardless of config. Fail-closed is the intended behavior; existing protected apps get the protection with no config change.
- Wildcard patterns in `auth.api.public` and `auth.api.roles` now also match agent ids.

## Notes

- Verified beyond unit tests by building a real app config (`auth.api.protected: true` + one exempted agent) through the real pipeline: artifacts stamp `{public: false}`/`{public: true}` correctly. A full HTTP check via `scripts/dev.mjs` was blocked by a pre-existing, unrelated Next build failure (`<Html> should not be imported outside of pages/_document` prerendering `/404`).
- No docs updated in this PR — `packages/docs/agents/` has no auth section yet; happy to add a sentence to the agents introduction if wanted.
