### PR TITLE
fix: `hasFeedback: false` leads to strange display

### DIFF
--- a/packages/plugins/blocks/blocks-antd/src/blocks/Label/Label.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Label/Label.js
@@ -61,6 +61,7 @@ const Label = ({
     rowStyle,
     showExtra,
     showFeedback,
+    showFeedbackIcon,
     wrapperCol,
   } = labelLogic({ blockId, blockClassNames, content, properties, required, styles, validation });
   if (!iconMap) {
@@ -71,13 +72,12 @@ const Label = ({
       warning: () => <Icon properties="AiFillExclamationCircle" />,
     };
   }
-  const IconNode = validation.status && iconMap[validation.status];
-  const icon =
-    validation.status && IconNode ? (
-      <span className={iconClassName}>
-        <IconNode />
-      </span>
-    ) : null;
+  const IconNode = showFeedbackIcon && iconMap[validation.status];
+  const icon = IconNode ? (
+    <span className={iconClassName}>
+      <IconNode />
+    </span>
+  ) : null;
 
   // tooltip is either a string (the tooltip text) or an object that also
   // customizes the icon and color. The onClick is exposed as the block's

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Label/labelLogic.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Label/labelLogic.js
@@ -117,8 +117,11 @@ const labelLogic = ({
     'ldf-feedback-icon': true,
   });
 
+  const hasFeedback = properties.hasFeedback !== false;
   const showExtra = !!properties.extra && (!validation.status || validation.status === 'success');
-  const showFeedback = validation.status === 'warning' || validation.status === 'error';
+  const showFeedback =
+    hasFeedback && (validation.status === 'warning' || validation.status === 'error');
+  const showFeedbackIcon = hasFeedback && !type.isNone(validation.status);
   return {
     extraClassName,
     extraStyle,
@@ -135,6 +138,7 @@ const labelLogic = ({
     rowStyle,
     showExtra,
     showFeedback,
+    showFeedbackIcon,
     wrapperCol,
   };
 };


### PR DESCRIPTION
Fixes #1471

## Root cause

label.hasFeedback property is never read by Label block logic

## Changes

- labelLogic now derives `hasFeedback` from `properties.hasFeedback` and gates both the feedback message (`showFeedback`) and a new `showFeedbackIcon` flag on it; Label.js renders the status icon only when `showFeedbackIcon` is true. Validation itself and the input's error/warning styling are untouched.