### PR TITLE
fix(server-dev): Build the page JIT before serving a request

### DIFF
--- a/.changeset/fix-server-dev-request-jit-build.md
+++ b/.changeset/fix-server-dev-request-jit-build.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/server-dev': patch
+---
+
+fix(server-dev): Build the page JIT before serving a request. Page artifacts are built on `GET /api/page/*` and dropped on every page invalidation, so a client that already held the page config could fire a request during a rebuild and get `Request "x" does not exist.` — a fresh sign-in landing on a protected gate page hit this every time a config file was saved. `POST /api/request/*` now runs the same idempotent `buildPageIfNeeded` the page route runs.

--- a/packages/servers/server-dev/src/routes/request.js
+++ b/packages/servers/server-dev/src/routes/request.js
@@ -17,6 +17,7 @@
 import { callRequest, redactErrorResponse } from '@lowdefy/api';
 import { serializer } from '@lowdefy/helpers';
 
+import buildPageIfNeeded from '../../lib/server/jitPageBuilder.js';
 import getPathSegments from '../lib/getPathSegments.js';
 import { getMock } from '../../lib/docs/devMockRegistry.js';
 
@@ -51,6 +52,19 @@ async function requestHandler(c) {
     }
     return c.json({ success: true, response: serializer.serialize(mock.response) });
   }
+
+  // Page artifacts (including pages/{pageId}/requests/{requestId}.json) are
+  // built JIT by GET /api/page/* and thrown away on every page invalidation
+  // (lowdefyBuildWatcher / moduleBuildWatcher). A client that already holds
+  // the page config keeps firing requests across that window — and a request
+  // that arrived before the page was rebuilt failed with
+  // `Request "x" does not exist.` Run the same idempotent build the page route
+  // runs (a no-op once the page is compiled) so the request artifact is there.
+  await buildPageIfNeeded({
+    pageId,
+    buildDirectory: context.buildDirectory,
+    configDirectory: context.configDirectory,
+  });
 
   context.logger.info({ event: 'call_request', pageId, requestId, blockId, actionId });
   const response = await callRequest(context, { blockId, pageId, payload, requestId });

--- a/packages/servers/server-dev/src/routes/request.test.mjs
+++ b/packages/servers/server-dev/src/routes/request.test.mjs
@@ -1,0 +1,124 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { Hono } from 'hono';
+import { jest } from '@jest/globals';
+
+const mockCallRequest = jest.fn();
+jest.unstable_mockModule('@lowdefy/api', () => ({
+  callRequest: mockCallRequest,
+  redactErrorResponse: jest.fn((context, error) => ({ error: error.message })),
+}));
+
+const mockBuildPageIfNeeded = jest.fn(async () => true);
+jest.unstable_mockModule('../../lib/server/jitPageBuilder.js', () => ({
+  default: mockBuildPageIfNeeded,
+  getPageJitEnrichment: jest.fn(() => ({})),
+}));
+
+const mockGetMock = jest.fn(() => null);
+jest.unstable_mockModule('../../lib/docs/devMockRegistry.js', () => ({
+  getMock: mockGetMock,
+}));
+
+const { default: requestHandler } = await import('./request.js');
+
+const callOrder = [];
+
+function createApp() {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('lowdefyContext', {
+      buildDirectory: '/build',
+      configDirectory: '/config',
+      logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn() },
+    });
+    await next();
+  });
+  app.all('/api/request/*', requestHandler);
+  return app;
+}
+
+function post(app, path, body = { actionId: 'a', blockId: 'b', payload: {} }) {
+  return app.request(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  callOrder.length = 0;
+  mockBuildPageIfNeeded.mockImplementation(async () => {
+    callOrder.push('build');
+    return true;
+  });
+  mockCallRequest.mockImplementation(async () => {
+    callOrder.push('call');
+    return { success: true, response: { ok: true } };
+  });
+});
+
+afterEach(() => {
+  mockCallRequest.mockReset();
+  mockBuildPageIfNeeded.mockReset();
+  mockGetMock.mockReset();
+  mockGetMock.mockImplementation(() => null);
+});
+
+test('requestHandler builds the page JIT before calling the request', async () => {
+  const res = await post(createApp(), '/api/request/dashboard/get_rows');
+  expect(res.status).toEqual(200);
+  expect(await res.json()).toEqual({ success: true, response: { ok: true } });
+  expect(mockBuildPageIfNeeded).toHaveBeenCalledWith({
+    pageId: 'dashboard',
+    buildDirectory: '/build',
+    configDirectory: '/config',
+  });
+  expect(mockCallRequest).toHaveBeenCalledWith(
+    expect.objectContaining({ buildDirectory: '/build' }),
+    { blockId: 'b', pageId: 'dashboard', payload: {}, requestId: 'get_rows' }
+  );
+  expect(callOrder).toEqual(['build', 'call']);
+});
+
+test('requestHandler builds nested page ids as one page', async () => {
+  await post(createApp(), '/api/request/user-account/login/get_session');
+  expect(mockBuildPageIfNeeded).toHaveBeenCalledWith(
+    expect.objectContaining({ pageId: 'user-account/login' })
+  );
+  expect(mockCallRequest).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({ pageId: 'user-account/login', requestId: 'get_session' })
+  );
+});
+
+test('requestHandler replays a dev mock without building or calling the request', async () => {
+  mockGetMock.mockImplementation(() => ({ response: { rows: [1] } }));
+  const res = await post(createApp(), '/api/request/dashboard/get_rows');
+  expect(res.status).toEqual(200);
+  expect(await res.json()).toEqual({ success: true, response: { rows: [1] } });
+  expect(mockBuildPageIfNeeded).not.toHaveBeenCalled();
+  expect(mockCallRequest).not.toHaveBeenCalled();
+});
+
+test('requestHandler rejects non-POST methods', async () => {
+  const app = createApp();
+  app.onError((err, c) => c.json({ error: err.message }, 500));
+  const res = await app.request('/api/request/dashboard/get_rows');
+  expect(res.status).toEqual(500);
+  expect(mockBuildPageIfNeeded).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
### What are the changes and their implications?

**Bug.** In the dev server, page artifacts — including `pages/{pageId}/requests/{requestId}.json` — are built just-in-time by `GET /api/page/*` (`jitPage.js` → `buildPageIfNeeded`) and thrown away on every page invalidation (`lowdefyBuildWatcher` / `moduleBuildWatcher` touch `build/invalidatePages`, a skeleton change runs a full build). `POST /api/request/*` (`src/routes/request.js`) went straight to `callRequest`, so a browser tab that already held the page config and fired a request inside that window got:

```
[ConfigError] Request "get_org_profile" does not exist.
```

Seen on every config save while a freshly signed-in user was sitting on a protected gate page (`get-started` in encircle): the request fails at T+0, the page-config refetch times out while the rebuild runs, and the page is only rebuilt at T+3s. The page's own try/catch then surfaces it as a load error.

**Fix.** The request route now runs the same idempotent `buildPageIfNeeded({ pageId, buildDirectory, configDirectory })` the page route runs, before `callRequest`. It short-circuits via `pageCache.isCompiled` once the page is built, so the steady-state cost is a cache check. This mirrors what `lib/docs/runRequest.js` already does for the MCP `lowdefy_run_request` tool. Dev-mock replays (`devMockRegistry`) still short-circuit before any build.

No config or contract changes. `@lowdefy/server-dev` patch changeset included.

**Tests.** New `src/routes/request.test.mjs` (same Hono + `unstable_mockModule` style as `jitPage.test.mjs`): build runs before `callRequest` with the context's directories, nested page ids are built as one page, dev mocks skip both build and call, non-POST rejected. Full `server-dev` suite: 34 suites / 249 tests green.

## Checklist

- [x] Pull request is made to the `auth-upgrade` integration branch (not `develop` — per the multi-tenant program)
- [x] Tests added
- [ ] Documentation added/updated — n/a, dev-server internals
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
