### PR TITLE
fix: MSSQL custom port

### DIFF
--- a/packages/plugins/connections/connection-knex/src/connections/Knex/KnexBuilder/KnexBuilder.test.js
+++ b/packages/plugins/connections/connection-knex/src/connections/Knex/KnexBuilder/KnexBuilder.test.js
@@ -20,6 +20,7 @@ import { validate } from '@lowdefy/ajv';
 const mockKnexClient = jest.fn(() => mockKnexClient);
 const mockKnex = jest.fn(() => mockKnexClient);
 
+mockKnexClient.client = { connectionSettings: {} };
 mockKnexClient.select = jest.fn(() => mockKnexClient);
 mockKnexClient.from = jest.fn(() => mockKnexClient);
 mockKnexClient.where = jest.fn(() => mockKnexClient);

--- a/packages/plugins/connections/connection-knex/src/connections/Knex/KnexRaw/KnexRaw.test.js
+++ b/packages/plugins/connections/connection-knex/src/connections/Knex/KnexRaw/KnexRaw.test.js
@@ -24,6 +24,7 @@ const mockRaw = jest.fn(() => {
 jest.unstable_mockModule('knex', () => {
   return {
     default: jest.fn(() => ({
+      client: { connectionSettings: {} },
       raw: mockRaw,
     })),
   };

--- a/packages/plugins/connections/connection-knex/src/connections/Knex/createKnex.js
+++ b/packages/plugins/connections/connection-knex/src/connections/Knex/createKnex.js
@@ -17,6 +17,8 @@
 import knex from 'knex';
 import { ConfigError } from '@lowdefy/errors';
 
+import normalizeConnectionPort from './normalizeConnectionPort.js';
+
 function createKnex(connection) {
   if (connection.client === 'sqlite3') {
     throw new ConfigError(
@@ -29,9 +31,9 @@ function createKnex(connection) {
     );
   }
   if (connection.client === 'sqlite') {
-    return knex({ ...connection, client: 'better-sqlite3' });
+    return normalizeConnectionPort(knex({ ...connection, client: 'better-sqlite3' }));
   }
-  return knex(connection);
+  return normalizeConnectionPort(knex(connection));
 }
 
 export default createKnex;

--- a/packages/plugins/connections/connection-knex/src/connections/Knex/createKnex.test.js
+++ b/packages/plugins/connections/connection-knex/src/connections/Knex/createKnex.test.js
@@ -16,7 +16,11 @@
 
 import { jest } from '@jest/globals';
 
-const mockKnex = jest.fn(() => ({}));
+const mockKnex = jest.fn((config) => ({
+  client: {
+    connectionSettings: typeof config.connection === 'object' ? { ...config.connection } : {},
+  },
+}));
 
 jest.unstable_mockModule('knex', () => ({ default: mockKnex }));
 
@@ -67,4 +71,45 @@ test('createKnex passes "mysql2" through unchanged', async () => {
   const createKnex = (await import('./createKnex.js')).default;
   createKnex({ client: 'mysql2', connection: 'mysql://u:p@h/db' });
   expect(mockKnex.mock.calls).toEqual([[{ client: 'mysql2', connection: 'mysql://u:p@h/db' }]]);
+});
+
+test('createKnex converts a connection object port given as a string to a number', async () => {
+  const createKnex = (await import('./createKnex.js')).default;
+  const knexClient = createKnex({
+    client: 'mssql',
+    connection: { server: 'server', port: '45678', database: 'db' },
+  });
+  expect(knexClient.client.connectionSettings).toEqual({
+    server: 'server',
+    port: 45678,
+    database: 'db',
+  });
+});
+
+test('createKnex converts a port parsed from a connection string to a number', async () => {
+  const createKnex = (await import('./createKnex.js')).default;
+  mockKnex.mockImplementationOnce(() => ({
+    client: { connectionSettings: { server: 'server', port: '45678', database: 'db' } },
+  }));
+  const knexClient = createKnex({
+    client: 'mssql',
+    connection: 'mssql://user:password@server:45678/db',
+  });
+  expect(knexClient.client.connectionSettings.port).toBe(45678);
+});
+
+test('createKnex throws when the connection port is not a valid port number', async () => {
+  const createKnex = (await import('./createKnex.js')).default;
+  expect(() =>
+    createKnex({ client: 'mssql', connection: { server: 'server', port: 'port', database: 'db' } })
+  ).toThrow('Knex connection port is not a valid port number. Received "port".');
+});
+
+test('createKnex leaves a numeric connection port unchanged', async () => {
+  const createKnex = (await import('./createKnex.js')).default;
+  const knexClient = createKnex({
+    client: 'mssql',
+    connection: { server: 'server', port: 45678, database: 'db' },
+  });
+  expect(knexClient.client.connectionSettings.port).toBe(45678);
 });


### PR DESCRIPTION
Fixes #1513

## Root cause

Knex connection port passed to driver as a string

## Changes

- Normalize the knex client connection port to a number in `createKnex`, covering both object connections (string ports from secrets/env) and ports parsed from connection strings, with a clear ConfigError for invalid ports.