### PR TITLE
deps: bump jsonata to 1.8.9 in operators-jsonata (4 security advisories)

### DIFF
--- a/packages/plugins/operators/operators-jsonata/package.json
+++ b/packages/plugins/operators/operators-jsonata/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@lowdefy/helpers": "5.5.1",
     "@lowdefy/operators": "5.5.1",
-    "jsonata": "1.8.7"
+    "jsonata": "1.8.9"
   },
   "devDependencies": {
     "@jest/globals": "28.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1751,8 +1751,8 @@ importers:
         specifier: 5.5.1
         version: link:../../../operators
       jsonata:
-        specifier: 1.8.7
-        version: 1.8.7
+        specifier: 1.8.9
+        version: 1.8.9
     devDependencies:
       '@jest/globals':
         specifier: 28.1.3
@@ -7674,6 +7674,7 @@ packages:
 
   crypto-js@4.1.1:
     resolution: {integrity: sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   css-select@5.1.0:
     resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
@@ -7956,6 +7957,7 @@ packages:
 
   deep-diff@1.0.2:
     resolution: {integrity: sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   deep-equal@1.1.1:
     resolution: {integrity: sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==}
@@ -8952,6 +8954,7 @@ packages:
   glob@10.3.12:
     resolution: {integrity: sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@13.0.6:
@@ -8960,7 +8963,7 @@ packages:
 
   glob@7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -9926,8 +9929,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  jsonata@1.8.7:
-    resolution: {integrity: sha512-tOW2/hZ+nR2bcQZs+0T62LVe5CHaNa3laFFWb/262r39utN6whJGBF7IR2Wq1QXrDbhftolk5gggW8uUJYlBTQ==}
+  jsonata@1.8.9:
+    resolution: {integrity: sha512-Vk6QF2zjeprCS6FXCK/3yTaTbB3wxh6C4Adp4Gt4FJ3e53kGKRLwfTLDWVWfwAHEsVYegsQRgBDUl8TdFSt7Qg==}
     engines: {node: '>= 8'}
 
   jsonc-parser@3.2.0:
@@ -12812,6 +12815,7 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -22141,7 +22145,7 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsonata@1.8.7: {}
+  jsonata@1.8.9: {}
 
   jsonc-parser@3.2.0: {}
 


### PR DESCRIPTION
Updates `jsonata` from 1.8.7 to 1.8.9 in `packages/plugins/operators/operators-jsonata` to clear four security advisories.

Evidence:
- `packages/plugins/operators/operators-jsonata/package.json` pinned `jsonata@1.8.7`
- `osv-scanner` reported GHSA-66mm-25pp-rfff, GHSA-2943-5xfg-gq5f, GHSA-8gq3-vp5j-2grp, GHSA-86vw-mfpg-wwv9 against jsonata 1.8.7 before the update
- updated version: `1.8.9`

Validation:
- `osv-scanner --lockfile=pnpm-lock.yaml` no longer reports any of the four jsonata advisories after the update
- `pnpm --filter @lowdefy/operators-jsonata test` passes: 18 tests, 1 snapshot (run after building @lowdefy/helpers, @lowdefy/operators, @lowdefy/errors)

Scope: dependency/lockfile update only (operators-jsonata/package.json, pnpm-lock.yaml).
