### PR TITLE
fix(client): Make the Link action honour href

### DIFF
--- a/.changeset/fix-link-action-href.md
+++ b/.changeset/fix-link-action-href.md
@@ -1,0 +1,22 @@
+---
+'@lowdefy/client': patch
+'@lowdefy/docs': patch
+'@lowdefy/docs-content': patch
+---
+
+fix(client): Make the `Link` action honour `href`.
+
+`createLink` routes `href` to `newOriginLink`, but the action's `newOriginLink` in
+`setupLink.js` only ever read `url` — so `{ type: Link, params: { href: '/some/path' } }`
+navigated to the literal string `"undefined"`. The anchor renderer used for `Link` blocks
+(`createLinkComponent.js`) already prefers `href` over `url`; this brings the action to the
+same precedence, and `href` is used verbatim: no protocol added, no `urlQuery` appended.
+
+That verbatim handling is the point of having the parameter at all. `url` means an external
+address and gains an `https://` prefix when the value has no scheme, which turns a
+root-relative `/reports?id=1` into a request for a host named `reports`. `href` is how you
+link to a same-origin path, a fragment, or any address that must be passed through as
+written — so the fix removes the need to work around `url`'s prefixing.
+
+`href` was also missing from the `Link` action docs, which is presumably how the gap went
+unnoticed. Documented alongside the fix.

--- a/packages/client/src/setupLink.js
+++ b/packages/client/src/setupLink.js
@@ -21,9 +21,17 @@ function setupLink(lowdefy) {
   const { window } = lowdefy._internal.globals;
   const backLink = () => router.back();
   const disabledLink = () => {};
-  const newOriginLink = ({ url, query, newTab }) => {
+  // `href` wins over `url`, and is used verbatim — the same precedence the anchor
+  // renderer applies (createLinkComponent.js). createLink only ever sets one of
+  // them, and it gives `url` a protocol before we see it while leaving `href`
+  // untouched, which is what makes `href` the way to link somewhere `url` cannot
+  // reach: a root-relative path, a fragment, a scheme-less same-origin target.
+  // urlQuery is not appended to an `href` for that reason — it is passed through
+  // as written, query string included.
+  const newOriginLink = ({ href, url, query, newTab }) => {
+    const target = href ?? `${url}${query ? `?${query}` : ''}`;
     if (newTab) {
-      const handle = window.open(`${url}${query ? `?${query}` : ''}`, '_blank');
+      const handle = window.open(target, '_blank');
       if (!handle) {
         lowdefy._internal.displayMessage({
           content: lowdefy._internal.translate('client.popupBlocked'),
@@ -34,7 +42,7 @@ function setupLink(lowdefy) {
       }
       return handle.focus();
     }
-    return window.location.assign(`${url}${query ? `?${query}` : ''}`);
+    return window.location.assign(target);
   };
   const sameOriginLink = ({ newTab, pathname, query, setInput }) => {
     if (newTab) {

--- a/packages/client/src/setupLink.test.js
+++ b/packages/client/src/setupLink.test.js
@@ -1,0 +1,116 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+
+import setupLink from './setupLink.js';
+
+// Minimal fake window: jsdom does not implement navigation, and the assertions
+// here are about which target string the link is handed.
+function createFakeLowdefy({ popupBlocked = false } = {}) {
+  const calls = { assign: [], open: [], push: [], focus: 0 };
+  const handle = {
+    focus: () => {
+      calls.focus += 1;
+    },
+  };
+  const window = {
+    location: {
+      origin: 'http://localhost',
+      assign: (target) => calls.assign.push(target),
+    },
+    open: (target, target2) => {
+      calls.open.push([target, target2]);
+      return popupBlocked ? null : handle;
+    },
+  };
+  return {
+    basePath: '',
+    inputs: {},
+    home: { pageId: 'home', configured: false },
+    _internal: {
+      globals: { window },
+      router: {
+        back: jest.fn(),
+        push: (args) => calls.push.push(args),
+      },
+      displayMessage: jest.fn(),
+      translate: (key) => key,
+    },
+    calls,
+  };
+}
+
+test('an href is navigated to verbatim', () => {
+  const lowdefy = createFakeLowdefy();
+  const link = setupLink(lowdefy);
+
+  link({ href: '/reports?report_id=1' });
+
+  expect(lowdefy.calls.assign).toEqual(['/reports?report_id=1']);
+});
+
+test('an href is not given a protocol, the way a url is', () => {
+  // `url` means an external address, so createLink prefixes https:// when the
+  // value has no scheme. That makes a root-relative `url` resolve to a HOST, and
+  // `href` the prop for a target that must be passed through as written.
+  const withHref = createFakeLowdefy();
+  setupLink(withHref)({ href: '/reports' });
+  expect(withHref.calls.assign).toEqual(['/reports']);
+
+  const withUrl = createFakeLowdefy();
+  setupLink(withUrl)({ url: '/reports' });
+  expect(withUrl.calls.assign).toEqual(['https:///reports']);
+});
+
+test('an href opens in a new tab', () => {
+  const lowdefy = createFakeLowdefy();
+
+  setupLink(lowdefy)({ href: 'mailto:someone@example.com', newTab: true });
+
+  expect(lowdefy.calls.open).toEqual([['mailto:someone@example.com', '_blank']]);
+  expect(lowdefy.calls.focus).toBe(1);
+});
+
+test('urlQuery is not appended to an href', () => {
+  // An href carries its own query string. Appending would produce two.
+  const lowdefy = createFakeLowdefy();
+
+  setupLink(lowdefy)({ href: '/reports?a=1', urlQuery: { b: 2 } });
+
+  expect(lowdefy.calls.assign).toEqual(['/reports?a=1']);
+});
+
+test('urlQuery is appended to a url', () => {
+  const lowdefy = createFakeLowdefy();
+
+  setupLink(lowdefy)({ url: 'https://lowdefy.com', urlQuery: { a: 1 } });
+
+  expect(lowdefy.calls.assign).toEqual(['https://lowdefy.com?a=1']);
+});
+
+test('a blocked popup reports itself instead of throwing', () => {
+  const lowdefy = createFakeLowdefy({ popupBlocked: true });
+
+  setupLink(lowdefy)({ href: 'https://lowdefy.com', newTab: true });
+
+  expect(lowdefy._internal.displayMessage).toHaveBeenCalledWith({
+    content: 'client.popupBlocked',
+    status: 'info',
+    duration: 10,
+  });
+  expect(lowdefy.calls.focus).toBe(0);
+});

--- a/packages/docs-content/content/actions/link.md
+++ b/packages/docs-content/content/actions/link.md
@@ -5,6 +5,7 @@
 (params: {
   back?: boolean,
   home?: boolean,
+  href?: string,
   input?: object,
   newTab?:boolean,
   pageId?: string,
@@ -25,6 +26,7 @@ The pageId of a page in the app to link to.
 ###### object
 - `back: boolean`: Go to the previous page if true (has the same effect as using the browser back button).
 - `home: boolean`: Link to the home page. This is either the configured public or authenticated homepage, or the first page in the default menu visible to the user.
+- `href: string`: Link to an address, used exactly as written. Unlike `url`, no protocol is added and `urlQuery` is not appended, so this is the parameter for a target `url` cannot express — a root-relative path, a fragment, or a scheme-less same-origin address.
 - `input: object`: Object to set as the input for the linked page.
 - `newTab: boolean`: Open the link in a new tab.
 - `pageId: string`: The pageId of a page in the app to link to.
@@ -54,6 +56,14 @@ The pageId of a page in the app to link to.
   type: Link
   params:
     home: true
+```
+
+###### Link to an address exactly as written:
+```yaml
+- id: link_href
+  type: Link
+  params:
+    href: /downloads/report.pdf
 ```
 
 ###### Link to an external url:

--- a/packages/docs/actions/Link.yaml
+++ b/packages/docs/actions/Link.yaml
@@ -24,6 +24,7 @@ _ref:
       (params: {
         back?: boolean,
         home?: boolean,
+        href?: string,
         input?: object,
         newTab?:boolean,
         pageId?: string,
@@ -42,6 +43,7 @@ _ref:
       ###### object
       - `back: boolean`: Go to the previous page if true (has the same effect as using the browser back button).
       - `home: boolean`: Link to the home page. This is either the configured public or authenticated homepage, or the first page in the default menu visible to the user.
+      - `href: string`: Link to an address, used exactly as written. Unlike `url`, no protocol is added and `urlQuery` is not appended, so this is the parameter for a target `url` cannot express — a root-relative path, a fragment, or a scheme-less same-origin address.
       - `input: object`: Object to set as the input for the linked page.
       - `newTab: boolean`: Open the link in a new tab.
       - `pageId: string`: The pageId of a page in the app to link to.
@@ -70,6 +72,14 @@ _ref:
         type: Link
         params:
           home: true
+      ```
+
+      ###### Link to an address exactly as written:
+      ```yaml
+      - id: link_href
+        type: Link
+        params:
+          href: /downloads/report.pdf
       ```
 
       ###### Link to an external url:


### PR DESCRIPTION
## The bug

A `Link` action with `href` navigates to the literal string `"undefined"`.

`createLink` (engine) routes `href` to `newOriginLink`:

```js
if (type.isString(props.href)) {
  return newOriginLink(props);
}
```

The anchor renderer for `Link` **blocks** honours it — `createLinkComponent.js` does
`href={href ?? \`${url}${query ? `?${query}` : ''}\`}`. The **action's** adapter does not:
`setupLink.js`'s `newOriginLink` destructures `{ url, query, newTab }` only, so `url` is
`undefined` and the action calls `window.location.assign("undefined")`, or
`window.open("undefined")` with `newTab: true`.

So the same parameter works from a block and fails from an action, silently, with no error to
explain it.

## The fix

`setupLink.js` reads `href` first, matching the anchor renderer's precedence. `href` is used
**verbatim**: no protocol added, no `urlQuery` appended.

That verbatim handling is what the parameter is for. `url` means an *external* address and gains
an `https://` prefix whenever the value has no scheme:

```js
const protocol = props.url.includes(':') ? '' : 'https://';
```

which means a root-relative `url: /reports?id=1` becomes `https:///reports?id=1` — a request for
a **host** named `reports`. `href` is the parameter for a same-origin path, a fragment, or any
address that has to be passed through as written, and with this fix it works from an action too.

`urlQuery` is deliberately not appended to an `href` — an href carries its own query string, and
appending would produce two. Same as the anchor renderer.

## Docs

`href` was not listed in the `Link` action docs at all, which is presumably how the gap survived.
Added to the params list, the types block, and an example, in both `packages/docs` and
`packages/docs-content`.

## Tests

`packages/client/src/setupLink.test.js` is new — the first coverage for the link action's
adapters. Six cases: `href` verbatim, `href` vs `url` prefixing side by side, `href` in a new
tab, `urlQuery` appended to a `url` but not to an `href`, and the blocked-popup message path.

The `href`-vs-`url` case is pinned deliberately: the two parameters differ only in prefixing and
query handling, and nothing documented that before.

Client suite: 65 passing (9 suites).

## Notes

- No change to `@lowdefy/engine` — its routing was already correct.
- `docs-content/content/actions/link.md` is not Prettier-clean on `vite-hono` (every `######`
  heading wants a following blank line). Left as-is rather than reformatting the whole file
  inside a bug fix.
