### PR TITLE
fix(api): guard missing auth config

### DIFF
--- a/packages/api/src/context/createAuthorize.js
+++ b/packages/api/src/context/createAuthorize.js
@@ -30,15 +30,15 @@ function createAuthorize({ session }) {
 
   function authorize(config) {
     const { auth } = config;
-    if (auth.public === true) return true;
-    if (auth.public === false) {
+    if (auth?.public === true) return true;
+    if (auth?.public === false) {
       if (auth.roles) {
         return authenticated && auth.roles.some((role) => roles.includes(role));
       }
       return authenticated;
     }
     throw new ConfigError('auth.public must be true or false.', {
-      received: auth.public,
+      received: auth?.public,
       configKey: config['~k'],
     });
   }

--- a/packages/api/src/context/createAuthorize.test.js
+++ b/packages/api/src/context/createAuthorize.test.js
@@ -68,6 +68,12 @@ test('throws ConfigError with helpful message when auth.public is undefined', ()
   expect(() => authorize({ auth: {} })).toThrow('auth.public must be true or false.');
 });
 
+test('throws ConfigError when auth is missing or null', () => {
+  const authorize = createAuthorize({});
+  expect(() => authorize({})).toThrow('auth.public must be true or false.');
+  expect(() => authorize({ auth: null })).toThrow('auth.public must be true or false.');
+});
+
 test('throws ConfigError with received value when auth.public is wrong type', () => {
   const authorize = createAuthorize({});
   try {


### PR DESCRIPTION
Closes #2203

## Background

The API authorization helper accessed auth.public directly. Missing or null config.auth raised an unhandled TypeError instead of the intended descriptive ConfigError.

## Changes

- Guard auth.public accesses with optional chaining.
- Preserve the existing ConfigError message and config-key context.
- Add regression coverage for missing and null auth configuration.

## Compatibility

Valid auth.public values and role-based authorization behavior are unchanged.

## Verification

- `git diff --check` — passed.
- Docker: `node:24-alpine` with `pnpm install --frozen-lockfile --filter @lowdefy/api...`.
- `pnpm --filter @lowdefy/errors build` — passed.
- Focused Jest test — passed: 1 suite, 10 tests.

Command:

`node --experimental-vm-modules node_modules/jest/bin/jest.js --runTestsByPath src/context/createAuthorize.test.js`

No broader test suite was run because this change is isolated to the authorization context helper.