### PR TITLE
fix(blocks-tiptap): Serialise a string identifier in mention data-id

### DIFF
--- a/.changeset/fix-tiptap-mention-data-id.md
+++ b/.changeset/fix-tiptap-mention-data-id.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/blocks-tiptap': patch
+---
+
+fix(blocks-tiptap): Mentions with object options serialise a real identifier in `data-id` instead of `[object Object]`. `TiptapMentionInput` now renders `data-id` from the option's scalar identity (`value`, `value._id`/`value.id`, or the option's own `_id`/`id`) — or omits it when there is none — and always writes the display label to `data-label`, so saved html round-trips with a readable mention.

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/TiptapMentionInput.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/TiptapMentionInput.js
@@ -33,9 +33,70 @@ import useTiptapMentionState from './useTiptapMentionState.js';
 
 import './style.css';
 
+// A mention node's `id` attribute holds whatever option the user picked — a
+// plain string, or the option object ({ label, value, tag }) — so the label
+// and the DOM identifier are both derived from it. Content loaded back from
+// saved html arrives with a STRING id (tiptap's parseHTML reads data-id) and
+// the label in `data-label`, which is why both render paths take the node's
+// attributes rather than the id alone.
 function mentionLabel(id) {
   return id?.tag?.title ?? id?.label ?? id;
 }
+
+// The string that goes into the DOM as data-id. Option objects are commonly
+// { label, value } with the identity inside `value` (a string, or an object
+// with _id / id); fall back to the object's own _id / id. Anything without a
+// scalar identity yields undefined and data-id is omitted — never the
+// "[object Object]" tiptap's stock attribute renderer produces when it
+// stringifies the whole option.
+function scalarId(candidate) {
+  if (type.isString(candidate) || type.isNumber(candidate)) return String(candidate);
+  return undefined;
+}
+
+function mentionId(id) {
+  if (type.isNone(id)) return undefined;
+  if (type.isString(id) || type.isNumber(id)) return String(id);
+  if (!type.isObject(id)) return undefined;
+  const value = id.value;
+  if (type.isObject(value)) {
+    return scalarId(value._id) ?? scalarId(value.id) ?? scalarId(value.value);
+  }
+  return scalarId(value) ?? scalarId(id._id) ?? scalarId(id.id);
+}
+
+function nodeLabel(attrs) {
+  const label = type.isString(attrs.label) && attrs.label !== '' ? attrs.label : undefined;
+  const derived = mentionLabel(attrs.id);
+  return label ?? (type.isString(derived) || type.isNumber(derived) ? derived : undefined);
+}
+
+// Mention with its `id` and `label` attributes rendered through the helpers
+// above: data-id is always a scalar identifier (or absent), and data-label
+// always carries the display label so saved html round-trips with a readable
+// mention even though the id comes back as a string.
+const LowdefyMention = Mention.extend({
+  addAttributes() {
+    const parent = this.parent?.() ?? {};
+    return {
+      ...parent,
+      id: {
+        ...parent.id,
+        renderHTML: (attributes) => {
+          const id = mentionId(attributes.id);
+          return type.isNone(id) ? {} : { 'data-id': id };
+        },
+      },
+      label: {
+        ...parent.label,
+        renderHTML: (attributes) => {
+          const label = nodeLabel(attributes);
+          return type.isNone(label) ? {} : { 'data-label': label };
+        },
+      },
+    };
+  },
+});
 
 const TiptapMentionInput = ({
   blockId,
@@ -62,11 +123,11 @@ const TiptapMentionInput = ({
   const allowSpaces = properties.mentions?.allowSpaces !== false;
   const limit = properties.mentions?.limit ?? 5;
 
-  const mentionExtension = Mention.configure({
+  const mentionExtension = LowdefyMention.configure({
     HTMLAttributes: { class: 'tiptap-mention' },
     renderHTML({ options, node }) {
       const id = node.attrs.id;
-      const label = mentionLabel(id);
+      const label = nodeLabel(node.attrs) ?? '';
       const group = id?.tag?.group;
       const modifier = {};
       if (!type.isNone(group)) {
@@ -83,14 +144,14 @@ const TiptapMentionInput = ({
       if (!type.isNone(href)) {
         return [
           'a',
-          mergeAttributes({ href, 'data-id': id?._id }, options.HTMLAttributes, modifier),
+          mergeAttributes({ href }, options.HTMLAttributes, modifier),
           `${char}${label}`,
         ];
       }
       return ['span', mergeAttributes(options.HTMLAttributes, modifier), `${char}${label}`];
     },
     renderText({ node }) {
-      return `${char}${mentionLabel(node.attrs.id)}`;
+      return `${char}${nodeLabel(node.attrs) ?? ''}`;
     },
     suggestion: suggestion({ methods, char, allowSpaces, limit }),
   });

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests/TiptapMentionInput.e2e.spec.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests/TiptapMentionInput.e2e.spec.js
@@ -71,6 +71,50 @@ test.describe('TiptapMentionInput Block', () => {
     await expect(editor).not.toContainText('undefined');
   });
 
+  test.describe('mention identity in saved html', () => {
+    test('picked option with value._id serialises data-id and data-label', async ({ page }) => {
+      const editor = editorLocator(page, 'tiptap_mention_options');
+      await editor.click();
+      await page.keyboard.type('@Al');
+      await page
+        .locator('.tiptap-mention-items .tiptap-mention-item', { hasText: 'Alice' })
+        .click();
+      const mention = editor.locator('.tiptap-mention');
+      await expect(mention).toHaveAttribute('data-id', 'user_1');
+      await expect(mention).toHaveAttribute('data-label', 'Alice');
+      const html = await editor.evaluate((n) => n.innerHTML);
+      expect(html).not.toContain('[object Object]');
+    });
+
+    test('option whose value has no scalar id omits data-id (never "[object Object]")', async ({
+      page,
+    }) => {
+      const editor = editorLocator(page, 'tiptap_mention_object_values');
+      await editor.click();
+      await page.keyboard.type('@C');
+      await page
+        .locator('.tiptap-mention-items .tiptap-mention-item', { hasText: 'Carol' })
+        .click();
+      const mention = editor.locator('.tiptap-mention');
+      await expect(mention).toHaveText('@Carol');
+      await expect(mention).toHaveAttribute('data-label', 'Carol');
+      expect(await mention.getAttribute('data-id')).toBeNull();
+      const html = await editor.evaluate((n) => n.innerHTML);
+      expect(html).not.toContain('[object Object]');
+    });
+
+    test('saved html with a string data-id renders the data-label and keeps the id', async ({
+      page,
+    }) => {
+      const editor = editorLocator(page, 'tiptap_mention_saved');
+      const mention = editor.locator('.tiptap-mention');
+      await expect(mention).toHaveText('@Zed');
+      await expect(mention).toHaveAttribute('data-id', 'user_9');
+      await expect(mention).toHaveAttribute('data-label', 'Zed');
+      await expect(editor).toContainText('Ping @Zed please.');
+    });
+  });
+
   test.describe('group mentions', () => {
     const groupsId = 'tiptap_mention_groups';
 
@@ -121,7 +165,9 @@ test.describe('TiptapMentionInput Block', () => {
       const editor = editorLocator(page, groupsId);
       await editor.click();
       await page.keyboard.type('@Finance');
-      await page.locator('.tiptap-mention-items .tiptap-mention-item', { hasText: 'Finance' }).click();
+      await page
+        .locator('.tiptap-mention-items .tiptap-mention-item', { hasText: 'Finance' })
+        .click();
       const chip = editor.locator('.tiptap-mention-group');
       await expect(chip).toHaveText('@Finance');
       await expect(chip).toHaveClass(/tiptap-mention\b/);
@@ -135,7 +181,9 @@ test.describe('TiptapMentionInput Block', () => {
       const editor = editorLocator(page, groupsId);
       await editor.click();
       await page.keyboard.type('@Alice');
-      await page.locator('.tiptap-mention-items .tiptap-mention-item', { hasText: 'Alice' }).click();
+      await page
+        .locator('.tiptap-mention-items .tiptap-mention-item', { hasText: 'Alice' })
+        .click();
       const chip = editor.locator('a.tiptap-mention', { hasText: '@Alice' });
       await expect(chip).toBeVisible();
       await expect(chip).toHaveAttribute('href', '/contacts?_id=user_1');
@@ -146,12 +194,16 @@ test.describe('TiptapMentionInput Block', () => {
       const editor = editorLocator(page, groupsId);
       await editor.click();
       await page.keyboard.type('@Finance');
-      await page.locator('.tiptap-mention-items .tiptap-mention-item', { hasText: 'Finance' }).click();
+      await page
+        .locator('.tiptap-mention-items .tiptap-mention-item', { hasText: 'Finance' })
+        .click();
       const chip = editor.locator('.tiptap-mention-group');
       await chip.hover();
       const popover = page.locator('.tiptap-mention-group-popover');
       await expect(popover).toBeVisible();
-      await expect(popover.locator('.tiptap-mention-group-popover-header')).toContainText('Finance');
+      await expect(popover.locator('.tiptap-mention-group-popover-header')).toContainText(
+        'Finance'
+      );
       await expect(popover.locator('.tiptap-mention-group-popover-header')).toContainText('2');
       await expect(popover).toContainText('Jane Doe');
       await expect(popover).toContainText('jane@example.com');

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests/TiptapMentionInput.e2e.yaml
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/tests/TiptapMentionInput.e2e.yaml
@@ -24,6 +24,10 @@ events:
           html: '<p>Hi <span class="tiptap-mention">@Alice</span>.</p>'
         tiptap_mention_disabled:
           html: '<p>Disabled mention editor.</p>'
+        # Saved html round-trip: a mention node comes back with a STRING id
+        # (data-id) and its label in data-label.
+        tiptap_mention_saved:
+          html: '<p>Ping <span data-type="mention" class="tiptap-mention" data-id="user_9" data-label="Zed" data-mention-suggestion-char="@">@Zed</span> please.</p>'
 
 blocks:
   - id: tiptap_mention_empty
@@ -54,6 +58,24 @@ blocks:
           - label: Bob
             value:
               _id: user_2
+
+  - id: tiptap_mention_saved
+    type: TiptapMentionInput
+
+  # Options whose value has no scalar identity (the shape an app passes when
+  # the whole contact record is the value) — data-id must be omitted, never
+  # "[object Object]".
+  - id: tiptap_mention_object_values
+    type: TiptapMentionInput
+    properties:
+      placeholder: 'Try @C'
+      mentions:
+        options:
+          - label: Carol
+            value:
+              contact_id: c_1
+              name: Carol
+              email: carol@example.com
 
   - id: tiptap_mention_groups
     type: TiptapMentionInput

--- a/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/useTiptapMentionState.js
+++ b/packages/plugins/blocks/blocks-tiptap/src/blocks/TiptapMentionInput/useTiptapMentionState.js
@@ -49,7 +49,9 @@ function useTiptapMentionState({ value, methods, hasDownloadRequest }) {
       .filter((c) => c.type === 'paragraph')
       .forEach((c) => {
         c.content?.forEach((cc) => {
-          if (cc.type === 'mention') {
+          // Only freshly picked mentions carry the option object; a node parsed
+          // back from saved html has a string id and no `value` to report.
+          if (cc.type === 'mention' && cc.attrs.id?.value !== undefined) {
             mentionsMap.set(JSON.stringify(cc.attrs.id.value), cc.attrs.id.value);
           }
         });


### PR DESCRIPTION
### What are the changes and their implications?

**Bug.** `TiptapMentionInput` stores the picked option as the mention node's `id` attribute — a string, or the `{ label, value, tag }` option object. `@tiptap/extension-mention`'s stock `id` attribute renderer writes `attributes.id` straight into `data-id`, so every object-valued mention serialised as `[object Object]`. Only the `<a>` branch (when `mentions.getHref` returned a link) set its own `data-id`, and even that read `id._id`, which the `{ label, value }` shape never has.

Saved html from encircle, before:

```html
<span data-type="mention" class="tiptap-mention" data-id="[object Object]" data-mention-suggestion-char="@">@Anton van Wyk</span>
```

after (option `{ label: 'Alice', value: { _id: 'user_1' } }`):

```html
<span data-type="mention" class="tiptap-mention" data-id="user_1" data-label="Alice" data-mention-suggestion-char="@">@Alice</span>
```

and for an option whose value has no scalar identity (e.g. a whole contact record as the value) `data-id` is omitted rather than stringified.

**Fix.** The block now uses `Mention.extend()` to render its `id` and `label` attributes itself:

- `data-id` comes from `mentionId(option)`: a string/number option → itself; an object → `value` when scalar, else `value._id` / `value.id` / `value.value`, else the option's own `_id` / `id`; nothing scalar → attribute omitted. Applies to both the `<span>` and `<a>` branches (the anchor's ad-hoc `data-id: id?._id` is gone).
- `data-label` always carries the display label (`tag.title` → `label` → the string id), so html loaded back into the editor — where tiptap's `parseHTML` yields a **string** id — still renders `@Alice`, not `@user_1`. `renderHTML`/`renderText` read the label through the same helper.
- `useTiptapMentionState` only reports `value.mentions` for nodes that still carry the option object; a node parsed from saved html (string id) no longer contributes an `undefined` entry.

Legacy html that already contains `data-id="[object Object]"` and no `data-label` renders exactly as it did before this change (the string id is the only label available); it is not rewritten until the user edits the content.

No config changes. `@lowdefy/blocks-tiptap` patch changeset included.

**Tests.** Three new e2e cases in `TiptapMentionInput.e2e.spec.js` (+ fixtures in the e2e yaml): picked option serialises `data-id`/`data-label`; option without a scalar id omits `data-id` and never emits `[object Object]`; saved html with a string `data-id` renders its `data-label` and keeps the id. Package e2e: 19 pass; the 3 failures (`renders initial html value with mention node`, and the two `#722ed1` / `#13c2c2` colour assertions) fail identically on unmodified `auth-upgrade` in this environment — the seed fixture has no `data-type="mention"` so no mention node is created, and Chromium serialises the inline colour as `rgb()` — so they are pre-existing, not regressions.

## Checklist

- [x] Pull request is made to the `auth-upgrade` integration branch (not `develop` — per the multi-tenant program)
- [x] Tests added
- [ ] Documentation added/updated — n/a, behaviour fix
- [x] Code has been formatted with Prettier
- [x] Edits from maintainers are allowed
