### PR TITLE
fix(blocks-aggrid): Keep cell renderer identity stable; add menu cell

### DIFF
--- a/.changeset/feat-aggrid-menu-cell.md
+++ b/.changeset/feat-aggrid-menu-cell.md
@@ -1,0 +1,27 @@
+---
+'@lowdefy/blocks-aggrid': minor
+---
+
+feat(blocks-aggrid): Add a `menu` cell for row actions.
+
+`cell.type: menu` renders a row's actions as a dropdown behind one trigger button, instead of spending a wide column on a `buttons` cell. Each `cell.items[]` entry declares its own `eventName`, so items wire to block-level events exactly as buttons do, and the same `*Field` row-data resolution applies (`titleField`, `iconField`, `disabledField`, `hiddenField`).
+
+```yaml
+- headerName: ''
+  colId: menu
+  width: 60
+  cell:
+    type: menu
+    items:
+      - eventName: onMenuRename
+        title: Rename
+        icon: AiOutlineEdit
+        hiddenField: readOnly
+      - eventName: onMenuDelete
+        title: Delete
+        icon: AiOutlineDelete
+        danger: true
+        hiddenField: readOnly
+```
+
+A hidden item is dropped rather than disabled, and a row on which every item is hidden renders no trigger at all rather than a button that opens an empty menu. The trigger's `type` and `shape` are fixed rather than configurable, because both keys are already taken at cell level (`type` names the renderer, `shape` is the avatar's); `icon` and `placement` are configurable.

--- a/.changeset/fix-aggrid-cell-renderer-identity.md
+++ b/.changeset/fix-aggrid-cell-renderer-identity.md
@@ -1,0 +1,11 @@
+---
+'@lowdefy/blocks-aggrid': patch
+---
+
+fix(blocks-aggrid): Stop cells being destroyed on every render.
+
+`processColDefs` built a fresh `cellRenderer` function for every column on every render. A cellRenderer is a React element type, so a new function is a different component: ag-grid's `CellCtrl.refreshCellRenderer` bails when `cellRendererClass !== componentClass` and the cell is recreated. Anything a cell was holding died with it — an open popup, the focus and half-typed value of a `selector`, `textInput` or `paragraphInput` cell — whenever anything else re-rendered the block, including a request finishing elsewhere on the page.
+
+Each column now keeps one renderer adapter for its lifetime and the closure behind it is replaced in place, so ag-grid keeps the cell and the cell still renders the current config. Because cells are no longer recreated when a column definition changes — ag-grid refreshes body cells on data changes and does not listen for `colDefChanged` — the block now calls `refreshCells({ force: true })` when the authored `columnDefs` change, which re-renders the mounted cells in place. Function-valued column properties are compared by identity, since `JSON.stringify` cannot see them.
+
+Both the display and input grids are fixed.

--- a/packages/plugins/blocks/blocks-aggrid/src/AgGrid.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/AgGrid.js
@@ -19,7 +19,7 @@ import { AgGridReact } from '@ag-grid-community/react';
 import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
 import { CsvExportModule } from '@ag-grid-community/csv-export';
 
-import processColDefs from './processColDefs.js';
+import useColDefs from './useColDefs.js';
 import assignRowId from './assignRowId.js';
 import LoadingOverlay from './LoadingOverlay.js';
 
@@ -37,6 +37,7 @@ const AgGrid = ({ properties, methods, loading, events, components }) => {
   const gridRef = useRef();
 
   const memoDefaultColDef = useMemo(() => defaultColDef);
+  const processedColDefs = useColDefs({ columnDefs, methods, components, gridRef });
 
   const getRowId = useCallback(
     (params) => {
@@ -168,7 +169,7 @@ const AgGrid = ({ properties, methods, loading, events, components }) => {
         onRowClicked={onRowClick}
         onCellClicked={onCellClicked}
         modules={[ClientSideRowModelModule, CsvExportModule]}
-        columnDefs={processColDefs(columnDefs, methods, components)}
+        columnDefs={processedColDefs}
         ref={gridRef}
         getRowId={getRowId}
         suppressLoadingOverlay

--- a/packages/plugins/blocks/blocks-aggrid/src/AgGridInput.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/AgGridInput.js
@@ -19,7 +19,7 @@ import { AgGridReact } from '@ag-grid-community/react';
 import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
 import { CsvExportModule } from '@ag-grid-community/csv-export';
 
-import processColDefs from './processColDefs.js';
+import useColDefs from './useColDefs.js';
 import assignRowId from './assignRowId.js';
 import LoadingOverlay from './LoadingOverlay.js';
 
@@ -30,6 +30,7 @@ const AgGridInput = ({ properties, methods, loading, events, value }) => {
   const gridRef = useRef();
 
   const memoDefaultColDef = useMemo(() => defaultColDef);
+  const processedColDefs = useColDefs({ columnDefs, methods, gridRef });
 
   const getRowId = useCallback(
     (params) => {
@@ -212,7 +213,7 @@ const AgGridInput = ({ properties, methods, loading, events, value }) => {
         onRowDragEnd={onRowDragEnd}
         defaultColDef={memoDefaultColDef}
         modules={[ClientSideRowModelModule, CsvExportModule]}
-        columnDefs={processColDefs(columnDefs, methods)}
+        columnDefs={processedColDefs}
         ref={gridRef}
         getRowId={getRowId}
         suppressLoadingOverlay

--- a/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridAlpine/gallery.yaml
+++ b/packages/plugins/blocks/blocks-aggrid/src/blocks/AgGridAlpine/gallery.yaml
@@ -1160,6 +1160,92 @@
                   - 'Delete '
                   - _event: row.name
 
+- title: Menu cell (row actions behind one trigger)
+  fullWidth: true
+  blocks:
+    - id: menu_cell_demo
+      type: AgGridAlpine
+      properties:
+        height: 260
+        defaultColDef:
+          resizable: true
+          flex: 1
+        columnDefs:
+          - headerName: Report
+            field: name
+          - headerName: Visibility
+            field: visibility
+            width: 130
+            cell:
+              type: tag
+              colorMap:
+                private: default
+                shared: blue
+          # Every item fires its own block-level event, the same as the buttons cell.
+          # `hiddenField` drops an item for rows it does not apply to, so one column
+          # definition serves owners and readers: TSK-003 is someone else's report, so
+          # its menu is Duplicate alone.
+          - headerName: ''
+            colId: menu
+            width: 60
+            sortable: false
+            filter: false
+            resizable: false
+            cell:
+              type: menu
+              items:
+                - eventName: onMenuRename
+                  title: Rename
+                  icon: AiOutlineEdit
+                  hiddenField: readOnly
+                - eventName: onMenuDuplicate
+                  title: Duplicate
+                  icon: AiOutlineCopy
+                - eventName: onMenuDelete
+                  title: Delete
+                  icon: AiOutlineDelete
+                  danger: true
+                  hiddenField: readOnly
+        rowData:
+          - _id: REP-001
+            name: Monthly spend by region
+            visibility: private
+            readOnly: false
+          - _id: REP-002
+            name: Open tickets by team
+            visibility: shared
+            readOnly: false
+          - _id: REP-003
+            name: Fleet utilisation (shared with you)
+            visibility: shared
+            readOnly: true
+      events:
+        onMenuRename:
+          - id: menu_rename_msg
+            type: DisplayMessage
+            params:
+              content:
+                _string.concat:
+                  - 'Rename '
+                  - _event: row.name
+        onMenuDuplicate:
+          - id: menu_duplicate_msg
+            type: DisplayMessage
+            params:
+              content:
+                _string.concat:
+                  - 'Duplicate '
+                  - _event: row.name
+        onMenuDelete:
+          - id: menu_delete_msg
+            type: DisplayMessage
+            params:
+              status: warning
+              content:
+                _string.concat:
+                  - 'Delete '
+                  - _event: row.name
+
 # Selector cells fire an event on change (event-only, like buttons) — the cell does not write to
 # the grid's row data. The app persists the change by updating the data bound to `rowData`. Here
 # each row's value is bound to state (with a `default`) and the event writes the new value back

--- a/packages/plugins/blocks/blocks-aggrid/src/cellRenderers/MenuCell.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/cellRenderers/MenuCell.js
@@ -1,0 +1,116 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import React from 'react';
+import { Button, Dropdown } from 'antd';
+import { type } from '@lowdefy/helpers';
+import { renderHtml } from '@lowdefy/block-utils';
+import NullCell from './NullCell.js';
+import { resolvePath } from './resolveFieldRefs.js';
+
+function resolveField(literalKey, fieldKey, item, data) {
+  if (type.isString(item?.[fieldKey])) return resolvePath(item[fieldKey], data);
+  return item?.[literalKey];
+}
+
+function MenuCell(params) {
+  const { value, data, cellConfig, methods, components } = params;
+  const Icon = components?.Icon;
+  const items = type.isArray(cellConfig?.items) ? cellConfig.items : [];
+
+  // Resolve every item against the row before antd sees it, and drop hidden items
+  // rather than disabling them — so a row whose every item is hidden renders no
+  // trigger at all, instead of a button that opens an empty menu.
+  const resolved = items
+    .map((item, idx) => {
+      if (!type.isObject(item) || !type.isString(item.eventName)) return null;
+      if (resolveField('hidden', 'hiddenField', item, data) === true) return null;
+      return {
+        idx,
+        item,
+        title: resolveField('title', 'titleField', item, data),
+        iconConfig: resolveField('icon', 'iconField', item, data),
+        disabled: resolveField('disabled', 'disabledField', item, data) === true,
+      };
+    })
+    .filter(Boolean);
+
+  if (resolved.length === 0) return <NullCell />;
+
+  const menuItems = resolved.map(({ idx, item, title, iconConfig, disabled }) => ({
+    // Keyed by the item's index in the AUTHORED array, not by its position in the
+    // resolved one, so onClick can find it back after hidden items have shifted
+    // everything.
+    key: String(idx),
+    label: type.isNone(title) ? undefined : renderHtml({ html: String(title), methods }),
+    icon:
+      iconConfig && Icon ? (
+        <Icon blockId={`menucell_${idx}_icon`} events={{}} properties={iconConfig} />
+      ) : undefined,
+    disabled,
+    danger: item.danger === true,
+  }));
+
+  function onClick({ key, domEvent }) {
+    domEvent?.stopPropagation?.();
+    const entry = resolved.find((r) => String(r.idx) === key);
+    if (!entry) return;
+    methods?.triggerEvent?.({
+      name: entry.item.eventName,
+      event: {
+        row: data,
+        value,
+        item: { eventName: entry.item.eventName, title: entry.title },
+        itemIndex: entry.idx,
+      },
+    });
+  }
+
+  // The trigger is icon-only: a row menu is an affordance, not a labelled action.
+  const triggerIcon = Icon ? (
+    <Icon
+      blockId="menucell_trigger_icon"
+      events={{}}
+      properties={cellConfig.icon ?? 'AiOutlineMore'}
+    />
+  ) : undefined;
+
+  return (
+    // stopPropagation lives on a wrapper, not on the Button: antd's Dropdown clones its
+    // child to attach the trigger handler, so an onClick of ours on the Button is the
+    // one that gets shadowed. It keeps a stray click from bubbling within React;
+    // ag-grid uses native listeners, so a grid that also wires onCellClick /
+    // onRowClick may still see the click — the same as the buttons cell.
+    <div onClick={(e) => e.stopPropagation()}>
+      <Dropdown
+        menu={{ items: menuItems, onClick }}
+        trigger={['click']}
+        placement={cellConfig.placement ?? 'bottomRight'}
+        // Render the menu to the body so it is not clipped by the cell, which hides
+        // its overflow — the same reason SelectorCell does it.
+        getPopupContainer={() => document.body}
+      >
+        {/* `type` and `shape` are fixed rather than configurable: both keys are already
+            taken at cell level (the renderer name, and the avatar shape), so exposing
+            them here would collide. These match the ButtonsCell defaults, which is what
+            a ⋯ sitting beside other cell buttons wants. */}
+        <Button size="small" type="text" shape="square" icon={triggerIcon} />
+      </Dropdown>
+    </div>
+  );
+}
+
+export default MenuCell;

--- a/packages/plugins/blocks/blocks-aggrid/src/cellRenderers/index.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/cellRenderers/index.js
@@ -22,6 +22,7 @@ import BooleanCell from './BooleanCell.js';
 import ProgressCell from './ProgressCell.js';
 import NumberCell from './NumberCell.js';
 import ButtonsCell from './ButtonsCell.js';
+import MenuCell from './MenuCell.js';
 import SelectorCell from './SelectorCell.js';
 import SwitchCell from './SwitchCell.js';
 import TextInputCell from './TextInputCell.js';
@@ -36,6 +37,7 @@ const CELL_RENDERERS = {
   progress: ProgressCell,
   number: NumberCell,
   buttons: ButtonsCell,
+  menu: MenuCell,
   selector: SelectorCell,
   multipleSelector: SelectorCell,
   switch: SwitchCell,

--- a/packages/plugins/blocks/blocks-aggrid/src/createDisplayMeta.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/createDisplayMeta.js
@@ -75,6 +75,16 @@ function createDisplayMeta(blockName) {
           buttonIndex: 'Zero-based index in the buttons array.',
         },
       },
+      onCellMenuItem: {
+        description:
+          'Documentation reference — the actual event name fired is the `eventName` string declared on each `cell.items[]` entry of a `cell.type: menu` cell. Wire any number of named events on the block (e.g. `onRename`, `onDelete`).',
+        event: {
+          row: 'The row data.',
+          value: 'The cell value.',
+          item: 'The clicked item: { eventName, title }.',
+          itemIndex: 'Zero-based index in the authored items array (unshifted by hidden items).',
+        },
+      },
     },
     properties: {
       type: 'object',
@@ -210,6 +220,7 @@ function createDisplayMeta(blockName) {
                       'progress',
                       'number',
                       'buttons',
+                      'menu',
                       'selector',
                       'multipleSelector',
                       'switch',
@@ -367,7 +378,8 @@ function createDisplayMeta(blockName) {
                   },
                   zeroColor: {
                     type: 'string',
-                    description: 'Number: CSS colour when value === 0 (requires `signColor: true`).',
+                    description:
+                      'Number: CSS colour when value === 0 (requires `signColor: true`).',
                   },
                   color: {
                     type: 'string',
@@ -464,6 +476,71 @@ function createDisplayMeta(blockName) {
                       },
                     },
                   },
+                  items: {
+                    type: 'array',
+                    description:
+                      'Menu cell: items in the row action menu, rendered in a dropdown behind a single trigger button. Each item triggers its own block-level event (declared in `events:`). `*Field` variants (`titleField`, `iconField`, `disabledField`, `hiddenField`) are row-data paths. A hidden item is dropped, not disabled — a row on which every item is hidden renders no trigger at all.',
+                    items: {
+                      type: 'object',
+                      required: ['eventName'],
+                      properties: {
+                        eventName: {
+                          type: 'string',
+                          description:
+                            'Block-level event name to trigger on click. Event payload is `{ row, value, item: { eventName, title }, itemIndex }`.',
+                        },
+                        title: {
+                          type: 'string',
+                          description: 'Item label - supports html.',
+                        },
+                        titleField: {
+                          type: 'string',
+                          description: 'Row-data path for the label.',
+                        },
+                        icon: {
+                          type: ['string', 'object'],
+                          description: 'Name of a React-Icon or Icon block config.',
+                          docs: { displayType: 'icon' },
+                        },
+                        iconField: {
+                          type: 'string',
+                          description: 'Row-data path for the icon name or config.',
+                        },
+                        danger: {
+                          type: 'boolean',
+                          default: false,
+                          description: 'Render the item in the danger colour.',
+                        },
+                        disabled: { type: 'boolean', default: false },
+                        disabledField: {
+                          type: 'string',
+                          description: 'Row-data path → boolean.',
+                        },
+                        hidden: {
+                          type: 'boolean',
+                          default: false,
+                          description: 'Hide the item entirely.',
+                        },
+                        hiddenField: {
+                          type: 'string',
+                          description: 'Row-data path → boolean.',
+                        },
+                      },
+                    },
+                  },
+                  icon: {
+                    type: ['string', 'object'],
+                    default: 'AiOutlineMore',
+                    description:
+                      'Menu cell: the trigger icon. Name of a React-Icon or Icon block config. The trigger is icon-only.',
+                    docs: { displayType: 'icon' },
+                  },
+                  placement: {
+                    type: 'string',
+                    enum: ['bottomLeft', 'bottom', 'bottomRight', 'topLeft', 'top', 'topRight'],
+                    default: 'bottomRight',
+                    description: 'Menu cell: where the dropdown opens relative to its trigger.',
+                  },
                   options: {
                     type: 'array',
                     description:
@@ -549,7 +626,8 @@ function createDisplayMeta(blockName) {
                   },
                   checkedIcon: {
                     type: ['string', 'object'],
-                    description: 'Switch: icon shown when on (React-Icon name or Icon block config).',
+                    description:
+                      'Switch: icon shown when on (React-Icon name or Icon block config).',
                     docs: { displayType: 'icon' },
                   },
                   uncheckedIcon: {

--- a/packages/plugins/blocks/blocks-aggrid/src/processColDefs.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/processColDefs.js
@@ -20,7 +20,7 @@ import { type } from '@lowdefy/helpers';
 import { getCellRenderer } from './cellRenderers/index.js';
 import createEllipsisCell from './cellRenderers/EllipsisCell.js';
 
-function applyEllipsis(colDef, ellipsis) {
+function applyEllipsis(colDef, ellipsis, makeEllipsisRenderer) {
   if (!type.isInt(ellipsis) || ellipsis < 1) return colDef;
   const clampClass = `lf-ellipsis-${Math.min(ellipsis, 6)}`;
   const existingClass = colDef.cellClass;
@@ -39,7 +39,7 @@ function applyEllipsis(colDef, ellipsis) {
   // ag-grid's internal cell wrappers. Skip if a cellRenderer is already set
   // (user or built-in cell.type takes precedence and can opt in via CSS).
   if (!colDef.cellRenderer) {
-    next.cellRenderer = createEllipsisCell(ellipsis);
+    next.cellRenderer = makeEllipsisRenderer();
   }
   return next;
 }
@@ -65,33 +65,80 @@ function applyAlignment(colDef, cell) {
   return { ...colDef, cellStyle, headerClass };
 }
 
-function buildCellRenderer({ cell, methods, components }) {
-  const Renderer = getCellRenderer(cell?.type);
-  if (!Renderer) return undefined;
-  // ag-grid calls the renderer as a React function component when returned directly.
-  return function CellRendererAdapter(params) {
-    return Renderer({ ...params, cellConfig: cell, methods, components });
-  };
+// A cellRenderer is a React element type, so a new function is a different
+// component: CellCtrl.refreshCellRenderer bails when `cellRendererClass !==
+// componentClass`, and the React cell comp re-keys. Building the renderers fresh on
+// every render therefore unmounted every cell whenever anything re-rendered the
+// block, destroying whatever a cell was holding — an open popup, a focused input, a
+// half-typed value in the selector / textInput / paragraphInput cells.
+//
+// So the adapter installed on the colDef is created once per column and kept, and
+// the closure it calls is replaced in place. ag-grid keeps the cell; the cell
+// renders the current config.
+function stableRenderer(entry, slot, render) {
+  let stable = entry[slot];
+  if (!stable) {
+    const box = { render };
+    // ag-grid calls the renderer as a React function component when returned directly.
+    function CellRendererAdapter(params) {
+      return box.render(params);
+    }
+    stable = { box, Adapter: CellRendererAdapter };
+    entry[slot] = stable;
+  }
+  stable.box.render = render;
+  return stable.Adapter;
 }
 
-function recProcessColDefs(columnDefs, methods, components) {
-  return columnDefs.map((col) => {
+// Keyed by colId or field so an adapter survives a column reorder, falling back to
+// position for columns that declare neither. A key already taken in this pass gets a
+// suffix, so two columns sharing a field do not share an adapter.
+function colKey(col, index, prefix, seen) {
+  const id = type.isString(col.colId)
+    ? col.colId
+    : type.isString(col.field)
+      ? col.field
+      : `${index}`;
+  const base = `${prefix}${id}`;
+  let key = base;
+  let n = 1;
+  while (seen.has(key)) {
+    key = `${base}#${n}`;
+    n += 1;
+  }
+  seen.add(key);
+  return key;
+}
+
+function recProcessColDefs(columnDefs, methods, components, cache, seen, prefix) {
+  return columnDefs.map((col, index) => {
+    const key = colKey(col, index, prefix, seen);
+    const entry = cache.get(key) ?? {};
+    cache.set(key, entry);
     const newColDef = {};
     if (type.isArray(col.children)) {
-      newColDef.children = recProcessColDefs(col.children, methods, components);
+      newColDef.children = recProcessColDefs(
+        col.children,
+        methods,
+        components,
+        cache,
+        seen,
+        `${key}/`
+      );
     }
     if (type.isObject(col.cell) && type.isString(col.cell.type)) {
-      const renderer = buildCellRenderer({ cell: col.cell, methods, components });
-      if (renderer) {
-        newColDef.cellRenderer = renderer;
+      const Renderer = getCellRenderer(col.cell.type);
+      if (Renderer) {
+        const cell = col.cell;
+        newColDef.cellRenderer = stableRenderer(entry, 'cell', (params) =>
+          Renderer({ ...params, cellConfig: cell, methods, components })
+        );
       }
     } else if (type.isFunction(col.cellRenderer)) {
-      newColDef.cellRenderer = (params) => {
-        return renderHtml({
-          html: col.cellRenderer(params),
-          methods,
-        });
-      };
+      const cellRenderer = col.cellRenderer;
+      newColDef.cellRenderer = stableRenderer(entry, 'cell', (params) =>
+        renderHtml({ html: cellRenderer(params), methods })
+      );
     }
     const merged = {
       ...col,
@@ -101,12 +148,22 @@ function recProcessColDefs(columnDefs, methods, components) {
     delete merged.cell;
     delete merged.ellipsis;
     const aligned = applyAlignment(merged, col.cell);
-    return applyEllipsis(aligned, col.ellipsis);
+    return applyEllipsis(aligned, col.ellipsis, () =>
+      stableRenderer(entry, 'ellipsis', createEllipsisCell(col.ellipsis))
+    );
   });
 }
 
-function processColDefs(columnDefs = [], methods, components) {
-  return recProcessColDefs(columnDefs, methods, components);
+function processColDefs(columnDefs = [], methods, components, cache = new Map()) {
+  const seen = new Set();
+  const processed = recProcessColDefs(columnDefs, methods, components, cache, seen, '');
+  // Drop columns that are no longer defined, so a grid whose columns come and go does
+  // not accumulate adapters. A column that returns gets a fresh one, which is correct
+  // — its cells were unmounted with it.
+  for (const key of cache.keys()) {
+    if (!seen.has(key)) cache.delete(key);
+  }
+  return processed;
 }
 
 export default processColDefs;

--- a/packages/plugins/blocks/blocks-aggrid/src/useColDefs.js
+++ b/packages/plugins/blocks/blocks-aggrid/src/useColDefs.js
@@ -1,0 +1,67 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { useEffect, useRef } from 'react';
+import { type } from '@lowdefy/helpers';
+
+import processColDefs from './processColDefs.js';
+
+// Fingerprint the authored columnDefs, functions included. JSON.stringify drops
+// function values unless a replacer returns something for them, and a cellRenderer or
+// valueGetter built by an operator is a new function on every evaluation — so identity
+// is the only signal available that one of them changed.
+function fingerprint(columnDefs) {
+  const functions = [];
+  const json = JSON.stringify(columnDefs, (_key, value) => {
+    if (type.isFunction(value)) {
+      functions.push(value);
+      return `__fn__${functions.length - 1}`;
+    }
+    return value;
+  });
+  return { json, functions };
+}
+
+function unchanged(previous, next) {
+  if (!previous) return false;
+  if (previous.json !== next.json) return false;
+  if (previous.functions.length !== next.functions.length) return false;
+  return previous.functions.every((fn, index) => fn === next.functions[index]);
+}
+
+// Cell renderers keep their identity across renders (see processColDefs), which is
+// what stops ag-grid destroying a cell mid-interaction — but it also means nothing
+// replaces a cell when its column definition changes. ag-grid refreshes body cells on
+// a data change; it does not listen for colDefChanged. So ask it: refreshCells
+// re-renders the mounted cells in place with the new definition. It passes
+// `newData: false`, so React keeps the instances, and with them whatever the cell
+// was holding.
+function useColDefs({ columnDefs, methods, components, gridRef }) {
+  const cache = useRef(new Map());
+  const previous = useRef();
+  const processed = processColDefs(columnDefs, methods, components, cache.current);
+  useEffect(() => {
+    const next = fingerprint(columnDefs);
+    const first = previous.current === undefined;
+    const same = unchanged(previous.current, next);
+    previous.current = next;
+    if (first || same) return;
+    gridRef.current?.api?.refreshCells({ force: true });
+  });
+  return processed;
+}
+
+export default useColDefs;


### PR DESCRIPTION
## Two changes, in order: a cell-lifecycle bug, then the cell that exposed it

### 1. `fix`: cell renderers were rebuilt on every render, so cells were destroyed on every render

`processColDefs` built a fresh `cellRenderer` function for every column on every render. A cellRenderer is a React element type, so a new function is a **different component**: `CellCtrl.refreshCellRenderer` bails when `cellRendererClass !== componentClass`, and the cell is recreated.

Anything a cell was holding died with it, and it did not take a grid-level change to trigger — any re-render of the block would do, including a request finishing elsewhere on the page:

- an open popup closes mid-click;
- a `selector` cell loses its open dropdown;
- a `textInput` / `paragraphInput` cell loses focus and the characters typed since the last render.

The input cells from #2201 have had this since they landed. It is easy to miss because it needs a re-render to coincide with an interaction, and most demo grids sit on a page where nothing else is changing.

**The fix.** Each column keeps one adapter for its lifetime, and the closure behind it is replaced in place:

```js
function stableRenderer(entry, slot, render) {
  let stable = entry[slot];
  if (!stable) {
    const box = { render };
    function CellRendererAdapter(params) {
      return box.render(params);
    }
    stable = { box, Adapter: CellRendererAdapter };
    entry[slot] = stable;
  }
  stable.box.render = render;
  return stable.Adapter;
}
```

ag-grid keeps the cell; the cell renders the current config. Adapters are keyed by `colId` or `field` so they survive a column reorder, with a suffix if two columns share a `field`, and columns that go away are dropped from the cache. The `cell.type` renderers, user `cellRenderer` functions and the `ellipsis` wrapper all go through it.

**The consequence, handled.** With identity stable, nothing recreates a cell when its column definition changes — and nothing else repaints it either, because ag-grid refreshes body cells on a data change and does not listen for `colDefChanged` (only the header and header-filter ctrls do). Previously a changed colDef reached the cell purely as a side effect of the renderer being replaced.

So `useColDefs` fingerprints the authored `columnDefs` and calls `refreshCells({ force: true })` when they change. That path passes `newData: false`, so React keeps the instances and re-renders them with the new params rather than remounting. Function-valued properties are compared by identity, since `JSON.stringify` cannot see them and an operator-built `cellRenderer` is a new function on every evaluation.

Both `AgGrid` and `AgGridInput` go through the hook, so they cannot drift.

### 2. `feat`: a `menu` cell

`cell.type: menu` renders a row's actions as a dropdown behind one trigger button, instead of spending a wide column on a `buttons` cell. It is the natural companion to #2201: same `items[]`-with-`eventName` shape as `buttons`, same `*Field` row-data resolution.

```yaml
- headerName: ''
  colId: menu
  width: 60
  cell:
    type: menu
    items:
      - eventName: onMenuRename
        title: Rename
        icon: AiOutlineEdit
        hiddenField: readOnly
      - eventName: onMenuDelete
        title: Delete
        icon: AiOutlineDelete
        danger: true
        hiddenField: readOnly
```

Two decisions worth flagging in review:

- **A hidden item is dropped, not disabled**, and a row on which every item is hidden renders **no trigger at all** rather than a button that opens an empty menu.
- **The trigger's `type` and `shape` are fixed rather than configurable.** Both keys are already taken at cell level — `type` names the renderer, `shape` is the avatar's — so exposing them here would collide. `icon` (default `AiOutlineMore`) and `placement` are configurable. The defaults match `ButtonsCell`, which is what a ⋯ sitting beside other cell buttons wants.

The menu mounts on `document.body`, for the same reason `SelectorCell` already does: a cell hides its overflow, so a dropdown rendered inside one is invisible. Without it the trigger looks inert.

## Verification

Both changes have been running as `dist/` patches in a real app — a reports list whose ⋯ column is this cell, with per-row owner/non-owner item visibility — behind a Playwright suite that clicks the trigger immediately after mount, while a scope request is still landing. That timing is what surfaced the identity bug: the menu opened only if you clicked late enough for renders to settle.

- Three specs on the cell (opens as a popover on the body; an item click runs its event; a non-owner sees only the items they may use): red before the identity fix, green after.
- 79 e2e specs across that app green, including four other grids that use the `tag`, `avatar`, `buttons`, `date` and `_function` renderers.

Not exercised: `AgGridInput`. Its half of the fix is the same code path, but nothing in that app uses the input grid.

## Notes for review

- `processColDefs` keeps its old 3-argument signature; the cache is an optional 4th argument, and without it the function behaves exactly as before.
- The gallery gains a **Menu cell** section next to **Buttons cell**, with per-row `hiddenField` so the third row shows a reader's menu.
