### PR TITLE
Report AgentChat link clicks and hold thumbs state

### DIFF
--- a/.changeset/feat-agentchat-feedback-value.md
+++ b/.changeset/feat-agentchat-feedback-value.md
@@ -8,4 +8,6 @@ The feedback control was write-only: it reported a rating and immediately forgot
 
 `Actions.Feedback` is now given a `value`, held per message id for the life of the chat. Being controlled, it takes on that component's selected behaviour: the chosen thumb stays highlighted and the opposite one is hidden, and clicking the selected thumb again clears the rating and brings both back. A rating can therefore be changed, but not submitted twice by accident.
 
+Note for apps already handling `onFeedback`: clearing a rating fires it with `rating: 'default'`. That value was unreachable before, because the control was never given one — so a handler that treats anything other than `like` as a dislike will now record a rejection for a rating the user has just withdrawn. Branch on the three values explicitly.
+
 Ratings are not persisted by the block — a reload or a conversation switch starts clean. Persisting them belongs to whatever stores the conversation.

--- a/.changeset/feat-agentchat-feedback-value.md
+++ b/.changeset/feat-agentchat-feedback-value.md
@@ -1,0 +1,11 @@
+---
+'@lowdefy/blocks-antd-x': minor
+---
+
+feat: AgentChat keeps a message's thumbs rating selected
+
+The feedback control was write-only: it reported a rating and immediately forgot it, so the thumb un-highlighted on the next render and a rated message looked unrated. On a streaming chat that is the very next chunk.
+
+`Actions.Feedback` is now given a `value`, held per message id for the life of the chat. Being controlled, it takes on that component's selected behaviour: the chosen thumb stays highlighted and the opposite one is hidden, and clicking the selected thumb again clears the rating and brings both back. A rating can therefore be changed, but not submitted twice by accident.
+
+Ratings are not persisted by the block — a reload or a conversation switch starts clean. Persisting them belongs to whatever stores the conversation.

--- a/.changeset/feat-agentchat-link-click.md
+++ b/.changeset/feat-agentchat-link-click.md
@@ -1,0 +1,11 @@
+---
+'@lowdefy/blocks-antd-x': minor
+---
+
+feat: AgentChat reports link clicks and routes in-app links client-side
+
+Links in an agent's answer were rendered as plain anchors, so following a citation was a full browser navigation: the conversation was left behind, and an app had no way to do anything else with the click.
+
+Markdown links now render through the app's `Link` component when the href is an in-app path, making them client-side routes rather than reloads. Links with a scheme open in a new tab, so the conversation stays on screen.
+
+A new `onLinkClick` event reports the click with `href` and `text`. Wiring it suppresses the default navigation for plain left clicks, so an app can show the target in place — a guide in a modal, a record in a drawer — instead of navigating. Apps that do not wire it are unaffected. Modified and non-primary clicks (new tab, middle click) are never intercepted.

--- a/packages/docs/agents/AgentChat.yaml
+++ b/packages/docs/agents/AgentChat.yaml
@@ -330,6 +330,7 @@ _ref:
             | `onSwitchChange` | User toggles a sender switch. | `key`, `checked` |
             | `onTitleGenerated` | A `data-chat-title` data part arrives — emitted automatically when the agent's [`generateTitle`](/agent-properties) property is set, or manually from an `onFinish` hook. | `title` |
             | `onDataPart` | Any data part arrives from the server. | `type`, `data`, `id` |
+            | `onLinkClick` | User clicks a link in a message. Wiring this event suppresses the default navigation for plain left clicks, so the app can open the target in place; modified clicks (new tab, middle click) always navigate. | `href`, `text` |
 
             ###### Validate messages before sending:
             ```yaml

--- a/packages/docs/agents/AgentChat.yaml
+++ b/packages/docs/agents/AgentChat.yaml
@@ -322,7 +322,7 @@ _ref:
             | `onToolResult` | A tool returns a result. | `toolName`, `toolCallId`, `output`, `error` |
             | `onError` | A streaming error occurs. | `message` |
             | `onStop` | User stops generation. | `messages` |
-            | `onFeedback` | User clicks thumbs up/down. | `messageId`, `messageContent`, `rating` |
+            | `onFeedback` | User clicks thumbs up/down. `rating` is `like` or `dislike`, or `default` when the user clicks the selected thumb again to clear the rating — branch on it explicitly rather than treating anything that is not `like` as a dislike. | `messageId`, `messageContent`, `rating` |
             | `onRegenerate` | User clicks regenerate. | `messageId`, `messages` |
             | `onDeleteMessage` | User deletes a message. | `messageId`, `content`, `messages` |
             | `onEditMessage` | User edits and resubmits. | `messageId`, `originalContent`, `newContent`, `messages` |

--- a/packages/plugins/blocks/blocks-antd-x/e2e/app/lowdefy.yaml
+++ b/packages/plugins/blocks/blocks-antd-x/e2e/app/lowdefy.yaml
@@ -1,0 +1,36 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+lowdefy: local
+name: blocks-antd-x E2E Tests
+
+connections:
+  - id: anthropic
+    type: Anthropic
+    properties:
+      apiKey: not-a-real-key
+
+# The chat is driven entirely from the messages property, so the agent is never called
+# and no request ever leaves the machine.
+agents:
+  - id: test_agent
+    type: ClaudeAgent
+    connectionId: anthropic
+    properties:
+      model: claude-haiku-4-5
+      instructions: Never invoked by these tests.
+
+pages:
+  - _ref: ../../src/blocks/AgentChat/tests/AgentChat.e2e.yaml
+  - _ref: ../../src/blocks/AgentChat/tests/AgentChatTarget.e2e.yaml

--- a/packages/plugins/blocks/blocks-antd-x/e2e/playwright.config.js
+++ b/packages/plugins/blocks/blocks-antd-x/e2e/playwright.config.js
@@ -1,0 +1,26 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createPlaywrightConfig } from '@lowdefy/block-dev-e2e';
+
+const packageDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+export default createPlaywrightConfig({
+  packageDir,
+  port: 3013,
+});

--- a/packages/plugins/blocks/blocks-antd-x/package.json
+++ b/packages/plugins/blocks/blocks-antd-x/package.json
@@ -40,6 +40,8 @@
     "build": "swc src --out-dir dist --config-file ../../../../.swcrc --cli-config-file ../../../../.swc-cli.json && pnpm copyfiles",
     "clean": "rm -rf dist",
     "copyfiles": "copyfiles -u 1 \"./src/**/*\" dist -e \"./src/**/*.js\" -e \"./src/**/*.yaml\" -e \"./src/**/*.snap\"",
+    "e2e": "playwright test --config e2e/playwright.config.js",
+    "e2e:ui": "playwright test --config e2e/playwright.config.js --ui",
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
@@ -52,6 +54,9 @@
     "ai": "6.0.176"
   },
   "devDependencies": {
+    "@lowdefy/block-dev-e2e": "5.4.0",
+    "@lowdefy/e2e-utils": "5.4.0",
+    "@playwright/test": "1.50.1",
     "@swc/cli": "0.8.0",
     "@swc/core": "1.15.18",
     "copyfiles": "2.4.1"

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-import React, { useRef, useMemo, useEffect, useState } from 'react';
+import React, { useRef, useMemo, useEffect, useState, useCallback } from 'react';
 import { useChat } from '@ai-sdk/react';
 import {
   lastAssistantMessageIsCompleteWithApprovalResponses,
@@ -34,7 +34,7 @@ import MessageList from './MessageList.js';
 import useAgentEvents, { collectExternalEventIds } from './useAgentEvents.js';
 import WelcomeScreen from './WelcomeScreen.js';
 
-function AgentChat({ blockId, components: { Icon }, methods, pageId, properties }) {
+function AgentChat({ blockId, components: { Icon, Link }, events, methods, pageId, properties }) {
   const {
     agentId,
     urlQuery,
@@ -415,7 +415,47 @@ function AgentChat({ blockId, components: { Icon }, methods, pageId, properties 
 
   const activeSuggestions = agentSuggestions ?? suggestions;
 
+  // A link in an answer was a plain anchor: a full browser navigation out of the
+  // conversation, with no way for an app to do anything else with it. Default is only
+  // prevented when the app actually handles onLinkClick — otherwise the link keeps
+  // navigating, so wiring nothing changes nothing.
+  //
+  // Modified and non-primary clicks are never intercepted: open-in-new-tab is a
+  // reasonable thing to do with a citation, and preventing it would be a regression.
+  const interceptLinks = Boolean(events?.onLinkClick);
+
+  // Stable identity: MessageBubble memoises its markdown component map on this, and the map
+  // is rebuilt on every streaming chunk otherwise — remounting every link in the answer as
+  // it streams.
+  const handleLinkClick = useCallback(
+    ({ href, text, domEvent }) => {
+      if (
+        !interceptLinks ||
+        domEvent.defaultPrevented ||
+        domEvent.button !== 0 ||
+        domEvent.metaKey ||
+        domEvent.ctrlKey ||
+        domEvent.shiftKey ||
+        domEvent.altKey
+      ) {
+        return;
+      }
+      // Prevented synchronously: Link checks defaultPrevented immediately after calling
+      // this, and an external anchor's default fires before any async work could run.
+      domEvent.preventDefault();
+      methods.triggerEvent({ name: 'onLinkClick', event: { href, text } });
+    },
+    [interceptLinks, methods]
+  );
+
+  // The control is otherwise write-only: it reports a rating and immediately forgets it,
+  // so the thumb un-highlights on the next render and the message looks unrated. Held per
+  // message for the life of the chat instance — a rating is not persisted by the block, so
+  // it does not survive a reload or a conversation switch.
+  const [feedbackValues, setFeedbackValues] = useState({});
+
   function handleFeedback({ messageId, rating }) {
+    setFeedbackValues((prev) => ({ ...prev, [messageId]: rating }));
     const message = messages.find((msg) => msg.id === messageId);
     const messageContent =
       message?.parts
@@ -485,6 +525,9 @@ function AgentChat({ blockId, components: { Icon }, methods, pageId, properties 
             config={messageDisplay}
             addToolApprovalResponse={addToolApprovalResponse}
             onFeedback={handleFeedback}
+            onLinkClick={handleLinkClick}
+            Link={Link}
+            feedbackValues={feedbackValues}
             onRegenerate={handleRegenerate}
             onDelete={handleDelete}
             onEditMessage={handleEditMessage}

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js
@@ -115,6 +115,16 @@ function resolveToolResultMode(toolResultDisplay, toolName) {
   return 'summary';
 }
 
+// Plain link text arrives as a string, but any inline formatting makes it an element tree —
+// so it is flattened rather than reported as absent.
+function linkText(children) {
+  if (typeof children === 'string') return children;
+  if (typeof children === 'number') return String(children);
+  if (Array.isArray(children)) return children.map(linkText).join('');
+  if (React.isValidElement(children)) return linkText(children.props?.children);
+  return '';
+}
+
 // An in-app path renders through the app's Link, so following a citation is a client-side
 // route rather than a reload that drops the conversation. Anything with a scheme opens in a
 // new tab for the same reason. Both still report the click, so an app that handles
@@ -122,7 +132,7 @@ function resolveToolResultMode(toolResultDisplay, toolName) {
 function MarkdownLink({ Link, onLinkClick }) {
   return function MarkdownAnchor({ href, children, ...props }) {
     if (!href) return <span {...props}>{children}</span>;
-    const text = typeof children === 'string' ? children : undefined;
+    const text = linkText(children);
     const handleClick = (domEvent) => onLinkClick?.({ href, text, domEvent });
     const external = /^[a-z][a-z0-9+.-]*:/i.test(href) || href.startsWith('//');
     // A fragment cannot be expressed as a pageId link, so it keeps the anchor.

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageBubble.js
@@ -115,6 +115,48 @@ function resolveToolResultMode(toolResultDisplay, toolName) {
   return 'summary';
 }
 
+// An in-app path renders through the app's Link, so following a citation is a client-side
+// route rather than a reload that drops the conversation. Anything with a scheme opens in a
+// new tab for the same reason. Both still report the click, so an app that handles
+// onLinkClick can show the target in place instead.
+function MarkdownLink({ Link, onLinkClick }) {
+  return function MarkdownAnchor({ href, children, ...props }) {
+    if (!href) return <span {...props}>{children}</span>;
+    const text = typeof children === 'string' ? children : undefined;
+    const handleClick = (domEvent) => onLinkClick?.({ href, text, domEvent });
+    const external = /^[a-z][a-z0-9+.-]*:/i.test(href) || href.startsWith('//');
+    // A fragment cannot be expressed as a pageId link, so it keeps the anchor.
+    const inApp = !external && href.startsWith('/') && !href.includes('#');
+    if (!inApp || !Link) {
+      return (
+        <a
+          {...props}
+          href={href}
+          target={external ? '_blank' : undefined}
+          rel={external ? 'noopener noreferrer' : undefined}
+          onClick={handleClick}
+        >
+          {children}
+        </a>
+      );
+    }
+    // `pageId`, not `href`: Link renders a plain anchor for href and url — its new-origin form —
+    // and only routes client-side for a pageId. Passing the path as href therefore went through
+    // Link and still reloaded the page, dropping the conversation this exists to preserve.
+    const [pathname, search = ''] = href.slice(1).split('?');
+    return (
+      <Link
+        {...props}
+        pageId={pathname}
+        urlQuery={Object.fromEntries(new URLSearchParams(search))}
+        onClick={handleClick}
+      >
+        {children}
+      </Link>
+    );
+  };
+}
+
 function normalizeActions(actions) {
   if (Array.isArray(actions)) {
     const obj = {};
@@ -131,6 +173,7 @@ function BubbleActions({
   textContent,
   messageId,
   onFeedback,
+  feedbackValue,
   onRegenerate,
   onDelete,
   translate,
@@ -150,7 +193,10 @@ function BubbleActions({
       key: 'feedback',
       label: translate('agent.message.feedback'),
       actionRender: () => (
-        <Actions.Feedback onChange={(rating) => onFeedback?.({ messageId, rating })} />
+        <Actions.Feedback
+          value={feedbackValue ?? 'default'}
+          onChange={(rating) => onFeedback?.({ messageId, rating })}
+        />
       ),
     });
   }
@@ -203,6 +249,9 @@ function MessageBubble({
   actions,
   messageId,
   onFeedback,
+  feedbackValue,
+  onLinkClick,
+  Link,
   onRegenerate,
   onDelete,
   translate,
@@ -217,9 +266,12 @@ function MessageBubble({
   const markdownConfig = renderLatex ? getLatexConfig() : undefined;
 
   const markdownComponents = useMemo(() => {
-    if (!renderMermaid && !codeHighlighter) return { code: PlainCodeBlock };
-    return { code: RichCodeBlock({ renderMermaid, codeHighlighter }) };
-  }, [renderMermaid, codeHighlighter]);
+    const code =
+      !renderMermaid && !codeHighlighter
+        ? PlainCodeBlock
+        : RichCodeBlock({ renderMermaid, codeHighlighter });
+    return { code, a: MarkdownLink({ Link, onLinkClick }) };
+  }, [renderMermaid, codeHighlighter, Link, onLinkClick]);
 
   const normalizedActions = normalizeActions(actions);
   const showActions = Object.values(normalizedActions).some(Boolean) && !isStreaming;
@@ -246,6 +298,7 @@ function MessageBubble({
             textContent={content}
             messageId={messageId}
             onFeedback={onFeedback}
+            feedbackValue={feedbackValue}
             onRegenerate={onRegenerate}
             onDelete={onDelete}
             translate={translate}
@@ -501,6 +554,7 @@ function MessageBubble({
           textContent={allTextContent}
           messageId={messageId}
           onFeedback={onFeedback}
+          feedbackValue={feedbackValue}
           onRegenerate={onRegenerate}
           onDelete={onDelete}
           translate={translate}

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageList.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/MessageList.js
@@ -59,6 +59,9 @@ const MessageList = React.forwardRef(function MessageList(
     config,
     addToolApprovalResponse,
     onFeedback,
+    onLinkClick,
+    Link,
+    feedbackValues,
     onRegenerate,
     onDelete,
     onEditMessage,
@@ -213,6 +216,9 @@ const MessageList = React.forwardRef(function MessageList(
                 actions={config?.actions}
                 messageId={info.key}
                 onFeedback={onFeedback}
+                onLinkClick={onLinkClick}
+                Link={Link}
+                feedbackValue={feedbackValues?.[info.key]}
                 onRegenerate={onRegenerate}
                 onDelete={onDelete}
                 translate={translate}

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/meta.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/meta.js
@@ -37,6 +37,8 @@ export default {
     onSwitchChange: 'Trigger when the user toggles a sender switch.',
     onDataPart:
       'Trigger when the agent sends a custom data part. Event contains type, data, and id.',
+    onLinkClick:
+      'Trigger when the user clicks a link in a message. Event contains href and text. Wiring this event suppresses the default navigation for plain left clicks, so the app can open the target in place; modified clicks (new tab, middle click) always navigate.',
   },
   methods: {
     regenerate:

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/meta.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/meta.js
@@ -26,7 +26,8 @@ export default {
     onConversationStart:
       'Trigger once when a conversation starts, on its first user message. Event contains the conversationId (auto-minted when no conversationId property is set).',
     onError: 'Trigger on stream error.',
-    onFeedback: 'Trigger when the user clicks thumbs up or down on a message.',
+    onFeedback:
+      'Trigger when the user clicks thumbs up or down on a message. Event contains messageId, messageContent and rating, where rating is `like`, `dislike`, or `default` when the user clicks the selected thumb again to clear the rating.',
     onRegenerate: 'Trigger when the user clicks regenerate on a message.',
     onDeleteMessage: 'Trigger when the user deletes a message.',
     onEditMessage: 'Trigger when the user edits and resubmits a message.',

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/tests/AgentChat.e2e.spec.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/tests/AgentChat.e2e.spec.js
@@ -1,0 +1,116 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { test, expect } from '@playwright/test';
+import { getBlock, navigateToTestPage } from '@lowdefy/block-dev-e2e';
+
+const inAppLink = (page, blockId) =>
+  getBlock(page, blockId).locator('a[href="/agent-chat-target"]').first();
+const externalLink = (page, blockId) =>
+  getBlock(page, blockId).locator('a[href="https://example.com"]').first();
+
+test.describe('AgentChat links', () => {
+  test.beforeEach(async ({ page }) => {
+    await navigateToTestPage(page, 'agent-chat');
+  });
+
+  test('renders markdown links from an assistant message', async ({ page }) => {
+    await expect(inAppLink(page, 'chat_wired')).toBeVisible();
+    await expect(externalLink(page, 'chat_wired')).toBeVisible();
+  });
+
+  test('opens an external link in a new tab', async ({ page }) => {
+    const link = externalLink(page, 'chat_wired');
+    await expect(link).toHaveAttribute('target', '_blank');
+    await expect(link).toHaveAttribute('rel', /noopener/);
+  });
+
+  test('onLinkClick suppresses navigation and reports the href', async ({ page }) => {
+    await page.evaluate(() => {
+      window.__notReloaded = true;
+    });
+    await inAppLink(page, 'chat_wired').click();
+
+    await expect(page.locator('#readout_href')).toHaveText('/agent-chat-target');
+    await expect(page.locator('#readout_text')).toHaveText('in-app link');
+    await expect(page.locator('#readout_count')).toHaveText('1');
+    expect(new URL(page.url()).pathname).toBe('/agent-chat');
+    // A reload would clear the marker, so this also proves no navigation happened.
+    expect(await page.evaluate(() => window.__notReloaded)).toBe(true);
+  });
+
+  test('onLinkClick suppresses an external link too', async ({ page }) => {
+    const pagesBefore = page.context().pages().length;
+    await externalLink(page, 'chat_wired').click();
+
+    await expect(page.locator('#readout_href')).toHaveText('https://example.com');
+    expect(page.context().pages().length).toBe(pagesBefore);
+  });
+
+  test('a modified click is never intercepted', async ({ page, context }) => {
+    const popupPromise = context.waitForEvent('page', { timeout: 10000 });
+    // Ctrl/Meta+click is the browser's open-in-new-tab gesture; the block must leave it be.
+    await inAppLink(page, 'chat_wired').click({
+      modifiers: [process.platform === 'darwin' ? 'Meta' : 'Control'],
+    });
+    const popup = await popupPromise;
+    // A popup is about:blank until it navigates, and domcontentloaded fires on that blank
+    // document — so the URL, not the load state, is what has to be waited for.
+    await popup.waitForURL(/agent-chat-target/);
+    expect(new URL(popup.url()).pathname).toBe('/agent-chat-target');
+    // The event does not fire for a click the block did not handle.
+    await expect(page.locator('#readout_count')).toHaveText('0');
+    await popup.close();
+  });
+
+  test('an in-app link routes client-side when onLinkClick is not wired', async ({ page }) => {
+    await page.evaluate(() => {
+      window.__notReloaded = true;
+    });
+    await inAppLink(page, 'chat_unwired').click();
+
+    await expect(page.locator('#target_marker')).toBeVisible();
+    expect(new URL(page.url()).pathname).toBe('/agent-chat-target');
+    // Still set, so the router navigated rather than the browser reloading.
+    expect(await page.evaluate(() => window.__notReloaded)).toBe(true);
+  });
+});
+
+test.describe('AgentChat feedback', () => {
+  test.beforeEach(async ({ page }) => {
+    await navigateToTestPage(page, 'agent-chat');
+  });
+
+  test('keeps a rating selected after it is given', async ({ page }) => {
+    const feedback = getBlock(page, 'chat_wired').locator('[class*="feedback"]').first();
+    await expect(feedback).toBeVisible();
+    const before = await feedback.innerHTML();
+
+    await feedback.locator('[class*="like"]').first().click();
+
+    // Controlled: the chosen thumb stays and the opposite one is hidden. Uncontrolled, the
+    // markup returned to its unrated state on the next render.
+    await expect
+      .poll(async () => (await feedback.innerHTML()) !== before, { timeout: 5000 })
+      .toBe(true);
+    const after = await feedback.innerHTML();
+
+    // Survives a re-render driven by unrelated state.
+    await inAppLink(page, 'chat_wired').click();
+    await expect(page.locator('#readout_count')).toHaveText('1');
+    expect(await feedback.innerHTML()).toBe(after);
+  });
+});

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/tests/AgentChat.e2e.spec.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/tests/AgentChat.e2e.spec.js
@@ -21,6 +21,8 @@ const inAppLink = (page, blockId) =>
   getBlock(page, blockId).locator('a[href="/agent-chat-target"]').first();
 const externalLink = (page, blockId) =>
   getBlock(page, blockId).locator('a[href="https://example.com"]').first();
+const formattedLink = (page, blockId) =>
+  getBlock(page, blockId).locator('a[href="/agent-chat-target?tab=two"]').first();
 
 test.describe('AgentChat links', () => {
   test.beforeEach(async ({ page }) => {
@@ -76,6 +78,17 @@ test.describe('AgentChat links', () => {
     await popup.close();
   });
 
+  // Link text is only a plain string when the label carries no formatting, and an in-app href
+  // with a query has to survive the split into pageId and urlQuery.
+  test('reports the flattened text of a formatted link, and keeps its query', async ({ page }) => {
+    const link = formattedLink(page, 'chat_wired');
+    await expect(link).toBeVisible();
+    await link.click();
+
+    await expect(page.locator('#readout_href')).toHaveText('/agent-chat-target?tab=two');
+    await expect(page.locator('#readout_text')).toHaveText('bold link');
+  });
+
   test('an in-app link routes client-side when onLinkClick is not wired', async ({ page }) => {
     await page.evaluate(() => {
       window.__notReloaded = true;
@@ -112,5 +125,19 @@ test.describe('AgentChat feedback', () => {
     await inAppLink(page, 'chat_wired').click();
     await expect(page.locator('#readout_count')).toHaveText('1');
     expect(await feedback.innerHTML()).toBe(after);
+  });
+
+  // Being controlled makes the clear gesture reachable for the first time, and it reports a
+  // third rating value. An app that treats anything other than `like` as a dislike would file
+  // a rejection for a rating the user just withdrew.
+  test('clicking the selected thumb again clears the rating and reports it', async ({ page }) => {
+    const feedback = getBlock(page, 'chat_wired').locator('[class*="feedback"]').first();
+    await feedback.locator('[class*="like"]').first().click();
+    await expect(page.locator('#readout_rating')).toHaveText('like');
+
+    await feedback.locator('[class*="like"]').first().click();
+    await expect(page.locator('#readout_rating')).toHaveText('default');
+    // Both thumbs are back, which is what unrated looks like.
+    await expect(feedback.locator('[class*="dislike"]').first()).toBeVisible();
   });
 });

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/tests/AgentChat.e2e.yaml
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/tests/AgentChat.e2e.yaml
@@ -34,7 +34,14 @@ blocks:
             - type: text
               text: |
                 [in-app link](/agent-chat-target) and [external link](https://example.com)
+                and [**bold** link](/agent-chat-target?tab=two)
     events:
+      onFeedback:
+        - id: record_rating
+          type: SetState
+          params:
+            last_rating:
+              _event: rating
       onLinkClick:
         - id: record_link_click
           type: SetState
@@ -59,6 +66,7 @@ blocks:
             <span id="readout_href">{{ href }}</span>
             <span id="readout_text">{{ text }}</span>
             <span id="readout_count">{{ count or 0 }}</span>
+            <span id="readout_rating">{{ rating }}</span>
           on:
             href:
               _state: last_href
@@ -66,6 +74,8 @@ blocks:
               _state: last_text
             count:
               _state: click_count
+            rating:
+              _state: last_rating
 
   - id: chat_unwired
     type: AgentChat

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/tests/AgentChat.e2e.yaml
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/tests/AgentChat.e2e.yaml
@@ -1,0 +1,81 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: agent-chat
+type: PageHeaderMenu
+properties:
+  title: AgentChat
+blocks:
+  # Both chats are driven from the messages property, so nothing here calls the agent.
+  - id: chat_wired
+    type: AgentChat
+    properties:
+      agentId: test_agent
+      height: 300
+      conversationId: wired
+      messageDisplay:
+        actions:
+          - feedback
+      messages:
+        - id: w1
+          role: assistant
+          parts:
+            - type: text
+              text: |
+                [in-app link](/agent-chat-target) and [external link](https://example.com)
+    events:
+      onLinkClick:
+        - id: record_link_click
+          type: SetState
+          params:
+            last_href:
+              _event: href
+            last_text:
+              _event: text
+            click_count:
+              _sum:
+                - _if_none:
+                    - _state: click_count
+                    - 0
+                - 1
+
+  - id: wired_readout
+    type: Html
+    properties:
+      html:
+        _nunjucks:
+          template: |
+            <span id="readout_href">{{ href }}</span>
+            <span id="readout_text">{{ text }}</span>
+            <span id="readout_count">{{ count or 0 }}</span>
+          on:
+            href:
+              _state: last_href
+            text:
+              _state: last_text
+            count:
+              _state: click_count
+
+  - id: chat_unwired
+    type: AgentChat
+    properties:
+      agentId: test_agent
+      height: 300
+      conversationId: unwired
+      messages:
+        - id: u1
+          role: assistant
+          parts:
+            - type: text
+              text: '[in-app link](/agent-chat-target) and [external link](https://example.com)'

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/tests/AgentChatTarget.e2e.yaml
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/tests/AgentChatTarget.e2e.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: agent-chat-target
+type: PageHeaderMenu
+properties:
+  title: Link target
+blocks:
+  - id: target_marker
+    type: Html
+    properties:
+      # No id on the span: Lowdefy renders the block id into the DOM, so repeating it here
+      # gives two matching elements and a strict-mode violation.
+      html: <span>arrived</span>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -825,6 +825,15 @@ importers:
         specifier: 18.2.0
         version: 18.2.0
     devDependencies:
+      '@lowdefy/block-dev-e2e':
+        specifier: 5.4.0
+        version: link:../../../utils/block-dev-e2e
+      '@lowdefy/e2e-utils':
+        specifier: 5.4.0
+        version: link:../../../utils/e2e-utils
+      '@playwright/test':
+        specifier: 1.50.1
+        version: 1.50.1
       '@swc/cli':
         specifier: 0.8.0
         version: 0.8.0(@swc/core@1.15.18)
@@ -1448,7 +1457,7 @@ importers:
         version: link:../../../utils/helpers
       '@next-auth/mongodb-adapter':
         specifier: 1.1.3
-        version: 1.1.3(mongodb@6.3.0(@aws-sdk/credential-providers@3.425.0)(socks@2.7.1))(next-auth@4.24.10(next@16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 1.1.3(mongodb@6.3.0(@aws-sdk/credential-providers@3.425.0)(socks@2.7.1))(next-auth@4.24.10(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       mongodb:
         specifier: 6.3.0
         version: 6.3.0(@aws-sdk/credential-providers@3.425.0)(socks@2.7.1)
@@ -1476,13 +1485,13 @@ importers:
         version: 0.2.39(@swc/core@1.15.18)
       jest:
         specifier: 28.1.3
-        version: 28.1.3(@types/node@16.18.101)
+        version: 28.1.3(@types/node@20.6.2)
       jest-environment-node:
         specifier: 28.1.3
         version: 28.1.3
       next:
         specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-auth:
         specifier: 4.24.10
         version: 4.24.10(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -2025,7 +2034,7 @@ importers:
     dependencies:
       next:
         specifier: '>=16'
-        version: 16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-auth:
         specifier: '>=4.24'
         version: 4.24.10(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -2122,7 +2131,7 @@ importers:
         version: 1.11.19
       next:
         specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-auth:
         specifier: 4.24.10
         version: 4.24.10(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -2273,7 +2282,7 @@ importers:
         version: 16.3.1
       next:
         specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-auth:
         specifier: 4.24.10
         version: 4.24.10(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -2400,7 +2409,7 @@ importers:
         version: 1.11.19
       next:
         specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       pino:
         specifier: 8.16.2
         version: 8.16.2
@@ -2674,7 +2683,7 @@ importers:
         version: 0.2.39(@swc/core@1.15.18)
       jest:
         specifier: 28.1.3
-        version: 28.1.3(@types/node@20.6.2)
+        version: 28.1.3(@types/node@16.18.101)
 
   packages/utils/helpers:
     dependencies:
@@ -15333,7 +15342,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next-auth/mongodb-adapter@1.1.3(mongodb@6.3.0(@aws-sdk/credential-providers@3.425.0)(socks@2.7.1))(next-auth@4.24.10(next@16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+  '@next-auth/mongodb-adapter@1.1.3(mongodb@6.3.0(@aws-sdk/credential-providers@3.425.0)(socks@2.7.1))(next-auth@4.24.10(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
       mongodb: 6.3.0(@aws-sdk/credential-providers@3.425.0)(socks@2.7.1)
       next-auth: 4.24.10(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(nodemailer@6.9.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -16350,7 +16359,7 @@ snapshots:
       '@sentry/vercel-edge': 8.53.0
       '@sentry/webpack-plugin': 2.22.7(encoding@0.1.13)(webpack@5.94.0)
       chalk: 3.0.0
-      next: 16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       resolve: 1.22.8
       rollup: 3.29.5
       stacktrace-parser: 0.1.11
@@ -23051,7 +23060,7 @@ snapshots:
       '@panva/hkdf': 1.1.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       oauth: 0.9.15
       openid-client: 5.6.0
       preact: 10.28.3
@@ -23091,7 +23100,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.1.6(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -23100,7 +23109,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.6(@babel/core@7.23.3)(react@18.2.0)
+      styled-jsx: 5.1.6(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.6
       '@next/swc-darwin-x64': 16.1.6
@@ -24819,12 +24828,10 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
-  styled-jsx@5.1.6(@babel/core@7.23.3)(react@18.2.0):
+  styled-jsx@5.1.6(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
-    optionalDependencies:
-      '@babel/core': 7.23.3
 
   stylis@4.3.6: {}
 


### PR DESCRIPTION
## Summary

Two things an app could not reach through AgentChat, and the e2e harness that caught the interesting one. Links in an answer rendered as plain anchors, so following a citation was a full browser navigation — the conversation was left behind, and an app had no way to do anything else with the click. Separately, the feedback control was write-only: it reported a rating and immediately forgot it, so the thumb un-highlighted on the next render, which on a streaming chat is the very next chunk, and a rated message looked unrated.

## Changes

All in **@lowdefy/blocks-antd-x**:

- **In-app links route client-side** — a markdown link whose href is an in-app path now renders through the app's `Link` component as a client-side route rather than a reload. Anything carrying a scheme opens in a new tab, so a citation does not cost you the conversation, and a fragment keeps the plain anchor because it cannot be expressed as a `pageId` link.
- **`onLinkClick`** — a new event reporting `href` and `text`. Default navigation is suppressed only when the app actually handles the event, so wiring nothing changes nothing; presence is read from the block's configured events, which `Events.init` populates at construction, so it holds from the first click. Modified and non-primary clicks are never intercepted, because open-in-new-tab is a reasonable thing to do with a citation.
- **Feedback is controlled** — `Actions.Feedback` accepts a `value` but was never given one. It is now held per message id for the life of the chat instance, which also brings that component's selected behaviour: the chosen thumb stays highlighted, the opposite one is hidden, and clicking the selected thumb again clears the rating and brings both back. A rating can be changed, but not submitted twice by accident. Clearing one fires `onFeedback` with `rating: 'default'` — a value that was unreachable while the control was uncontrolled, so it is documented in `meta.js`, in the docs events table and as an upgrade note on the changeset. The block does not persist ratings — a reload or a conversation switch starts clean, since that belongs to whatever stores the conversation.
- **The package's first e2e suite**, and the harness to run it: link rendering, interception and its modifier-click exemption, client-side routing when `onLinkClick` is unwired, and a rating surviving a re-render. Every chat in it is driven from the `messages` property, so no agent is called and no request leaves the machine.

**@lowdefy/docs**: `onLinkClick` added to the AgentChat events table, and `onFeedback` now says what `rating` can be.

## Key Files

- `src/blocks/AgentChat/MessageBubble.js` — link rendering, and the `createLink` prop dispatch described under Notes
- `src/blocks/AgentChat/AgentChat.js` — `onLinkClick` wiring, the memoised handler, and the per-message rating map
- `src/blocks/AgentChat/MessageList.js` — threads `Link`, `onLinkClick` and the rating value down to each bubble
- `src/blocks/AgentChat/meta.js` — declares the new event
- `src/blocks/AgentChat/tests/AgentChat.e2e.spec.js` — the suite

## Notes

**`createLink` dispatches on which prop it is given.** `href` and `url` both select the new-origin form — a plain anchor that does a full page load — and only `pageId` routes client-side. Passing an in-app path as `href` therefore goes through `Link` and still drops the conversation. That is why the path is passed as `pageId` with `urlQuery`, and why the e2e asserts on a window flag surviving the click rather than on the URL: the URL is identical either way.

The link handler is memoised deliberately. `MessageBubble` keys its markdown component map on it, and an unstable identity would rebuild that map on every streaming chunk, remounting every link in the answer as it streams.

Two behaviour changes existing apps get without opting in, both `minor` on the changesets but worth a reviewer's eye. A link with a scheme now opens in a new tab where it previously navigated in place. And `onFeedback` can now report `rating: 'default'`, so a handler written as `like` against everything else will record a dislike for a rating the user just withdrew — the first app to wire this up did exactly that.

Not covered by the suite: nested `pageId`s. An in-app href carrying a query is covered, together with a formatted link label.

`pnpm-lock.yaml` carries more churn than the three new devDependencies account for. `develop`'s lockfile dates from July, so a local install re-resolves some peers (`@babel/core` on `next` and `styled-jsx`, `@types/node` on jest). None of it comes from this branch — happy to restore the file if that churn is unwanted.
