### PR TITLE
fix(api,plugin-better-auth): Resolve the caller display identity per organization (T18)

### DIFF
--- a/.changeset/fix-per-org-caller-name.md
+++ b/.changeset/fix-per-org-caller-name.md
@@ -1,0 +1,19 @@
+---
+'@lowdefy/api': patch
+'@lowdefy/plugin-better-auth': patch
+---
+
+fix(api,plugin-better-auth): Resolve the caller's name and image per organization (T18).
+
+The user row's `name`/`image` are deployment-global and last-edit-wins across workspaces, so a
+caller acting in organization A was stamped and rendered with the identity last saved in
+organization B — change stamps, the header avatar, and every `_user: name` read named another
+workspace's identity.
+
+`UpdateUserProfile` now also denormalizes the display copies onto the target's member row in the
+organization the authority floor resolved (declared as internal `input: false` member
+additionalFields), and `resolveMemberCaller` prefers the member copies, falling back to the global
+user row for members who have never saved a profile in that organization. Empty strings are never
+written to the member copy, so the fallback cannot be masked. No new authorization surface: the
+denorm rides the existing step call under the same floor, and a self-service caller with no member
+row in the resolved organization skips it silently.

--- a/packages/api/src/context/resolveAuthentication.js
+++ b/packages/api/src/context/resolveAuthentication.js
@@ -150,6 +150,14 @@ async function resolveMemberCaller(context, { adapter, auth, organizationId, use
   // merge below verbatim - app-owned keys inside it are never renamed.
   return normalizeCaller({
     ...user,
+    // Per-organization display copies, denormalized onto the member row by
+    // UpdateUserProfile. The user row's name/image are deployment-global and
+    // last-edit-wins across workspaces, so a caller acting in organization A
+    // would otherwise be stamped and rendered with the identity last saved in
+    // organization B (T18). Nullish-coalesced: a member who has never saved a
+    // profile in this organization falls back to the global copies.
+    name: member.name ?? user.name,
+    image: member.image ?? user.image,
     // Absent on a member row minted with no app roles - never falls back to
     // member.role, which would make the two fields one dual-storage scheme.
     roles: member.appRoles ?? [],

--- a/packages/api/src/context/resolveAuthentication.test.js
+++ b/packages/api/src/context/resolveAuthentication.test.js
@@ -1063,3 +1063,42 @@ describe('MCP bearer branch and the general-path audience invariant', () => {
     expect(strategies[0].verify).toHaveBeenCalled();
   });
 });
+
+test('prefers the member row display copies for name and image (per-organization identity)', async () => {
+  const { auth } = mockAuth({
+    session: {
+      user: { id: 'user_1', name: 'Alice in B', image: 'data:image/svg;b' },
+      session: { id: 'sess_1', activeOrganizationId: 'org_a' },
+    },
+    member: {
+      id: 'member_1',
+      role: 'member',
+      name: 'Alice Anderson',
+      image: 'data:image/svg;a',
+    },
+  });
+  const context = {};
+
+  await resolveAuthentication(context, { auth, headers: {} });
+
+  // The user row is deployment-global and last-edit-wins across workspaces;
+  // the member copies carry the identity saved in THIS organization (T18).
+  expect(context.user.name).toBe('Alice Anderson');
+  expect(context.user.image).toBe('data:image/svg;a');
+});
+
+test('falls back to the global user row for name and image when the member row carries no copies', async () => {
+  const { auth } = mockAuth({
+    session: {
+      user: { id: 'user_1', name: 'Alice Anderson', image: 'data:image/svg;a' },
+      session: { id: 'sess_1', activeOrganizationId: 'org_a' },
+    },
+    member: { id: 'member_1', role: 'member' },
+  });
+  const context = {};
+
+  await resolveAuthentication(context, { auth, headers: {} });
+
+  expect(context.user.name).toBe('Alice Anderson');
+  expect(context.user.image).toBe('data:image/svg;a');
+});

--- a/packages/api/src/routes/auth/organizations/buildOrganizationPlugin.js
+++ b/packages/api/src/routes/auth/organizations/buildOrganizationPlugin.js
@@ -74,6 +74,16 @@ function buildOrganizationPlugin({ getAuth, logger, sendInvitationEmail }) {
         additionalFields: {
           appRoles: { type: 'string[]', required: false, input: false },
           attributes: { type: 'json', required: false, input: false },
+          // Per-organization display copies, denormalized by UpdateUserProfile
+          // when a profile is saved with that organization resolved. The user
+          // row's name/image are deployment-global and last-edit-wins across
+          // workspaces; these carry the identity as saved in THIS organization
+          // and resolveMemberCaller prefers them, so change stamps and the
+          // header identity name the workspace's identity (T18). Absent on a
+          // member who has never saved a profile in the organization - the
+          // caller then falls back to the global copies.
+          name: { type: 'string', required: false, input: false },
+          image: { type: 'string', required: false, input: false },
         },
       },
       invitation: {

--- a/packages/plugins/plugins/plugin-better-auth/src/steps/UpdateUserProfile.js
+++ b/packages/plugins/plugins/plugin-better-auth/src/steps/UpdateUserProfile.js
@@ -32,7 +32,7 @@ const allowedProperties = ['contactId', 'image', 'name', 'organizationId', 'prof
 // and never joins the profile merge. The step writes nothing else - not
 // email, not emailVerified, not attributes, not roles. Adapter-direct like
 // UpdateUserAttributes: fires NO user.update database hooks.
-async function UpdateUserProfile({ auth, properties }) {
+async function UpdateUserProfile({ auth, organizationId, properties }) {
   const { contactId, image, name, profile, userId } = properties;
   const unknownProperties = Object.keys(properties).filter(
     (key) => !allowedProperties.includes(key)
@@ -106,11 +106,40 @@ async function UpdateUserProfile({ auth, properties }) {
   if (!type.isNone(image)) {
     update.image = image;
   }
-  return adapter.update({
+  const updatedUser = await adapter.update({
     model: 'user',
     where: [{ field: 'id', value: userId }],
     update,
   });
+  // Denormalize the display copies onto the target's member row in the
+  // organization the floor resolved (organizationId is the floor's resolved
+  // target, like UpdateMemberAttributes). The user row is deployment-global and
+  // last-edit-wins across workspaces; the member copy carries the identity as
+  // saved in THIS organization, and resolveMemberCaller prefers it, so change
+  // stamps and the header identity name the workspace's identity (T18). Empty
+  // strings are not written - resolveMemberCaller coalesces on nullish, so an
+  // empty member copy would mask the global fallback. No member row is a
+  // silent skip, not an error: selfTargetExempt lets a caller save their own
+  // profile without holding a member row in the resolved organization, and the
+  // global write above has already landed.
+  const memberUpdate = {};
+  if (!type.isNone(name) && name !== '') {
+    memberUpdate.name = name;
+  }
+  if (!type.isNone(image) && image !== '') {
+    memberUpdate.image = image;
+  }
+  if (!type.isNone(organizationId) && Object.keys(memberUpdate).length > 0) {
+    await adapter.update({
+      model: 'member',
+      where: [
+        { field: 'userId', value: userId },
+        { field: 'organizationId', value: organizationId },
+      ],
+      update: memberUpdate,
+    });
+  }
+  return updatedUser;
 }
 
 // The self-service save is the core flow: selfTargetExempt names the property

--- a/packages/plugins/plugins/plugin-better-auth/src/steps/UpdateUserProfile.test.js
+++ b/packages/plugins/plugins/plugin-better-auth/src/steps/UpdateUserProfile.test.js
@@ -267,3 +267,112 @@ test('UpdateUserProfile declares the userId self-target exemption inside its aut
   expect(UpdateUserProfile.meta.authority.selfTargetExempt).toEqual('userId');
   expect(UpdateUserProfile.meta.selfTargetExempt).toBeUndefined();
 });
+
+test('UpdateUserProfile denormalizes name and image onto the member row of the resolved organization', async () => {
+  const adapter = {
+    findOne: jest.fn().mockResolvedValue({ id: 'user-1', profile: {} }),
+    update: jest
+      .fn()
+      .mockImplementation(async ({ model, update }) => ({ id: `${model}-1`, ...update })),
+  };
+  const { auth } = createMockAuth({ adapter });
+
+  const result = await UpdateUserProfile({
+    auth,
+    organizationId: 'org-a',
+    properties: { userId: 'user-1', name: 'Alice Anderson', image: 'data:image/svg;a' },
+  });
+
+  expect(adapter.update).toHaveBeenCalledTimes(2);
+  expect(adapter.update.mock.calls[0][0]).toEqual({
+    model: 'user',
+    where: [{ field: 'id', value: 'user-1' }],
+    update: { name: 'Alice Anderson', image: 'data:image/svg;a' },
+  });
+  expect(adapter.update.mock.calls[1][0]).toEqual({
+    model: 'member',
+    where: [
+      { field: 'userId', value: 'user-1' },
+      { field: 'organizationId', value: 'org-a' },
+    ],
+    update: { name: 'Alice Anderson', image: 'data:image/svg;a' },
+  });
+  // The step's return value is the user row, not the member denorm.
+  expect(result.id).toEqual('user-1');
+});
+
+test('UpdateUserProfile skips the member denorm when no organizationId is resolved', async () => {
+  const adapter = {
+    findOne: jest.fn().mockResolvedValue({ id: 'user-1', profile: {} }),
+    update: jest.fn().mockResolvedValue({ id: 'user-1' }),
+  };
+  const { auth } = createMockAuth({ adapter });
+
+  await UpdateUserProfile({
+    auth,
+    organizationId: null,
+    properties: { userId: 'user-1', name: 'Alice Anderson' },
+  });
+
+  expect(adapter.update).toHaveBeenCalledTimes(1);
+  expect(adapter.update.mock.calls[0][0].model).toEqual('user');
+});
+
+test('UpdateUserProfile skips the member denorm when only profile or contactId is written', async () => {
+  const adapter = {
+    findOne: jest.fn().mockResolvedValue({ id: 'user-1', profile: {} }),
+    update: jest.fn().mockResolvedValue({ id: 'user-1' }),
+  };
+  const { auth } = createMockAuth({ adapter });
+
+  await UpdateUserProfile({
+    auth,
+    organizationId: 'org-a',
+    properties: { userId: 'user-1', profile: { locale: 'en' }, contactId: 'contact-1' },
+  });
+
+  expect(adapter.update).toHaveBeenCalledTimes(1);
+  expect(adapter.update.mock.calls[0][0].model).toEqual('user');
+});
+
+test('UpdateUserProfile does not denorm an empty-string display copy onto the member row', async () => {
+  const adapter = {
+    findOne: jest.fn().mockResolvedValue({ id: 'user-1', profile: {} }),
+    update: jest.fn().mockResolvedValue({ id: 'user-1' }),
+  };
+  const { auth } = createMockAuth({ adapter });
+
+  await UpdateUserProfile({
+    auth,
+    organizationId: 'org-a',
+    properties: { userId: 'user-1', name: '', image: 'data:image/svg;a' },
+  });
+
+  // name '' still writes the user row (existing contract) but only image
+  // reaches the member copy - resolveMemberCaller coalesces on nullish, so an
+  // empty member.name would mask the global fallback.
+  expect(adapter.update).toHaveBeenCalledTimes(2);
+  expect(adapter.update.mock.calls[1][0].update).toEqual({ image: 'data:image/svg;a' });
+});
+
+test('UpdateUserProfile tolerates a caller with no member row in the resolved organization', async () => {
+  const adapter = {
+    findOne: jest.fn().mockResolvedValue({ id: 'user-1', profile: {} }),
+    update: jest
+      .fn()
+      .mockImplementationOnce(async ({ update }) => ({ id: 'user-1', ...update }))
+      // Adapter update on a no-match member returns null - selfTargetExempt
+      // lets a caller save their own profile without membership there.
+      .mockResolvedValueOnce(null),
+  };
+  const { auth } = createMockAuth({ adapter });
+
+  const result = await UpdateUserProfile({
+    auth,
+    organizationId: 'org-a',
+    properties: { userId: 'user-1', name: 'Alice Anderson' },
+  });
+
+  expect(adapter.update).toHaveBeenCalledTimes(2);
+  expect(result).toEqual({ id: 'user-1', name: 'Alice Anderson' });
+});


### PR DESCRIPTION
## Finding

**T18** (modules-mongodb `designs/auth-tenancy-verification/findings.md`): a profile edit in workspace B overwrites the single global `users.name`/`users.profile`, so while viewing workspace A the layout avatar renders B's identity and — worse for a governance product — **change stamps made in A are attributed with B's name**. Related attribution faults T1/T2 are fixed module-side (modules-mongodb PR, same series).

## Fix

Two halves, no new authorization surface:

1. **`UpdateUserProfile`** now also denormalizes the display copies (`name`, `image`) onto the target's member row in the organization the authority floor resolved (`organizationId` is the floor's resolved target, passed to every step — same contract as `UpdateMemberAttributes`). Declared as internal `input: false` member `additionalFields`. Empty strings are never written (they would mask the fallback). A caller with no member row in the resolved organization skips the denorm silently — `selfTargetExempt` allows exactly that shape, and the global write has already landed.
2. **`resolveMemberCaller`** prefers `member.name`/`member.image` over the global user row, nullish-coalesced, so members who have never saved a profile in the organization keep today's behavior.

Alternatives rejected:
- `UpdateMemberAttributes` from module config: requires `member:update` org authority with **no self-target exemption**, so it refuses every self-service profile save.
- Stamp-template-only fixes in modules: the change stamp is a plain template with only `_user` in scope; without a per-org `_user.name` there is nothing correct for it to read.

## Tests

- `plugin-better-auth`: 5 new tests (denorm write shape, null-org skip, profile/contactId-only skip, empty-string guard, no-member-row tolerance) — package suite 210/210.
- `api`: 2 new resolver tests (member-copy preference, global fallback) — package suite 1215/1215.

Backfill: none needed — absent member copies fall back to the global row; copies appear on the next profile save in each organization.