### PR TITLE
Restore thumbs ratings an app has stored

### DIFF
--- a/.changeset/feat-agentchat-feedback-value.md
+++ b/.changeset/feat-agentchat-feedback-value.md
@@ -10,4 +10,6 @@ The feedback control was write-only: it reported a rating and immediately forgot
 
 Note for apps already handling `onFeedback`: clearing a rating fires it with `rating: 'default'`. That value was unreachable before, because the control was never given one — so a handler that treats anything other than `like` as a dislike will now record a rejection for a rating the user has just withdrawn. Branch on the three values explicitly.
 
-Ratings are not persisted by the block — a reload or a conversation switch starts clean. Persisting them belongs to whatever stores the conversation.
+The block still persists nothing itself — storing a rating belongs to whatever stores the conversation — but it can now be told what was stored. The new `feedbackValues` property takes a map of message id to `like` or `dislike`, so a restored conversation comes back with its ratings showing instead of looking untouched. Without it, a reload or a conversation switch shows every message unrated even where the app recorded the rating, which reads as a lost write rather than a display gap.
+
+A rating clicked during the visit takes precedence over the supplied one, so the thumb still responds immediately, and a rating the user has just withdrawn is not re-lit by a value fetched before the withdrawal. Ratings clicked in a conversation are dropped when `conversationId` changes: they are keyed by message id, and the incoming conversation supplies its own.

--- a/packages/docs/agents/AgentChat.yaml
+++ b/packages/docs/agents/AgentChat.yaml
@@ -92,6 +92,7 @@ _ref:
             | `agentId` | string | | __Required__ - The `id` of the agent to connect to. |
             | `conversationId` | string | | Active conversation ID. When this changes, messages are cleared. If left empty, the block auto-mints a stable id for the session and surfaces it via `onConversationStart`, so every turn posts a consistent id. App-supplied ids are always authoritative. |
             | `messages` | array | | Load messages externally. `undefined` = no sync, `null` = clear, array = load. |
+            | `feedbackValues` | object | | Ratings already recorded for messages in this conversation, keyed by message id, each `like` or `dislike`. The block does not persist a rating, so without this a reload or a conversation switch shows every message unrated even where your app stored it. A rating clicked this visit takes precedence, so the thumb still responds immediately and a rating the user has just withdrawn is not re-lit by a stale value. |
             | `urlQuery` | object | | Query parameters sent with each request. Available server-side via `_payload`. |
             | `sharedState` | object | | Two-way bridge between page state and the agent. See [Shared State](#shared-state). |
             | `height` | string | `'calc(100dvh - 170px)'` | CSS height of the chat container. Only applies when `display` is `'inline'`. |
@@ -360,6 +361,16 @@ _ref:
                   params:
                     content: Thanks for your feedback!
                     type: success
+            ```
+
+            Saving is only half of it — the block does not persist a rating, so a
+            reload or a conversation switch shows the message unrated again. Pass
+            what you stored back through `feedbackValues`, keyed by message id:
+
+            ```yaml
+            properties:
+              feedbackValues:
+                _request: saved_feedback_for_conversation
             ```
 
             ###### Adapt behavior based on sender switches:

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
@@ -43,6 +43,7 @@ function AgentChat({ blockId, components: { Icon, Link }, events, methods, pageI
     messageDisplay,
     sender,
     conversationId,
+    feedbackValues: storedFeedbackValues,
     messages: externalMessages,
     display,
     drawer: drawerConfig,
@@ -177,6 +178,20 @@ function AgentChat({ blockId, components: { Icon, Link }, events, methods, pageI
     },
   });
 
+  // The control is otherwise write-only: it reports a rating and immediately forgets it,
+  // so the thumb un-highlights on the next render and the message looks unrated. This holds
+  // what was clicked THIS visit; the block still persists nothing itself.
+  const [feedbackValues, setFeedbackValues] = useState({});
+
+  // Ratings the app already knows about, keyed by message id — what a reload or a
+  // conversation switch would otherwise lose, since the block stores nothing. A click this
+  // visit wins over the stored value, so the thumb responds immediately and a rating the
+  // user has just withdrawn is not re-lit by a stale prop.
+  // Not memoised: the property arrives from operators that rebuild it every render, so a
+  // dependency on it would miss every time — the same reason the message sync below
+  // compares by count and id rather than by reference.
+  const effectiveFeedbackValues = { ...(storedFeedbackValues ?? {}), ...feedbackValues };
+
   // Clear messages when conversationId changes so the new conversation starts clean.
   // Developers load saved messages via the messages property if needed.
   const prevConversationIdRef = useRef(effectiveConversationId);
@@ -184,6 +199,9 @@ function AgentChat({ blockId, components: { Icon, Link }, events, methods, pageI
     if (effectiveConversationId !== prevConversationIdRef.current) {
       prevConversationIdRef.current = effectiveConversationId;
       setMessages([]);
+      // Ratings clicked in the thread being left must not carry over: they are keyed by
+      // message id, and the incoming conversation supplies its own through feedbackValues.
+      setFeedbackValues({});
     }
   }, [effectiveConversationId, setMessages]);
 
@@ -448,12 +466,6 @@ function AgentChat({ blockId, components: { Icon, Link }, events, methods, pageI
     [interceptLinks, methods]
   );
 
-  // The control is otherwise write-only: it reports a rating and immediately forgets it,
-  // so the thumb un-highlights on the next render and the message looks unrated. Held per
-  // message for the life of the chat instance — a rating is not persisted by the block, so
-  // it does not survive a reload or a conversation switch.
-  const [feedbackValues, setFeedbackValues] = useState({});
-
   function handleFeedback({ messageId, rating }) {
     setFeedbackValues((prev) => ({ ...prev, [messageId]: rating }));
     const message = messages.find((msg) => msg.id === messageId);
@@ -527,7 +539,7 @@ function AgentChat({ blockId, components: { Icon, Link }, events, methods, pageI
             onFeedback={handleFeedback}
             onLinkClick={handleLinkClick}
             Link={Link}
-            feedbackValues={feedbackValues}
+            feedbackValues={effectiveFeedbackValues}
             onRegenerate={handleRegenerate}
             onDelete={handleDelete}
             onEditMessage={handleEditMessage}

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/schema.json
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/schema.json
@@ -162,6 +162,10 @@
     "messages": {
       "type": "array"
     },
+    "feedbackValues": {
+      "type": "object",
+      "description": "Ratings already recorded, keyed by message id, each `like` or `dislike`. Restores the thumbs on a conversation the block did not rate this visit. A rating clicked this visit takes precedence."
+    },
     "conversationId": {
       "type": "string",
       "description": "Active conversation ID. When this value changes, messages are automatically cleared."

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/tests/AgentChat.e2e.spec.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/tests/AgentChat.e2e.spec.js
@@ -140,4 +140,25 @@ test.describe('AgentChat feedback', () => {
     // Both thumbs are back, which is what unrated looks like.
     await expect(feedback.locator('[class*="dislike"]').first()).toBeVisible();
   });
+
+  // The block persists nothing, so a rating only survives a reload or a conversation switch
+  // if the app can hand back what it stored.
+  test('shows a rating supplied through feedbackValues', async ({ page }) => {
+    const feedback = getBlock(page, 'chat_seeded').locator('[class*="feedback"]').first();
+    await expect(feedback).toBeVisible();
+    // Selected on arrival, with no click: the opposite thumb is hidden, same as after a click.
+    await expect(feedback.locator('[class*="dislike"]').first()).toBeHidden();
+  });
+
+  // Clicking the thumb the supplied rating already selected CLEARS it, so `default` proves
+  // two things at once: the control was holding the supplied value, and the click outranked
+  // it. Were the stored value to win, withdrawing a rating would re-light the thumb and the
+  // withdrawal would look like it had failed.
+  test('a click this visit wins over the supplied rating', async ({ page }) => {
+    const feedback = getBlock(page, 'chat_seeded').locator('[class*="feedback"]').first();
+    await feedback.locator('[class*="like"]').first().click();
+
+    await expect(page.locator('#readout_seeded_rating')).toHaveText('default');
+    await expect(feedback.locator('[class*="dislike"]').first()).toBeVisible();
+  });
 });

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/tests/AgentChat.e2e.yaml
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/tests/AgentChat.e2e.yaml
@@ -57,6 +57,33 @@ blocks:
                     - 0
                 - 1
 
+  # Seeded from feedbackValues rather than from a click: what a reload or a conversation
+  # switch looks like to an app that stored the rating itself.
+  - id: chat_seeded
+    type: AgentChat
+    properties:
+      agentId: test_agent
+      height: 300
+      conversationId: seeded
+      messageDisplay:
+        actions:
+          - feedback
+      feedbackValues:
+        s1: like
+      messages:
+        - id: s1
+          role: assistant
+          parts:
+            - type: text
+              text: A rated answer.
+    events:
+      onFeedback:
+        - id: record_seeded_rating
+          type: SetState
+          params:
+            seeded_rating:
+              _event: rating
+
   - id: wired_readout
     type: Html
     properties:
@@ -67,6 +94,7 @@ blocks:
             <span id="readout_text">{{ text }}</span>
             <span id="readout_count">{{ count or 0 }}</span>
             <span id="readout_rating">{{ rating }}</span>
+            <span id="readout_seeded_rating">{{ seeded_rating }}</span>
           on:
             href:
               _state: last_href
@@ -76,6 +104,8 @@ blocks:
               _state: click_count
             rating:
               _state: last_rating
+            seeded_rating:
+              _state: seeded_rating
 
   - id: chat_unwired
     type: AgentChat


### PR DESCRIPTION
## Summary

Making `Actions.Feedback` controlled fixed the thumb un-highlighting mid-stream, and handed persistence to the app — but gave the app no way to hand the rating back. So the delegation was one-directional: "you store it", with no "and here's how to show it". The first app to wire it up stored ratings correctly and still showed every restored message unrated, which reads as a lost write rather than a display gap.

`AgentChat` now takes a `feedbackValues` property: a map of message id to `like` or `dislike`. The block still persists nothing itself — storing a rating remains the app's job — but a restored conversation comes back with its ratings showing.

## Changes

- **@lowdefy/blocks-antd-x**: New `feedbackValues` property on `AgentChat`, merged over the ratings clicked this visit and passed to `MessageList`. Ratings clicked in a conversation are dropped when `conversationId` changes, since they are keyed by message id and the arriving conversation supplies its own. Two e2e cases cover it.
- **@lowdefy/docs**: The property is documented in the `AgentChat` properties table, and the "Save feedback to the database" example now continues into the round-trip — that example is where a reader most likely meets this, and it previously stopped at the write.

## Notes

The merge is `{ ...stored, ...local }`, so a click this visit outranks the supplied value. The order matters: clearing a rating stores `default` locally while a value fetched before the withdrawal still says `like`, so the reverse order would re-light a thumb the user had just withdrawn and make the withdrawal look like it failed.

That is also what the second e2e case pins down, and its assertion is subtler than it looks. Clicking the thumb the supplied rating already selected *clears* it, so asserting `default` proves two things at once: the control was holding the supplied value, and the click outranked it.

No new changeset. `feat-agentchat-feedback-value.md` is unreleased and closes by saying a reload or conversation switch starts clean, which this removes — two entries would publish a limitation and then withdraw it in the same changelog. It is amended instead.