### PR TITLE
fix: Accept a repeated MCP-Protocol-Version header on /api/mcp

### DIFF
--- a/.changeset/fix-mcp-protocol-version-header.md
+++ b/.changeset/fix-mcp-protocol-version-header.md
@@ -1,0 +1,8 @@
+---
+'@lowdefy/server': patch
+'@lowdefy/server-dev': patch
+---
+
+fix: Accept a repeated `MCP-Protocol-Version` header on `/api/mcp`.
+
+Claude Code sends the negotiated protocol version under two spellings of the header, which the Fetch Headers constructor folds into one comma-joined value (`2025-11-25, 2025-11-25`). The MCP transport compared that raw string against its supported list and answered 404 "Unsupported protocol version" — shown by Claude Code as "MCP endpoint not found". The route now collapses a repeated value to the single version it names before the transport reads it; a header naming two different versions is still refused.

--- a/packages/servers/server-dev/src/routes/mcp.js
+++ b/packages/servers/server-dev/src/routes/mcp.js
@@ -19,6 +19,7 @@ import { createMcpServer, getMcpResourceMetadataUri, getMcpResourceUri } from '@
 import { type } from '@lowdefy/helpers';
 
 import authJson from '../../lib/build/auth.js';
+import normalizeMcpProtocolVersionHeader from './normalizeMcpProtocolVersionHeader.js';
 
 // The RFC 6750 challenge for the MCP resource, pointing at its RFC 9728
 // metadata. The invalid_token extension exists for the two failures a client
@@ -65,6 +66,7 @@ function isOriginAllowed({ c, context }) {
 // boundary a role or scope shortfall stays opaque inside the tool surface,
 // never a 403 or insufficient_scope.
 async function mcpHandler(c) {
+  normalizeMcpProtocolVersionHeader({ request: c.req.raw });
   const context = c.get('lowdefyContext');
   const mcpConfig = await context.readConfigFile('mcp.json');
   if (type.isNone(mcpConfig) || mcpConfig.configured !== true) {

--- a/packages/servers/server-dev/src/routes/normalizeMcpProtocolVersionHeader.js
+++ b/packages/servers/server-dev/src/routes/normalizeMcpProtocolVersionHeader.js
@@ -1,0 +1,46 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Claude Code merges the protocol version it negotiated (mcp-protocol-version)
+// with a static MCP-Protocol-Version it sets on every request, and the Fetch
+// Headers constructor folds the two spellings of one header into a single
+// comma-joined value: "2025-11-25, 2025-11-25". @hono/mcp compares that raw
+// string against its supported list, so a client that agrees with the server
+// twice over is answered 404 "Unsupported protocol version" - which Claude Code
+// shows as "MCP endpoint not found". Collapsing a repeated value to the one
+// version it names is lossless; a header naming two DIFFERENT versions is left
+// for the transport to refuse. Runs before the transport reads the header: the
+// transport reads c.req.header(), which reads the raw request headers live.
+function normalizeMcpProtocolVersionHeader({ request }) {
+  const value = request.headers.get('mcp-protocol-version');
+  if (value === null || !value.includes(',')) {
+    return;
+  }
+  const versions = [
+    ...new Set(
+      value
+        .split(',')
+        .map((version) => version.trim())
+        .filter(Boolean)
+    ),
+  ];
+  if (versions.length !== 1) {
+    return;
+  }
+  request.headers.set('mcp-protocol-version', versions[0]);
+}
+
+export default normalizeMcpProtocolVersionHeader;

--- a/packages/servers/server-dev/src/routes/normalizeMcpProtocolVersionHeader.test.mjs
+++ b/packages/servers/server-dev/src/routes/normalizeMcpProtocolVersionHeader.test.mjs
@@ -1,0 +1,62 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { Hono } from 'hono';
+
+import normalizeMcpProtocolVersionHeader from './normalizeMcpProtocolVersionHeader.js';
+
+function createApp() {
+  const app = new Hono();
+  app.post('/api/mcp', (c) => {
+    normalizeMcpProtocolVersionHeader({ request: c.req.raw });
+    return c.json({ protocolVersion: c.req.header('mcp-protocol-version') ?? null });
+  });
+  return app;
+}
+
+async function send(headerValue) {
+  const headers = new Headers();
+  if (headerValue !== undefined) {
+    headers.set('mcp-protocol-version', headerValue);
+  }
+  const res = await createApp().request('/api/mcp', { method: 'POST', headers });
+  return (await res.json()).protocolVersion;
+}
+
+test('collapses a repeated protocol version to the single version it names', async () => {
+  expect(await send('2025-11-25, 2025-11-25')).toEqual('2025-11-25');
+});
+
+test('collapses the value the Fetch Headers constructor builds from both header spellings', async () => {
+  const headers = new Headers({
+    'mcp-protocol-version': '2025-11-25',
+    'MCP-Protocol-Version': '2025-11-25',
+  });
+  const res = await createApp().request('/api/mcp', { method: 'POST', headers });
+  expect((await res.json()).protocolVersion).toEqual('2025-11-25');
+});
+
+test('leaves a single protocol version untouched', async () => {
+  expect(await send('2025-06-18')).toEqual('2025-06-18');
+});
+
+test('leaves a header naming two different versions for the transport to refuse', async () => {
+  expect(await send('2025-11-25, 2025-06-18')).toEqual('2025-11-25, 2025-06-18');
+});
+
+test('leaves an absent header absent', async () => {
+  expect(await send(undefined)).toEqual(null);
+});

--- a/packages/servers/server/src/routes/mcp.js
+++ b/packages/servers/server/src/routes/mcp.js
@@ -19,6 +19,7 @@ import { createMcpServer, getMcpResourceMetadataUri, getMcpResourceUri } from '@
 import { type } from '@lowdefy/helpers';
 
 import authJson from '../../lib/build/auth.js';
+import normalizeMcpProtocolVersionHeader from './normalizeMcpProtocolVersionHeader.js';
 
 // The RFC 6750 challenge for the MCP resource, pointing at its RFC 9728
 // metadata. The invalid_token extension exists for the two failures a client
@@ -65,6 +66,7 @@ function isOriginAllowed({ c, context }) {
 // boundary a role or scope shortfall stays opaque inside the tool surface,
 // never a 403 or insufficient_scope.
 async function mcpHandler(c) {
+  normalizeMcpProtocolVersionHeader({ request: c.req.raw });
   const context = c.get('lowdefyContext');
   const mcpConfig = await context.readConfigFile('mcp.json');
   if (type.isNone(mcpConfig) || mcpConfig.configured !== true) {

--- a/packages/servers/server/src/routes/normalizeMcpProtocolVersionHeader.js
+++ b/packages/servers/server/src/routes/normalizeMcpProtocolVersionHeader.js
@@ -1,0 +1,46 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Claude Code merges the protocol version it negotiated (mcp-protocol-version)
+// with a static MCP-Protocol-Version it sets on every request, and the Fetch
+// Headers constructor folds the two spellings of one header into a single
+// comma-joined value: "2025-11-25, 2025-11-25". @hono/mcp compares that raw
+// string against its supported list, so a client that agrees with the server
+// twice over is answered 404 "Unsupported protocol version" - which Claude Code
+// shows as "MCP endpoint not found". Collapsing a repeated value to the one
+// version it names is lossless; a header naming two DIFFERENT versions is left
+// for the transport to refuse. Runs before the transport reads the header: the
+// transport reads c.req.header(), which reads the raw request headers live.
+function normalizeMcpProtocolVersionHeader({ request }) {
+  const value = request.headers.get('mcp-protocol-version');
+  if (value === null || !value.includes(',')) {
+    return;
+  }
+  const versions = [
+    ...new Set(
+      value
+        .split(',')
+        .map((version) => version.trim())
+        .filter(Boolean)
+    ),
+  ];
+  if (versions.length !== 1) {
+    return;
+  }
+  request.headers.set('mcp-protocol-version', versions[0]);
+}
+
+export default normalizeMcpProtocolVersionHeader;

--- a/packages/servers/server/src/routes/normalizeMcpProtocolVersionHeader.test.mjs
+++ b/packages/servers/server/src/routes/normalizeMcpProtocolVersionHeader.test.mjs
@@ -1,0 +1,62 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { Hono } from 'hono';
+
+import normalizeMcpProtocolVersionHeader from './normalizeMcpProtocolVersionHeader.js';
+
+function createApp() {
+  const app = new Hono();
+  app.post('/api/mcp', (c) => {
+    normalizeMcpProtocolVersionHeader({ request: c.req.raw });
+    return c.json({ protocolVersion: c.req.header('mcp-protocol-version') ?? null });
+  });
+  return app;
+}
+
+async function send(headerValue) {
+  const headers = new Headers();
+  if (headerValue !== undefined) {
+    headers.set('mcp-protocol-version', headerValue);
+  }
+  const res = await createApp().request('/api/mcp', { method: 'POST', headers });
+  return (await res.json()).protocolVersion;
+}
+
+test('collapses a repeated protocol version to the single version it names', async () => {
+  expect(await send('2025-11-25, 2025-11-25')).toEqual('2025-11-25');
+});
+
+test('collapses the value the Fetch Headers constructor builds from both header spellings', async () => {
+  const headers = new Headers({
+    'mcp-protocol-version': '2025-11-25',
+    'MCP-Protocol-Version': '2025-11-25',
+  });
+  const res = await createApp().request('/api/mcp', { method: 'POST', headers });
+  expect((await res.json()).protocolVersion).toEqual('2025-11-25');
+});
+
+test('leaves a single protocol version untouched', async () => {
+  expect(await send('2025-06-18')).toEqual('2025-06-18');
+});
+
+test('leaves a header naming two different versions for the transport to refuse', async () => {
+  expect(await send('2025-11-25, 2025-06-18')).toEqual('2025-11-25, 2025-06-18');
+});
+
+test('leaves an absent header absent', async () => {
+  expect(await send(undefined)).toEqual(null);
+});


### PR DESCRIPTION
## Summary
Claude Code (2.1.x) fails to connect to a Lowdefy MCP server with **"MCP endpoint not found"** even though the route exists. Root cause, reproduced against `@hono/mcp@0.3.0` + SDK 1.29:

- Claude Code builds request headers as `new Headers({ ...commonHeaders, ...requestInit.headers })`, where `commonHeaders` carries the negotiated `mcp-protocol-version` and `requestInit.headers` (its "init-projection headers") carries a static `MCP-Protocol-Version`. The Fetch `Headers` constructor treats the two spellings as one header and **appends**: the server receives `mcp-protocol-version: 2025-11-25, 2025-11-25`.
- `@hono/mcp` `#validateProtocolVersion` compares that raw string against `SUPPORTED_PROTOCOL_VERSIONS` and answers **404** `Unsupported protocol version` on every non-`initialize` request (it handles an array, not a comma-joined string). Claude Code renders any 404 from the endpoint as "MCP endpoint not found".

Fix: `normalizeMcpProtocolVersionHeader` runs at the top of `mcpHandler` in both servers and collapses a *repeated* value to the single version it names (`c.req.header()` reads the raw request headers live, so the transport then sees one value). A header naming two **different** versions is left untouched for the transport to refuse.

## Test plan
- [x] Repro script: `2025-11-25` → 200; `2025-11-25, 2025-11-25` → 404 `Unsupported protocol version`; `new Headers({'mcp-protocol-version': …, 'MCP-Protocol-Version': …}).get(…)` → `"2025-11-25, 2025-11-25"`.
- [x] New `normalizeMcpProtocolVersionHeader.test.mjs` in both servers (repeated value, both-spellings construction, single value, two different values, absent header); `routes/mcp` suites pass (18/18 each).
- [ ] Claude Code `claude mcp add --transport http … /api/mcp` connects and lists tools once a pin carrying this ships (encircle-mvp will verify).