### PR TITLE
fix(api,build): Diagnose the stranded invitee and guard the accept-time active-org switch (T7, T16)

### DIFF
--- a/.changeset/fix-tenant-admission-t7-t16.md
+++ b/.changeset/fix-tenant-admission-t7-t16.md
@@ -1,0 +1,19 @@
+---
+'@lowdefy/api': patch
+'@lowdefy/build': patch
+---
+
+fix(api): Diagnose the stranded invitee and stop invitation accept from stealing the active organization.
+
+Two tenant-admission fixes (findings T7 and T16 from the auth-tenancy verification pass):
+
+- A caller awaiting an organization now carries `has_pending_invitation` (always true or false) and,
+  when one exists, `pending_invitation_id` — so an app can route an invited user who signed up
+  directly (instead of via the invitation link) to the accept page rather than leaving them in a
+  silent login loop. Diagnosis only: nothing is auto-accepted.
+- Accepting an invitation no longer silently switches a session that is already active in another
+  organization — the membership is created, the caller stays where they were, and switching remains
+  their own explicit act. A session with no active organization still gains the accepted
+  organization (the repair path for the directly-signed-up invitee). Implemented as an engine-tier
+  `session.update.before` hook scoped to the accept-invitation route; the point is also added to the
+  bindable hook catalog.

--- a/packages/api/src/context/resolveAuthentication.js
+++ b/packages/api/src/context/resolveAuthentication.js
@@ -19,6 +19,7 @@
 import { decodeJwt, jwtVerify } from 'jose';
 import { normalizeCaller, type } from '@lowdefy/helpers';
 
+import findPendingInvitation from '../routes/auth/organizations/findPendingInvitation.js';
 import { getRegisteredOrganization } from '../routes/auth/organizations/getOrganizationBinding.js';
 import { getAsIssuer, getMcpResourceUri, getMcpUriPrefix } from '../routes/mcp/getMcpUri.js';
 import getMcpJwks from '../routes/mcp/getMcpJwks.js';
@@ -347,6 +348,20 @@ async function resolveAuthentication(context, { auth, headers, strategies, resou
     context.logger.debug(
       `Session for user "${session.user.id}" has no active organization under tenant - resolved awaiting organization.`
     );
+    // Why they are awaiting matters to the app: an invited user who signed up
+    // directly (instead of via the invitation link) holds a pending invitation
+    // and no member row, and without a marker the public pages cannot tell
+    // them from a caller awaiting operator provisioning - the invited user is
+    // stranded the moment they lose the invitation email. The pending
+    // invitation is read here (only for this rare caller, one indexed read) so
+    // the app can route them to the accept page and hand it the invitation id.
+    // Diagnosis only - accepting stays the caller's own, explicit act.
+    const pendingInvitation = type.isString(session.user.email)
+      ? await findPendingInvitation({
+          adapter: (await auth.$context).adapter,
+          email: session.user.email,
+        })
+      : null;
     // No member row, so no per-organization attributes and no roles of either
     // kind - the global attributes ride alone.
     context.user = normalizeCaller({
@@ -355,6 +370,13 @@ async function resolveAuthentication(context, { auth, headers, strategies, resou
       orgRoles: [],
       attributes: session.user.attributes ?? {},
       awaitingOrganization: true,
+      // Always present on the awaiting caller (true or false) so app config
+      // can branch on it without an absent-key case. The invitation id rides
+      // only when one exists - never synthesized to null - and is safe to hand
+      // to its own invitee: the accept route re-verifies that the session's
+      // email matches the invitation before minting anything.
+      hasPendingInvitation: !type.isNone(pendingInvitation),
+      ...(type.isNone(pendingInvitation) ? {} : { pendingInvitationId: pendingInvitation.id }),
     });
     return;
   }

--- a/packages/api/src/context/resolveAuthentication.test.js
+++ b/packages/api/src/context/resolveAuthentication.test.js
@@ -20,17 +20,18 @@ import { exportJWK, generateKeyPair, SignJWT } from 'jose';
 import { registerOrganizationBinding } from '../routes/auth/organizations/getOrganizationBinding.js';
 import resolveAuthentication from './resolveAuthentication.js';
 
-function mockAuth({ session, member, count, passkey } = {}) {
+function mockAuth({ session, member, count, passkey, invitations } = {}) {
   const findOne = jest.fn().mockResolvedValue(member ?? null);
   const countFn = jest.fn().mockResolvedValue(count ?? 0);
+  const findMany = jest.fn().mockResolvedValue(invitations ?? []);
   const auth = {
     api: { getSession: jest.fn().mockResolvedValue(session ?? null) },
-    $context: Promise.resolve({ adapter: { findOne, count: countFn } }),
+    $context: Promise.resolve({ adapter: { findOne, count: countFn, findMany } }),
   };
   if (passkey) {
     auth.options = { plugins: [{ id: 'passkey' }] };
   }
-  return { auth, findOne, count: countFn };
+  return { auth, findOne, count: countFn, findMany };
 }
 
 test('sets context.user to null when auth is not configured', async () => {
@@ -630,9 +631,85 @@ test('resolves a caller awaiting an organization when a tenant session carries n
     org_roles: [],
     attributes: {},
     awaiting_organization: true,
+    has_pending_invitation: false,
   });
   // No organization means there is no member row to read.
   expect(findOne).not.toHaveBeenCalled();
+});
+
+test('an awaiting caller with a pending invitation carries the diagnosis and the invitation id', async () => {
+  const { auth, findMany } = mockAuth({
+    session: {
+      user: { id: 'user_1', email: 'Invited@Example.com' },
+      session: { id: 'sess_1' },
+    },
+    invitations: [
+      {
+        id: 'invitation_1',
+        organizationId: 'org_9',
+        status: 'pending',
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      },
+    ],
+  });
+  registerOrganizationBinding({ auth, organizations: { policy: 'tenant' } });
+  const context = { logger: mockLogger() };
+
+  await resolveAuthentication(context, { auth, headers: {} });
+
+  expect(context.user.awaiting_organization).toBe(true);
+  expect(context.user.has_pending_invitation).toBe(true);
+  expect(context.user.pending_invitation_id).toBe('invitation_1');
+  // The lookup mirrors the organization plugin's own: lowercased email,
+  // status pending, expiry filtered in code.
+  expect(findMany).toHaveBeenCalledWith({
+    model: 'invitation',
+    where: [
+      { field: 'email', value: 'invited@example.com' },
+      { field: 'status', value: 'pending' },
+    ],
+  });
+});
+
+test('an expired invitation does not mark an awaiting caller as pending', async () => {
+  const { auth } = mockAuth({
+    session: {
+      user: { id: 'user_1', email: 'invited@example.com' },
+      session: { id: 'sess_1' },
+    },
+    invitations: [
+      {
+        id: 'invitation_1',
+        status: 'pending',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+      },
+    ],
+  });
+  registerOrganizationBinding({ auth, organizations: { policy: 'tenant' } });
+  const context = { logger: mockLogger() };
+
+  await resolveAuthentication(context, { auth, headers: {} });
+
+  expect(context.user.awaiting_organization).toBe(true);
+  expect(context.user.has_pending_invitation).toBe(false);
+  expect(context.user.pending_invitation_id).toBeUndefined();
+});
+
+test('an awaiting caller with no email skips the invitation lookup', async () => {
+  const { auth, findMany } = mockAuth({
+    session: {
+      user: { id: 'user_1' },
+      session: { id: 'sess_1' },
+    },
+  });
+  registerOrganizationBinding({ auth, organizations: { policy: 'tenant' } });
+  const context = { logger: mockLogger() };
+
+  await resolveAuthentication(context, { auth, headers: {} });
+
+  expect(context.user.awaiting_organization).toBe(true);
+  expect(context.user.has_pending_invitation).toBe(false);
+  expect(findMany).not.toHaveBeenCalled();
 });
 
 test('a caller awaiting an organization carries the global attributes alone', async () => {

--- a/packages/api/src/routes/auth/hooks/authHookPoints.js
+++ b/packages/api/src/routes/auth/hooks/authHookPoints.js
@@ -87,6 +87,15 @@ const authHookPoints = {
       user: await findHookUser({ ctx, userId: data.userId }),
     }),
   },
+  'session.update.before': {
+    kind: 'database',
+    model: 'session',
+    operation: 'update',
+    timing: 'before',
+    // Like user.update.before: BetterAuth hands the before hook only the
+    // changed fields, with no way to identify the subject session.
+    buildPayload: (data) => ({ session: null, changes: data }),
+  },
   'session.delete.after': {
     kind: 'database',
     model: 'session',

--- a/packages/api/src/routes/auth/hooks/authHookPoints.test.js
+++ b/packages/api/src/routes/auth/hooks/authHookPoints.test.js
@@ -27,6 +27,7 @@ test('the catalog covers the frozen launch point set', () => {
       'user.update.after',
       'session.create.before',
       'session.create.after',
+      'session.update.before',
       'session.delete.after',
       'account.create.before',
       'account.create.after',
@@ -50,6 +51,14 @@ test('user.update.before hands { user: null, changes } - BetterAuth provides onl
   const changes = { name: 'New Name' };
   expect(authHookPoints['user.update.before'].buildPayload(changes)).toEqual({
     user: null,
+    changes,
+  });
+});
+
+test('session.update.before hands { session: null, changes } - BetterAuth provides only the changed fields', () => {
+  const changes = { activeOrganizationId: 'org_1' };
+  expect(authHookPoints['session.update.before'].buildPayload(changes)).toEqual({
+    session: null,
     changes,
   });
 });

--- a/packages/api/src/routes/auth/hooks/buildEngineHooks.js
+++ b/packages/api/src/routes/auth/hooks/buildEngineHooks.js
@@ -14,6 +14,7 @@
   limitations under the License.
 */
 
+import createAcceptActiveOrgGuardHook from '../organizations/createAcceptActiveOrgGuardHook.js';
 import createActiveOrgPolicyHook from '../organizations/createActiveOrgPolicyHook.js';
 import createAdmissionGateHook from '../organizations/createAdmissionGateHook.js';
 import createAutoJoinHook from '../organizations/createAutoJoinHook.js';
@@ -29,6 +30,11 @@ function buildEngineHooks({ authConfig, getAuth, logger }) {
 
   const engineHooks = {
     'session.create.before': [createActiveOrgPolicyHook({ getAuth, logger, organizations })],
+    // Bound under both policies: the guard keys on the accept-invitation path
+    // and only ever vetoes a switch away from an existing active organization,
+    // so under pinned (one organization: accept re-sets the same id, or repairs
+    // an org-less invitee session) it never bites.
+    'session.update.before': [createAcceptActiveOrgGuardHook({ logger })],
   };
 
   // The admission gate bites only under pinned + invite-only (the predicate

--- a/packages/api/src/routes/auth/hooks/buildHooks.test.js
+++ b/packages/api/src/routes/auth/hooks/buildHooks.test.js
@@ -72,6 +72,7 @@ function buildTestHooks({ endpointConfigs, hooks, organizations = { policy: 'ten
     authConfig: { hooks, organizations },
     createSystemContext: createMockSystemContextFactory({ endpointConfigs }),
     getAuth: () => ({}),
+    logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
   });
 }
 
@@ -86,6 +87,27 @@ test('buildHooks always registers the engine session.create.before policy slot',
   expect(databaseHooks.session.create.before).toBeInstanceOf(Function);
   expect(databaseHooks.user).toBeUndefined();
   expect(afterEmailVerification).toBeUndefined();
+});
+
+test('buildHooks always registers the engine session.update.before accept guard slot', () => {
+  const { databaseHooks } = buildTestHooks({
+    hooks: [],
+  });
+  expect(databaseHooks.session.update.before).toBeInstanceOf(Function);
+});
+
+test('the accept guard slot vetoes an accept-route switch away from an active organization', async () => {
+  const { databaseHooks } = buildTestHooks({
+    hooks: [],
+  });
+  const result = await databaseHooks.session.update.before(
+    { activeOrganizationId: 'org_b' },
+    {
+      path: '/organization/accept-invitation',
+      context: { session: { session: { id: 'sess_1', activeOrganizationId: 'org_a' } } },
+    }
+  );
+  expect(result).toBe(false);
 });
 
 test('buildHooks registers the auto-join user.create.after slot for open signup under pinned', () => {

--- a/packages/api/src/routes/auth/organizations/createAcceptActiveOrgGuardHook.js
+++ b/packages/api/src/routes/auth/organizations/createAcceptActiveOrgGuardHook.js
@@ -1,0 +1,63 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { type } from '@lowdefy/helpers';
+
+// The engine-tier session.update.before hook that makes the accept-invitation
+// route's active-organization set conditional. BetterAuth's accept route sets
+// the accepting session's active organization unconditionally after minting
+// the member row (crud-invites.mjs), which silently relocates a caller who was
+// working in another organization - everything they create next lands in the
+// inviter's workspace. The same set is also the only repair for an org-less
+// session (the invited user who signed up directly holds a session with no
+// active organization until they accept), so the set cannot simply be removed:
+//
+//   - session had no active organization -> let the set through (the rescue);
+//   - session already active in an organization -> veto the write, so the
+//     caller stays where they were. The member row is already minted by then,
+//     so the new organization is joined either way - it just does not steal
+//     focus. Switching is the caller's own, explicit act via
+//     SetActiveOrganization.
+//
+// Scoped by endpoint path so the set-active-organization route - the explicit
+// switch - is never touched, and keyed on activeOrganizationId so the team
+// branch's activeTeamId session write passes through untouched. The current
+// active organization is read from the endpoint's own resolved session
+// (orgSessionMiddleware ran before the route body), not re-read from the
+// database - it is the same session row the update targets.
+function createAcceptActiveOrgGuardHook({ logger }) {
+  return async function acceptActiveOrgGuardHook(data, ctx) {
+    if (ctx?.path !== '/organization/accept-invitation') {
+      return;
+    }
+    if (type.isNone(data?.activeOrganizationId)) {
+      return;
+    }
+    const currentActiveOrganizationId = ctx?.context?.session?.session?.activeOrganizationId;
+    if (type.isNone(currentActiveOrganizationId)) {
+      return;
+    }
+    if (currentActiveOrganizationId === data.activeOrganizationId) {
+      return;
+    }
+    logger.debug(
+      `Invitation accept for organization "${data.activeOrganizationId}" left the session active in "${currentActiveOrganizationId}" - membership created, active organization unchanged.`
+    );
+    return false;
+  };
+}
+
+export default createAcceptActiveOrgGuardHook;

--- a/packages/api/src/routes/auth/organizations/createAcceptActiveOrgGuardHook.test.js
+++ b/packages/api/src/routes/auth/organizations/createAcceptActiveOrgGuardHook.test.js
@@ -1,0 +1,106 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+
+import createAcceptActiveOrgGuardHook from './createAcceptActiveOrgGuardHook.js';
+
+function mockLogger() {
+  return { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+}
+
+function acceptCtx({ activeOrganizationId } = {}) {
+  return {
+    path: '/organization/accept-invitation',
+    context: {
+      session: {
+        session: { id: 'sess_1', token: 'token_1', activeOrganizationId },
+        user: { id: 'user_1', email: 'invited@example.com' },
+      },
+    },
+  };
+}
+
+test('vetoes the active-organization switch when the session is already active elsewhere', async () => {
+  const logger = mockLogger();
+  const hook = createAcceptActiveOrgGuardHook({ logger });
+
+  const result = await hook(
+    { activeOrganizationId: 'org_b' },
+    acceptCtx({ activeOrganizationId: 'org_a' })
+  );
+
+  expect(result).toBe(false);
+  expect(logger.debug).toHaveBeenCalledWith(
+    'Invitation accept for organization "org_b" left the session active in "org_a" - membership created, active organization unchanged.'
+  );
+});
+
+test('lets the set through for an org-less session - the rescue path', async () => {
+  const hook = createAcceptActiveOrgGuardHook({ logger: mockLogger() });
+
+  const result = await hook(
+    { activeOrganizationId: 'org_b' },
+    acceptCtx({ activeOrganizationId: undefined })
+  );
+
+  expect(result).toBeUndefined();
+});
+
+test('lets a same-organization set through - pinned re-accept is a no-op write', async () => {
+  const hook = createAcceptActiveOrgGuardHook({ logger: mockLogger() });
+
+  const result = await hook(
+    { activeOrganizationId: 'org_a' },
+    acceptCtx({ activeOrganizationId: 'org_a' })
+  );
+
+  expect(result).toBeUndefined();
+});
+
+test('ignores session updates from every other endpoint - the explicit switch stays free', async () => {
+  const hook = createAcceptActiveOrgGuardHook({ logger: mockLogger() });
+
+  const result = await hook(
+    { activeOrganizationId: 'org_b' },
+    {
+      path: '/organization/set-active',
+      context: {
+        session: {
+          session: { id: 'sess_1', activeOrganizationId: 'org_a' },
+        },
+      },
+    }
+  );
+
+  expect(result).toBeUndefined();
+});
+
+test('ignores accept-route session writes that do not set an active organization', async () => {
+  const hook = createAcceptActiveOrgGuardHook({ logger: mockLogger() });
+
+  const result = await hook({ activeTeamId: 'team_1' }, acceptCtx({ activeOrganizationId: 'org_a' }));
+
+  expect(result).toBeUndefined();
+});
+
+test('lets the set through when no endpoint context is available', async () => {
+  const hook = createAcceptActiveOrgGuardHook({ logger: mockLogger() });
+
+  const result = await hook({ activeOrganizationId: 'org_b' }, null);
+
+  expect(result).toBeUndefined();
+});

--- a/packages/build/src/build/buildAuth/authHookPoints.js
+++ b/packages/build/src/build/buildAuth/authHookPoints.js
@@ -27,6 +27,7 @@ const authHookPoints = [
   'user.update.after',
   'session.create.before',
   'session.create.after',
+  'session.update.before',
   'session.delete.after',
   'account.create.before',
   'account.create.after',

--- a/packages/build/src/build/buildAuth/buildAuthHooks.test.js
+++ b/packages/build/src/build/buildAuth/buildAuthHooks.test.js
@@ -52,6 +52,7 @@ test('buildAuthHooks accepts every point in the frozen catalog', () => {
     'user.update.after',
     'session.create.before',
     'session.create.after',
+    'session.update.before',
     'session.delete.after',
     'account.create.before',
     'account.create.after',


### PR DESCRIPTION
Fixes the two tenant-admission gaps recorded as **T7** and **T16** in `modules-mongodb/designs/auth-tenancy-verification/findings.md`, hit by Encircle's multi-tenant adoption (first real-world consumer of this branch).

## T7 — invited user who signs up directly is stranded

Under `policy: tenant`, a user holding a pending invitation who signs up from the signup page (instead of via the invitation link) gets a session with no active organization (`createActiveOrgPolicyHook` deliberately mints nothing while an invitation is pending). They resolve as the awaiting-organization caller, every protected page refuses them, and **no diagnosis reaches the app** — the finding's candidate (c), made actually useful.

**Fix shape:** the awaiting caller now carries the diagnosis:
- `_user.has_pending_invitation` — always present (`true`/`false`) on awaiting callers, so config can branch without an absent-key case.
- `_user.pending_invitation_id` — present only when a pending, unexpired invitation exists (never synthesized to `null`), safe to hand to its own invitee: the accept route re-verifies the session email against the invitation before minting anything.

The lookup reuses `findPendingInvitation` (the same lowercased-email/pending/unexpired read the policy hook uses), costs one indexed read, and only for this rare caller. Nothing is auto-accepted — candidate (a) (auto-accept on verified email) was rejected as a policy decision the accepting user must make; candidate (b) (redirect) is now buildable app-side from the marker.

## T16 — accept silently steals the active organization

BetterAuth's accept route calls `adapter.setActiveOrganization` unconditionally after minting the member row (`crud-invites.mjs`), silently relocating a caller who was working in another org — subsequent records land in the inviter's workspace. The same call is the only repair for the org-less session of the T7 population, so it cannot be removed; per the finding, the fix is **conditional**.

**Fix shape:** no vendor patch. `adapter.setActiveOrganization` routes through `internalAdapter.updateSession`, which runs `session.update.before` database hooks with the endpoint context. A new engine-tier hook (`createAcceptActiveOrgGuardHook`, bound in `buildEngineHooks` under both policies):
- keys on `ctx.path === '/organization/accept-invitation'` — the explicit `/organization/set-active` switch is never touched;
- keys on `data.activeOrganizationId` — the team branch's `activeTeamId` write passes through;
- reads the current active org from the route's own resolved session (`ctx.context.session`, set by `orgSessionMiddleware` — the same session row the update targets);
- **org-less session → set goes through** (rescue preserved); **already active elsewhere → returns `false`**, aborting the session write entirely (the member row is already created; joining still happens, focus is not stolen).

`session.update.before` is added to both hook-point catalogs (api runtime + build frozen set, kept in sync per their twin-catalog comments), payload mirroring `user.update.before` (`{ session: null, changes }`), so it is also user-bindable — an additive, non-breaking catalog change by the build catalog's own comment.

## Alternatives rejected
- Auto-accept on verified email (T7 option a): admission is a user decision; out of scope for an engine default.
- Restoring the previous org in `organizationHooks.afterAcceptInvitation`: runs after the transaction with no session token in its payload — a second racing write at best.
- pnpm-patching `crud-invites.mjs`: a hook seam exists; the patch would have to be re-verified on every better-auth bump.

## Tests
- `packages/api`: **1225 passed** (109 suites) — includes 3 new awaiting-caller tests (pending id surfaces; expired invitation → `false`; no email skips the lookup) and 6 new guard-hook unit tests (veto, rescue, same-org, foreign path, team write, no ctx), plus 2 composed-slot tests through `buildHooks`.
- `packages/build`: **2216 passed** (159 suites) — frozen catalog updated.

Changeset included. Feeds Encircle's awaiting-organization page (multi-tenant design §3.3).