### PR TITLE
feat(auth): Configurable organization invitation expiry

### DIFF
--- a/.changeset/feat-auth-organizations-invitation-expires-in.md
+++ b/.changeset/feat-auth-organizations-invitation-expires-in.md
@@ -1,0 +1,15 @@
+---
+'@lowdefy/build': minor
+'@lowdefy/api': minor
+---
+
+feat(auth): `auth.organizations.invitationExpiresIn` sets how long organization invitations stay acceptable
+
+Invitations expired after BetterAuth's fixed 48 hours, which is too short for real invitees who open the email days later. The new key takes seconds (at least 60) and is validated at build time; re-sending an invitation refreshes its expiry as before. Unset, the 48-hour default still applies.
+
+```yaml
+auth:
+  organizations:
+    policy: tenant
+    invitationExpiresIn: 1209600 # 14 days
+```

--- a/packages/api/src/routes/auth/getBetterAuthConfig.js
+++ b/packages/api/src/routes/auth/getBetterAuthConfig.js
@@ -530,7 +530,9 @@ function getBetterAuthConfig({
     await sendEmail({ to: email, subject, html, text, context });
   }
 
-  options.plugins.push(buildOrganizationPlugin({ getAuth, logger, sendInvitationEmail }));
+  options.plugins.push(
+    buildOrganizationPlugin({ authConfig, getAuth, logger, sendInvitationEmail })
+  );
 
   // BetterAuth's default /get-session body includes the raw session token - the
   // credential half of the httpOnly session cookie. Lowdefy is cookie-based and

--- a/packages/api/src/routes/auth/organizations/buildOrganizationPlugin.js
+++ b/packages/api/src/routes/auth/organizations/buildOrganizationPlugin.js
@@ -49,7 +49,7 @@ import {
 // creator-protection guards, which key on the member's role string. With app
 // roles out of that field and the fabricated acting member claiming "owner"
 // itself, there is nothing left to defend against.
-function buildOrganizationPlugin({ getAuth, logger, sendInvitationEmail }) {
+function buildOrganizationPlugin({ authConfig = {}, getAuth, logger, sendInvitationEmail }) {
   const options = {
     ac,
     roles,
@@ -62,6 +62,12 @@ function buildOrganizationPlugin({ getAuth, logger, sendInvitationEmail }) {
     // (old accept links die with the canceled row). resend: true instead
     // re-sends the existing invitation unchanged with a refreshed expiry.
     cancelPendingInvitationsOnReInvite: true,
+    // How long an invitation stays acceptable. Left to BetterAuth's 48h
+    // default unless auth.organizations.invitationExpiresIn (seconds, build-
+    // validated) says otherwise - real invitees often need longer than two days.
+    ...(Number.isFinite(authConfig.organizations?.invitationExpiresIn)
+      ? { invitationExpiresIn: authConfig.organizations.invitationExpiresIn }
+      : {}),
     schema: {
       organization: { modelName: modelNames.organization },
       member: {

--- a/packages/api/src/routes/auth/organizations/buildOrganizationPlugin.test.js
+++ b/packages/api/src/routes/auth/organizations/buildOrganizationPlugin.test.js
@@ -257,3 +257,33 @@ test('buildOrganizationPlugin org lifecycle hooks are no-ops without an MCP reso
   expect(adapter.create).not.toHaveBeenCalled();
   expect(adapter.update).not.toHaveBeenCalled();
 });
+
+test('buildOrganizationPlugin leaves invitationExpiresIn to the BetterAuth default when unset', () => {
+  const plugin = buildOrganizationPlugin({
+    authConfig,
+    getAuth: () => ({}),
+    sendInvitationEmail: async () => {},
+  });
+  expect('invitationExpiresIn' in plugin.options).toBe(false);
+});
+
+test('buildOrganizationPlugin passes auth.organizations.invitationExpiresIn through in seconds', () => {
+  const plugin = buildOrganizationPlugin({
+    authConfig: {
+      ...authConfig,
+      organizations: { ...authConfig.organizations, invitationExpiresIn: 1209600 },
+    },
+    getAuth: () => ({}),
+    sendInvitationEmail: async () => {},
+  });
+  expect(plugin.options.invitationExpiresIn).toBe(1209600);
+});
+
+test('buildOrganizationPlugin tolerates a missing authConfig', () => {
+  const plugin = buildOrganizationPlugin({
+    getAuth: () => ({}),
+    sendInvitationEmail: async () => {},
+  });
+  expect(plugin.id).toBe('organization');
+  expect(plugin.options.invitationExpiresIn).toBeUndefined();
+});

--- a/packages/build/src/build/buildAuth/validateAuthConfig.test.js
+++ b/packages/build/src/build/buildAuth/validateAuthConfig.test.js
@@ -736,6 +736,46 @@ test('validateAuthConfig throws when organizations.signup is not a known policy'
   );
 });
 
+test('validateAuthConfig passes an organizations block with an invitation expiry', () => {
+  const components = {
+    auth: {
+      secret: validSecret,
+      database: validDatabase,
+      emailAndPassword: { enabled: true },
+      organizations: { policy: 'tenant', invitationExpiresIn: 1209600 },
+    },
+  };
+  expect(() => validateAuthConfig({ components, context })).not.toThrow();
+});
+
+test('validateAuthConfig throws when organizations.invitationExpiresIn is not an integer', () => {
+  const components = {
+    auth: {
+      secret: validSecret,
+      database: validDatabase,
+      emailAndPassword: { enabled: true },
+      organizations: { invitationExpiresIn: '14d' },
+    },
+  };
+  expect(() => validateAuthConfig({ components, context })).toThrow(
+    'Auth "organizations.invitationExpiresIn" should be an integer number of seconds.'
+  );
+});
+
+test('validateAuthConfig throws when organizations.invitationExpiresIn is under a minute', () => {
+  const components = {
+    auth: {
+      secret: validSecret,
+      database: validDatabase,
+      emailAndPassword: { enabled: true },
+      organizations: { invitationExpiresIn: 5 },
+    },
+  };
+  expect(() => validateAuthConfig({ components, context })).toThrow(
+    'Auth "organizations.invitationExpiresIn" should be at least 60 seconds.'
+  );
+});
+
 test('validateAuthConfig throws when organizations contains an unknown property', () => {
   const components = {
     auth: {

--- a/packages/build/src/lowdefySchema.js
+++ b/packages/build/src/lowdefySchema.js
@@ -1546,11 +1546,21 @@ export default {
                 enum: 'Auth "organizations.create" should be "auto" or "operator".',
               },
             },
+            invitationExpiresIn: {
+              type: 'integer',
+              minimum: 60,
+              description:
+                'How long an organization invitation stays acceptable, in seconds. Defaults to 48 hours (172800). Re-sending an invitation refreshes its expiry.',
+              errorMessage: {
+                type: 'Auth "organizations.invitationExpiresIn" should be an integer number of seconds.',
+                minimum: 'Auth "organizations.invitationExpiresIn" should be at least 60 seconds.',
+              },
+            },
           },
           errorMessage: {
             type: 'Auth "organizations" should be an object.',
             additionalProperties:
-              'Auth "organizations" contains an unknown property. The known properties are "policy", "org", "signup" and "create".',
+              'Auth "organizations" contains an unknown property. The known properties are "policy", "org", "signup", "create" and "invitationExpiresIn".',
           },
         },
         dev: {


### PR DESCRIPTION
### What are the changes and their implications?

Organization invitations expired after BetterAuth's fixed 48 hours — too short for real invitees, who often open the email days later. Encircle has been carrying a pnpm patch on `@lowdefy/api` that hardcodes `invitationExpiresIn: 1209600` in `buildOrganizationPlugin.js`; this makes it config.

**New key:** `auth.organizations.invitationExpiresIn` — integer seconds, minimum 60, validated by the build schema (`lowdefySchema.js`), with the usual per-property error messages. The `organizations` block already reaches `auth.json` verbatim, so no build-step or projection change is needed; `setAuthDefaults` leaves it unset so BetterAuth's default applies unless configured.

**Runtime:** `buildOrganizationPlugin` now takes `authConfig` (which `getBetterAuthConfig` already has in scope and now passes) and sets the plugin's `invitationExpiresIn` only when the key is a finite number — the option stays absent otherwise, so nothing changes for existing apps. `cancelPendingInvitationsOnReInvite` behaviour is unchanged; a re-send still refreshes the expiry.

```yaml
auth:
  organizations:
    policy: tenant
    invitationExpiresIn: 1209600 # 14 days
```

No breaking changes. Changesets: `@lowdefy/build` minor, `@lowdefy/api` minor.

**Tests:** `validateAuthConfig.test.js` — accepts the key, rejects a non-integer, rejects < 60 s. `buildOrganizationPlugin.test.js` — option absent when unset, passed through when set, tolerates a missing `authConfig`. `packages/build` buildAuth suite 19/318 green; `packages/api` routes/auth suite 38/401 green.

## Checklist

- [x] Pull request is made to the `auth-upgrade` integration branch (not `develop` — multi-tenant program)
- [x] Tests added
- [x] Documentation added/updated — schema `description` on the new key (no docs page lists the organizations keys yet)
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
