### PR TITLE
fix: Apply community fixes (hidden list restore, label hasFeedback, MSSQL port, jsonata 1.8.9) and helpers CodeQL hardening

### DIFF
--- a/.changeset/chore-jsonata-1-8-9.md
+++ b/.changeset/chore-jsonata-1-8-9.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/operators-jsonata': patch
+---
+
+chore(operators-jsonata): Bump `jsonata` to 1.8.9 to clear four security advisories (GHSA-66mm-25pp-rfff, GHSA-2943-5xfg-gq5f, GHSA-8gq3-vp5j-2grp, GHSA-86vw-mfpg-wwv9).

--- a/.changeset/fix-blocks-antd-label-has-feedback.md
+++ b/.changeset/fix-blocks-antd-label-has-feedback.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/blocks-antd': patch
+---
+
+fix(blocks-antd): Honour `label.hasFeedback: false`.
+
+The Label rendered the validation status icon (and message) regardless of `hasFeedback`, so an input configured with `label.hasFeedback: false` still showed a detached grey icon after `Validate`. Both the icon and the feedback message are now gated on `hasFeedback`; validation itself and the input's error/warning styling are unchanged.

--- a/.changeset/fix-engine-hidden-list-restore.md
+++ b/.changeset/fix-engine-hidden-list-restore.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/engine': patch
+---
+
+fix(engine): Restore a list's items when the list becomes visible again.
+
+Hiding a list (or a container holding one) removed its array from state, and revealing it again rebuilt the list empty — the items were gone. The engine now keeps an in-memory copy of a list's state value while it is hidden and republishes it when the list becomes visible and the state field is absent. A `SetState` performed while hidden still takes precedence.

--- a/.changeset/fix-helpers-dot-path-resolution.md
+++ b/.changeset/fix-helpers-dot-path-resolution.md
@@ -57,3 +57,10 @@ cleared, hidden input no longer leaves a stale key behind in `_state`. The same 
 `Map` or `Set`, an empty-source `RegExp`, and a blank-message `Error`. And a block id written with an
 escaped dot used to crash the delete: `unset({ 'a.b': { c: 1 } }, 'a\.b.c')` threw
 `TypeError: Cannot read properties of undefined` and now deletes `c`.
+
+**The dot-path escape grammar now covers the backslash itself.** `\.` remains a literal dot and `\\`
+is now a literal backslash, so `joinPath` can escape a segment that ends in a backslash — before, it
+only escaped dots, and `joinPath(['a\\', 'b'])` produced a path `splitPath` read back as the single
+key `a.b`. Any other backslash is still an ordinary character, so a key such as `a\b` needs no
+escaping. The one observable change is a doubled backslash directly before a dot:
+`splitPath('a\\\\.b')` used to yield `['a\\.b']` and now yields `['a\\', 'b']`.

--- a/.changeset/fix-knex-connection-port-number.md
+++ b/.changeset/fix-knex-connection-port-number.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/connection-knex': patch
+---
+
+fix(connection-knex): Pass a numeric port to the database driver.
+
+A port taken from a connection string or a `_secret` reached the driver as a string, which `mssql` (tedious) rejects with `The "config.options.port" property must be of type number`. The Knex connection now coerces a string port to a number for every client, and fails with a `ConfigError` when the port is not a valid port number.

--- a/packages/engine/src/Block.js
+++ b/packages/engine/src/Block.js
@@ -339,6 +339,10 @@ class Block {
       repeat.value = true;
     }
 
+    if (this.isList() && !this.isVisible()) {
+      this.captureHiddenValue();
+    }
+
     if (this.visibleEval.output !== false) {
       this.propertiesEval = this.parse(this.properties);
       this.requiredEval = this.parse(this.required);
@@ -444,8 +448,26 @@ class Block {
     });
   };
 
+  captureHiddenValue = () => {
+    const stateValue = get(this.context.state, this.blockId);
+    if (type.isUndefined(stateValue)) return;
+    this.hiddenValue = serializer.copy(stateValue);
+  };
+
+  restoreHiddenValue = () => {
+    if (type.isUndefined(this.hiddenValue)) return;
+    if (type.isUndefined(get(this.context.state, this.blockId))) {
+      this.context._internal.State.set(this.blockId, this.hiddenValue);
+    }
+    this.hiddenValue = undefined;
+  };
+
   updateState = (toSet) => {
     if (!this.isVisible()) return;
+
+    if (this.isList()) {
+      this.restoreHiddenValue();
+    }
 
     if (this.isContainer() || this.isList()) {
       if (this.subSlots && this.subSlots.length > 0) {

--- a/packages/engine/test/Block/list.test.js
+++ b/packages/engine/test/Block/list.test.js
@@ -599,6 +599,220 @@ test('list block with visible', async () => {
   expect(context.state).toEqual({ list: [{ a: 'a' }], swtch: true });
 });
 
+test('list of display blocks in a hidden container restores its items in state when revealed', async () => {
+  const pageConfig = {
+    id: 'root',
+    type: 'Box',
+    events: {
+      onInit: [
+        {
+          id: 'initState',
+          type: 'SetState',
+          params: {
+            visible: true,
+            object: { list: [{ value: 'a' }, { value: 'b' }, { value: 'c' }] },
+          },
+        },
+      ],
+    },
+    blocks: [
+      {
+        type: 'Switch',
+        id: 'visible',
+      },
+      {
+        type: 'Box',
+        id: 'box',
+        visible: { _state: 'visible' },
+        blocks: [
+          {
+            type: 'List',
+            id: 'object.list',
+            blocks: [
+              {
+                type: 'Paragraph',
+                id: 'object.list.$.value',
+                properties: { content: { _state: 'object.list.$.value' } },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const context = await testContext({
+    lowdefy,
+    pageConfig,
+  });
+  const visible = context._internal.RootSlots.map['visible'];
+  const list = context._internal.RootSlots.map['object.list'];
+  const initialState = {
+    visible: true,
+    object: { list: [{ value: 'a' }, { value: 'b' }, { value: 'c' }] },
+  };
+
+  expect(context.state).toEqual(initialState);
+
+  visible.setValue(false);
+  expect(context.state).toEqual({ visible: false });
+  expect(list.subSlots.length).toEqual(3);
+
+  visible.setValue(true);
+  expect(context.state).toEqual(initialState);
+  expect(list.subSlots.length).toEqual(3);
+  expect(context._internal.RootSlots.map['object.list.2.value'].eval.properties).toEqual({
+    content: 'c',
+  });
+});
+
+test('list of display blocks restores its items in state when revealed by SetState', async () => {
+  const pageConfig = {
+    id: 'root',
+    type: 'Box',
+    events: {
+      onInit: [
+        {
+          id: 'initState',
+          type: 'SetState',
+          params: {
+            show: false,
+            list: [{ value: 'a' }, { value: 'b' }],
+          },
+        },
+      ],
+    },
+    blocks: [
+      {
+        type: 'Box',
+        id: 'box',
+        visible: { _state: 'show' },
+        blocks: [
+          {
+            type: 'List',
+            id: 'list',
+            blocks: [
+              {
+                type: 'Paragraph',
+                id: 'list.$.value',
+                properties: { content: { _state: 'list.$.value' } },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'Button',
+        id: 'reveal',
+        events: {
+          onClick: [{ id: 'a', type: 'SetState', params: { show: true } }],
+        },
+      },
+      {
+        type: 'Button',
+        id: 'hide',
+        events: {
+          onClick: [{ id: 'a', type: 'SetState', params: { show: false } }],
+        },
+      },
+    ],
+  };
+  const context = await testContext({
+    lowdefy,
+    pageConfig,
+  });
+  const { reveal, hide } = context._internal.RootSlots.map;
+
+  expect(context.state).toEqual({ show: false });
+
+  await reveal.triggerEvent({ name: 'onClick' });
+  expect(context.state).toEqual({ show: true, list: [{ value: 'a' }, { value: 'b' }] });
+
+  await hide.triggerEvent({ name: 'onClick' });
+  expect(context.state).toEqual({ show: false });
+
+  await reveal.triggerEvent({ name: 'onClick' });
+  expect(context.state).toEqual({ show: true, list: [{ value: 'a' }, { value: 'b' }] });
+});
+
+test('list items changed by SetState while hidden take precedence over the preserved items', async () => {
+  const pageConfig = {
+    id: 'root',
+    type: 'Box',
+    events: {
+      onInit: [
+        {
+          id: 'initState',
+          type: 'SetState',
+          params: {
+            show: true,
+            list: [{ value: 'a' }, { value: 'b' }, { value: 'c' }],
+          },
+        },
+      ],
+    },
+    blocks: [
+      {
+        type: 'Box',
+        id: 'box',
+        visible: { _state: 'show' },
+        blocks: [
+          {
+            type: 'List',
+            id: 'list',
+            blocks: [
+              {
+                type: 'Paragraph',
+                id: 'list.$.value',
+                properties: { content: { _state: 'list.$.value' } },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'Button',
+        id: 'hide',
+        events: {
+          onClick: [{ id: 'a', type: 'SetState', params: { show: false } }],
+        },
+      },
+      {
+        type: 'Button',
+        id: 'replace',
+        events: {
+          onClick: [{ id: 'a', type: 'SetState', params: { list: [{ value: 'x' }] } }],
+        },
+      },
+      {
+        type: 'Button',
+        id: 'reveal',
+        events: {
+          onClick: [{ id: 'a', type: 'SetState', params: { show: true } }],
+        },
+      },
+    ],
+  };
+  const context = await testContext({
+    lowdefy,
+    pageConfig,
+  });
+  const { hide, replace, reveal } = context._internal.RootSlots.map;
+
+  expect(context.state).toEqual({
+    show: true,
+    list: [{ value: 'a' }, { value: 'b' }, { value: 'c' }],
+  });
+
+  await hide.triggerEvent({ name: 'onClick' });
+  expect(context.state).toEqual({ show: false });
+
+  await replace.triggerEvent({ name: 'onClick' });
+  expect(context.state).toEqual({ show: false });
+
+  await reveal.triggerEvent({ name: 'onClick' });
+  expect(context.state).toEqual({ show: true, list: [{ value: 'x' }] });
+});
+
 test('toggle list object field visibility with index', async () => {
   const pageConfig = {
     id: 'root',

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Label/Label.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Label/Label.js
@@ -61,6 +61,7 @@ const Label = ({
     rowStyle,
     showExtra,
     showFeedback,
+    showFeedbackIcon,
     wrapperCol,
   } = labelLogic({ blockId, blockClassNames, content, properties, required, styles, validation });
   if (!iconMap) {
@@ -71,13 +72,12 @@ const Label = ({
       warning: () => <Icon properties="AiFillExclamationCircle" />,
     };
   }
-  const IconNode = validation.status && iconMap[validation.status];
-  const icon =
-    validation.status && IconNode ? (
-      <span className={iconClassName}>
-        <IconNode />
-      </span>
-    ) : null;
+  const IconNode = showFeedbackIcon && iconMap[validation.status];
+  const icon = IconNode ? (
+    <span className={iconClassName}>
+      <IconNode />
+    </span>
+  ) : null;
 
   // tooltip is either a string (the tooltip text) or an object that also
   // customizes the icon and color. The onClick is exposed as the block's

--- a/packages/plugins/blocks/blocks-antd/src/blocks/Label/labelLogic.js
+++ b/packages/plugins/blocks/blocks-antd/src/blocks/Label/labelLogic.js
@@ -117,8 +117,11 @@ const labelLogic = ({
     'ldf-feedback-icon': true,
   });
 
+  const hasFeedback = properties.hasFeedback !== false;
   const showExtra = !!properties.extra && (!validation.status || validation.status === 'success');
-  const showFeedback = validation.status === 'warning' || validation.status === 'error';
+  const showFeedback =
+    hasFeedback && (validation.status === 'warning' || validation.status === 'error');
+  const showFeedbackIcon = hasFeedback && !type.isNone(validation.status);
   return {
     extraClassName,
     extraStyle,
@@ -135,6 +138,7 @@ const labelLogic = ({
     rowStyle,
     showExtra,
     showFeedback,
+    showFeedbackIcon,
     wrapperCol,
   };
 };

--- a/packages/plugins/connections/connection-knex/src/connections/Knex/KnexBuilder/KnexBuilder.test.js
+++ b/packages/plugins/connections/connection-knex/src/connections/Knex/KnexBuilder/KnexBuilder.test.js
@@ -20,6 +20,7 @@ import { validate } from '@lowdefy/ajv';
 const mockKnexClient = jest.fn(() => mockKnexClient);
 const mockKnex = jest.fn(() => mockKnexClient);
 
+mockKnexClient.client = { connectionSettings: {} };
 mockKnexClient.select = jest.fn(() => mockKnexClient);
 mockKnexClient.from = jest.fn(() => mockKnexClient);
 mockKnexClient.where = jest.fn(() => mockKnexClient);

--- a/packages/plugins/connections/connection-knex/src/connections/Knex/KnexRaw/KnexRaw.test.js
+++ b/packages/plugins/connections/connection-knex/src/connections/Knex/KnexRaw/KnexRaw.test.js
@@ -24,6 +24,7 @@ const mockRaw = jest.fn(() => {
 jest.unstable_mockModule('knex', () => {
   return {
     default: jest.fn(() => ({
+      client: { connectionSettings: {} },
       raw: mockRaw,
     })),
   };

--- a/packages/plugins/connections/connection-knex/src/connections/Knex/createKnex.js
+++ b/packages/plugins/connections/connection-knex/src/connections/Knex/createKnex.js
@@ -17,6 +17,8 @@
 import knex from 'knex';
 import { ConfigError } from '@lowdefy/errors';
 
+import normalizeConnectionPort from './normalizeConnectionPort.js';
+
 function createKnex(connection) {
   if (connection.client === 'sqlite3') {
     throw new ConfigError(
@@ -29,9 +31,9 @@ function createKnex(connection) {
     );
   }
   if (connection.client === 'sqlite') {
-    return knex({ ...connection, client: 'better-sqlite3' });
+    return normalizeConnectionPort(knex({ ...connection, client: 'better-sqlite3' }));
   }
-  return knex(connection);
+  return normalizeConnectionPort(knex(connection));
 }
 
 export default createKnex;

--- a/packages/plugins/connections/connection-knex/src/connections/Knex/createKnex.test.js
+++ b/packages/plugins/connections/connection-knex/src/connections/Knex/createKnex.test.js
@@ -16,7 +16,11 @@
 
 import { jest } from '@jest/globals';
 
-const mockKnex = jest.fn(() => ({}));
+const mockKnex = jest.fn((config) => ({
+  client: {
+    connectionSettings: typeof config.connection === 'object' ? { ...config.connection } : {},
+  },
+}));
 
 jest.unstable_mockModule('knex', () => ({ default: mockKnex }));
 
@@ -67,4 +71,45 @@ test('createKnex passes "mysql2" through unchanged', async () => {
   const createKnex = (await import('./createKnex.js')).default;
   createKnex({ client: 'mysql2', connection: 'mysql://u:p@h/db' });
   expect(mockKnex.mock.calls).toEqual([[{ client: 'mysql2', connection: 'mysql://u:p@h/db' }]]);
+});
+
+test('createKnex converts a connection object port given as a string to a number', async () => {
+  const createKnex = (await import('./createKnex.js')).default;
+  const knexClient = createKnex({
+    client: 'mssql',
+    connection: { server: 'server', port: '45678', database: 'db' },
+  });
+  expect(knexClient.client.connectionSettings).toEqual({
+    server: 'server',
+    port: 45678,
+    database: 'db',
+  });
+});
+
+test('createKnex converts a port parsed from a connection string to a number', async () => {
+  const createKnex = (await import('./createKnex.js')).default;
+  mockKnex.mockImplementationOnce(() => ({
+    client: { connectionSettings: { server: 'server', port: '45678', database: 'db' } },
+  }));
+  const knexClient = createKnex({
+    client: 'mssql',
+    connection: 'mssql://user:password@server:45678/db',
+  });
+  expect(knexClient.client.connectionSettings.port).toBe(45678);
+});
+
+test('createKnex throws when the connection port is not a valid port number', async () => {
+  const createKnex = (await import('./createKnex.js')).default;
+  expect(() =>
+    createKnex({ client: 'mssql', connection: { server: 'server', port: 'port', database: 'db' } })
+  ).toThrow('Knex connection port is not a valid port number. Received "port".');
+});
+
+test('createKnex leaves a numeric connection port unchanged', async () => {
+  const createKnex = (await import('./createKnex.js')).default;
+  const knexClient = createKnex({
+    client: 'mssql',
+    connection: { server: 'server', port: 45678, database: 'db' },
+  });
+  expect(knexClient.client.connectionSettings.port).toBe(45678);
 });

--- a/packages/plugins/connections/connection-knex/src/connections/Knex/normalizeConnectionPort.js
+++ b/packages/plugins/connections/connection-knex/src/connections/Knex/normalizeConnectionPort.js
@@ -1,0 +1,38 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ConfigError } from '@lowdefy/errors';
+import { type } from '@lowdefy/helpers';
+
+// knex hands connectionSettings.port to the driver as it received it, and a port
+// parsed from a connection string or read from a _secret arrives as a string.
+// tedious (mssql) refuses a string port, so coerce it once for every client.
+function normalizeConnectionPort(knexClient) {
+  const settings = knexClient.client?.connectionSettings;
+  if (!type.isObject(settings) || !type.isString(settings.port)) {
+    return knexClient;
+  }
+  const port = Number(settings.port);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new ConfigError(
+      `Knex connection port is not a valid port number. Received ${JSON.stringify(settings.port)}.`
+    );
+  }
+  settings.port = port;
+  return knexClient;
+}
+
+export default normalizeConnectionPort;

--- a/packages/plugins/connections/connection-knex/src/connections/Knex/normalizeConnectionPort.test.js
+++ b/packages/plugins/connections/connection-knex/src/connections/Knex/normalizeConnectionPort.test.js
@@ -1,0 +1,54 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ConfigError } from '@lowdefy/errors';
+
+import normalizeConnectionPort from './normalizeConnectionPort.js';
+
+test('normalizeConnectionPort converts a string port to a number', () => {
+  const knexClient = { client: { connectionSettings: { host: 'h', port: '45678' } } };
+  expect(normalizeConnectionPort(knexClient)).toBe(knexClient);
+  expect(knexClient.client.connectionSettings.port).toBe(45678);
+});
+
+test('normalizeConnectionPort leaves a numeric port unchanged', () => {
+  const knexClient = { client: { connectionSettings: { host: 'h', port: 1433 } } };
+  normalizeConnectionPort(knexClient);
+  expect(knexClient.client.connectionSettings.port).toBe(1433);
+});
+
+test('normalizeConnectionPort leaves settings without a port unchanged', () => {
+  const knexClient = { client: { connectionSettings: { filename: ':memory:' } } };
+  normalizeConnectionPort(knexClient);
+  expect(knexClient.client.connectionSettings).toEqual({ filename: ':memory:' });
+});
+
+test('normalizeConnectionPort returns the client when it has no connection settings', () => {
+  const knexClient = { client: {} };
+  expect(normalizeConnectionPort(knexClient)).toBe(knexClient);
+});
+
+test('normalizeConnectionPort throws a ConfigError for a port that is not a number', () => {
+  const knexClient = { client: { connectionSettings: { port: 'abc' } } };
+  expect(() => normalizeConnectionPort(knexClient)).toThrow(
+    'Knex connection port is not a valid port number. Received "abc".'
+  );
+});
+
+test('normalizeConnectionPort throws a ConfigError for a port outside the valid range', () => {
+  const knexClient = { client: { connectionSettings: { port: '70000' } } };
+  expect(() => normalizeConnectionPort(knexClient)).toThrow(ConfigError);
+});

--- a/packages/plugins/operators/operators-jsonata/package.json
+++ b/packages/plugins/operators/operators-jsonata/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@lowdefy/helpers": "5.4.0",
     "@lowdefy/operators": "5.4.0",
-    "jsonata": "1.8.7"
+    "jsonata": "1.8.9"
   },
   "devDependencies": {
     "@jest/globals": "28.1.3",

--- a/packages/utils/helpers/README.md
+++ b/packages/utils/helpers/README.md
@@ -242,7 +242,7 @@ isReserved('toString'); // returns false
 (segments: string[]): string
 ```
 
-Join segments into a dot-path, re-escaping literal dots inside a segment. Inverse of `splitPath`. Throws `TypeError` if `segments` is not an array. Non-string segments are coerced with `String`.
+Join segments into a dot-path, re-escaping literal backslashes (`\\\\`) and literal dots (`\\.`) inside a segment. Inverse of `splitPath`. Throws `TypeError` if `segments` is not an array. Non-string segments are coerced with `String`.
 
 ```js
 joinPath(['a.b', 'c']); // returns 'a\\.b.c'
@@ -390,7 +390,7 @@ Use `setKey` rather than `obj[userKey] = value` wherever the key is derived from
 (path: string): string[]
 ```
 
-Split a dot-path into segments. A trailing backslash escapes the dot that follows, so the escaped dot stays inside the segment. Throws `TypeError` if `path` is not a string. A trailing backslash with nothing after it is kept as a literal backslash.
+Split a dot-path into segments. `\\.` is a literal dot and `\\\\` a literal backslash; any other backslash is an ordinary character, so a key such as `a\\b` needs no escaping. Throws `TypeError` if `path` is not a string.
 
 ```js
 splitPath('a.b.c'); // returns ['a', 'b', 'c']

--- a/packages/utils/helpers/src/joinPath.js
+++ b/packages/utils/helpers/src/joinPath.js
@@ -22,7 +22,11 @@ function joinPath(segments) {
       `joinPath: segments must be an array. Received ${JSON.stringify(segments)}.`
     );
   }
-  return segments.map((segment) => String(segment).replace(/\./g, '\\.')).join('.');
+  // Escape the escape character first, then the separator, so a segment ending in a
+  // backslash cannot swallow the dot that follows it when splitPath reads it back.
+  return segments
+    .map((segment) => String(segment).replace(/\\/g, '\\\\').replace(/\./g, '\\.'))
+    .join('.');
 }
 
 export default joinPath;

--- a/packages/utils/helpers/src/joinPath.test.js
+++ b/packages/utils/helpers/src/joinPath.test.js
@@ -61,3 +61,12 @@ test('joinPath round-trips segments with a literal dot through splitPath', () =>
 test('joinPath round-trips plain segments through splitPath', () => {
   expect(splitPath(joinPath(['a', 'b', 'c']))).toEqual(['a', 'b', 'c']);
 });
+
+test('joinPath escapes a literal backslash inside a segment', () => {
+  expect(joinPath(['a\\', 'b'])).toEqual('a\\\\.b');
+  expect(joinPath(['a\\.b'])).toEqual('a\\\\\\.b');
+});
+
+test('joinPath round-trips a segment with a backslash and a dot through splitPath', () => {
+  expect(splitPath(joinPath(['a\\.b', 'c']))).toEqual(['a\\.b', 'c']);
+});

--- a/packages/utils/helpers/src/set.js
+++ b/packages/utils/helpers/src/set.js
@@ -102,6 +102,13 @@ function set(target, path, value) {
       }
     }
 
+    // Every segment was already rejected by isReserved above, but the assignments
+    // below are the prototype-pollution sinks, so the check also sits beside them
+    // on the resolved key, where it is local to the write.
+    if (prop === '__proto__' || prop === 'constructor' || prop === 'prototype') {
+      throw new ReservedKeyError(prop);
+    }
+
     if (next === len) {
       target[prop] = value;
       break;

--- a/packages/utils/helpers/src/splitPath.js
+++ b/packages/utils/helpers/src/splitPath.js
@@ -16,24 +16,39 @@
 
 import type from './type.js';
 
+// Dot-path grammar: `.` separates segments, `\.` is a literal dot and `\\` a
+// literal backslash. Any other backslash is an ordinary character, so keys such
+// as 'a\b' keep working unescaped. joinPath is the inverse.
 function splitPath(path) {
   if (!type.isString(path)) {
     throw new TypeError(`splitPath: path must be a string. Received ${JSON.stringify(path)}.`);
   }
-  const parts = path.split('.');
   const segments = [];
+  let segment = '';
   let i = 0;
-  while (i < parts.length) {
-    let segment = parts[i];
-    // A trailing backslash escapes the dot that follows, so the next part
-    // continues the current segment instead of starting a new one.
-    while (segment && segment.slice(-1) === '\\' && !type.isUndefined(parts[i + 1])) {
+  while (i < path.length) {
+    const char = path[i];
+    if (char === '\\') {
+      const next = path[i + 1];
+      if (next === '.' || next === '\\') {
+        segment += next;
+        i += 2;
+        continue;
+      }
+      segment += char;
       i += 1;
-      segment = `${segment.slice(0, -1)}.${parts[i]}`;
+      continue;
     }
-    segments.push(segment);
+    if (char === '.') {
+      segments.push(segment);
+      segment = '';
+      i += 1;
+      continue;
+    }
+    segment += char;
     i += 1;
   }
+  segments.push(segment);
   return segments;
 }
 

--- a/packages/utils/helpers/src/splitPath.test.js
+++ b/packages/utils/helpers/src/splitPath.test.js
@@ -77,3 +77,12 @@ test('splitPath throws a TypeError when path is undefined', () => {
 test('splitPath round-trips a path with an escaped dot through joinPath', () => {
   expect(joinPath(splitPath('a.b\\.c.d'))).toEqual('a.b\\.c.d');
 });
+
+test('splitPath treats a doubled backslash as one literal backslash', () => {
+  expect(splitPath('a\\\\.b')).toEqual(['a\\', 'b']);
+  expect(splitPath('a\\\\b')).toEqual(['a\\b']);
+});
+
+test('splitPath round-trips a segment ending in a backslash through joinPath', () => {
+  expect(splitPath(joinPath(['a\\', 'b']))).toEqual(['a\\', 'b']);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1751,8 +1751,8 @@ importers:
         specifier: 5.4.0
         version: link:../../../operators
       jsonata:
-        specifier: 1.8.7
-        version: 1.8.7
+        specifier: 1.8.9
+        version: 1.8.9
     devDependencies:
       '@jest/globals':
         specifier: 28.1.3
@@ -9913,8 +9913,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  jsonata@1.8.7:
-    resolution: {integrity: sha512-tOW2/hZ+nR2bcQZs+0T62LVe5CHaNa3laFFWb/262r39utN6whJGBF7IR2Wq1QXrDbhftolk5gggW8uUJYlBTQ==}
+  jsonata@1.8.9:
+    resolution: {integrity: sha512-Vk6QF2zjeprCS6FXCK/3yTaTbB3wxh6C4Adp4Gt4FJ3e53kGKRLwfTLDWVWfwAHEsVYegsQRgBDUl8TdFSt7Qg==}
     engines: {node: '>= 8'}
 
   jsonc-parser@3.2.0:
@@ -22115,7 +22115,7 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsonata@1.8.7: {}
+  jsonata@1.8.9: {}
 
   jsonc-parser@3.2.0: {}
 


### PR DESCRIPTION
## Summary

Applies the community fixes worth taking from the open `main`-targeted PRs onto `develop` (so they flow into `vite-hono` → `auth-upgrade`), plus the helpers hardening CodeQL asked for on #2336.

### Applied (with author credit)
- **#2320** — `fix(engine)`: a hidden list keeps an in-memory copy of its state value and republishes it when revealed (fixes #1120). Cherry-picked from @Roshan931 with tests.
- **#2318** — `fix(blocks-antd)`: `label.hasFeedback: false` now hides both the status icon and the feedback message (fixes #1471). Cherry-picked from @Roshan931.
- **#2319** — `fix(connection-knex)`: string ports (connection strings, `_secret`s) are coerced to numbers before reaching the driver, fixing MSSQL custom ports (fixes #1513). Cherry-picked from @Roshan931; the PR was missing its `normalizeConnectionPort.js`, added here with unit tests and a `ConfigError` for invalid ports.
- **#2324** — `chore(operators-jsonata)`: jsonata 1.8.7 → 1.8.9, clearing four advisories. Re-applied on develop's lockfile, co-authored @katsugtgz.

### Not applied
- **#2323** (`auth?.public` guard) — build always stamps `auth` on every request/endpoint artifact, so a missing `auth` is a corrupt artifact, not a config error; optional chaining would only turn a TypeError into a misleading `ConfigError`. Closing with that explanation.

### CodeQL follow-ups from #2336
- `joinPath` escaped dots but not backslashes (js/incomplete-sanitization): `\\` is now a literal backslash in both directions; the only observable change is a doubled backslash directly before a dot.
- `set` re-checks the resolved write key for `__proto__`/`constructor`/`prototype` beside the assignment (js/prototype-pollution-*); `isReserved` already rejected every segment, this makes the sink self-evidently safe.
- The three `apiWrapper` "stack trace exposure" alerts were dismissed as false positives — `omitErrorProps` always strips `stack` and `received` before serialisation.

Same helpers fix is already on `auth-upgrade` (6db41d5ad).

Tests: engine 381, connection-knex 35, operators-jsonata 18, helpers 666, blocks-antd builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
