### PR TITLE
fix(ajv): Stop the validation error cap from failing valid oneOf data

### DIFF
--- a/.changeset/fix-ajv-error-cap-breaks-oneof.md
+++ b/.changeset/fix-ajv-error-cap-breaks-oneof.md
@@ -1,0 +1,23 @@
+---
+'@lowdefy/ajv': patch
+---
+
+fix: Stop the validation error cap from failing valid `oneOf` data.
+
+The error cap added for CodeQL `js/resource-exhaustion-from-deep-object-traversal`
+made the generated validator `return false` once it had collected
+`MAX_VALIDATION_ERRORS` errors. Ajv only decides a `oneOf`/`anyOf` after trying
+every branch, and each branch that rejects the data pushes one error per entry it
+rejects — so on a long enough array the earlier branches spent the whole budget
+and the validator gave up before reaching the branch that matched.
+
+For a `oneOf` of differently-typed arrays — the shape every selector's `options`
+property uses (a list of primitives, or a list of `{ label, value }` pairs) — that
+meant any list longer than about six entries was rejected regardless of what it
+held. Blocks whose options are built server-side and reach the validator as a
+literal array, rather than as an operator the client evaluates, failed
+validation outright.
+
+The cap now truncates the retained error array instead of abandoning the walk.
+Error counting is untouched, so validity is still decided by Ajv, `.errors` stays
+bounded at `MAX_VALIDATION_ERRORS`, and retained memory stays bounded.

--- a/packages/utils/ajv/src/ajvInstance.js
+++ b/packages/utils/ajv/src/ajvInstance.js
@@ -19,28 +19,28 @@ import addFormats from 'ajv-formats';
 import addKeywords from 'ajv-keywords';
 import ajvErrors from 'ajv-errors';
 
-// Hard cap on errors collected per generated validator function.
+// Cap on the error objects a generated validator retains.
 // `allErrors: true` is required for ajv-errors (errorMessage:), but without a
 // cap an attacker can make Ajv allocate an unbounded number of error objects
 // (CodeQL js/resource-exhaustion-from-deep-object-traversal). The code.process
-// hook below rewrites every `errors++;` site to early-exit at this threshold,
-// bounding memory at ~MAX_VALIDATION_ERRORS * ~500 bytes per validate() call.
+// hook below truncates each validator's error array at this threshold, bounding
+// retained memory at ~MAX_VALIDATION_ERRORS * ~500 bytes per validate() call.
 const MAX_VALIDATION_ERRORS = 20;
 
 // Ajv 8 emits the exact pattern `errors++;` after every error push (see
-// ajv/lib/compile/errors.ts addError), and ends each generated validator with
-// `<validateName>.errors = vErrors; return errors === 0;`. We inject a
-// `<validateName>.errors = vErrors; return false;` guard immediately after
-// each `errors++;` so the validator stops walking the input once the cap is
-// reached *and* the caller still sees the (capped) errors array on the
-// function's `.errors` property — which is how `ajv.errors` is populated.
+// ajv/lib/compile/errors.ts addError), which makes it the one hook point that
+// sees every allocation. Truncate there; never early-exit. A `oneOf`/`anyOf` is
+// only decided once every branch has been tried, and each branch that rejects
+// the data pushes an error per item it rejects — so returning false at the cap
+// abandoned the walk before the branch that would have matched was reached. A
+// `oneOf` of differently-typed arrays then rejected any list longer than a
+// handful of entries whatever it held, since the earlier branches alone spent
+// the budget. Counting is left alone, so `errors === 0` still decides validity
+// and only the retained objects are bounded.
 function capErrors(code) {
-  const fnMatch = code.match(/return\s+function\s+(\w+)\s*\(/);
-  if (!fnMatch) return code;
-  const fnName = fnMatch[1];
   return code.replace(
     /errors\+\+;/g,
-    `errors++;if(errors>=${MAX_VALIDATION_ERRORS}){${fnName}.errors=vErrors;return false;}`
+    `errors++;if(vErrors!==null&&vErrors.length>${MAX_VALIDATION_ERRORS}){vErrors.length=${MAX_VALIDATION_ERRORS};}`
   );
 }
 

--- a/packages/utils/ajv/src/validate.test.js
+++ b/packages/utils/ajv/src/validate.test.js
@@ -367,3 +367,58 @@ test('Error count below cap is returned in full', () => {
   expect(result.valid).toBe(false);
   expect(result.errors).toHaveLength(3);
 });
+
+test('A oneOf branch still matches when earlier branches exhaust the error cap', () => {
+  // The shape every Lowdefy selector's `options` uses: a list of primitives, or
+  // a list of label/value objects. Each branch that rejects the data spends one
+  // error per entry, so a list long enough to exhaust the cap on the earlier
+  // branches alone must still be judged on the branch that fits it.
+  const schema = {
+    type: 'object',
+    properties: {
+      options: {
+        oneOf: [
+          { type: 'array', items: { type: 'string' } },
+          { type: 'array', items: { type: 'number' } },
+          {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: { label: { type: 'string' }, value: { type: 'string' } },
+            },
+          },
+        ],
+      },
+    },
+  };
+  const long = (make) => Array.from({ length: MAX_VALIDATION_ERRORS * 5 }, (_, i) => make(i));
+
+  expect(validate({ schema, data: { options: long((i) => `option ${i}`) } })).toEqual({
+    valid: true,
+  });
+  expect(validate({ schema, data: { options: long((i) => i) } })).toEqual({ valid: true });
+  expect(
+    validate({
+      schema,
+      data: { options: long((i) => ({ label: `option ${i}`, value: `${i}` })) },
+    })
+  ).toEqual({ valid: true });
+});
+
+test('A oneOf that no branch satisfies still fails, with errors capped', () => {
+  const schema = {
+    type: 'object',
+    properties: {
+      options: {
+        oneOf: [
+          { type: 'array', items: { type: 'string' } },
+          { type: 'array', items: { type: 'number' } },
+        ],
+      },
+    },
+  };
+  const data = { options: Array.from({ length: MAX_VALIDATION_ERRORS * 5 }, () => true) };
+  const result = validate({ schema, data, returnErrors: true });
+  expect(result.valid).toBe(false);
+  expect(result.errors.length).toBeLessThanOrEqual(MAX_VALIDATION_ERRORS);
+});


### PR DESCRIPTION
## Problem

A `Selector`/`MultipleSelector` whose `options` reach schema validation as a literal array is rejected once the list passes about six entries — whatever it contains:

| options shape | largest list that validates |
| --- | --- |
| plain strings | 6 |
| `{ label, value }` pairs | 5 |

The reported errors are misleading. Validating 20 valid string options yields twenty `must be string` errors and no `must match exactly one schema in oneOf`, which reads like a data problem in the first branch rather than an aborted walk.

## Cause

The error cap added for CodeQL `js/resource-exhaustion-from-deep-object-traversal` rewrites every `errors++;` site so the generated validator returns `false` once it has collected `MAX_VALIDATION_ERRORS` errors.

But Ajv only decides a `oneOf`/`anyOf` after trying **every** branch, and each branch that rejects the data pushes one error per entry it rejects. On a long enough array the earlier branches spend the entire budget, so the validator gives up before reaching the branch that would have matched.

Selector `options` is exactly that shape — a `oneOf` of `string[]`, `number[]`, `boolean[]`, `{ label, value }[]`. A list of 20 strings fails because branches 2, 3 and 4 alone raise 60 errors between them.

## Why it went unnoticed

In hand-written pages `options` is nearly always an operator (`_request`, `_state`), which block validation skips and the client evaluates, so the literal never reaches Ajv. It surfaces where options are compiled server-side into a literal array — a `Dynamic` block resolving a fragment, in this case a report filter built from a query.

## Fix

Truncate the retained error array at the cap instead of abandoning the walk. Error counting is untouched, so Ajv still decides validity, `.errors` stays bounded at `MAX_VALIDATION_ERRORS`, and retained memory stays bounded. `capErrors` no longer needs to find the validator's function name.

## Tests

Two added to `validate.test.js`:

- a `oneOf` branch still matches when earlier branches exhaust the cap — checked for all three option shapes, at `MAX_VALIDATION_ERRORS * 5` entries. **Fails without the fix.**
- a `oneOf` no branch satisfies still fails, with errors capped — guards the fix against over-correcting.

The two existing DoS-guard tests (`validate.test.js`, `compile.test.js`) pass unchanged, so the cap still bounds allocation.

`packages/build` and `packages/api` were run against a clean `main` baseline: identical failure counts before and after, so nothing here regressed them.

## Note for review

The `codeql[js/resource-exhaustion-from-deep-object-traversal]` suppression on the `Ajv` constructor may want a fresh look. Retained memory is still bounded, but transient allocation is now proportional to the input rather than stopping at 20 — the walk completes instead of exiting early.