### PR TITLE
fix(server-dev): Inject the resolved caller into the dev page shell

### DIFF
--- a/.changeset/fix-dev-server-resolved-caller.md
+++ b/.changeset/fix-dev-server-resolved-caller.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/server-dev': patch
+---
+
+Inject the resolved caller into the dev page shell so client-side `_user` carries roles and organization_id under `lowdefy dev`, matching the production server. Without it, any page logic branching on `_user` misroutes in dev — under `auth.organizations.policy: tenant` a signed-in user bounced in an infinite dashboard → router → gate loop.

--- a/packages/servers/server-dev/client/App.jsx
+++ b/packages/servers/server-dev/client/App.jsx
@@ -40,7 +40,7 @@ function ThemeTokenResolver({ lowdefyRef, children }) {
   return children;
 }
 
-function App({ router }) {
+function App({ config, router }) {
   const lowdefyRef = useRef({});
   const [runtimeErrors, setRuntimeErrors] = useState([]);
   // Subscribe to rootConfig SWR cache — deduplicates with Routing's fetch.
@@ -143,7 +143,7 @@ function App({ router }) {
                   />
                 }
               >
-                <Auth>
+                <Auth user={config?.user}>
                   {(auth) => {
                     return <Routing auth={auth} lowdefy={lowdefyRef.current} router={router} />;
                   }}

--- a/packages/servers/server-dev/src/app.js
+++ b/packages/servers/server-dev/src/app.js
@@ -183,6 +183,10 @@ function createApp() {
 
   // Every page path renders the same shell — the client fetches config and
   // handles home/404 routing, exactly like the old dev pages router did.
+  // The context middleware runs here too (mirroring the production server)
+  // so the shell can inject the resolved caller — without it the client's
+  // _user never carries roles/organization_id under `lowdefy dev`.
+  app.use('/*', apiContext());
   app.get('/', (c) => renderDevPage(c, { basePath }));
   app.get('/:rest{.+}', (c) => renderDevPage(c, { basePath }));
 

--- a/packages/servers/server-dev/src/html/renderDevPage.js
+++ b/packages/servers/server-dev/src/html/renderDevPage.js
@@ -37,6 +37,9 @@ function readBuildJson(name) {
 }
 
 function renderDevPage(c, { basePath = '' }) {
+  // The resolved caller, injected like the production server's template.js —
+  // the client's Auth provider seeds _user from it (roles, organization_id).
+  const user = c.get('lowdefyContext')?.user ?? null;
   const themeConfig = readBuildJson('theme');
   const appJson = readBuildJson('app');
 
@@ -74,7 +77,7 @@ window.__vite_plugin_react_preamble_installed__ = true;
   </head>
   <body>
     <div id="root"></div>
-    <script id="__LOWDEFY_CONFIG__" type="application/json">${safeScriptJson({ basePath })}</script>
+    <script id="__LOWDEFY_CONFIG__" type="application/json">${safeScriptJson({ basePath, user })}</script>
     ${appJson.html?.appendBody ?? ''}
     <script type="module" src="${basePath}/client/main.jsx"></script>
   </body>


### PR DESCRIPTION
Under `lowdefy dev`, client-side `_user` never carried `roles`/`organization_id`: the dev shell injected only `{ basePath }` into `__LOWDEFY_CONFIG__` and rendered `<Auth>` with no `user`, so the Auth provider fell back to the raw better-auth session shape forever (`/api/user` is only fetched on session *change*, never on cold load).

Consequence under `auth.organizations.policy: tenant`: any page whose onMount branches on `_user: organization_id` misroutes — reproduced in a real Chromium session as an infinite `dashboard → router → get-started` navigation loop (~3 hops/second), while every server-side request for the same session resolved the caller correctly. The production server is unaffected (`server/src/app.js:140` runs `apiContext()` on page routes and `template.js` injects `user`).

Fix mirrors production in three places:
- `src/app.js`: `app.use('/*', apiContext())` before the page routes.
- `src/html/renderDevPage.js`: inject `{ basePath, user }` (resolved caller from the request context, `null` when anonymous).
- `client/App.jsx`: accept `config` and render `<Auth user={config?.user}>`.

Verified: `@lowdefy/server-dev` suite 33/33 suites, 245/245 tests; the reproducing browser loop confirmed fixed downstream against a patched install (real magic-link session lands on the dashboard and stays there).