### PR TITLE
fix: Visible change removes value in list from state

### DIFF
--- a/packages/engine/src/Block.js
+++ b/packages/engine/src/Block.js
@@ -339,6 +339,10 @@ class Block {
       repeat.value = true;
     }
 
+    if (this.isList() && !this.isVisible()) {
+      this.captureHiddenValue();
+    }
+
     if (this.visibleEval.output !== false) {
       this.propertiesEval = this.parse(this.properties);
       this.requiredEval = this.parse(this.required);
@@ -444,8 +448,26 @@ class Block {
     });
   };
 
+  captureHiddenValue = () => {
+    const stateValue = get(this.context.state, this.blockId);
+    if (type.isUndefined(stateValue)) return;
+    this.hiddenValue = serializer.copy(stateValue);
+  };
+
+  restoreHiddenValue = () => {
+    if (type.isUndefined(this.hiddenValue)) return;
+    if (type.isUndefined(get(this.context.state, this.blockId))) {
+      this.context._internal.State.set(this.blockId, this.hiddenValue);
+    }
+    this.hiddenValue = undefined;
+  };
+
   updateState = (toSet) => {
     if (!this.isVisible()) return;
+
+    if (this.isList()) {
+      this.restoreHiddenValue();
+    }
 
     if (this.isContainer() || this.isList()) {
       if (this.subSlots && this.subSlots.length > 0) {

--- a/packages/engine/test/Block/list.test.js
+++ b/packages/engine/test/Block/list.test.js
@@ -599,6 +599,220 @@ test('list block with visible', async () => {
   expect(context.state).toEqual({ list: [{ a: 'a' }], swtch: true });
 });
 
+test('list of display blocks in a hidden container restores its items in state when revealed', async () => {
+  const pageConfig = {
+    id: 'root',
+    type: 'Box',
+    events: {
+      onInit: [
+        {
+          id: 'initState',
+          type: 'SetState',
+          params: {
+            visible: true,
+            object: { list: [{ value: 'a' }, { value: 'b' }, { value: 'c' }] },
+          },
+        },
+      ],
+    },
+    blocks: [
+      {
+        type: 'Switch',
+        id: 'visible',
+      },
+      {
+        type: 'Box',
+        id: 'box',
+        visible: { _state: 'visible' },
+        blocks: [
+          {
+            type: 'List',
+            id: 'object.list',
+            blocks: [
+              {
+                type: 'Paragraph',
+                id: 'object.list.$.value',
+                properties: { content: { _state: 'object.list.$.value' } },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const context = await testContext({
+    lowdefy,
+    pageConfig,
+  });
+  const visible = context._internal.RootSlots.map['visible'];
+  const list = context._internal.RootSlots.map['object.list'];
+  const initialState = {
+    visible: true,
+    object: { list: [{ value: 'a' }, { value: 'b' }, { value: 'c' }] },
+  };
+
+  expect(context.state).toEqual(initialState);
+
+  visible.setValue(false);
+  expect(context.state).toEqual({ visible: false });
+  expect(list.subSlots.length).toEqual(3);
+
+  visible.setValue(true);
+  expect(context.state).toEqual(initialState);
+  expect(list.subSlots.length).toEqual(3);
+  expect(context._internal.RootSlots.map['object.list.2.value'].eval.properties).toEqual({
+    content: 'c',
+  });
+});
+
+test('list of display blocks restores its items in state when revealed by SetState', async () => {
+  const pageConfig = {
+    id: 'root',
+    type: 'Box',
+    events: {
+      onInit: [
+        {
+          id: 'initState',
+          type: 'SetState',
+          params: {
+            show: false,
+            list: [{ value: 'a' }, { value: 'b' }],
+          },
+        },
+      ],
+    },
+    blocks: [
+      {
+        type: 'Box',
+        id: 'box',
+        visible: { _state: 'show' },
+        blocks: [
+          {
+            type: 'List',
+            id: 'list',
+            blocks: [
+              {
+                type: 'Paragraph',
+                id: 'list.$.value',
+                properties: { content: { _state: 'list.$.value' } },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'Button',
+        id: 'reveal',
+        events: {
+          onClick: [{ id: 'a', type: 'SetState', params: { show: true } }],
+        },
+      },
+      {
+        type: 'Button',
+        id: 'hide',
+        events: {
+          onClick: [{ id: 'a', type: 'SetState', params: { show: false } }],
+        },
+      },
+    ],
+  };
+  const context = await testContext({
+    lowdefy,
+    pageConfig,
+  });
+  const { reveal, hide } = context._internal.RootSlots.map;
+
+  expect(context.state).toEqual({ show: false });
+
+  await reveal.triggerEvent({ name: 'onClick' });
+  expect(context.state).toEqual({ show: true, list: [{ value: 'a' }, { value: 'b' }] });
+
+  await hide.triggerEvent({ name: 'onClick' });
+  expect(context.state).toEqual({ show: false });
+
+  await reveal.triggerEvent({ name: 'onClick' });
+  expect(context.state).toEqual({ show: true, list: [{ value: 'a' }, { value: 'b' }] });
+});
+
+test('list items changed by SetState while hidden take precedence over the preserved items', async () => {
+  const pageConfig = {
+    id: 'root',
+    type: 'Box',
+    events: {
+      onInit: [
+        {
+          id: 'initState',
+          type: 'SetState',
+          params: {
+            show: true,
+            list: [{ value: 'a' }, { value: 'b' }, { value: 'c' }],
+          },
+        },
+      ],
+    },
+    blocks: [
+      {
+        type: 'Box',
+        id: 'box',
+        visible: { _state: 'show' },
+        blocks: [
+          {
+            type: 'List',
+            id: 'list',
+            blocks: [
+              {
+                type: 'Paragraph',
+                id: 'list.$.value',
+                properties: { content: { _state: 'list.$.value' } },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'Button',
+        id: 'hide',
+        events: {
+          onClick: [{ id: 'a', type: 'SetState', params: { show: false } }],
+        },
+      },
+      {
+        type: 'Button',
+        id: 'replace',
+        events: {
+          onClick: [{ id: 'a', type: 'SetState', params: { list: [{ value: 'x' }] } }],
+        },
+      },
+      {
+        type: 'Button',
+        id: 'reveal',
+        events: {
+          onClick: [{ id: 'a', type: 'SetState', params: { show: true } }],
+        },
+      },
+    ],
+  };
+  const context = await testContext({
+    lowdefy,
+    pageConfig,
+  });
+  const { hide, replace, reveal } = context._internal.RootSlots.map;
+
+  expect(context.state).toEqual({
+    show: true,
+    list: [{ value: 'a' }, { value: 'b' }, { value: 'c' }],
+  });
+
+  await hide.triggerEvent({ name: 'onClick' });
+  expect(context.state).toEqual({ show: false });
+
+  await replace.triggerEvent({ name: 'onClick' });
+  expect(context.state).toEqual({ show: false });
+
+  await reveal.triggerEvent({ name: 'onClick' });
+  expect(context.state).toEqual({ show: true, list: [{ value: 'x' }] });
+});
+
 test('toggle list object field visibility with index', async () => {
   const pageConfig = {
     id: 'root',


### PR DESCRIPTION
Fixes #1120

## Root cause

Hidden list's state array is deleted with no in-memory copy to restore from

## Changes

- Block now keeps an in-memory copy of a list's state value while the list is hidden (`captureHiddenValue` during `evaluate`) and republishes it when the list becomes visible again and the state field is absent (`restoreHiddenValue` at the start of `updateState`). Sub-block values are still republished on top of the restored array, and a `SetState` performed while hidden re-captures, so explicit changes keep precedence. Added three regression tests to `list.test.js` plus a changeset.