### PR TITLE
fix(server): Restore GenericOAuth client sign-in on better-auth 1.7.0

### DIFF
--- a/.changeset/fix-better-auth-generic-oauth-client.md
+++ b/.changeset/fix-better-auth-generic-oauth-client.md
@@ -1,0 +1,10 @@
+---
+'@lowdefy/server': patch
+'@lowdefy/server-dev': patch
+---
+
+fix: Restore GenericOAuth client sign-in on BetterAuth 1.7.0.
+
+BetterAuth 1.7.0 removed `genericOAuthClient` from its client plugin entry point. Both servers still imported it, so every client build failed on a clean install with `"genericOAuthClient" is not exported by "better-auth/client/plugins"` — apps could not be built or started at all.
+
+The import and the plugin registration are dropped. Through BetterAuth 1.6.x this client plugin only carried an id, a version, an empty type-inference marker and the generic-oauth error codes — no actions, atoms, request hooks or route methods — so sign-in with a `GenericOAuth` provider works exactly as before without it.

--- a/packages/servers/server-dev/lib/client/auth/AuthConfigured.jsx
+++ b/packages/servers/server-dev/lib/client/auth/AuthConfigured.jsx
@@ -18,7 +18,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { createAuthClient } from 'better-auth/react';
 import {
   adminClient,
-  genericOAuthClient,
   magicLinkClient,
   organizationClient,
   phoneNumberClient,
@@ -33,11 +32,18 @@ import rawLowdefyConfig from '../../../build/config.json';
 
 const lowdefyConfig = serializer.deserialize(rawLowdefyConfig);
 
+// GenericOAuth providers have no client plugin here. BetterAuth 1.7.0 dropped
+// genericOAuthClient from better-auth/client/plugins, and nothing replaces it:
+// through 1.6.x it was a marker plugin carrying only an id, a version, an empty
+// $InferServerPlugin for TypeScript inference, and the generic-oauth error
+// codes - no actions, atoms, fetch plugins or path methods. signIn.oauth2 is
+// resolved by the client's dynamic path proxy from the call itself
+// (signIn.oauth2 -> POST /sign-in/oauth2, POST because providerId is always
+// sent), so the sign-in a Lowdefy GenericOAuth provider makes is unaffected.
 const authClient = createAuthClient({
   baseURL: `${window.location.origin}${lowdefyConfig.basePath ?? ''}/api/auth`,
   plugins: [
     adminClient(),
-    genericOAuthClient(),
     magicLinkClient(),
     oauthProviderClient(),
     organizationClient(),

--- a/packages/servers/server/lib/client/auth/AuthConfigured.jsx
+++ b/packages/servers/server/lib/client/auth/AuthConfigured.jsx
@@ -18,7 +18,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { createAuthClient } from 'better-auth/react';
 import {
   adminClient,
-  genericOAuthClient,
   magicLinkClient,
   organizationClient,
   phoneNumberClient,
@@ -33,11 +32,18 @@ import rawLowdefyConfig from '../../../build/config.json';
 
 const lowdefyConfig = serializer.deserialize(rawLowdefyConfig);
 
+// GenericOAuth providers have no client plugin here. BetterAuth 1.7.0 dropped
+// genericOAuthClient from better-auth/client/plugins, and nothing replaces it:
+// through 1.6.x it was a marker plugin carrying only an id, a version, an empty
+// $InferServerPlugin for TypeScript inference, and the generic-oauth error
+// codes - no actions, atoms, fetch plugins or path methods. signIn.oauth2 is
+// resolved by the client's dynamic path proxy from the call itself
+// (signIn.oauth2 -> POST /sign-in/oauth2, POST because providerId is always
+// sent), so the sign-in a Lowdefy GenericOAuth provider makes is unaffected.
 const authClient = createAuthClient({
   baseURL: `${window.location.origin}${lowdefyConfig.basePath ?? ''}/api/auth`,
   plugins: [
     adminClient(),
-    genericOAuthClient(),
     magicLinkClient(),
     oauthProviderClient(),
     organizationClient(),


### PR DESCRIPTION
## The removal

better-auth 1.7.0 stable (published 2026-08-18, pinned across the workspace in b56bb7a4c) removed three exports from `better-auth/client/plugins`: `genericOAuthClient`, `GENERIC_OAUTH_ERROR_CODES` and `oidcClient`. Nothing was renamed and nothing moved — `./plugins/generic-oauth` (server side) is the only generic-oauth subpath 1.7.0 exports, and it exports only the server plugin and its bundled providers. The 1.6.x `dist/plugins/generic-oauth/client.mjs` file is gone from the package entirely.

Both `@lowdefy/server` and `@lowdefy/server-dev` still imported `genericOAuthClient` in `lib/client/auth/AuthConfigured.jsx`, so every client build on a clean install failed:

```
[MISSING_EXPORT] "genericOAuthClient" is not exported by
  node_modules/.../better-auth/dist/client/plugins/index.mjs
```

This is a hard blocker — no app could be built or started.

## The fix

Drop the import and the plugin registration, with a comment recording why there is no client plugin for GenericOAuth providers.

That is safe because the plugin never did anything at runtime. Its entire 1.6.23 implementation:

```js
const genericOAuthClient = () => ({
  id: 'generic-oauth-client',
  version: PACKAGE_VERSION,
  $InferServerPlugin: {},
  $ERROR_CODES: GENERIC_OAUTH_ERROR_CODES,
});
```

No `getActions`, no `getAtoms`, no `fetchPlugins`, no `atomListeners`, no `pathMethods`. `$InferServerPlugin` is a TypeScript-only inference marker (these files are plain JSX), and `$ERROR_CODES` is never read anywhere in this repo.

The one call that goes through it, `authClient.signIn.oauth2(...)` (used by `createAuthMethods` when a provider's type is `GenericOAuth`), is served by BetterAuth's `createDynamicPathProxy`: the property path is kebab-cased into the route (`signIn.oauth2` → `/sign-in/oauth2`) and `getMethod` picks POST whenever the call carries a body — the Lowdefy call always sends `providerId`. So GenericOAuth sign-in behaves exactly as before.

## Alternatives rejected

- **Update the import path** — there is no new path. Verified against the 1.7.0 tarball's `exports` map and file tree.
- **Vendor the client plugin into Lowdefy** — would reintroduce a no-op object plus a dependency on internal error-code exports that 1.7.0 also removed. Dead weight.
- **Workspace-level pnpm patch of better-auth** — a patch to restore an export we do not need; it would have to be carried through every future better-auth bump.

## Verification

- `packages/servers/server`: 5 suites / 23 tests pass.
- `packages/servers/server-dev`: 33 suites / 245 tests pass.
- `packages/client`: 10 suites / 225 tests pass (the `createAuthMethods` GenericOAuth → `signInOauth2` routing tests included).
- **Full production app build including the Vite client bundle**, `node scripts/build.mjs --config-directory packages/docs` — succeeds: `11571 modules transformed`, `dist/client/assets/main-*.js`, exit 0.
- **A/B control on the same built tree**: re-adding the import to `_server/prod/lib/client/auth/AuthConfigured.jsx` and re-running `pnpm run build:client` fails with the `MISSING_EXPORT` above; restoring the fixed file builds clean again. So the build genuinely exercises this file, and this change is what unblocks it.

Verified against the 1.7.0 install in the repo, diffed export-for-export against a fresh `better-auth@1.6.23` tarball.

## Notes

- A downstream consumer is carrying a temporary pnpm patch that re-adds the 1.6.23 `genericOAuthClient` to the installed package as a workaround; it can be dropped once this ships.
- Unrelated, flagging while nearby: `@lowdefy/modules-mongodb-plugins` needs a republish from `modules-mongodb`'s reconciled branch — npm `0.17.0` lacks the tenant capability declarations. Different repo, no action here.

