### PR TITLE
fix(auth): Offer offline_access so MCP clients get refresh tokens

### DIFF
--- a/.changeset/fix-mcp-offline-access-refresh-tokens.md
+++ b/.changeset/fix-mcp-offline-access-refresh-tokens.md
@@ -1,0 +1,17 @@
+---
+'@lowdefy/api': patch
+'@lowdefy/server': patch
+'@lowdefy/server-dev': patch
+---
+
+fix(auth): MCP clients stay connected instead of re-consenting every hour.
+
+The OAuth authorization server offered only `mcp:read` and `mcp:write`, and the
+oauth-provider issues a refresh token only when the grant carries
+`offline_access` - so every MCP access token died after an hour with nothing to
+renew it and Claude / ChatGPT had to re-authorize. `offline_access` is now part
+of the MCP scope vocabulary (shared `MCP_OAUTH_SCOPES`, exported from
+`@lowdefy/api`) and advertised in every per-org protected-resource metadata
+document's `scopes_supported`, so clients that request what is advertised get a
+refresh token and renew silently. Token lifetimes are unchanged (oauth-provider
+defaults: 1 hour access, 30 days refresh).

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -27,6 +27,7 @@ import createSystemContext from './context/createSystemContext.js';
 import createWebSocketConnection from './routes/websocket/createWebSocketConnection.js';
 import getAuthStrategies from './routes/auth/strategies/getAuthStrategies.js';
 import getBetterAuth from './routes/auth/getBetterAuth.js';
+import { MCP_OAUTH_SCOPES } from './routes/auth/getBetterAuthConfig.js';
 import {
   getAsIssuer,
   getMcpResourceMetadataUri,
@@ -73,6 +74,7 @@ export {
   getAsIssuer,
   getAuthStrategies,
   getBetterAuth,
+  MCP_OAUTH_SCOPES,
   getHomeAndMenus,
   getMcpResourceBinding,
   getMcpResourceMetadataUri,

--- a/packages/api/src/routes/auth/getBetterAuthConfig.js
+++ b/packages/api/src/routes/auth/getBetterAuthConfig.js
@@ -115,6 +115,11 @@ const ADMIN_PATHS_DISABLED = [
 // bridge a firing hook uses to invoke its InternalApi endpoint.
 // getAuth returns the constructed BetterAuth instance - the engine-tier
 // hooks resolve it lazily at fire time, after construction completes.
+// The scopes the authorization server offers MCP clients, and the vocabulary
+// the per-org protected-resource metadata advertises (RFC 9728
+// scopes_supported) - both read this list so they can never drift apart.
+const MCP_OAUTH_SCOPES = ['mcp:read', 'mcp:write', 'offline_access'];
+
 function getBetterAuthConfig({
   appMeta,
   authJson,
@@ -420,8 +425,11 @@ function getBetterAuthConfig({
         consentPage: `${baseUrlOrigin}${oauthPagesBasePath}${authConfig.oauthProvider.consentPage}`,
         // The closed MCP scope vocabulary. Without "openid" the OIDC surface
         // (id tokens, /oauth2/userinfo, /.well-known/openid-configuration)
-        // stays dormant.
-        scopes: ['mcp:read', 'mcp:write'],
+        // stays dormant. "offline_access" is the OAuth-standard opt-in for a
+        // refresh token: the oauth-provider issues one only when the grant
+        // carries it, so without it every MCP client is signed out the moment
+        // its access token lapses (hourly) and has to re-consent.
+        scopes: MCP_OAUTH_SCOPES,
         // No client_credentials - every access token is user-consented.
         grantTypes: ['authorization_code', 'refresh_token'],
         // Any registered client may request any enabled resource - access is
@@ -578,3 +586,4 @@ function getBetterAuthConfig({
 }
 
 export default getBetterAuthConfig;
+export { MCP_OAUTH_SCOPES };

--- a/packages/api/src/routes/auth/getBetterAuthConfig.test.js
+++ b/packages/api/src/routes/auth/getBetterAuthConfig.test.js
@@ -1575,7 +1575,9 @@ describe('oauthProvider authorization server plugins', () => {
   test('configures the oauth-provider with the closed mcp scope vocabulary and JWT access tokens', () => {
     const options = getOAuthOptions();
     const plugin = options.plugins.find((p) => p.id === 'oauth-provider');
-    expect(plugin.options.scopes).toEqual(['mcp:read', 'mcp:write']);
+    // offline_access is the refresh-token opt-in: without it the provider
+    // issues no refresh token and every MCP client re-consents hourly.
+    expect(plugin.options.scopes).toEqual(['mcp:read', 'mcp:write', 'offline_access']);
     expect(plugin.options.grantTypes).toEqual(['authorization_code', 'refresh_token']);
     // disableJwtPlugin false is the JWT access-token mode - opaque tokens off.
     expect(plugin.options.disableJwtPlugin).toBe(false);

--- a/packages/api/src/routes/auth/oauthProviderPluginContract.test.js
+++ b/packages/api/src/routes/auth/oauthProviderPluginContract.test.js
@@ -110,7 +110,7 @@ test('serves the RFC 8414 metadata document with the mcp scope vocabulary and no
   expect(metadata.jwks_uri).toBe(`${ORIGIN}/api/auth/jwks`);
   expect(metadata.introspection_endpoint).toBe(`${ORIGIN}/api/auth/oauth2/introspect`);
   expect(metadata.revocation_endpoint).toBe(`${ORIGIN}/api/auth/oauth2/revoke`);
-  expect(metadata.scopes_supported).toEqual(['mcp:read', 'mcp:write']);
+  expect(metadata.scopes_supported).toEqual(['mcp:read', 'mcp:write', 'offline_access']);
   expect(metadata.code_challenge_methods_supported).toEqual(['S256']);
   expect(metadata.grant_types_supported).toEqual(['authorization_code', 'refresh_token']);
   expect(metadata.client_id_metadata_document_supported).toBe(true);

--- a/packages/servers/server-dev/src/routes/mcpProtectedResourceMetadata.js
+++ b/packages/servers/server-dev/src/routes/mcpProtectedResourceMetadata.js
@@ -14,7 +14,12 @@
   limitations under the License.
 */
 
-import { getAsIssuer, getMcpResourceUri, isWellFormedOrgSegment } from '@lowdefy/api';
+import {
+  getAsIssuer,
+  getMcpResourceUri,
+  isWellFormedOrgSegment,
+  MCP_OAUTH_SCOPES,
+} from '@lowdefy/api';
 
 import lowdefyConfig from '../../lib/build/config.js';
 
@@ -31,7 +36,10 @@ function mcpProtectedResourceMetadataHandler(c) {
   return c.json({
     resource: getMcpResourceUri({ config: lowdefyConfig, orgId }),
     authorization_servers: [getAsIssuer({ config: lowdefyConfig })],
-    scopes_supported: ['mcp:read', 'mcp:write'],
+    // The same list the authorization server offers, so a client that requests
+    // exactly what is advertised (the MCP spec's guidance) gets offline_access
+    // and with it a refresh token - otherwise it re-consents every hour.
+    scopes_supported: MCP_OAUTH_SCOPES,
     bearer_methods_supported: ['header'],
   });
 }

--- a/packages/servers/server-dev/src/routes/mcpProtectedResourceMetadata.test.mjs
+++ b/packages/servers/server-dev/src/routes/mcpProtectedResourceMetadata.test.mjs
@@ -54,7 +54,7 @@ test('metadata handler serves the static template for an org', async () => {
   expect(await res.json()).toEqual({
     resource: 'https://app.test.com/api/mcp/org_1',
     authorization_servers: ['https://app.test.com/api/auth'],
-    scopes_supported: ['mcp:read', 'mcp:write'],
+    scopes_supported: ['mcp:read', 'mcp:write', 'offline_access'],
     bearer_methods_supported: ['header'],
   });
 });

--- a/packages/servers/server/src/routes/mcpProtectedResourceMetadata.js
+++ b/packages/servers/server/src/routes/mcpProtectedResourceMetadata.js
@@ -14,7 +14,12 @@
   limitations under the License.
 */
 
-import { getAsIssuer, getMcpResourceUri, isWellFormedOrgSegment } from '@lowdefy/api';
+import {
+  getAsIssuer,
+  getMcpResourceUri,
+  isWellFormedOrgSegment,
+  MCP_OAUTH_SCOPES,
+} from '@lowdefy/api';
 
 import lowdefyConfig from '../../lib/build/config.js';
 
@@ -31,7 +36,10 @@ function mcpProtectedResourceMetadataHandler(c) {
   return c.json({
     resource: getMcpResourceUri({ config: lowdefyConfig, orgId }),
     authorization_servers: [getAsIssuer({ config: lowdefyConfig })],
-    scopes_supported: ['mcp:read', 'mcp:write'],
+    // The same list the authorization server offers, so a client that requests
+    // exactly what is advertised (the MCP spec's guidance) gets offline_access
+    // and with it a refresh token - otherwise it re-consents every hour.
+    scopes_supported: MCP_OAUTH_SCOPES,
     bearer_methods_supported: ['header'],
   });
 }

--- a/packages/servers/server/src/routes/mcpProtectedResourceMetadata.test.mjs
+++ b/packages/servers/server/src/routes/mcpProtectedResourceMetadata.test.mjs
@@ -54,7 +54,7 @@ test('metadata handler serves the static template for an org', async () => {
   expect(await res.json()).toEqual({
     resource: 'https://app.test.com/api/mcp/org_1',
     authorization_servers: ['https://app.test.com/api/auth'],
-    scopes_supported: ['mcp:read', 'mcp:write'],
+    scopes_supported: ['mcp:read', 'mcp:write', 'offline_access'],
     bearer_methods_supported: ['header'],
   });
 });


### PR DESCRIPTION
## Problem

MCP clients (Claude, ChatGPT, Claude Code) connected to a per-org MCP route were signed out roughly an hour after authorizing and had to re-consent.

The authorization server offered only `mcp:read` and `mcp:write`, and `@better-auth/oauth-provider` issues a refresh token **only when the grant carries `offline_access`** (`isRefreshToken = user && clientAllowsGrant(client, "refresh_token") && scopes.includes("offline_access")`). So every access token (1h JWT) expired with nothing to renew it; the MCP route answered 401 with its challenge and the client re-prompted.

The per-org RFC 9728 protected-resource metadata advertised the same two scopes in `scopes_supported`, and MCP clients request what is advertised — so even a client willing to ask for `offline_access` had no way to learn it existed (and authorize would have rejected it as `invalid_scope`).

## Fix

- `MCP_OAUTH_SCOPES = ['mcp:read', 'mcp:write', 'offline_access']` — one shared constant in `getBetterAuthConfig.js`, exported from `@lowdefy/api`.
- The oauth-provider `scopes` and both protected-resource metadata routes (`server`, `server-dev`) read it, so the AS offer and `scopes_supported` cannot drift.
- Token lifetimes are unchanged (oauth-provider defaults: 1h access, 30d refresh).

## Notes

- Existing CIMD client rows store the scope list from registration; they pick up `offline_access` on their next metadata re-fetch (cache expiry or restart).
- The consent page receives `offline_access` in `scope` like any other scope — apps that map scope→copy should add an entry for it.

## Tests

`getBetterAuthConfig.test.js` and `oauthProviderPluginContract.test.js` updated for the new vocabulary (86/86 pass). Prettier clean. Changeset included (`@lowdefy/api`, `@lowdefy/server`, `@lowdefy/server-dev`).