### PR TITLE
fix(apps): Repair the stale email shape in the tenant reference apps

### DIFF
--- a/apps/auth-reference-b/lowdefy.yaml
+++ b/apps/auth-reference-b/lowdefy.yaml
@@ -35,15 +35,12 @@ auth:
     enabled: true
     expiresIn: 300
 
+  # Local dev sending: run Mailpit (see ../auth-reference/README.md) and point
+  # the auth_email SMTP connection at it. auth.email only names the connection -
+  # the transport, the from address and the delivery filter live on the
+  # connection itself.
   email:
-    from: auth-reference-b@localhost
-    provider:
-      type: smtp
-      properties:
-        host:
-          _secret: SMTP_HOST
-        port: 1025
-        secure: false
+    connectionId: auth_email
 
   providers:
     - id: google
@@ -78,6 +75,17 @@ auth:
     signIn: /login
     signUp: /signup
     verifyEmail: /verify-email
+
+# The transport auth.email sends through - Mailpit for the walkthrough.
+connections:
+  - id: auth_email
+    type: SMTP
+    properties:
+      from: auth-reference-b@localhost
+      host:
+        _secret: SMTP_HOST
+      port: 1025
+      secure: false
 
 # Per-step floor demos: a user-initiated admin step is floored on the
 # caller's org authority and refuses without it; the same step as

--- a/apps/auth-reference-tenant/lowdefy.yaml
+++ b/apps/auth-reference-tenant/lowdefy.yaml
@@ -32,15 +32,12 @@ auth:
     enabled: true
     expiresIn: 300
 
+  # Local dev sending: run Mailpit (see ../auth-reference/README.md) and point
+  # the auth_email SMTP connection at it. auth.email only names the connection -
+  # the transport, the from address and the delivery filter live on the
+  # connection itself.
   email:
-    from: auth-reference-tenant@localhost
-    provider:
-      type: smtp
-      properties:
-        host:
-          _secret: SMTP_HOST
-        port: 1025
-        secure: false
+    connectionId: auth_email
 
   # tenant: active org = the user's business, oldest membership when they
   # belong to several; the user switches with SetActiveOrganization.
@@ -61,6 +58,17 @@ auth:
     signIn: /login
     signUp: /signup
     verifyEmail: /verify-email
+
+# The transport auth.email sends through - Mailpit for the walkthrough.
+connections:
+  - id: auth_email
+    type: SMTP
+    properties:
+      from: auth-reference-tenant@localhost
+      host:
+        _secret: SMTP_HOST
+      port: 1025
+      secure: false
 
 # Phase-8 error demos: under the tenant policy there is no single implied
 # organization, so _organization fails at evaluation and an org-scoped step


### PR DESCRIPTION
## What was broken

`apps/auth-reference-b/lowdefy.yaml` and `apps/auth-reference-tenant/lowdefy.yaml` still carried the removed inline transport shape:

```yaml
email:
  from: auth-reference-b@localhost
  provider:
    type: smtp
    properties: { host: {_secret: SMTP_HOST}, port: 1025, secure: false }
```

`definitions.authConfig` now allows only `connectionId` and `templates` under `auth.email` (`additionalProperties: false`), so both apps failed `validateAuthConfig` at build with:

> Auth "email" should only have properties "connectionId" and "templates". The old inline "from"/"provider" transport shape moved onto the SMTP connection referenced by "connectionId".

Because both apps also set `requireEmailVerification: true` and `magicLink.enabled: true`, `auth.email` is mandatory for them — there was no way to build either one. That left `organizations.policy: tenant` with no runnable reference app at all, and the org-b membership-wall walkthrough unbuildable too.

## What changed

Both apps now follow `apps/auth-reference` exactly:

- `auth.email` reduced to `connectionId: auth_email`.
- A new `connections:` block with an `auth_email` SMTP connection carrying the app's own `from` address (`auth-reference-b@localhost` / `auth-reference-tenant@localhost`), `host: {_secret: SMTP_HOST}`, `port: 1025`, `secure: false`.

There were no `templates:` entries in the old shape, so nothing was dropped. No new secrets are required — `SMTP_HOST` is the same secret the old inline shape used and is already documented in `apps/auth-reference/README.md`, which is the shared env reference for all three apps (none of them ship a `.env.example`).

## How it was validated

A script validated each app's `auth` block against `lowdefySchema.definitions.authConfig` with `@lowdefy/ajv` — the same call `packages/build/src/build/buildAuth/validateAuthConfig.js` makes — and additionally asserted that `auth.email.connectionId` names a `type: SMTP` connection whose properties satisfy the SMTP connection schema (with `_secret` operators resolved, as the build resolves them).

Before (on `mcp-server-auth`):

```
PASS  auth-reference
FAIL  auth-reference-b        auth: /email :: Auth "email" should only have properties "connectionId" and "templates" ...
FAIL  auth-reference-tenant   auth: /email :: Auth "email" should only have properties "connectionId" and "templates" ...
PASS  auth-strategies (no auth.email configured)
```

After (this branch):

```
PASS  auth-reference          (email -> SMTP connection "auth_email", from "auth-reference@localhost")
PASS  auth-reference-b        (email -> SMTP connection "auth_email", from "auth-reference-b@localhost")
PASS  auth-reference-tenant   (email -> SMTP connection "auth_email", from "auth-reference-tenant@localhost")
PASS  auth-strategies         (no auth.email configured)
```

`auth-reference` and `auth-strategies` pass on both runs, so the method itself is not what changed.

No changeset: apps are not published packages, and comparable apps-only commits on this branch carry none.