### PR TITLE
fix(api): Resolve tenant capability for non-scoping connection types

### DIFF
--- a/.changeset/fix-runtime-tenant-capability.md
+++ b/.changeset/fix-runtime-tenant-capability.md
@@ -1,0 +1,23 @@
+---
+'@lowdefy/build': patch
+'@lowdefy/api': patch
+---
+
+fix(api,build): Resolve tenant capability for non-scoping connection types.
+
+Under `auth.organizations.policy: tenant`, `resolveTenant` read the tenant
+capability from the runtime connection export, but the declarations live in
+build-side `types.js` connectionMetas — and only `MongoDBCollection` mirrored
+its capability onto the runtime export. Every other connection type (SMTP,
+SendGrid, AxiosHttp, the AI connections, and third-party plugin types) threw a
+ConfigError on first use under the tenant policy; the first real-world hit was
+every notification email send.
+
+The build now stamps the validated capability onto each connection artifact
+(`tenantCapability`), and `resolveTenant` serves from it when the runtime
+export carries no meta — one source of truth, so build-declared capability and
+runtime behavior can no longer diverge, and third-party types are covered
+without any package changes. The runtime meta still wins when present, a stamp
+of `true` without runtime enforcement refuses as version drift instead of
+serving unscoped, and a type declaring nothing anywhere keeps its fail-closed
+build and runtime errors.

--- a/packages/api/src/routes/request/resolveTenant.js
+++ b/packages/api/src/routes/request/resolveTenant.js
@@ -60,7 +60,16 @@ import { type } from '@lowdefy/helpers';
 //   jobs) and strategy callers have none, so they fail here by design - the
 //   wall never degrades to unscoped access.
 function resolveTenant(context, { connection, connectionConfig, requestConfig }) {
-  const capability = connection.meta?.tenant;
+  // Capability resolves from the runtime connection export first, then from
+  // the tenantCapability the build stamped onto the connection artifact
+  // (buildConnections) — the same types.js declaration the build check
+  // validated. The stamp is what lets non-scoping types (SMTP, SendGrid,
+  // AxiosHttp, AI connections, third-party plugins) serve under
+  // policy: tenant without every package mirroring meta.tenant onto its
+  // runtime export; the runtime meta still wins when present, so a drifted
+  // artifact can never downgrade a type that now enforces the contract.
+  const runtimeCapability = connection.meta?.tenant;
+  const capability = runtimeCapability ?? connectionConfig.tenantCapability;
   if (!type.isNone(connectionConfig.tenant) && capability !== true) {
     throw new ConfigError(
       `Connection type "${connectionConfig.type}" does not implement the tenant scoping contract, so "tenant" can not be declared at connection "${connectionConfig.connectionId}".`,
@@ -79,6 +88,19 @@ function resolveTenant(context, { connection, connectionConfig, requestConfig })
   if (capability !== true) {
     throw new ConfigError(
       `Connection type "${connectionConfig.type}" declares no tenant capability, so connection "${connectionConfig.connectionId}" can not be served under auth.organizations.policy: tenant. The type must declare meta tenant: true (implements the scoping contract) or tenant: false (non-scopable).`,
+      { configKey: connectionConfig['~k'] }
+    );
+  }
+  // The scoping contract is enforced by the connection package itself (the
+  // resolvers stamp writes and merge filters from the verdict), so a stamp of
+  // true is only serveable when the installed package carries the runtime
+  // meta. A build artifact claiming the contract for a runtime that does not
+  // implement it is version drift between build and server: the verdict would
+  // be computed and then silently ignored, which is exactly the unscoped
+  // access the wall exists to prevent - refuse instead.
+  if (runtimeCapability !== true) {
+    throw new ConfigError(
+      `Connection type "${connectionConfig.type}" does not implement the tenant scoping contract in the installed version, but the build artifact for connection "${connectionConfig.connectionId}" declares it. The build and the running server have drifted - rebuild the app with the installed version, or align the versions.`,
       { configKey: connectionConfig['~k'] }
     );
   }

--- a/packages/api/src/routes/request/resolveTenant.test.js
+++ b/packages/api/src/routes/request/resolveTenant.test.js
@@ -147,6 +147,70 @@ test('throws ConfigError under the tenant policy when meta tenant is not exactly
   ).toThrow(ConfigError);
 });
 
+// The build stamps the types.js capability onto the connection artifact
+// (buildConnections tenantCapability), so a runtime export carrying no meta
+// serves from the build-validated declaration - the SMTP/SendGrid/Axios/AI
+// case that used to throw on every request under the tenant policy.
+test('a build-stamped non-scopable capability serves a runtime export with no meta', () => {
+  const res = resolveTenant(contextWithOrg, {
+    connection: plainConnection,
+    connectionConfig: { ...defaultConnectionConfig, tenantCapability: false },
+    requestConfig: defaultRequestConfig,
+  });
+  expect(res).toBe(null);
+});
+
+test('a build-stamped non-scopable capability does not require a caller organization', () => {
+  const res = resolveTenant(
+    { ...tenantPolicy, user: null },
+    {
+      connection: plainConnection,
+      connectionConfig: { ...defaultConnectionConfig, tenantCapability: false },
+      requestConfig: defaultRequestConfig,
+    }
+  );
+  expect(res).toBe(null);
+});
+
+test('a build-stamped scoping capability without runtime enforcement refuses as drift', () => {
+  const call = () =>
+    resolveTenant(contextWithOrg, {
+      connection: plainConnection,
+      connectionConfig: { ...defaultConnectionConfig, tenantCapability: true },
+      requestConfig: defaultRequestConfig,
+    });
+  expect(call).toThrow(ConfigError);
+  expect(call).toThrow(
+    'Connection type "TestConnection" does not implement the tenant scoping contract in the installed version, but the build artifact for connection "testConnection" declares it.'
+  );
+});
+
+test('the runtime meta wins over a stale build stamp', () => {
+  // Runtime says non-scopable, stamp claims the contract: never scope on paper.
+  const res = resolveTenant(contextWithOrg, {
+    connection: nonScopableConnection,
+    connectionConfig: { ...defaultConnectionConfig, tenantCapability: true },
+    requestConfig: defaultRequestConfig,
+  });
+  expect(res).toBe(null);
+  // Runtime enforces the contract, stamp predates it: the runtime scopes.
+  const scoped = resolveTenant(contextWithOrg, {
+    connection: tenantConnection,
+    connectionConfig: { ...defaultConnectionConfig, tenantCapability: false },
+    requestConfig: defaultRequestConfig,
+  });
+  expect(scoped).toEqual({ field: 'organization_id', value: 'org-1' });
+});
+
+test('a build-stamped scoping capability with runtime enforcement resolves the verdict', () => {
+  const res = resolveTenant(contextWithOrg, {
+    connection: tenantConnection,
+    connectionConfig: { ...defaultConnectionConfig, tenantCapability: true },
+    requestConfig: defaultRequestConfig,
+  });
+  expect(res).toEqual({ field: 'organization_id', value: 'org-1' });
+});
+
 test('a type declaring no capability returns null under the pinned policy', () => {
   const res = resolveTenant(
     { organization: { policy: 'pinned' }, user: { id: 'id', organization_id: 'org-1' } },

--- a/packages/build/src/build/buildConnections.js
+++ b/packages/build/src/build/buildConnections.js
@@ -188,6 +188,22 @@ function buildConnections({ components, context }) {
     // Store connectionId for request validation and rename id
     connection.connectionId = connection.id;
     context.connectionIds.add(connection.connectionId);
+    // Stamp the build-validated tenant capability onto the connection
+    // artifact, so the runtime check in resolveTenant reads the SAME
+    // declaration validateTenant just validated (types.js connectionMetas)
+    // instead of requiring every connection package to mirror it onto its
+    // runtime export — which only MongoDBCollection did, so every other type
+    // (SMTP, SendGrid, AxiosHttp, the AI connections, third-party plugins)
+    // threw on first use under policy: tenant. Only the two valid booleans
+    // are stamped: an absent declaration stays absent, keeping the runtime
+    // fail-closed error for artifacts of types that declare nothing. A
+    // runtime meta.tenant still wins over the stamp (resolveTenant), and a
+    // stamp of true without runtime enforcement refuses rather than serves,
+    // so a drifted artifact can never silently unscope.
+    const tenantCapability = context.typesMap?.connectionMetas?.[connection.type]?.tenant;
+    if (tenantCapability === true || tenantCapability === false) {
+      connection.tenantCapability = tenantCapability;
+    }
     if (
       tenantPolicy &&
       context.typesMap?.connectionMetas?.[connection.type]?.tenant === true &&

--- a/packages/build/src/build/buildConnections.test.js
+++ b/packages/build/src/build/buildConnections.test.js
@@ -170,8 +170,33 @@ test('buildConnections tenant shared on an implementing connection type passes',
       connectionId: 'connection1',
       type: 'TestType',
       tenant: 'shared',
+      tenantCapability: true,
     },
   ]);
+});
+
+// The artifact stamp is what resolveTenant serves non-scoping types from at
+// runtime - types.js is build-side only, and only MongoDBCollection mirrors
+// its capability onto the runtime export.
+test('buildConnections stamps the build-validated tenant capability onto the artifact', () => {
+  const components = {
+    connections: [
+      { id: 'scoping', type: 'TestType' },
+      { id: 'nonScoping', type: 'PlainType' },
+      { id: 'undeclared', type: 'UnknownType' },
+    ],
+  };
+  const res = buildConnections({
+    components,
+    context: tenantContext({
+      connectionMetas: { TestType: { tenant: true }, PlainType: { tenant: false } },
+    }),
+  });
+  expect(res.connections[0].tenantCapability).toBe(true);
+  expect(res.connections[1].tenantCapability).toBe(false);
+  // An absent declaration stays absent so the runtime keeps its fail-closed
+  // error for undeclared types.
+  expect(res.connections[2]).not.toHaveProperty('tenantCapability');
 });
 
 test('buildConnections throws when tenant is true', () => {


### PR DESCRIPTION
## The failure

Under `auth.organizations.policy: tenant`, `resolveTenant` reads the tenant capability from the **runtime connection export** (`connection.meta?.tenant`), but the capability declarations live in build-side `types.js` `connectionMetas` — and only `MongoDBCollection` mirrors its declaration onto the runtime export. Every other stock connection type (SMTP, SendGrid, AxiosHttp, the AI connections) and every third-party plugin type therefore threw:

> Connection type "SMTP" declares no tenant capability, so connection "auth_email" can not be served under auth.organizations.policy: tenant.

…on **first use at runtime**, after the build's own capability check had already validated exactly that declaration and passed. First real-world hit: every notification email send in a tenant deployment.

## The seam

Single source of truth instead of hand-mirroring `meta.tenant` into every connection package:

- **`@lowdefy/build`**: `buildConnections` stamps the validated `types.js` capability onto each connection artifact as `tenantCapability` (booleans only; an absent declaration stays absent). The artifact is what `getConnectionConfig` serves at runtime, so the stamp reaches `resolveTenant` with no new plumbing — and covers third-party plugin types automatically.
- **`@lowdefy/api`**: `resolveTenant` resolves capability as `connection.meta?.tenant ?? connectionConfig.tenantCapability`.

Drift safety, both directions:
- The **runtime meta wins** when present, so a stale artifact can never downgrade a type that now enforces the contract.
- A stamp of `true` on a runtime export that does **not** implement the contract refuses with a version-drift ConfigError instead of computing a verdict the resolvers would silently ignore (scope-on-paper = unscoped access).
- A type declaring nothing anywhere keeps the existing fail-closed build error **and** runtime error — pre-fix artifacts behave exactly as before.

## Verification

- 6 new `resolveTenant` tests (the exact SMTP failure shape, org-less caller on a stamped non-scoping type, drift refusal, both stale-stamp directions, stamped scoping verdict) + 1 new `buildConnections` stamp test.
- Full suites green: `@lowdefy/build` 159 suites / 2217 tests, `@lowdefy/api` 109 suites / 1232 tests.

A downstream consumer currently carries a temporary pnpm patch working around this; this fix retires it (their next version pin picks it up with no further action — the stamp lands in their rebuild automatically).