### PR TITLE
docs: v7 BetterAuth auth, organizations, tenant wall & MCP OAuth

### DIFF
--- a/.changeset/docs-v7-auth-mcp.md
+++ b/.changeset/docs-v7-auth-mcp.md
@@ -1,0 +1,6 @@
+---
+'@lowdefy/docs': patch
+'@lowdefy/docs-content': patch
+---
+
+docs: Document the v7 (BetterAuth) auth surface — a new "MCP Server & OAuth" page (single `/api/mcp` resource, `auth.oauthProvider`, the `organization_id` token claim, `mcp.endpoints[].scope`, the keep-MCP-endpoints-out-of-`auth.api.public` rule, consent and organisation-picker pages, `RevokeMcpGrant`), a new "Organizations & Multi-Tenancy" page (pinned vs tenant policies and the connection tenant wall), and a new "Auth Steps" page (the org/system/caller authority model and every step's scope and permission). Rewrites the stale User Object and Auth Configuration pages for BetterAuth, corrects the wrong `_user.sub` examples to `_user.id`, updates Roles for membership-based app roles, and extends the Auth Upgrade guide with the MCP/OAuth changes. Regenerates `@lowdefy/docs-content`.

--- a/packages/docs-content/content/agents/agentchat.md
+++ b/packages/docs-content/content/agents/agentchat.md
@@ -68,6 +68,7 @@ The `AgentChat` block renders a streaming AI chat interface. It connects to a [L
 | `agentId` | string | | __Required__ - The `id` of the agent to connect to. |
 | `conversationId` | string | | Active conversation ID. When this changes, messages are cleared. If left empty, the block auto-mints a stable id for the session and surfaces it via `onConversationStart`, so every turn posts a consistent id. App-supplied ids are always authoritative. |
 | `messages` | array | | Load messages externally. `undefined` = no sync, `null` = clear, array = load. |
+| `feedbackValues` | object | | Ratings already recorded for messages in this conversation, keyed by message id, each `like` or `dislike`. The block does not persist a rating, so without this a reload or a conversation switch shows every message unrated even where your app stored it. A rating clicked this visit takes precedence, so the thumb still responds immediately and a rating the user has just withdrawn is not re-lit by a stale value. |
 | `urlQuery` | object | | Query parameters sent with each request. Available server-side via `_payload`. |
 | `sharedState` | object | | Two-way bridge between page state and the agent. See [Shared State](#shared-state). |
 | `height` | string | `'calc(100dvh - 170px)'` | CSS height of the chat container. Only applies when `display` is `'inline'`. |
@@ -326,7 +327,7 @@ With the curated form above, the agent can read `legal_name` and `registration_n
 | `onToolResult` | A tool returns a result. | `toolName`, `toolCallId`, `output`, `error` |
 | `onError` | A streaming error occurs. | `message` |
 | `onStop` | User stops generation. | `messages` |
-| `onFeedback` | User clicks thumbs up/down. | `messageId`, `messageContent`, `rating` |
+| `onFeedback` | User clicks thumbs up/down. `rating` is `like` or `dislike`, or `default` when the user clicks the selected thumb again to clear the rating — branch on it explicitly rather than treating anything that is not `like` as a dislike. | `messageId`, `messageContent`, `rating` |
 | `onRegenerate` | User clicks regenerate. | `messageId`, `messages` |
 | `onDeleteMessage` | User deletes a message. | `messageId`, `content`, `messages` |
 | `onEditMessage` | User edits and resubmits. | `messageId`, `originalContent`, `newContent`, `messages` |
@@ -334,6 +335,7 @@ With the curated form above, the agent can read `legal_name` and `registration_n
 | `onSwitchChange` | User toggles a sender switch. | `key`, `checked` |
 | `onTitleGenerated` | A `data-chat-title` data part arrives — emitted automatically when the agent's [`generateTitle`](/agent-properties) property is set, or manually from an `onFinish` hook. | `title` |
 | `onDataPart` | Any data part arrives from the server. | `type`, `data`, `id` |
+| `onLinkClick` | User clicks a link in a message. Wiring this event suppresses the default navigation for plain left clicks, so the app can open the target in place; modified clicks (new tab, middle click) always navigate. | `href`, `text` |
 
 ###### Validate messages before sending:
 ```yaml
@@ -363,6 +365,16 @@ events:
       params:
         content: Thanks for your feedback!
         type: success
+```
+
+Saving is only half of it — the block does not persist a rating, so a
+reload or a conversation switch shows the message unrated again. Pass
+what you stored back through `feedbackValues`, keyed by message id:
+
+```yaml
+properties:
+  feedbackValues:
+    _request: saved_feedback_for_conversation
 ```
 
 ###### Adapt behavior based on sender switches:

--- a/packages/docs-content/content/input-blocks/checkboxselector.md
+++ b/packages/docs-content/content/input-blocks/checkboxselector.md
@@ -703,13 +703,89 @@ Checkbox group for selecting multiple options.
     valueKey: id
 ```
 
+```yaml
+- id: columns_two
+  type: CheckboxSelector
+  properties:
+    title: Two columns
+    columns: 2
+    options:
+      - Weekday mornings
+      - Weekday afternoons
+      - Weekday evenings
+      - Weekend mornings
+      - Weekend afternoons
+      - Weekend evenings
+- id: columns_four
+  type: CheckboxSelector
+  properties:
+    title: Four columns
+    columns: 4
+    options:
+      - January
+      - February
+      - March
+      - April
+      - May
+      - June
+      - July
+      - August
+- id: columns_responsive
+  type: CheckboxSelector
+  properties:
+    title: One column below md, three from md up
+    columns:
+      xs: 1
+      md: 3
+    options:
+      - Email
+      - SMS
+      - Push notification
+      - Webhook
+      - In-app message
+      - Weekly digest
+- id: columns_gutter
+  type: CheckboxSelector
+  properties:
+    title: Wider gutter
+    columns: 2
+    gutter:
+      - 24
+      - 12
+    options:
+      - Read
+      - Write
+      - Delete
+      - Administer
+- id: columns_per_option_color
+  type: CheckboxSelector
+  properties:
+    title: Coloured options in a grid
+    columns: 2
+    options:
+      - label: Low
+        value: low
+        color: "#16a34a"
+      - label: Medium
+        value: medium
+        color: "#d97706"
+      - label: High
+        value: high
+        color: "#dc2626"
+      - label: Critical
+        value: critical
+        color: "#7e22ce"
+```
+
 | Property | Type | Default | Description |
 | --- | --- | --- | --- |
-| `align` | string | `"start"` | Align options. Enum: `start`, `end`, `center`, `baseline`. |
+| `align` | string | `"start"` | Align options. Ignored when 'columns' is set. Enum: `start`, `end`, `center`, `baseline`. |
 | `color` | string | - | Selected checkbox color. |
+| `columns` | integer \| object | - | Number of columns to lay the options out in, or a responsive breakpoint object. Use a count that divides 24 evenly. |
 | `disabled` | boolean | `false` | Disable the block if true. |
-| `direction` | string | `"horizontal"` | List options horizontally or vertical. Enum: `horizontal`, `vertical`. |
-| `wrap` | boolean | `true` | Specifies wrapping of options. Applies when 'direction' is 'horizontal'. |
+| `direction` | string | `"horizontal"` | List options horizontally or vertical. Ignored when 'columns' is set. Enum: `horizontal`, `vertical`. |
+| `gutter` | number \| array | - | Gap between options in the grid. Number or [horizontal, vertical] array. Applies when 'columns' is set. |
+| `wrap` | boolean | `true` | Specifies wrapping of options. Applies when 'direction' is 'horizontal'. Ignored when 'columns' is set. |
 | `options` | array | `[]` | Options can either be an array of primitive values, on an array of label, value pairs - supports html. |
 | `options.$.label` | string | - | Value label shown to user - supports html. |
 | `options.$.value` | string \| number \| boolean | - | Option value. |
@@ -746,7 +822,7 @@ Checkbox group for selecting multiple options.
 | `theme.lineWidth` | number | `1` | Border width of the checkbox. |
 | `theme.lineType` | string | `"solid"` | Border style of the checkbox. |
 | `theme.fontSize` | number | `14` | Font size for checkbox labels. |
-| `theme.marginXS` | number | `8` | Horizontal gap between checkboxes in a group. |
+| `theme.marginXS` | number | `8` | Column gap on the checkbox group element. Does not space the options apart; set 'gutter' for a grid. |
 | `theme.paddingXS` | number | `8` | Inline padding between the checkbox and its label text. |
 
 | Event | Event Data | Description |

--- a/packages/docs-content/content/input-blocks/radioselector.md
+++ b/packages/docs-content/content/input-blocks/radioselector.md
@@ -752,13 +752,75 @@ Radio group for selecting a single option.
     valueKey: id
 ```
 
+```yaml
+- id: radio_columns_two
+  type: RadioSelector
+  properties:
+    title: Two columns
+    columns: 2
+    options:
+      - Weekday mornings
+      - Weekday afternoons
+      - Weekday evenings
+      - Weekend mornings
+      - Weekend afternoons
+      - Weekend evenings
+- id: radio_columns_responsive
+  type: RadioSelector
+  properties:
+    title: One column below md, three from md up
+    columns:
+      xs: 1
+      md: 3
+    options:
+      - Email
+      - SMS
+      - Push notification
+      - Webhook
+      - In-app message
+      - Weekly digest
+- id: radio_columns_gutter
+  type: RadioSelector
+  properties:
+    title: Wider gutter
+    columns: 2
+    gutter:
+      - 24
+      - 12
+    options:
+      - Read only
+      - Read and write
+      - Administer
+      - No access
+- id: radio_columns_per_option_color
+  type: RadioSelector
+  properties:
+    title: Coloured options in a grid
+    columns: 2
+    options:
+      - label: Low
+        value: low
+        color: "#16a34a"
+      - label: Medium
+        value: medium
+        color: "#d97706"
+      - label: High
+        value: high
+        color: "#dc2626"
+      - label: Critical
+        value: critical
+        color: "#7e22ce"
+```
+
 | Property | Type | Default | Description |
 | --- | --- | --- | --- |
-| `align` | string | `"start"` | Align options. Enum: `start`, `end`, `center`, `baseline`. |
+| `align` | string | `"start"` | Align options. Ignored when 'columns' is set. Enum: `start`, `end`, `center`, `baseline`. |
 | `color` | string | - | Selected radio color. |
+| `columns` | integer \| object | - | Number of columns to lay the options out in, or a responsive breakpoint object. Use a count that divides 24 evenly. |
 | `disabled` | boolean | `false` | Disable the block if true. |
-| `direction` | string | `"horizontal"` | List options horizontally or vertical. Enum: `horizontal`, `vertical`. |
-| `wrap` | boolean | `true` | Specifies wrapping of options. Applies when 'direction' is 'horizontal'. |
+| `direction` | string | `"horizontal"` | List options horizontally or vertical. Ignored when 'columns' is set. Enum: `horizontal`, `vertical`. |
+| `gutter` | number \| array | - | Gap between options in the grid. Number or [horizontal, vertical] array. Applies when 'columns' is set. |
+| `wrap` | boolean | `true` | Specifies wrapping of options. Applies when 'direction' is 'horizontal'. Ignored when 'columns' is set. |
 | `label` | object | - | Label properties. |
 | `label.align` | string | `"left"` | Align label left or right when inline. Enum: `left`, `right`. |
 | `label.colon` | boolean | `true` | Append label with colon. |

--- a/packages/docs-content/content/migration/auth-upgrade.md
+++ b/packages/docs-content/content/migration/auth-upgrade.md
@@ -6,25 +6,25 @@ API auth strategies (`auth.strategies`) are purely additive — an app with no s
 
 ## Summary of breaking changes
 
-| Change                                                 | Old                                                       | New                                                                                                                                   |
-| ------------------------------------------------------ | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Database required                                      | Optional (JWT-only possible)                              | `auth.database` required for any login method                                                                                         |
-| Provider type names                                    | `GoogleProvider`, `GitHubProvider`, ...                   | `Google`, `GitHub`, ... (`OpenIDConnectProvider` → `GenericOAuth`)                                                                    |
-| Callbacks / events                                     | `auth.callbacks`, `auth.events` (JS plugins)              | `auth.hooks` — bindings to `InternalApi` endpoints                                                                                    |
-| Session strategy                                       | `session.strategy: jwt` supported                         | Database sessions only; `maxAge` → `expiresIn`                                                                                        |
-| Collection names                                       | `users`, `accounts`, `sessions`                           | `user-*` convention, fixed by the adapter                                                                                             |
-| `userFields`                                           | Mapped provider claims onto the session                   | Removed — each mapped key has a new home (see below)                                                                                  |
-| Secret                                                 | `NEXTAUTH_SECRET` env var                                 | `auth.secret` with the `_secret` operator                                                                                             |
-| Auth UI                                                | NextAuth built-in pages, `auth.theme`                     | Removed — the app provides its own pages                                                                                              |
-| Magic link                                             | `EmailProvider` in `providers`                            | `auth.magicLink` + `auth.email`                                                                                                       |
-| `authPages`                                            | `signIn`, `signOut`, `error`, `verifyRequest`, `newUser`  | `signIn`, `signUp`, `error`, `forgotPassword`, `resetPassword`, `verifyEmail`                                                         |
-| OIDC profile claims                                    | ~20 claims copied onto the session user                   | Only `id`, `name`, `email`, `image`, `email_verified`                                                                                 |
-| `sub`                                                  | `_user.sub` = provider's OIDC subject                     | Removed — `_user.id` is the internal id (a different value)                                                                           |
-| Roles                                                  | On the user record via `userFields`                       | App roles on `member.appRoles` (`_user.roles`); the organization's `owner`/`admin`/`member` tier on `member.role` (`_user.org_roles`) |
-| Attributes                                             | `_user.app_attributes`, `_user.global_attributes`         | One merged `_user.attributes` bag                                                                                                     |
-| Signed-out request to any URL                          | `/404` if the page is missing, sign-in if protected       | Sign-in for every URL, in apps whose unlisted ids default to protected                                                                |
-| Missing request / endpoint id, signed out (auth'd app) | `500` (missing) vs `401` (protected)                      | `401` for both                                                                                                                        |
-| 404 page                                               | Had to serve signed-out visitors refused a protected page | Only ever serves signed-in visitors, in a protected app                                                                               |
+| Change | Old | New |
+|---|---|---|
+| Database required | Optional (JWT-only possible) | `auth.database` required for any login method |
+| Provider type names | `GoogleProvider`, `GitHubProvider`, ... | `Google`, `GitHub`, ... (`OpenIDConnectProvider` → `GenericOAuth`) |
+| Callbacks / events | `auth.callbacks`, `auth.events` (JS plugins) | `auth.hooks` — bindings to `InternalApi` endpoints |
+| Session strategy | `session.strategy: jwt` supported | Database sessions only; `maxAge` → `expiresIn` |
+| Collection names | `users`, `accounts`, `sessions` | `user-*` convention, fixed by the adapter |
+| `userFields` | Mapped provider claims onto the session | Removed — each mapped key has a new home (see below) |
+| Secret | `NEXTAUTH_SECRET` env var | `auth.secret` with the `_secret` operator |
+| Auth UI | NextAuth built-in pages, `auth.theme` | Removed — the app provides its own pages |
+| Magic link | `EmailProvider` in `providers` | `auth.magicLink` + `auth.email` |
+| `authPages` | `signIn`, `signOut`, `error`, `verifyRequest`, `newUser` | `signIn`, `signUp`, `error`, `forgotPassword`, `resetPassword`, `verifyEmail` |
+| OIDC profile claims | ~20 claims copied onto the session user | Only `id`, `name`, `email`, `image`, `email_verified` |
+| `sub` | `_user.sub` = provider's OIDC subject | Removed — `_user.id` is the internal id (a different value) |
+| Roles | On the user record via `userFields` | App roles on `member.appRoles` (`_user.roles`); the organization's `owner`/`admin`/`member` tier on `member.role` (`_user.org_roles`) |
+| Attributes | `_user.app_attributes`, `_user.global_attributes` | One merged `_user.attributes` bag |
+| Signed-out request to any URL | `/404` if the page is missing, sign-in if protected | Sign-in for every URL, in apps whose unlisted ids default to protected |
+| Missing request / endpoint id, signed out (auth'd app) | `500` (missing) vs `401` (protected) | `401` for both |
+| 404 page | Had to serve signed-out visitors refused a protected page | Only ever serves signed-in visitors, in a protected app |
 
 ## Upgrade steps
 
@@ -106,7 +106,7 @@ auth:
     enabled: true
     expiresIn: 300
   email:
-    connectionId: email # an SMTP connection in connections[]
+    connectionId: email   # an SMTP connection in connections[]
 ```
 
 The client signs in with the `Login` action: `params: { magicLink: true, email: ... }`.
@@ -121,7 +121,7 @@ The client signs in with the `Login` action: `params: { magicLink: true, email: 
 auth:
   email:
     connectionId: email
-    templates: # all optional; unset → branded stock template
+    templates:            # all optional; unset → branded stock template
       verifyEmail: verify-email-notification
       resetPassword: reset-password-notification
       magicLink: magic-link-notification
@@ -146,17 +146,17 @@ auth:
 
 Where old slots land:
 
-| Old                              | New point                                                                            |
-| -------------------------------- | ------------------------------------------------------------------------------------ |
-| `createUser` event               | `user.create.after`                                                                  |
-| `signIn` event                   | `session.create.after`                                                               |
-| `signOut` event                  | `session.delete.after`                                                               |
-| `linkAccount` event              | `account.create.after`                                                               |
-| `updateUser` event               | `user.update.after`                                                                  |
-| `signIn` callback (allow / deny) | `session.create.before` — `:reject` vetoes the sign-in                               |
-| `jwt` callback                   | None — database sessions carry no JWT; persist data via a create hook instead        |
-| `redirect` callback              | None — post-login navigation is the `Login` action's `callbackUrl`                   |
-| `session` callback               | None — the session shape is fixed; store extra data in attributes or app collections |
+| Old | New point |
+|---|---|
+| `createUser` event | `user.create.after` |
+| `signIn` event | `session.create.after` |
+| `signOut` event | `session.delete.after` |
+| `linkAccount` event | `account.create.after` |
+| `updateUser` event | `user.update.after` |
+| `signIn` callback (allow / deny) | `session.create.before` — `:reject` vetoes the sign-in |
+| `jwt` callback | None — database sessions carry no JWT; persist data via a create hook instead |
+| `redirect` callback | None — post-login navigation is the `Login` action's `callbackUrl` |
+| `session` callback | None — the session shape is fixed; store extra data in attributes or app collections |
 
 Custom callback/event plugin logic moves into the endpoint's routine; anything a routine can't express goes in a custom request plugin called from the routine.
 
@@ -174,7 +174,7 @@ auth:
 
 The old `signOut`, `verifyRequest`, and `newUser` keys are removed. New optional keys for email flows: `signUp`, `forgotPassword`, `resetPassword`, `verifyEmail`. `twoFactor` is a further key, and unlike those it is **required** when `auth.twoFactor.enabled` is true — the build fails without it, because the engine routes the two-factor challenge to that page itself. See [Two-Factor Authentication](/two-factor).
 
-`acceptInvitation` is a further key, naming the page that consumes an `?invitationId=` link. **Write its copy for the unauthenticated case.** Where one app sends another organization's invitations, the invitee accepts on the _sending_ app, and `AcceptInvitation` sets the active organization inside its own transaction — so the accept page itself renders unauthenticated the moment the accept succeeds. That page must tell an already-signed-in invitee to sign in again **at the app they are on**, not at the app that sent the invitation: the active-organization policy runs at every session create and re-pins them here, while the production cookie prefix is shared across apps on one host, so signing in at the other app flips the shared session back the other way.
+`acceptInvitation` is a further key, naming the page that consumes an `?invitationId=` link. **Write its copy for the unauthenticated case.** Where one app sends another organization's invitations, the invitee accepts on the *sending* app, and `AcceptInvitation` sets the active organization inside its own transaction — so the accept page itself renders unauthenticated the moment the accept succeeds. That page must tell an already-signed-in invitee to sign in again **at the app they are on**, not at the app that sent the invitation: the active-organization policy runs at every session create and re-pins them here, while the production cookie prefix is shared across apps on one host, so signing in at the other app flips the shared session back the other way.
 
 Sign-in uses the `Login` action, which dispatches by parameter — `providerId` for OAuth, `magicLink: true`, or `email` + `password`. Email/password sign-up pages use the new `SignUp` action; social and magic-link "sign-up" pages use `Login`, since those methods create the account on first sign-in. Sign-in errors now surface inline (the `Login` action returns `error.code`) rather than as a `?error=` query parameter on the error page.
 
@@ -200,33 +200,33 @@ There is no `impersonatedBy` field on the session user. Impersonation is not par
 
 Where old `_user` reads land:
 
-| Old read                                                         | New home                                                                                                                                                                             |
-| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `_user.sub`                                                      | `_user.id` — a **different value**: the internal id, not the provider subject. The provider subject lives on the `user-accounts` collection (`accountId`).                           |
-| `_user.picture`                                                  | `_user.image`                                                                                                                                                                        |
-| `_user.email_verified`                                           | `_user.email_verified` — unchanged; the pre-upgrade OIDC claim and the resolved caller field already share this name.                                                                |
-| `_user.roles`                                                    | Unchanged read — but roles now resolve from the active organization membership's `appRoles`, granted via invitations and auth steps, not provider claims.                            |
-| `_user.orgRoles`                                                 | `_user.org_roles` — the organization tier from `member.role` (`owner`, `admin`, `member`).                                                                                           |
-| `_user.twoFactorEnrolled`                                        | `_user.two_factor_enrolled` — whether the caller holds a factor satisfying `auth.twoFactor.required`.                                                                                |
-| `_user.authMethod`                                               | `_user.auth_method` — the strategy that authenticated the caller, on strategy-resolved callers only.                                                                                 |
-| `_user.app_attributes.*`                                         | `_user.attributes.*` — per-app values live on the membership (`member.attributes`).                                                                                                  |
-| `_user.global_attributes.*`                                      | `_user.attributes.*` — global values live on the user (`user.attributes`); merged per key, member wins.                                                                              |
+| Old read | New home |
+|---|---|
+| `_user.sub` | `_user.id` — a **different value**: the internal id, not the provider subject. The provider subject lives on the `user-accounts` collection (`accountId`). |
+| `_user.picture` | `_user.image` |
+| `_user.email_verified` | `_user.email_verified` — unchanged; the pre-upgrade OIDC claim and the resolved caller field already share this name. |
+| `_user.roles` | Unchanged read — but roles now resolve from the active organization membership's `appRoles`, granted via invitations and auth steps, not provider claims. |
+| `_user.orgRoles` | `_user.org_roles` — the organization tier from `member.role` (`owner`, `admin`, `member`). |
+| `_user.twoFactorEnrolled` | `_user.two_factor_enrolled` — whether the caller holds a factor satisfying `auth.twoFactor.required`. |
+| `_user.authMethod` | `_user.auth_method` — the strategy that authenticated the caller, on strategy-resolved callers only. |
+| `_user.app_attributes.*` | `_user.attributes.*` — per-app values live on the membership (`member.attributes`). |
+| `_user.global_attributes.*` | `_user.attributes.*` — global values live on the user (`user.attributes`); merged per key, member wins. |
 | Other OIDC claims (`given_name`, `phone_number`, `address`, ...) | Not in the session. Persist what you need at signup via an endpoint hook — profile data onto your contact collection, authorization inputs into attributes — and read it from there. |
 
 ## Page and API existence is no longer observable before you sign in
 
-This is a behaviour change every app inherits, not a two-factor feature. It removes an enumeration asymmetry — a logged-out caller used to be able to tell a real-but-protected id apart from an absent one by the response they got back. That is an information leak the engine design had accepted as a documented cost of following web convention, not an access-control failure: no protected page or request was ever reachable without a session. Nothing about who can _reach_ a surface changes here — only what a signed-out caller can _learn_ about which surfaces exist.
+This is a behaviour change every app inherits, not a two-factor feature. It removes an enumeration asymmetry — a logged-out caller used to be able to tell a real-but-protected id apart from an absent one by the response they got back. That is an information leak the engine design had accepted as a documented cost of following web convention, not an access-control failure: no protected page or request was ever reachable without a session. Nothing about who can *reach* a surface changes here — only what a signed-out caller can *learn* about which surfaces exist.
 
 **The rule.** When the caller is not authenticated, existence is never consulted. A protected app answers the sign-in page for any URL a logged-out visitor asks for — whether that URL is a real protected page or a typo that matches nothing. Existence is only resolved once there is a session to resolve it against.
 
-**Which apps change, which don't.** Only apps whose _unlisted_ page ids default to protected are affected. The `auth.pages.protected: [...]` shape (an explicit protected list, everything else public) is **untouched** — a logged-out visitor typing a wrong URL still gets `/404`, because unlisted ids there are public. Every other shape treats an unlisted id as protected, so a logged-out typo now lands on the sign-in page, then resolves to `/404` once the visitor authenticates — one extra hop for a wrong URL.
+**Which apps change, which don't.** Only apps whose *unlisted* page ids default to protected are affected. The `auth.pages.protected: [...]` shape (an explicit protected list, everything else public) is **untouched** — a logged-out visitor typing a wrong URL still gets `/404`, because unlisted ids there are public. Every other shape treats an unlisted id as protected, so a logged-out typo now lands on the sign-in page, then resolves to `/404` once the visitor authenticates — one extra hop for a wrong URL.
 
-| Config                        | An unlisted page id is |
-| ----------------------------- | ---------------------- |
-| `auth.pages.public: [...]`    | protected              |
-| `auth.pages.protected: true`  | protected              |
-| `auth.pages.protected: [...]` | public                 |
-| neither                       | public                 |
+| Config | An unlisted page id is |
+|---|---|
+| `auth.pages.public: [...]` | protected |
+| `auth.pages.protected: true` | protected |
+| `auth.pages.protected: [...]` | public |
+| neither | public |
 
 **A known imprecision, so nobody files it as a bug.** The default the runtime reads for an unlisted id is a single build-resolved boolean, deliberately coarser than the glob-list config that produced it. In an app configured `auth.pages.public: ['docs/**']` (so unlisted ids default to protected), a signed-out visitor typing `docs/typo` gets the sign-in page rather than `/404`, even though the `docs/**` namespace was declared public. Every id that **is** in the build carries its own resolved decision, so no real page changes behaviour — only a URL matching nothing reads the coarse default. Shipping the pattern lists into the build artifact and re-matching globs per request was considered and rejected: the artifact exists precisely so the runtime reads a resolved decision and never re-derives access from patterns.
 
@@ -240,33 +240,6 @@ This is a behaviour change every app inherits, not a two-factor feature. It remo
 
 Administering an organization means holding `admin` (or `owner`) in that organization — the `member.role` tier, on the caller's own member row there. There is no app-wide administering role, and no config key that grants administration across organizations: nothing to configure. Every auth step declares the authority it requires, and the step floor authorizes the caller against their member row in the organization the step names, so a caller who administers the team organization holds nothing in the customer organization. The steps that write the deployment-wide `user` row — `UpdateUserProfile`, `UpdateUserAttributes`, `BanUser`, `UnbanUser`, `DeleteUser`, `RevokeUserSessions` — additionally require the **target** to hold a member row in that organization, so an administrator can only reach people who are members of an organization they administer.
 
-## Organization admission and creation
-
-Two knobs on `auth.organizations` govern who may sign up and where organizations come from.
-
-**`auth.organizations.signup`** (`invite-only | open`) is now live under **both** policies — its previous "ignored under tenant" framing is gone. `open` admits everyone. `invite-only` refuses a sign-up without an invitation, and under `tenant + invite-only` the admission gate admits a caller who holds a membership **anywhere** in the deployment or a pending invitation **anywhere** in it — not scoped to any one organization.
-
-**`auth.organizations.create`** (`auto | operator`) is tenant-only, and rejected under `pinned`. `auto` (the default) is today's behaviour: a personal organization is lazily minted at first sign-in. `operator` removes that mint — organizations come only from the `CreateOrganization` step, and an org-less sign-in lands in the signed-in-awaiting-organization state: `_user.awaiting_organization` is `true`, the caller is visible to public pages (so an accept page can address them) and walled everywhere `auth.public` is false.
-
-The sales-led posture is two authored lines:
-
-```yaml
-auth:
-  organizations:
-    policy: tenant
-    signup: invite-only
-    create: operator
-```
-
-All four `signup × create` combinations build; none is rejected:
-
-| `signup × create`        | Behaviour                                                                                                                                                   |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `open + auto`            | Today's self-serve SaaS — anyone registers, each gets a personal organization minted at first sign-in.                                                      |
-| `open + operator`        | Anyone registers, but organizations come only from the operator; registrants sit org-less until invited or assigned.                                        |
-| `invite-only + operator` | The sales-led product — only invitees register, and organizations come only from the operator.                                                              |
-| `invite-only + auto`     | Behaves identically to `invite-only + operator`: the mint is unreachable, because every admitted caller already holds a membership or a pending invitation. |
-
 ## Bootstrapping the first administrator
 
 Nothing grants organization authority implicitly. On a fresh `policy: pinned` + `signup: invite-only` deployment that is a closed loop: nobody can be invited, because inviting needs `invitation: ['create']` authority that nobody holds, and nobody can sign up, because the admission gate admits only members and pending invitees. Breaking the loop is one document inserted into the `user-invitations` collection, by hand, outside the platform:
@@ -277,7 +250,7 @@ Nothing grants organization authority implicitly. On a fresh `policy: pinned` + 
   inviterId: 'bootstrap', expiresAt: <future date>, createdAt: new Date() }
 ```
 
-**`organizationId` is the configured slug.** Under `pinned` the organization's id _is_ `auth.organizations.org`, so there is no id to look up and the same document works in every environment.
+**`organizationId` is the configured slug.** Under `pinned` the organization's id *is* `auth.organizations.org`, so there is no id to look up and the same document works in every environment.
 
 **The key is `_id`, not `id`.** The adapter maps the logical `id` to the physical `_id` inbound and back outbound, so every invitation the platform writes stores its id at `_id`. A document inserted literally as `{ id: … }` gets a driver-generated `ObjectId` `_id` plus a stray `id` field, after which the accept flow's invitation lookup never finds it — while the admission gate, which queries by email and status, happily admits the person to sign up. The result is a user who can log in, an invitation that cannot be accepted, and no error pointing at either. Use `_id`.
 
@@ -299,78 +272,40 @@ Nothing grants organization authority implicitly. On a fresh `policy: pinned` + 
 
 The field names above are the live camelCase names. If the `snake-case-data-fields` change has landed in your version, they are `organization_id`, `inviter_id`, `expires_at`, `created_at` and `app_roles`.
 
-## Provisioning tenant organizations
-
-This is the tenant sibling of [Bootstrapping the first administrator](#bootstrapping-the-first-administrator) — the same seeded-owner invitation, plus the organization row a tenant deployment needs. The platform ships no provisioning endpoint: provisioning is an app-authored recipe over existing steps. (An operator console that would wrap it is a future module, not a shipped surface.)
-
-**The canonical recipe** is an `Api` endpoint that runs `CreateOrganization` then `InviteMember` as `system: true` steps:
-
-```yaml
-# api/provision-tenant.yaml
-id: provision-tenant
-type: Api
-routine:
-  - id: create_org
-    type: CreateOrganization
-    system: true
-    properties:
-      name: { _payload: name }
-      slug: { _payload: slug }
-  - id: invite_owner
-    type: InviteMember
-    system: true
-    properties:
-      organizationId: { _step: create_org.id }
-      email: { _payload: owner_email }
-      orgRole: owner
-```
-
-Gate the endpoint in `lowdefy.yaml`:
-
-```yaml
-auth:
-  api:
-    roles:
-      provision-tenant: [operator]
-```
-
-`operator` here is a **deployment-global** role, granted to an api-strategies API-key caller — never a catalog app role a tenant admin could self-assign. Any tenant admin can assign catalog roles at invite time, so gating operator powers on a catalog role would let a tenant admin mint organizations.
-
-The load-bearing facts:
-
-**Why `orgRole: owner`.** The fabricated system acting member claims `owner`, and `createInvitation` refuses an invitation whose role contains the creator role unless the inviter holds it — so a narrowed claim would fail an owner-role invitation with `YOU_ARE_NOT_ALLOWED_TO_INVITE_USER_WITH_THIS_ROLE`. And seeding a founding `owner` rather than an `admin` is what makes every last-owner and creator guard live, for exactly the reasons the bootstrap section spells out under ["The role is `owner`, not `admin`"](#bootstrapping-the-first-administrator).
-
-**The accept-invitation email has two prerequisites**, and missing either renders the email branded with no call-to-action link: `BETTER_AUTH_URL` must pin the app's canonical origin, and `authPages.acceptInvitation` must point at the accept page. Setting `authPages.acceptInvitation` is also what registers the always-public accept page, so the recipe presupposes accept-invitation wiring is already in place. The email never names the inviter, so the fabricated system caller never appears in it.
-
-**Email verification is required before accepting** — Lowdefy's function-form `advanced.database.generateId` flips the organization plugin's verified-email requirement for the accept-by-invitation-id action, the same as [bootstrap](#bootstrapping-the-first-administrator).
-
-**The founder's arc.** The pending invitation admits their sign-up at all three gates; their first session is org-less (`_user.awaiting_organization`); they follow the emailed accept link to the always-public accept page; and `acceptInvitation` mints their `owner` member from the invitation verbatim, copying its `appRoles` and `attributes`. Under `invite-only` they cannot be minted a stray personal organization in the meantime.
-
-**Recovery.** A founder who lost the email — re-run `InviteMember` with `resend: true`, which refreshes the still-pending invitation's TTL and re-sends it unchanged. An _expired_ invitation — a plain `InviteMember` re-run: BetterAuth filters expired rows out of the already-invited check, so a fresh invitation mints without ceremony.
-
-Two shorter recipes sit alongside the canonical one:
-
-**The founder already has an account** (`open + operator`, or a second organization for an existing user): `CreateOrganization { userId }` alone. Given the user id, that one step mints both the organization and its `owner` member in a single call — no invitation needed.
-
-**Hand-inserted documents** — the zero-config-change fallback, the tenant sibling of the bootstrap insert. Insert the organization row (`{ _id, name, slug, createdAt }`) and the invitation row exactly as the [bootstrap section](#bootstrapping-the-first-administrator) describes it (keyed `_id`, `role: 'owner'`, `appRoles: []`, a future `expiresAt`), with the invitation's `organizationId` set to the organization `_id` you just chose, then deliver the accept URL by hand. The bootstrap section's gotchas apply unchanged — the `id`-vs-`_id` trap, and the silent 404-but-admitted failure.
-
 ## Retired client actions
 
 Seven client actions are gone. An app that authors one fails at build with the unknown-action-type error; each has a named replacement, except the two that do not:
 
-| Retired action       | Replacement                                                                                                     |
-| -------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `ImpersonateUser`    | **None.** The capability is retired.                                                                            |
-| `StopImpersonating`  | **None.** The capability is retired.                                                                            |
-| `InviteMember`       | The `InviteMember` step                                                                                         |
-| `CancelInvitation`   | The `CancelInvitation` step                                                                                     |
-| `UpdateMemberRole`   | The `UpdateMemberOrgRole` step (the `owner`/`admin`/`member` tier). App roles are the `UpdateMemberRoles` step. |
-| `RemoveMember`       | The `RemoveMember` step                                                                                         |
-| `UpdateOrganization` | The `UpdateOrganization` step                                                                                   |
+| Retired action | Replacement |
+|---|---|
+| `ImpersonateUser` | **None.** The capability is retired. |
+| `StopImpersonating` | **None.** The capability is retired. |
+| `InviteMember` | The `InviteMember` step |
+| `CancelInvitation` | The `CancelInvitation` step |
+| `UpdateMemberRole` | The `UpdateMemberOrgRole` step (the `owner`/`admin`/`member` tier). App roles are the `UpdateMemberRoles` step. |
+| `RemoveMember` | The `RemoveMember` step |
+| `UpdateOrganization` | The `UpdateOrganization` step |
 
 The rule that produced the list also tells you which actions will keep existing: **a client action is an operation that mutates the caller's own session, and nothing else.** So `SetActiveOrganization`, `AcceptInvitation` and `LeaveOrganization` remain — each acts on the caller. An app administering **other** people's memberships authors a routine instead, and that is what earns it the per-step authority floor, an explicitly named target organization, and both role tiers (`appRoles` and `orgRole`) rather than one fused `role`.
 
 Two consequences. A `pinned` app never had these actions working in the first place — every organization route is disabled under `pinned` — so this reads as a removal only for `tenant` apps. And the step path is what makes cross-organization administration possible at all: a client action forwards no organization id, so it could only ever act on the session's active organization.
+
+## Exposing MCP tools to assistants
+
+New in this release: a Lowdefy app can be an **OAuth 2.1 authorization server** and expose its API endpoints as authenticated tools to MCP clients (Claude, ChatGPT, IDE assistants). There is one MCP resource at `/api/mcp`; the organization a call acts in is a token claim chosen at authorization, not a URL segment. Enable it with `auth.oauthProvider` and tag endpoints in the `mcp` block. This is entirely additive — an app with no `mcp` endpoints and no `auth.oauthProvider` is unaffected.
+
+**One rule to internalise before you ship it: never list an MCP endpoint id in `auth.api.public`.** A single public tool suppresses the OAuth challenge for the whole route, so a newly connected assistant reports "connected" and never authenticates. The full model — the flow, the `organization_id` claim, `mcp:read` / `mcp:write` scopes, the consent and organization-picker pages, and switching or disconnecting with `RevokeMcpGrant` — is on the [MCP Server & OAuth](/mcp-oauth) page.
+
+The `mcp.agents` config key is removed; MCP agent tools are not supported.
+
+## Where the details now live
+
+This guide is the migration path; the current behaviour is documented on the dedicated pages:
+
+- [Organizations & Multi-Tenancy](/organizations) — the `pinned` / `tenant` policies and the tenant wall.
+- [Auth Steps](/auth-steps) — the per-step authority model and every step's scope and permission.
+- [MCP Server & OAuth](/mcp-oauth) — the authenticated MCP surface.
+- [User Object](/user-object) — the fixed `_user` shape.
 
 ## What you don't need to change
 

--- a/packages/docs-content/content/operators/_user.md
+++ b/packages/docs-content/content/operators/_user.md
@@ -10,7 +10,7 @@
 }): any
 ```
 
-The `_user` operator gets a value from the [`user`](/user-object) object. The `user` object contains the data in the user idToken if OpenID Connect authentication is configured and a user is logged in.
+The `_user` operator gets a value from the [`user`](/user-object) object — the caller Lowdefy resolves for the signed-in user in their active organization. It has a [fixed shape](/user-object); see that page for the available fields.
 
 #### Arguments
 
@@ -50,7 +50,7 @@ Returns: The entire `user` object.
 ###### Dot notation:
 Assuming user:
 ```yaml
-sub: abc123
+id: abc123
 name: User Name
 my_object:
   subfield: 'Value'
@@ -76,7 +76,7 @@ Returns: The value of `might_not_exist`, or `"Default value"`.
 ###### Block list indices:
 Assuming `user`:
 ```yaml
-sub: abc123
+id: abc123
 name: User Name
 my_array:
   - value: 0

--- a/packages/docs-content/content/user-authentication/auth-steps.md
+++ b/packages/docs-content/content/user-authentication/auth-steps.md
@@ -1,0 +1,111 @@
+# Auth Steps
+
+Auth steps are routine steps that administer users, organizations and memberships — inviting a member, updating an app role, banning a user, creating an organization. They run **inside an `Api` or `InternalApi` endpoint routine**, not as client actions, because administering *other* people's memberships is a server operation that must be authorized against the caller, name its target organization explicitly, and be visible in a diff.
+
+> A **client action** mutates the caller's *own* session and nothing else — `SetActiveOrganization`, `AcceptInvitation`, `LeaveOrganization`. Anything that reaches another person's membership is an auth **step** in a routine, which is what earns it the per-step authority floor below. See the [Auth Upgrade guide](/auth-upgrade#retired-client-actions) for the actions that became steps.
+
+```yaml
+id: invite-member
+type: Api
+routine:
+  - id: invite
+    type: InviteMember
+    properties:
+      organizationId:
+        _user: organization_id
+      email:
+        _payload: email
+      appRoles:
+        _payload: roles
+  - ':return':
+      _step: invite
+```
+
+## The authority model
+
+Every auth step declares, in its own code, the authority it requires — and the engine's **authority floor** enforces that declaration mechanically before the step runs. This is not optional decoration: a step with no declared authority is a build/runtime error, so an app can never expose a member mutation by forgetting a check. The reason the floor exists in one place is that most steps go adapter-direct or through BetterAuth's admin plugin, whose check reads a single deployment-wide `user.role` field and **cannot** answer "is the caller an administrator of *this* organization". For those steps, the floor is the only authorization that can express per-organization authority.
+
+A step declares one of three **scopes**.
+
+### `org` — authorized against the caller's membership in the target organization
+
+The common case. The floor:
+
+1. **Resolves the target organization** (see below).
+2. **Finds the caller's `member` row** in that organization and checks its role against the step's required **permissions**. The caller's authority is their membership in the *target* organization — an administrator of the team organization holds nothing in the customer organization.
+3. For steps that write the deployment-wide `user` row, additionally requires the **target user** to be a member of that organization (`targetUser`), so org authority alone can never reach a user who is not the caller's business.
+
+Permissions map to the organization tier via BetterAuth's organization access control: `owner` and `admin` are granted the member-management permissions out of the box; `member` holds none of them. A refused caller gets a `ConfigError` naming exactly what was required.
+
+### `system` — caller-less, trusted runs only
+
+A `system`-scoped step (`CreateOrganization`, `ListUsers`) has no organization to be authorized in, so a caller can never satisfy it. It runs **only** where the run itself is trusted — a caller-less system routine. Mark the step `system: true`, or run it from a system context (cron, a verified webhook, an auth hook):
+
+```yaml
+- id: create_org
+  type: CreateOrganization
+  system: true
+  properties:
+    name:
+      _payload: name
+    slug:
+      _payload: slug
+    userId:
+      _payload: ownerUserId
+```
+
+### `caller` — acts on the caller's own records
+
+A `caller`-scoped step (`RevokeMcpGrant`) acts only on rows the caller owns, so it needs no organization authority — but it is meaningless without a caller, and the system has no rows of its own. It requires a real caller and refuses `system: true`.
+
+## `system: true` — the two doors to a caller-less run
+
+The floor's caller requirement passes on either of two independent doors:
+
+- a **run-level** system context (`context.system === true`) — a trusted, caller-less run such as a cron endpoint, an auth hook, or a verified webhook; or
+- a **per-step** `system: true` on a single step in an otherwise user-driven run — a waiver visible in the diff, for the one privileged operation in a member-facing routine.
+
+Either door makes the step act caller-less **as the system**, bypassing the org/permission checks. That is an explicit trust decision, not attribution — use it deliberately.
+
+## How the target organization is resolved
+
+For every `org`-scoped step the floor resolves the target organization once, and the step writes into the *same* one it authorized — they cannot drift. The rule:
+
+1. An explicit **`organizationId`** property always wins. This is what a multi-organization admin routine passes, and it is what lets a session pinned to the team organization administer the customer organization.
+2. `ListMembers` also accepts an **`organizationSlug`**, resolved to an id here.
+3. Otherwise the **pinned** organization is the default — **but under `policy: tenant` there is no pinned organization**, so an omitted `organizationId` is a runtime error naming the fix. Under `tenant`, always pass `organizationId` explicitly.
+
+## `targetUser` and `selfTargetExempt`
+
+Two refinements the floor reads from a step's declaration:
+
+- **`targetUser`** names the property holding the id of the user being acted on. Steps that write the shared `user` row declare it, so the floor can require that user to be a member of the target organization. An absent target-user property is the step's own required-property error, not the floor's.
+- **`selfTargetExempt`** lets a caller act on **their own** row without holding org authority — this is what makes `UpdateUserProfile` a self-service "save my profile" step as well as an admin one. When the named property equals the caller's own id, the org authority check is skipped.
+
+## Step reference
+
+Scope, required permission, and target for every auth step. Permissions are checked against the caller's `member.role` in the target organization; `owner`/`admin` hold them by default.
+
+| Step | Scope | Permission | Target | What it does |
+| ---- | ----- | ---------- | ------ | ------------ |
+| `InviteMember` | org | `invitation: [create]` | — | Invite a member by email; carries `appRoles`, `orgRole`, `attributes`, `contactId`, `profile`; `resend` refreshes. |
+| `CancelInvitation` | org | `invitation: [cancel]` | — | Cancel a pending invitation. |
+| `ListMembers` | org | `member: [list]` | — | List members of the organization (accepts `organizationSlug`). |
+| `RemoveMember` | org | `member: [delete]` | — | Remove a member from the organization. |
+| `UpdateMemberRoles` | org | `member: [update]` | — | Set the membership's **app roles** (`appRoles` array; empty clears). |
+| `UpdateMemberOrgRole` | org | `member: [update]` | — | Set the **org tier** (`owner`/`admin`/`member`). |
+| `UpdateMemberAttributes` | org | `member: [update]` | — | Set the membership's per-organization attributes. |
+| `UpdateOrganization` | org | `organization: [update]` | — | Update the organization row (name, slug, metadata). |
+| `UpdateUserProfile` | org | `user: [update]` | `userId` (self-exempt) | Update a member's display name/image (per-organization copy). Self-service save is exempt. |
+| `UpdateUserAttributes` | org | `user: [set-attributes]` | `userId` | Set global user attributes. |
+| `BanUser` | org | `user: [ban]` | `userId` | Ban a user. |
+| `UnbanUser` | org | `user: [ban]` | `userId` | Lift a ban. |
+| `DeleteUser` | org | `user: [delete]` | `userId` | Delete a user. |
+| `RevokeUserSessions` | org | `session: [revoke]` | `userId` | Sign a user out of all sessions. |
+| `ResetUserTwoFactor` | org | `user: [reset-two-factor]` | `userId` | Clear a user's two-factor enrolment and trust-device records. |
+| `RevokeUserPasskeys` | org | `user: [revoke-passkeys]` | `userId` | Remove a user's passkeys (`passkeyId` to target one). |
+| `CreateOrganization` | system | — | — | Create an organization (tenant provisioning). Needs `userId`, or `name`+`slug` for creator-less provisioning. |
+| `ListUsers` | system | — | — | List every user in the deployment. |
+| `RevokeMcpGrant` | caller | — | — | Revoke the calling assistant's own [MCP grant](/mcp-oauth#switching-organization-from-the-assistant). |
+
+The two role tiers a member carries — the `owner`/`admin`/`member` org tier and the app's own role strings — are explained in [Organizations & Multi-Tenancy](/organizations#the-owner-admin-member-tier-vs-app-roles). Recovering a user who lost their second factor is a worked routine on the [Two-Factor Authentication](/two-factor#recovering-a-user-who-has-lost-their-factor) page.

--- a/packages/docs-content/content/user-authentication/mcp-oauth.md
+++ b/packages/docs-content/content/user-authentication/mcp-oauth.md
@@ -1,0 +1,289 @@
+# MCP Server &amp; OAuth
+
+A Lowdefy app can expose its API endpoints as tools to an MCP client — Claude, ChatGPT, an IDE assistant — over the Model Context Protocol. When those tools touch anything but public data, the client has to prove who is calling, and Lowdefy handles that by turning the app itself into an **OAuth 2.1 authorization server**: the assistant runs a normal browser authorization, the user signs in, chooses the organization to work in, and grants consent, and the app mints an access token the assistant sends on every tool call.
+
+This page is about the *authenticated* MCP surface. Exposing tools to an app's own agents, and the `mcp` array on an agent (the app acting as an MCP *client*), are covered in [MCP tools for agents](/agent-mcp-tools) and the [`Mcp` connection](/Mcp). Here the app is the *server*, and the caller is an outside assistant.
+
+## One resource, one address
+
+There is a single MCP resource for the whole deployment, served at `/api/mcp`. The organization a call acts in is **not** part of the address — it is chosen once during authorization and carried inside the access token as a claim. Every assistant connects to the same URL; two users, or one user in two organizations, are told apart by their tokens, never by the path.
+
+This is the Linear model — one link, the workspace is a property of the authorization rather than the address — and it is deliberate. An earlier design keyed the resource per organization (`/api/mcp/{organization_id}`); that put the organization in the URL, the RFC 8707 `resource` parameter, and the token audience, and needed a per-organization resource row kept in sync. The single resource deletes all of that: one address to paste, one audience, and the organization rides the token.
+
+| Route | Purpose |
+| ----- | ------- |
+| `POST /api/mcp` | The MCP resource — streamable HTTP transport. Tools are listed and called here, per request, authorized against the bearer token. |
+| `GET /.well-known/oauth-protected-resource/api/mcp` | RFC 9728 protected-resource metadata: the resource URI, the authorization server, and the scopes it supports. Public and constant per deployment. |
+| `GET /.well-known/oauth-authorization-server/api/auth` | RFC 8414 authorization-server metadata, re-exposed at the path a client derives from the issuer. |
+| `/api/auth/*` | The authorization server itself — authorize, token, registration, and the OAuth endpoints the consent and picker pages call. |
+
+The `/.well-known` documents derive their URIs from the pinned `BETTER_AUTH_URL`, never from a request `Host` header, so they are the same for every caller. They mount **only when `auth.oauthProvider` is configured** — an app that is not an authorization server has nothing to discover, and its MCP tools are all public (see the rule below).
+
+## Turning the app into an authorization server
+
+Add `auth.oauthProvider`. It names the two pages the browser authorization flow hands control to, and whether unknown clients may register themselves:
+
+```yaml
+auth:
+  oauthProvider:
+    consentPage: /oauth-consent
+    postLoginPage: /oauth-select-organization
+    dynamicClientRegistration: false
+```
+
+- **`consentPage`** *(required)* — the Lowdefy page id of your consent screen. The authorization flow redirects the signed-in user here to approve or deny the client. The engine builds the redirect as `${origin}${basePath}${consentPage}`, joined with no separator, so **the leading slash is required**.
+- **`postLoginPage`** — the page where a signed-in user chooses which organization the authorization acts in. It is shown after login and before consent. It is **required under `organizations.policy: tenant`** (the build fails without it) and is skipped under `pinned`, where there is only ever one organization to act in.
+- **`dynamicClientRegistration`** — allow unregistered MCP clients to self-register per RFC 7591. Off by default; pre-registered clients are the primary path. Turn it on for public assistants you cannot pre-register.
+
+Both page ids are validated at build time the same way: the page must exist, and it must not be public-listed in a way that would let it render without a session — the flow only ever reaches them for a signed-in user.
+
+## Exposing tools, and their scopes
+
+The app-level `mcp` block declares the server's identity and which API endpoints are tools:
+
+```yaml
+mcp:
+  name: acme
+  version: '1.0.0'
+  title: Acme
+  websiteUrl: https://acme.example.com
+  icons:
+    - src: https://acme.example.com/icon-512.png
+      mimeType: image/png
+      sizes: ['512x512']
+  endpoints:
+    - id: search-customers
+      scope: mcp:read
+    - id: create-invoice
+      scope: mcp:write
+```
+
+`name`, `version`, `title`, `websiteUrl` and `icons` are the server branding a client shows the user in the `initialize` handshake. Each `endpoints` entry needs an `id` and a `scope`.
+
+**`scope` is a closed vocabulary — `mcp:read` or `mcp:write`, and nothing else.** Apps cannot mint their own scopes. `mcp:write` implies `mcp:read` at runtime, so a token granted write can call both. Tag a tool that only reads with `mcp:read` and one that mutates with `mcp:write`; the consent screen then lets a user grant an assistant read-only access to the whole surface if they choose.
+
+Three rules the build enforces on every tool:
+
+- **Only `Api` endpoints can be tools.** An `InternalApi` endpoint is not reachable as one — it has no external caller by design.
+- **Every tool needs a `description` and a `payloadSchema`.** The description is what the assistant reads to decide when to call the tool; the `payloadSchema` becomes the tool's input schema. A tool with neither is not a usable tool, so the build refuses it.
+- **The `mcp.agents` key is gone.** MCP agent tools are not supported; remove it if you are upgrading.
+
+## A tool is gated twice
+
+When a call arrives at `/api/mcp`, a tool is listed and callable only when **both** hold:
+
+1. the caller's **role outcome** allows the endpoint — the same `auth.api` / `auth.api.roles` gate every API call passes; and
+2. the **token's granted scope** covers the tool's tag.
+
+The 401 challenge is decided once, at the route boundary, before the MCP transport runs. Past that boundary the transport answers over HTTP 200, so a role or scope shortfall never surfaces as a `403` or an `insufficient_scope` error to the assistant — the tool is simply not offered. This is intentional: the tool surface does not disclose the existence of tools the caller may not use.
+
+## The rule that catches everyone: keep MCP endpoints out of `auth.api.public`
+
+> **Never list an MCP endpoint id in `auth.api.public`.**
+
+One public tool suppresses the 401 challenge for the *whole* route. The build sets `mcp.json`'s `hasPublicTool` flag when any exposed endpoint is public, and the `/api/mcp` route then serves an anonymous caller a `200` with the public tools instead of a `401` with the `WWW-Authenticate` challenge. A freshly added assistant reports "connected, 1 tool" and **never runs the OAuth flow** — only a *stale* token would take the challenge branch. Every protected tool then sits behind a door the client was never told to knock on.
+
+So a protected app keeps its `auth.api` gates and leaves every `mcp.endpoints` id out of the public list:
+
+```yaml
+auth:
+  api:
+    protected: true
+    # Keep MCP endpoint ids OUT of this list. A single public tool
+    # flips mcp.json hasPublicTool, and /api/mcp then serves anonymous
+    # callers a 200 with that tool instead of the 401 challenge.
+    public:
+      - webhooks/stripe   # a webhook receiver, not an MCP tool
+```
+
+The build has a matching guard from the other direction: a protected or role-gated MCP endpoint **requires** `auth.oauthProvider`. Without the authorization server there is no way to authenticate the caller, so the build fails rather than shipping an unreachable tool — make the endpoint public (accepting the trade above) or configure `oauthProvider`.
+
+## The authorization flow, end to end
+
+1. The assistant reads `/.well-known/oauth-protected-resource/api/mcp`, finds the authorization server, and (if it is not pre-registered and `dynamicClientRegistration` is on) registers itself.
+2. It opens a browser to the authorization endpoint. The user signs in through your normal sign-in page.
+3. **Under `tenant`,** the flow redirects to `postLoginPage`. The user picks the organization to work in; the page sets it active and continues the authorization. **Under `pinned`,** this step is skipped.
+4. The flow redirects to `consentPage`. The user approves the client and the requested scopes — or, if they have already consented for this client in this organization, consent is skipped.
+5. The app mints an access token whose **`organization_id` claim is the chosen organization** (the consent `referenceId`), and the assistant sends it as a `Bearer` token on every `/api/mcp` call.
+
+Consent is recorded per **(client, user, organization)**. Re-authorizing into an organization the user has already consented for skips the consent screen; a first authorization into a *different* organization asks for consent again, for that organization.
+
+### How a token becomes a caller
+
+On every `/api/mcp` request the token is verified in-process against the authorization server's own signing keys: the issuer and audience must match the resource, and the token must carry both a `sub` (the user) and an `organization_id` claim. The claim is not trusted on its own — the **consent row for `(client, user, organization)` must still exist**. That liveness read on every call is what makes switching and disconnecting take effect *immediately*: revoke the grant and the next call is refused at once, not at the token's expiry.
+
+The caller is then resolved as a member of that organization, exactly as a session caller is — same membership wall, same role source, same `_user` shape — with one extra field: **`_user.auth_method` is `'mcp'`**, so a routine can tell an assistant apart from a browser without any app-side plumbing.
+
+```yaml
+# In an endpoint routine, branch on how the caller arrived:
+- id: set_channel
+  type: SetState
+  params:
+    channel:
+      _if:
+        test:
+          _eq:
+            - _user: auth_method
+            - mcp
+        then: mcp
+        else: ui
+```
+
+A token that cannot be verified (for example, an opaque token minted because the client omitted the RFC 8707 `resource` parameter), or one whose grant has been revoked, gets a `401` with a `WWW-Authenticate` challenge that tells the client what to do — reconnect and re-run the authorization, including the organization choice.
+
+## Building the consent and picker pages
+
+Both pages are ordinary Lowdefy pages that read the authorization request from the URL query, show the user what is being asked, and finish the flow with client actions. Four actions do the work:
+
+| Action | What it does |
+| ------ | ------------ |
+| [`ListOrganizations`](/actions) | Returns the caller's organization memberships — the rows the picker renders. |
+| `SetActiveOrganization` | Sets the caller's active organization. The picker calls it for the chosen organization. |
+| `OAuthContinue` | Continues the authorization after the organization is chosen (`POST /api/auth/oauth2/continue`). Returns `{ url }` to redirect to. |
+| `OAuthConsent` | Approves (`accept: true`) or denies (`accept: false`) the client. Returns `{ url }` to redirect to. |
+
+### The organization picker (`postLoginPage`)
+
+On mount the page calls `ListOrganizations` and stores the rows in state; a `ListSelector` renders them, and its click handler sets the chosen organization active and continues:
+
+```yaml
+id: select_org_rows
+type: ListSelector
+properties:
+  selectable: false
+  hoverable: true
+  data:
+    _state: organizations
+events:
+  onClick:
+    - id: set_active_organization
+      type: SetActiveOrganization
+      skip:
+        _eq:
+          - _event: item.id
+          - _user: organization_id
+      params:
+        organizationId:
+          _event: item.id
+    - id: continue_authorization
+      type: OAuthContinue
+      messages:
+        error: false
+    - id: continue_redirect
+      type: Link
+      params:
+        url:
+          _actions: continue_authorization.response.url
+```
+
+`SetActiveOrganization` is skipped when the chosen organization is already the active one, so re-picking the current organization is a no-op that still continues the flow.
+
+### The consent screen (`consentPage`)
+
+Reads the request from the query, shows the client and scopes, and finishes on the user's decision:
+
+```yaml
+id: consent_allow
+type: Button
+properties:
+  title: Allow access
+events:
+  onClick:
+    - id: consent_allow_action
+      type: OAuthConsent
+      messages:
+        error: false
+      params:
+        accept: true
+    - id: consent_allow_redirect
+      type: Link
+      params:
+        url:
+          _actions: consent_allow_action.response.url
+```
+
+The deny button is identical with `params: { accept: false }`. Read `_url_query: client_id` and `_url_query: scope` to render what the client is asking for, and `_url_query: resource` to confirm the audience. Fetch the client's own metadata (name, logo) from `/api/auth/oauth2/public-client?client_id=...` to show a human-readable client name rather than an opaque id.
+
+## Switching organization from the assistant
+
+An assistant connected to one organization switches by *disconnecting* — the client then re-runs the authorization and the user picks a different organization. Expose a tool that revokes the calling grant with the `RevokeMcpGrant` step:
+
+```yaml
+id: switch-organization
+type: Api
+description: >
+  Disconnect this assistant from the organization it is connected to so
+  the user can connect it to another one. Use ONLY when the user asks to
+  work in a different organization. After it succeeds the connection is
+  gone: tell the user to reconnect in their assistant — the browser will
+  ask which organization to connect to.
+payloadSchema:
+  type: object
+  additionalProperties: false
+  properties: {}
+routine:
+  - id: revoke_grant
+    type: RevokeMcpGrant
+  - ':return':
+      disconnected: true
+      organization_id:
+        _step: revoke_grant.organizationId
+      message: >-
+        Disconnected. Ask the user to reconnect in their assistant.
+```
+
+[`RevokeMcpGrant`](/auth-steps) reads the calling token's `(client, user, organization)` from the request context, deletes that one consent row, and revokes its refresh tokens. It is **caller-scoped**: it touches only the grant the call arrived on, so another assistant the same person connected, or this assistant's grant in another organization, is untouched. It refuses to run for any caller that did not arrive over MCP — there is no grant behind a browser session for it to revoke.
+
+Expose it as an `mcp:read` tool. The next tool call the assistant makes gets a `401`, the client re-runs OAuth, and the user lands back on the organization picker.
+
+## Disconnecting assistants from the app
+
+The mirror control belongs in your app's UI: a person removing every assistant connected to their active organization. It deletes the caller's consent rows for that organization and revokes the matching refresh tokens — the same two writes `RevokeMcpGrant` makes, scoped to the active organization instead of one client:
+
+```yaml
+id: disconnect-assistants
+type: Api
+description: Disconnect every assistant connected to the caller's active organization.
+payloadSchema:
+  type: object
+  additionalProperties: false
+  properties: {}
+routine:
+  - id: revoke_refresh_tokens
+    type: MongoDBUpdateMany
+    connectionId: oauth-refresh-tokens
+    properties:
+      filter:
+        user_id:
+          _user: id
+        reference_id:
+          _user: organization_id
+        revoked: null
+      update:
+        $set:
+          revoked:
+            _date: now
+  - id: delete_consents
+    type: MongoDBDeleteMany
+    connectionId: oauth-consents
+    properties:
+      filter:
+        user_id:
+          _user: id
+        reference_id:
+          _user: organization_id
+  - ':return':
+      disconnected:
+        _step: delete_consents.deletedCount
+```
+
+Because the `/api/mcp` route reads the live consent row on every call, every affected assistant is refused on its next call, not at token expiry.
+
+## Summary
+
+- The app is an OAuth 2.1 authorization server; enable it with `auth.oauthProvider`.
+- There is one MCP resource at `/api/mcp`. The organization is a token claim, not a URL segment.
+- Tag each tool `mcp:read` or `mcp:write`; a tool is gated by both role and scope.
+- **Never list an MCP endpoint id in `auth.api.public`** — one public tool suppresses the challenge for the whole route.
+- Consent is per `(client, user, organization)` and read live on every call, so `RevokeMcpGrant` and disconnecting take effect immediately.
+- `_user.auth_method` is `'mcp'` for assistant callers.

--- a/packages/docs-content/content/user-authentication/organizations.md
+++ b/packages/docs-content/content/user-authentication/organizations.md
@@ -1,0 +1,134 @@
+# Organizations &amp; Multi-Tenancy
+
+Every Lowdefy app has organizations — always, even a single-team internal tool. A signed-in caller is a **member** of an organization, and it is the membership, not the user record, that carries the caller's app roles and per-organization attributes. This is the unit the whole auth system is built on: `_user.roles` is the active membership's roles, and the [tenant wall](#the-tenant-wall) scopes data to the active organization.
+
+The single knob that decides how organizations behave is `auth.organizations.policy`.
+
+## Two policies: `pinned` and `tenant`
+
+```yaml
+auth:
+  organizations:
+    policy: pinned   # or "tenant"
+```
+
+**`pinned`** *(the default)* — one organization for the whole deployment, ensured at startup. This is the shape for an internal app or a single-customer install: there is one workspace, everyone is a member of it, and the active organization is never switched. The organization plugin's per-organization routes (create, switch, self-service org management) are disabled.
+
+**`tenant`** — organizations are created per user, and a caller can belong to several and switch between them. This is the shape for a multi-tenant SaaS: each customer is an organization, members are invited into it, and `SetActiveOrganization` moves the caller between the workspaces they belong to.
+
+An app that sets nothing gets `pinned` with one auto-seeded organization, invite-only. The policy is not something you can leave to a default and change later without thought — it changes what `_user.organization_id` means, whether the tenant wall is active, and whether the MCP flow needs an [organization picker](/mcp-oauth). Choose it up front.
+
+## The `organizations` keys
+
+| Key | Type | Applies to | Default | Meaning |
+| --- | ---- | ---------- | ------- | ------- |
+| `policy` | `pinned` \| `tenant` | both | `pinned` | The organization model, above. |
+| `org` | string | **pinned only** | `default` | The slug the deployment pins as the active organization. Under `pinned` the slug **is** the organization's id. |
+| `signup` | `invite-only` \| `open` | both | `pinned` → `invite-only`, `tenant` → `open` | Whether uninvited sign-ups are admitted. `invite-only` refuses a sign-up with no invitation; `open` admits everyone. |
+| `create` | `auto` \| `operator` | **tenant only** | `tenant` → `auto` | How a tenant organization comes into being: `auto` mints one for a user at first session; `operator` leaves creation to your own config (the `CreateOrganization` step). |
+| `invitationExpiresIn` | integer (seconds, min 60) | both | `172800` (48h) | How long an invitation stays acceptable. Re-sending an invitation refreshes its expiry. |
+
+The build cross-checks these, and the errors are worth knowing before you hit them:
+
+- **`org` is required under `pinned`** and **rejected under `tenant`** — under `tenant` there is no single organization to pin; organizations are created per user.
+- **`create` is rejected under `pinned`** — the active organization is ensured at startup, so there is nothing to create on demand.
+- **Renaming `org` strands the existing membership.** The startup ensure is by slug, so changing `org` mints a *fresh* organization rather than renaming the old one, and every existing `member` row still points at the old id. Treat the pinned slug as permanent.
+
+Defaults line up with intent: `pinned` defaults to a closed, invite-only internal app; `tenant` defaults to self-serve SaaS (`signup: open`, `create: auto`).
+
+## The `owner` / `admin` / `member` tier vs app roles
+
+A membership carries **two** independent role authorities, and keeping them apart is the whole point:
+
+- **`_user.org_roles`** — the organization tier: `owner`, `admin`, or `member`. This is BetterAuth's administrative fact about the membership, and it is what the [auth-step authority floor](/auth-steps) checks. **No page or API gate reads it.**
+- **`_user.roles`** — the app's own role strings, from the membership's `appRoles`. These are what [`auth.pages.roles` and `auth.api.roles`](/roles) match, and the only thing they match.
+
+So an app that wants a page for organization administrators does **not** gate it on the `admin` tier — it gates on one of its own app roles, and lets the write authority answer the administration question separately, at the step. See [Roles](/roles) for page and API gating, and [Auth Steps](/auth-steps) for the administration model.
+
+## Bootstrapping the first administrator
+
+Nothing grants organization authority implicitly — not even to the first user. On a fresh `pinned` + `invite-only` deployment that is a closed loop: nobody can invite (inviting needs authority nobody holds) and nobody can sign up (the gate admits only members and pending invitees). Breaking the loop is a single invitation document inserted by hand into the `user-invitations` collection, seeded with the `owner` tier. The full recipe — the exact document, why the key must be `_id`, why the role must be `owner`, and how to deliver the accept link — is in the [Auth Upgrade guide](/auth-upgrade#bootstrapping-the-first-administrator).
+
+## The tenant wall
+
+Under `policy: tenant`, data must not leak across organizations. The **tenant wall** enforces that mechanically: a scoping-capable connection is filtered to the caller's active organization on every read and stamped with it on every write, without the request author writing a single filter clause. The wall is declared **on the connection**; requests, steps and websockets only declare *exceptions*.
+
+### Declaring scope on a connection
+
+Under `tenant`, a connection whose type implements the scoping contract (MongoDB does) is **scoped by default** — silence means scoped. You only ever declare the two exceptions:
+
+```yaml
+connections:
+  # Scoped by default under tenant policy — nothing to declare.
+  - id: app_data
+    type: MongoDBCollection
+    properties:
+      databaseUri:
+        _secret: MONGODB_URI
+      collection: records
+
+  # Data deliberately shared across organizations (reference data,
+  # a global catalogue) — opt out of scoping explicitly.
+  - id: countries
+    type: MongoDBCollection
+    tenant: shared
+    properties:
+      databaseUri:
+        _secret: MONGODB_URI
+      collection: countries
+
+  # Scope on a field other than the default organization_id.
+  - id: legacy_records
+    type: MongoDBCollection
+    tenant:
+      field: tenant_id
+    properties:
+      databaseUri:
+        _secret: MONGODB_URI
+      collection: legacy
+```
+
+`tenant` on a connection is either the string `shared` or `{ field: <name> }` (a non-empty name with no dots). The default scoping field is `organization_id`. There is deliberately **no `tenant: true`** — under `tenant` policy a capable connection is already scoped, so `true` would only restate the default; the build rejects it.
+
+**Under `tenant` policy every connection type must declare its capability.** A connection whose type does not declare tenant support (`connectionMetas.tenant`) fails the build — no connection is ever *silently* unscoped. Connection plugins declare this in their `types.js`; you do not set it.
+
+### Exceptions at the point of use
+
+The wall scopes mechanically, but a few operations need an explicit opt-out or opt-in, declared on the request, step or websocket — never on the connection:
+
+| Surface | Allowed values | Meaning |
+| ------- | -------------- | ------- |
+| Request | `none` | Opt this request out of scoping entirely. |
+| Request | `authored` | The request authors its own tenant clause (audited at runtime). |
+| Websocket | `none` | Opt out. `authored` is not allowed — change streams are always scoped mechanically. |
+
+An aggregation stage the wall cannot scope mechanically — `$search`, `$searchMeta`, `$vectorSearch`, `$geoNear`, `$graphLookup` — must declare `tenant: authored` and author the organization clause *inside the stage*. The runtime audits that clause against the caller's active organization; it does not trust the declaration alone.
+
+```yaml
+# A $search aggregation on a scoped connection: author the org filter
+# inside the stage and declare it.
+id: search_records
+type: MongoDBAggregation
+connectionId: app_data
+tenant: authored
+properties:
+  pipeline:
+    - $search:
+        compound:
+          filter:
+            - equals:
+                path: organization_id
+                value:
+                  _user: organization_id
+          must:
+            - text:
+                query:
+                  _payload: q
+                path: title
+```
+
+### Why the wall lives on the connection
+
+Putting scope on the connection, and only exceptions at the point of use, means the default is safe: a developer who forgets to think about tenancy gets a scoped read and a stamped write, not a leak. The dangerous states — sharing across organizations, opting a request out, authoring a raw clause — are the ones that have to be typed out, reviewed in a diff, and (for `authored`) audited at runtime. This inverts the usual footgun where the safe path is the verbose one.
+
+Under `policy: pinned` the wall is inert — there is one organization, so scoping to it is a no-op — but declaring `tenant` on connections does no harm, which lets one config serve both a pinned install and a tenant deployment.

--- a/packages/docs-content/content/user-authentication/two-factor.md
+++ b/packages/docs-content/content/user-authentication/two-factor.md
@@ -49,18 +49,7 @@ Only app-relative, same-origin destinations are carried; anything else falls thr
 
 ### Trusting a device
 
-`TwoFactorVerify`'s `trustDevice` param sets a cookie that short-circuits the challenge on later sign-ins from the same browser. It applies on every one of the challenged paths above, not just the one it was set from. The window is 30 days.
-
-`auth.twoFactor.trustDevice` turns this off deployment-wide:
-
-```yaml
-auth:
-  twoFactor:
-    enabled: true
-    trustDevice: false
-```
-
-It defaults to `true` (the 30-day skip above). Set `false` for deployments that must challenge a second factor on **every** login. The disable is server-authoritative: no device is durably trusted, and a forged `trustDevice: true` cannot bypass it — the engine mints every trust record already expired rather than trusting the client to opt out. A device trusted before you set `false` is challenged again from its next login. The value is readable in config as `_build.authConfig: twoFactor.trustDevice`, so a challenge page can hide its own "trust this device" switch when the deployment has disabled it.
+`TwoFactorVerify`'s `trustDevice` param sets a cookie that short-circuits the challenge on later sign-ins from the same browser. It applies on every one of the challenged paths above, not just the one it was set from.
 
 ## Trusting an OAuth provider
 
@@ -156,7 +145,7 @@ The enrolled factor is not inert, though. It is what a password or magic-link si
 
 The four BetterAuth two-factor endpoints that mutate a factor are password-gated: they call `shouldRequirePassword`, which demands the caller's current password unless `allowPasswordless` is set. Lowdefy sets `allowPasswordless: true`, so an OAuth or magic-link user who never set a password can still enrol TOTP.
 
-The waiver is **per user**, not per app. A caller who _does_ hold a password still faces the password gate on all four endpoints — the waiver only lifts it for the users who have no password to give. There is no route difference to configure: the same enrol flow serves both.
+The waiver is **per user**, not per app. A caller who *does* hold a password still faces the password gate on all four endpoints — the waiver only lifts it for the users who have no password to give. There is no route difference to configure: the same enrol flow serves both.
 
 ## The enrolment page
 
@@ -170,10 +159,10 @@ Reached with no session at all, it behaves like any protected page: the user is 
 
 When a member loses their authenticator or has a security key stolen, an administrator restores their access with two org-scoped steps:
 
-| Step                 | Properties             | Permission                   |
-| -------------------- | ---------------------- | ---------------------------- |
-| `ResetUserTwoFactor` | `userId`               | `user: ['reset-two-factor']` |
-| `RevokeUserPasskeys` | `userId`, `passkeyId?` | `user: ['revoke-passkeys']`  |
+| Step                                            | Properties            | Permission                    |
+| ----------------------------------------------- | --------------------- | ----------------------------- |
+| `ResetUserTwoFactor`                            | `userId`              | `user: ['reset-two-factor']`  |
+| `RevokeUserPasskeys`                            | `userId`, `passkeyId?`| `user: ['revoke-passkeys']`   |
 
 Both are `org`-scoped and bounded by target membership: an administrator can only reach a user who holds a member row in an organization they administer. Both permissions ship granted to `owner` and `admin`; a narrower custom role can be given member management without either of them.
 

--- a/packages/docs-content/content/user-authentication/user-object.md
+++ b/packages/docs-content/content/user-authentication/user-object.md
@@ -1,0 +1,58 @@
+# User Object
+
+The `user` object holds data about the currently signed-in **caller**, read with the [`_user`](/_user) operator on both the server and the client. It is not the provider's profile — it is a caller Lowdefy resolves from the user's row *and their membership in the active organization*, so the same person carries a different `_user` in two organizations they belong to.
+
+Its shape is **fixed**. Unlike the old provider-claim mapping, there is no `userFields` config and no set of OpenID Connect claims copied onto the session — the provider subject and extra claims are not on the user object at all. If you need a provider claim at signup, persist it with an [auth hook](/auth-upgrade#7-rewrite-callbacks-and-events-as-hooks) and read it from where you stored it.
+
+## Fields
+
+| Field | On which callers | Meaning |
+| ----- | ---------------- | ------- |
+| `id` | all | The internal user id. **This replaces the old `sub`** — it is a *different value* (the provider subject lives on the `user-accounts` collection as `accountId`). |
+| `email` | all | The user's email. |
+| `email_verified` | session | Whether the email is verified. |
+| `name`, `image` | session | Display name and avatar — the **per-organization** copies from the active membership, falling back to the deployment-global user record. |
+| `roles` | session, strategy | The app's own role strings, from the active membership's `appRoles`. **The only thing `auth.pages.roles` / `auth.api.roles` match.** |
+| `org_roles` | session | The organization tier from `member.role`: `owner`, `admin` or `member`. An administrative fact — **no gate reads it**. |
+| `attributes` | session | One merged bag: global `user.attributes` under the active `member.attributes`, per key, member wins. |
+| `organization_id` | session, mcp | The organization the caller acts in — the value the [tenant wall](/organizations#the-tenant-wall) stamps and filters on. |
+| `active_organization_id` | session | The active organization id (equal to `organization_id`). |
+| `two_factor_enrolled` | session | Whether the caller holds a factor satisfying `auth.twoFactor.required`. |
+| `auth_method` | strategy, mcp | How the caller authenticated — the strategy id, or `'mcp'` for an [assistant](/mcp-oauth). Absent on browser sessions. |
+| `profile` | session | The user record's opaque display/app-data bag. Absent (never `{}`) when the user has written no profile. |
+| `contact_id` | session | Link to the app's canonical record for this person, when one exists. |
+
+> **`_user.role` (singular) carries nothing.** Lowdefy never writes it; it sits one character from `roles`, so gating on `_user.role` is gating on a constant. Read `roles`.
+
+A caller resolved from an [API strategy](/auth-configuration) (`apiKey`, `jwt`) sits outside the membership boundary: it carries `id`, `roles`, `attributes` and `auth_method`, but no organization, `name`, `image`, `profile` or `two_factor_enrolled`. A signed-in user who holds only a pending invitation (before they accept, under `tenant`) is an *awaiting-organization* caller — known to the always-public accept page, refused everywhere else.
+
+## Examples
+
+###### Use the user's avatar in an Avatar block:
+```yaml
+id: avatar
+type: Avatar
+properties:
+  src:
+    _user: image
+```
+
+###### Stamp the creator when inserting a document:
+```yaml
+id: insert_data
+type: MongoDBInsertOne
+properties:
+  doc:
+    field:
+      _state: field
+    created_by:
+      name:
+        _user: name
+      id:
+        _user: id
+```
+
+###### Read a value out of the merged attributes bag:
+```yaml
+_user: attributes.plan
+```

--- a/packages/docs-content/index.json
+++ b/packages/docs-content/index.json
@@ -290,6 +290,30 @@
       "path": "content/user-authentication/two-factor.md"
     },
     {
+      "slug": "user-authentication/organizations",
+      "title": "Organizations &amp; Multi-Tenancy",
+      "section": "User Authentication",
+      "path": "content/user-authentication/organizations.md"
+    },
+    {
+      "slug": "user-authentication/auth-steps",
+      "title": "Auth Steps",
+      "section": "User Authentication",
+      "path": "content/user-authentication/auth-steps.md"
+    },
+    {
+      "slug": "user-authentication/mcp-oauth",
+      "title": "MCP Server &amp; OAuth",
+      "section": "User Authentication",
+      "path": "content/user-authentication/mcp-oauth.md"
+    },
+    {
+      "slug": "user-authentication/user-object",
+      "title": "User Object",
+      "section": "User Authentication",
+      "path": "content/user-authentication/user-object.md"
+    },
+    {
       "slug": "other/next-auth-providers",
       "title": "next-auth-providers",
       "section": "Other",

--- a/packages/docs/menus.yaml
+++ b/packages/docs/menus.yaml
@@ -343,6 +343,21 @@
           pageId: roles
           properties:
             title: Roles
+        - id: organizations
+          type: MenuLink
+          pageId: organizations
+          properties:
+            title: Organizations & Multi-Tenancy
+        - id: auth-steps
+          type: MenuLink
+          pageId: auth-steps
+          properties:
+            title: Auth Steps
+        - id: mcp-oauth
+          type: MenuLink
+          pageId: mcp-oauth
+          properties:
+            title: MCP Server & OAuth
         - id: user-object
           type: MenuLink
           pageId: user-object

--- a/packages/docs/migration/auth-upgrade.yaml
+++ b/packages/docs/migration/auth-upgrade.yaml
@@ -316,6 +316,23 @@ _ref:
 
             Two consequences. A `pinned` app never had these actions working in the first place — every organization route is disabled under `pinned` — so this reads as a removal only for `tenant` apps. And the step path is what makes cross-organization administration possible at all: a client action forwards no organization id, so it could only ever act on the session's active organization.
 
+            ## Exposing MCP tools to assistants
+
+            New in this release: a Lowdefy app can be an **OAuth 2.1 authorization server** and expose its API endpoints as authenticated tools to MCP clients (Claude, ChatGPT, IDE assistants). There is one MCP resource at `/api/mcp`; the organization a call acts in is a token claim chosen at authorization, not a URL segment. Enable it with `auth.oauthProvider` and tag endpoints in the `mcp` block. This is entirely additive — an app with no `mcp` endpoints and no `auth.oauthProvider` is unaffected.
+
+            **One rule to internalise before you ship it: never list an MCP endpoint id in `auth.api.public`.** A single public tool suppresses the OAuth challenge for the whole route, so a newly connected assistant reports "connected" and never authenticates. The full model — the flow, the `organization_id` claim, `mcp:read` / `mcp:write` scopes, the consent and organization-picker pages, and switching or disconnecting with `RevokeMcpGrant` — is on the [MCP Server & OAuth](/mcp-oauth) page.
+
+            The `mcp.agents` config key is removed; MCP agent tools are not supported.
+
+            ## Where the details now live
+
+            This guide is the migration path; the current behaviour is documented on the dedicated pages:
+
+            - [Organizations & Multi-Tenancy](/organizations) — the `pinned` / `tenant` policies and the tenant wall.
+            - [Auth Steps](/auth-steps) — the per-step authority model and every step's scope and permission.
+            - [MCP Server & OAuth](/mcp-oauth) — the authenticated MCP surface.
+            - [User Object](/user-object) — the fixed `_user` shape.
+
             ## What you don't need to change
 
             - **Page and API authorization** — `auth.pages` and `auth.api` (`protected` / `public` / `roles`) keep their shape and semantics.

--- a/packages/docs/operators/_user.yaml
+++ b/packages/docs/operators/_user.yaml
@@ -30,7 +30,7 @@ _ref:
       }): any
       ```
     description: |
-      The `_user` operator gets a value from the [`user`](/user-object) object. The `user` object contains the data in the user idToken if OpenID Connect authentication is configured and a user is logged in.
+      The `_user` operator gets a value from the [`user`](/user-object) object — the caller Lowdefy resolves for the signed-in user in their active organization. It has a [fixed shape](/user-object); see that page for the available fields.
 
     arguments: |
       ###### string
@@ -121,7 +121,7 @@ _ref:
       ###### Dot notation:
       Assuming user:
       ```yaml
-      sub: abc123
+      id: abc123
       name: User Name
       my_object:
         subfield: 'Value'
@@ -147,7 +147,7 @@ _ref:
       ###### Block list indices:
       Assuming `user`:
       ```yaml
-      sub: abc123
+      id: abc123
       name: User Name
       my_array:
         - value: 0

--- a/packages/docs/pages.yaml
+++ b/packages/docs/pages.yaml
@@ -64,6 +64,9 @@
 - _ref: users/two-factor.yaml
 - _ref: users/protected-pages-apis.yaml
 - _ref: users/roles.yaml
+- _ref: users/organizations.yaml
+- _ref: users/auth-steps.yaml
+- _ref: users/mcp-oauth.yaml
 - _ref: users/user-object.yaml
 - _ref: users/auth-configuration.yaml
 

--- a/packages/docs/users/auth-configuration.yaml
+++ b/packages/docs/users/auth-configuration.yaml
@@ -29,68 +29,145 @@ _ref:
                 version:
                   _ref: version.yaml
               template: |
-                The `auth` section of the Lowdefy configuration is used to configure the user authentication settings.
+                The `auth` section configures user authentication. Lowdefy's auth is built on [BetterAuth](https://www.better-auth.com/): sessions are database-backed, the app owns its auth UI, and roles live on organization memberships. If you are moving from the previous NextAuth-shaped config, start with the [Auth Upgrade guide](/auth-upgrade) — several keys were renamed or removed.
 
-                The `_secret` operator is evaluated over the entire section.
+                The `_secret` operator is evaluated over the entire `auth` section, so any value can be a secret reference.
 
-                ## User Fields
+                For a login method to work you must configure **at least one mechanism** (`emailAndPassword`, `magicLink`, `phoneNumber`, an OAuth `providers` entry, or an API `strategies` entry), a `secret`, and a `database`. An `auth` block with none of these fails the build.
 
-                The `auth.userFields` section of the auth config is used to configure which data fields from the provider are mapped to the `user` data object. Auth.js provides three data objects from which data can read, namely `account`, `profile` and `user`. The content of these objects depends on the provider that was used.
+                ## Secret
 
-                See [User Object](/user-object) and the [Auth.js callbacks reference](https://authjs.dev/reference/core#callbacks) for more details.
+                A required signing secret, given as a `_secret` reference:
 
-                ## Theme
-
-                The `auth.theme` section maps to the [Auth.js theme options](https://authjs.dev/reference/core/types#theme).
-
-                The options are:
-                - `colorScheme: enum`: Sets the color scheme of the Auth.js auth pages. Options are `"auto"`, `"dark"` and `"light"`. The default is `"auto"`.
-                - `brandColor: string`: A hex color code of the color to use as accent color on the Auth.js auth pages.
-                - `logo: string`: The absolute URL of an image to be used as logo on the auth pages.
-                - `buttonText: string`: A hex color code of the color to use for button text.
-
-                ## Auth Pages
-
-                The `auth.authPages` section can be used to override the auth pages provided by Auth.js. The values should link to pages inside the Lowdefy app.
-
-                See [here](https://authjs.dev/reference/core#pages) for more details.
-
-                The options are:
-                - `signIn: string`
-                - `signOut: string`
-                - `error: string`
-                - `verifyRequest: string`: Used for check email message.
-                - `newUser: string`: New users will be directed here on first sign in (leave the property out if not of interest)
-
-                ###### Configure a custom sign-in page
                 ```yaml
                 lowdefy: {{ version }}
+                auth:
+                  secret:
+                    _secret: BETTER_AUTH_SECRET
+                ```
 
+                Also set the `BETTER_AUTH_URL` environment variable to the app's canonical origin — auth builds password-reset, magic-link and verification links, and its CSRF origin allowlist, from it. See the [migration guide](/auth-upgrade#3-pin-the-canonical-url-with-better-auth-url).
+
+                ## Database
+
+                Sessions, users, accounts and organizations are stored through an adapter:
+
+                ```yaml
+                lowdefy: {{ version }}
+                auth:
+                  database:
+                    id: auth_db
+                    type: MongoDBAuthAdapter
+                    properties:
+                      uri:
+                        _secret: AUTH_DATABASE_URI
+                ```
+
+                See the [MongoDBAuthAdapter](/MongoDBAuthAdapter) reference. Collection names follow the `user-*` convention and are fixed by the adapter.
+
+                ## Login mechanisms
+
+                - **Email & password** — `auth.emailAndPassword` (`enabled`, `requireEmailVerification`, `minPasswordLength` (default 8), `disableSignUp`).
+                - **Magic link** — `auth.magicLink` (`enabled`, `expiresIn` seconds (default 300), `disableSignUp`), which needs `auth.email` (below).
+                - **OAuth providers** — `auth.providers`; see [Providers](/auth-providers).
+                - **Phone number** — `auth.phoneNumber` (OTP sign-in); needs a `phone.otp.send` hook to deliver the SMS.
+                - **Passkeys** — `auth.passkey` (`enabled`, `rpId`, `rpName`).
+
+                ```yaml
+                lowdefy: {{ version }}
+                auth:
+                  emailAndPassword:
+                    enabled: true
+                    requireEmailVerification: true
+                ```
+
+                ## Auth email
+
+                `auth.email` references an **SMTP connection** by id — the connection owns `from`, `replyTo`, the transport and the delivery filter, and is shared by every auth email flow. There is no inline transport shape. Optionally map individual flows to your own notification templates:
+
+                ```yaml
+                lowdefy: {{ version }}
+                auth:
+                  email:
+                    connectionId: email   # an SMTP connection in connections[]
+                    templates:            # all optional; unset → branded stock template
+                      verifyEmail: verify-email-notification
+                      resetPassword: reset-password-notification
+                      magicLink: magic-link-notification
+                      invitation: invite-notification
+                ```
+
+                ## Auth pages
+
+                BetterAuth ships no UI — your app owns its auth pages, and `auth.authPages` points at them. All are Lowdefy page paths:
+
+                | Key | Default | When required |
+                | --- | ------- | ------------- |
+                | `signIn` | `/login` | |
+                | `signUp` | `/signup` | |
+                | `error` | `/auth/error` | receives `?error=` code |
+                | `forgotPassword` | `/forgot-password` | |
+                | `resetPassword` | `/reset-password` | |
+                | `verifyEmail` | `/verify-email` | |
+                | `twoFactor` | — | **required** when `twoFactor.enabled` |
+                | `twoFactorEnrol` | — | **required** when `twoFactor.required` |
+                | `acceptInvitation` | — | consumes an `?invitationId=` link |
+
+                ```yaml
+                lowdefy: {{ version }}
                 auth:
                   authPages:
                     signIn: /login
+                    signUp: /signup
+                    error: /auth-error
                 ```
+
+                See [Two-Factor Authentication](/two-factor) for the two-factor pages, and the [MCP Server & OAuth](/mcp-oauth) page for `oauthProvider.consentPage` and `postLoginPage`.
 
                 ## Session
 
-                The `auth.session` config maps to the [Auth.js session](https://authjs.dev/reference/core#session) config option. It can be used to set the maximum session length using the `auth.session.maxAge` option.
+                Database sessions. Length is `expiresIn` (seconds, default 604800 = 7 days); `updateAge` (default 86400) is how often an active session's expiry is refreshed:
 
-                ###### Set a maximum session length of twelve hours
                 ```yaml
                 lowdefy: {{ version }}
-
                 auth:
                   session:
-                    maxAge: 43200 # 12 hours in seconds
+                    expiresIn: 43200 # 12 hours in seconds
+                    updateAge: 3600
                 ```
 
-                ## Debug
+                `session.cookieCache` (off by default) trades a short window of stale session reads for fewer database lookups — leave it off unless you understand the [revocation-latency trade](/two-factor#recovering-a-user-who-has-lost-their-factor).
 
-                If the server log level is set to `debug`, the Auth.js debug mode will be enabled. The `auth.debug` property can be set to false to disable authentication debug output.
+                ## Roles, organizations, and API strategies
 
-                ## Cookies
+                - **Roles** — declare app role names in `auth.roles` and gate pages/endpoints with `auth.pages.roles` / `auth.api.roles`. See [Roles](/roles).
+                - **Organizations** — `auth.organizations.policy` (`pinned` or `tenant`) decides the whole multi-tenancy model. See [Organizations & Multi-Tenancy](/organizations).
+                - **API strategies** — `auth.strategies` authenticates non-session callers (server-to-server) with an `apiKey` or a `jwt`:
 
-                The  `auth.advanced.cookies` section can be used to overwrite the Auth.js cookie options. This is an advanced option and using it is not recommended as you may break authentication or introduce security flaws into your application. See [here](https://authjs.dev/reference/core#cookies) for more details.
+                ```yaml
+                lowdefy: {{ version }}
+                auth:
+                  strategies:
+                    - id: service-key
+                      type: apiKey
+                      roles:
+                        - integrations
+                      properties:
+                        keys:
+                          - value:
+                              _secret: SERVICE_API_KEY
+                ```
+
+                A strategy caller carries the configured `roles` and `attributes` and its `auth_method` is the strategy type. A `jwt` strategy needs exactly one of `properties.secret` or `properties.jwksUri`, and a non-empty `algorithms` allowlist (which blocks `alg: none` downgrades).
+
+                ## Captcha
+
+                `auth.captcha` protects auth endpoints with Cloudflare Turnstile. The `siteKey` is public (a plain string, never a `_secret`); the `secretKey` is a `_secret` reference. See the [Captcha block](/Captcha) for the client side.
+
+                ## Rate limiting and account linking
+
+                - `auth.rateLimit` — brute-force protection, on by default (`enabled`, `window` seconds, `max`).
+                - `auth.account.accountLinking` — link a new OAuth sign-in to an existing account by verified email. `trustedProviders` lists providers whose email claim you trust for linking. **This is unrelated to `provider.twoFactorTrusted`** — see [Two-Factor Authentication](/two-factor#trusting-an-oauth-provider).
 
                 ## Mock User for Testing (Dev Server Only)
 
@@ -103,7 +180,7 @@ _ref:
                 Pass `--mock-user` to `lowdefy dev` to start the server as a mock user for that run. Supply a JSON user object to set the identity and roles, or use the bare flag for a default user with no roles:
 
                 ```bash
-                lowdefy dev --mock-user '{"sub":"test-user","email":"test@example.com","roles":["admin"]}'
+                lowdefy dev --mock-user '{"id":"test-user","email":"test@example.com","roles":["admin"]}'
                 ```
 
                 The flag sets `LOWDEFY_DEV_USER` for the dev server process, so it takes precedence over `auth.dev.mockUser` in the config file.
@@ -113,7 +190,7 @@ _ref:
                 Set the `LOWDEFY_DEV_USER` environment variable to a JSON string containing the mock user object:
 
                 ```bash
-                LOWDEFY_DEV_USER='{"sub":"test-user","email":"test@example.com","roles":["admin"]}'
+                LOWDEFY_DEV_USER='{"id":"test-user","email":"test@example.com","roles":["admin"]}'
                 ```
 
                 ### Config File
@@ -127,7 +204,7 @@ _ref:
                 auth:
                   providers:
                     - id: google
-                      type: GoogleProvider
+                      type: Google
                       properties:
                         clientId:
                           _secret: GOOGLE_CLIENT_ID
@@ -135,7 +212,7 @@ _ref:
                           _secret: GOOGLE_CLIENT_SECRET
                   dev:
                     mockUser:
-                      sub: test-user
+                      id: test-user
                       email: test@example.com
                       name: Test User
                       roles:
@@ -145,14 +222,14 @@ _ref:
                 When a mock user is configured:
                 - The environment variable takes precedence over the config file if both are set
                 - A warning is logged at dev server startup: "Mock user active - login bypassed"
-                - The mock user goes through the normal session callback, so `userFields` mappings and custom callbacks still apply
+                - The mock user is injected as a pre-resolved caller — its `roles` are authoritative
                 - The `_user` operator returns values from the mock user, on the server and in the browser client — the dev server serves the mock session to both
                 - Protected pages are accessible based on the mock user's roles
                 - The dev server's headless renderer (used by the AI-agent screenshot and state-inspection tools) renders as the mock user, so it can capture pages with roles the default user lacks
 
                 > **Note:** Mock users only work with the development server (`lowdefy dev`). The production server ignores mock user configuration for security.
 
-                > **Note:** Auth must be configured (at least one provider) for mock users to work, since the mock user is processed through the Auth.js session callback.
+                > **Note:** `dev.mockUser` bypasses the auth engine rather than exercising it — a config whose only auth substance is `dev.mockUser` still fails the "no auth mechanism" build check, and [auth steps](/auth-steps) (which need the running auth engine) are unavailable under a mock user.
 
       - _ref:
           path: templates/navigation_buttons.yaml

--- a/packages/docs/users/auth-steps.yaml
+++ b/packages/docs/users/auth-steps.yaml
@@ -1,0 +1,135 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_ref:
+  path: templates/general.yaml.njk
+  vars:
+    pageId: auth-steps
+    pageTitle: Auth Steps
+    section: User Authentication
+    filePath: users/auth-steps.yaml
+    content:
+      - id: content
+        type: MarkdownWithCode
+        properties:
+          content: |
+            Auth steps are routine steps that administer users, organizations and memberships — inviting a member, updating an app role, banning a user, creating an organization. They run **inside an `Api` or `InternalApi` endpoint routine**, not as client actions, because administering *other* people's memberships is a server operation that must be authorized against the caller, name its target organization explicitly, and be visible in a diff.
+
+            > A **client action** mutates the caller's *own* session and nothing else — `SetActiveOrganization`, `AcceptInvitation`, `LeaveOrganization`. Anything that reaches another person's membership is an auth **step** in a routine, which is what earns it the per-step authority floor below. See the [Auth Upgrade guide](/auth-upgrade#retired-client-actions) for the actions that became steps.
+
+            ```yaml
+            id: invite-member
+            type: Api
+            routine:
+              - id: invite
+                type: InviteMember
+                properties:
+                  organizationId:
+                    _user: organization_id
+                  email:
+                    _payload: email
+                  appRoles:
+                    _payload: roles
+              - ':return':
+                  _step: invite
+            ```
+
+            ## The authority model
+
+            Every auth step declares, in its own code, the authority it requires — and the engine's **authority floor** enforces that declaration mechanically before the step runs. This is not optional decoration: a step with no declared authority is a build/runtime error, so an app can never expose a member mutation by forgetting a check. The reason the floor exists in one place is that most steps go adapter-direct or through BetterAuth's admin plugin, whose check reads a single deployment-wide `user.role` field and **cannot** answer "is the caller an administrator of *this* organization". For those steps, the floor is the only authorization that can express per-organization authority.
+
+            A step declares one of three **scopes**.
+
+            ### `org` — authorized against the caller's membership in the target organization
+
+            The common case. The floor:
+
+            1. **Resolves the target organization** (see below).
+            2. **Finds the caller's `member` row** in that organization and checks its role against the step's required **permissions**. The caller's authority is their membership in the *target* organization — an administrator of the team organization holds nothing in the customer organization.
+            3. For steps that write the deployment-wide `user` row, additionally requires the **target user** to be a member of that organization (`targetUser`), so org authority alone can never reach a user who is not the caller's business.
+
+            Permissions map to the organization tier via BetterAuth's organization access control: `owner` and `admin` are granted the member-management permissions out of the box; `member` holds none of them. A refused caller gets a `ConfigError` naming exactly what was required.
+
+            ### `system` — caller-less, trusted runs only
+
+            A `system`-scoped step (`CreateOrganization`, `ListUsers`) has no organization to be authorized in, so a caller can never satisfy it. It runs **only** where the run itself is trusted — a caller-less system routine. Mark the step `system: true`, or run it from a system context (cron, a verified webhook, an auth hook):
+
+            ```yaml
+            - id: create_org
+              type: CreateOrganization
+              system: true
+              properties:
+                name:
+                  _payload: name
+                slug:
+                  _payload: slug
+                userId:
+                  _payload: ownerUserId
+            ```
+
+            ### `caller` — acts on the caller's own records
+
+            A `caller`-scoped step (`RevokeMcpGrant`) acts only on rows the caller owns, so it needs no organization authority — but it is meaningless without a caller, and the system has no rows of its own. It requires a real caller and refuses `system: true`.
+
+            ## `system: true` — the two doors to a caller-less run
+
+            The floor's caller requirement passes on either of two independent doors:
+
+            - a **run-level** system context (`context.system === true`) — a trusted, caller-less run such as a cron endpoint, an auth hook, or a verified webhook; or
+            - a **per-step** `system: true` on a single step in an otherwise user-driven run — a waiver visible in the diff, for the one privileged operation in a member-facing routine.
+
+            Either door makes the step act caller-less **as the system**, bypassing the org/permission checks. That is an explicit trust decision, not attribution — use it deliberately.
+
+            ## How the target organization is resolved
+
+            For every `org`-scoped step the floor resolves the target organization once, and the step writes into the *same* one it authorized — they cannot drift. The rule:
+
+            1. An explicit **`organizationId`** property always wins. This is what a multi-organization admin routine passes, and it is what lets a session pinned to the team organization administer the customer organization.
+            2. `ListMembers` also accepts an **`organizationSlug`**, resolved to an id here.
+            3. Otherwise the **pinned** organization is the default — **but under `policy: tenant` there is no pinned organization**, so an omitted `organizationId` is a runtime error naming the fix. Under `tenant`, always pass `organizationId` explicitly.
+
+            ## `targetUser` and `selfTargetExempt`
+
+            Two refinements the floor reads from a step's declaration:
+
+            - **`targetUser`** names the property holding the id of the user being acted on. Steps that write the shared `user` row declare it, so the floor can require that user to be a member of the target organization. An absent target-user property is the step's own required-property error, not the floor's.
+            - **`selfTargetExempt`** lets a caller act on **their own** row without holding org authority — this is what makes `UpdateUserProfile` a self-service "save my profile" step as well as an admin one. When the named property equals the caller's own id, the org authority check is skipped.
+
+            ## Step reference
+
+            Scope, required permission, and target for every auth step. Permissions are checked against the caller's `member.role` in the target organization; `owner`/`admin` hold them by default.
+
+            | Step | Scope | Permission | Target | What it does |
+            | ---- | ----- | ---------- | ------ | ------------ |
+            | `InviteMember` | org | `invitation: [create]` | — | Invite a member by email; carries `appRoles`, `orgRole`, `attributes`, `contactId`, `profile`; `resend` refreshes. |
+            | `CancelInvitation` | org | `invitation: [cancel]` | — | Cancel a pending invitation. |
+            | `ListMembers` | org | `member: [list]` | — | List members of the organization (accepts `organizationSlug`). |
+            | `RemoveMember` | org | `member: [delete]` | — | Remove a member from the organization. |
+            | `UpdateMemberRoles` | org | `member: [update]` | — | Set the membership's **app roles** (`appRoles` array; empty clears). |
+            | `UpdateMemberOrgRole` | org | `member: [update]` | — | Set the **org tier** (`owner`/`admin`/`member`). |
+            | `UpdateMemberAttributes` | org | `member: [update]` | — | Set the membership's per-organization attributes. |
+            | `UpdateOrganization` | org | `organization: [update]` | — | Update the organization row (name, slug, metadata). |
+            | `UpdateUserProfile` | org | `user: [update]` | `userId` (self-exempt) | Update a member's display name/image (per-organization copy). Self-service save is exempt. |
+            | `UpdateUserAttributes` | org | `user: [set-attributes]` | `userId` | Set global user attributes. |
+            | `BanUser` | org | `user: [ban]` | `userId` | Ban a user. |
+            | `UnbanUser` | org | `user: [ban]` | `userId` | Lift a ban. |
+            | `DeleteUser` | org | `user: [delete]` | `userId` | Delete a user. |
+            | `RevokeUserSessions` | org | `session: [revoke]` | `userId` | Sign a user out of all sessions. |
+            | `ResetUserTwoFactor` | org | `user: [reset-two-factor]` | `userId` | Clear a user's two-factor enrolment and trust-device records. |
+            | `RevokeUserPasskeys` | org | `user: [revoke-passkeys]` | `userId` | Remove a user's passkeys (`passkeyId` to target one). |
+            | `CreateOrganization` | system | — | — | Create an organization (tenant provisioning). Needs `userId`, or `name`+`slug` for creator-less provisioning. |
+            | `ListUsers` | system | — | — | List every user in the deployment. |
+            | `RevokeMcpGrant` | caller | — | — | Revoke the calling assistant's own [MCP grant](/mcp-oauth#switching-organization-from-the-assistant). |
+
+            The two role tiers a member carries — the `owner`/`admin`/`member` org tier and the app's own role strings — are explained in [Organizations & Multi-Tenancy](/organizations#the-owner-admin-member-tier-vs-app-roles). Recovering a user who lost their second factor is a worked routine on the [Two-Factor Authentication](/two-factor#recovering-a-user-who-has-lost-their-factor) page.

--- a/packages/docs/users/mcp-oauth.yaml
+++ b/packages/docs/users/mcp-oauth.yaml
@@ -1,0 +1,313 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_ref:
+  path: templates/general.yaml.njk
+  vars:
+    pageId: mcp-oauth
+    pageTitle: MCP Server & OAuth
+    section: User Authentication
+    filePath: users/mcp-oauth.yaml
+    content:
+      - id: content
+        type: MarkdownWithCode
+        properties:
+          content: |
+            A Lowdefy app can expose its API endpoints as tools to an MCP client — Claude, ChatGPT, an IDE assistant — over the Model Context Protocol. When those tools touch anything but public data, the client has to prove who is calling, and Lowdefy handles that by turning the app itself into an **OAuth 2.1 authorization server**: the assistant runs a normal browser authorization, the user signs in, chooses the organization to work in, and grants consent, and the app mints an access token the assistant sends on every tool call.
+
+            This page is about the *authenticated* MCP surface. Exposing tools to an app's own agents, and the `mcp` array on an agent (the app acting as an MCP *client*), are covered in [MCP tools for agents](/agent-mcp-tools) and the [`Mcp` connection](/Mcp). Here the app is the *server*, and the caller is an outside assistant.
+
+            ## One resource, one address
+
+            There is a single MCP resource for the whole deployment, served at `/api/mcp`. The organization a call acts in is **not** part of the address — it is chosen once during authorization and carried inside the access token as a claim. Every assistant connects to the same URL; two users, or one user in two organizations, are told apart by their tokens, never by the path.
+
+            This is the Linear model — one link, the workspace is a property of the authorization rather than the address — and it is deliberate. An earlier design keyed the resource per organization (`/api/mcp/{organization_id}`); that put the organization in the URL, the RFC 8707 `resource` parameter, and the token audience, and needed a per-organization resource row kept in sync. The single resource deletes all of that: one address to paste, one audience, and the organization rides the token.
+
+            | Route | Purpose |
+            | ----- | ------- |
+            | `POST /api/mcp` | The MCP resource — streamable HTTP transport. Tools are listed and called here, per request, authorized against the bearer token. |
+            | `GET /.well-known/oauth-protected-resource/api/mcp` | RFC 9728 protected-resource metadata: the resource URI, the authorization server, and the scopes it supports. Public and constant per deployment. |
+            | `GET /.well-known/oauth-authorization-server/api/auth` | RFC 8414 authorization-server metadata, re-exposed at the path a client derives from the issuer. |
+            | `/api/auth/*` | The authorization server itself — authorize, token, registration, and the OAuth endpoints the consent and picker pages call. |
+
+            The `/.well-known` documents derive their URIs from the pinned `BETTER_AUTH_URL`, never from a request `Host` header, so they are the same for every caller. They mount **only when `auth.oauthProvider` is configured** — an app that is not an authorization server has nothing to discover, and its MCP tools are all public (see the rule below).
+
+            ## Turning the app into an authorization server
+
+            Add `auth.oauthProvider`. It names the two pages the browser authorization flow hands control to, and whether unknown clients may register themselves:
+
+            ```yaml
+            auth:
+              oauthProvider:
+                consentPage: /oauth-consent
+                postLoginPage: /oauth-select-organization
+                dynamicClientRegistration: false
+            ```
+
+            - **`consentPage`** *(required)* — the Lowdefy page id of your consent screen. The authorization flow redirects the signed-in user here to approve or deny the client. The engine builds the redirect as `${origin}${basePath}${consentPage}`, joined with no separator, so **the leading slash is required**.
+            - **`postLoginPage`** — the page where a signed-in user chooses which organization the authorization acts in. It is shown after login and before consent. It is **required under `organizations.policy: tenant`** (the build fails without it) and is skipped under `pinned`, where there is only ever one organization to act in.
+            - **`dynamicClientRegistration`** — allow unregistered MCP clients to self-register per RFC 7591. Off by default; pre-registered clients are the primary path. Turn it on for public assistants you cannot pre-register.
+
+            Both page ids are validated at build time the same way: the page must exist, and it must not be public-listed in a way that would let it render without a session — the flow only ever reaches them for a signed-in user.
+
+            ## Exposing tools, and their scopes
+
+            The app-level `mcp` block declares the server's identity and which API endpoints are tools:
+
+            ```yaml
+            mcp:
+              name: acme
+              version: '1.0.0'
+              title: Acme
+              websiteUrl: https://acme.example.com
+              icons:
+                - src: https://acme.example.com/icon-512.png
+                  mimeType: image/png
+                  sizes: ['512x512']
+              endpoints:
+                - id: search-customers
+                  scope: mcp:read
+                - id: create-invoice
+                  scope: mcp:write
+            ```
+
+            `name`, `version`, `title`, `websiteUrl` and `icons` are the server branding a client shows the user in the `initialize` handshake. Each `endpoints` entry needs an `id` and a `scope`.
+
+            **`scope` is a closed vocabulary — `mcp:read` or `mcp:write`, and nothing else.** Apps cannot mint their own scopes. `mcp:write` implies `mcp:read` at runtime, so a token granted write can call both. Tag a tool that only reads with `mcp:read` and one that mutates with `mcp:write`; the consent screen then lets a user grant an assistant read-only access to the whole surface if they choose.
+
+            Three rules the build enforces on every tool:
+
+            - **Only `Api` endpoints can be tools.** An `InternalApi` endpoint is not reachable as one — it has no external caller by design.
+            - **Every tool needs a `description` and a `payloadSchema`.** The description is what the assistant reads to decide when to call the tool; the `payloadSchema` becomes the tool's input schema. A tool with neither is not a usable tool, so the build refuses it.
+            - **The `mcp.agents` key is gone.** MCP agent tools are not supported; remove it if you are upgrading.
+
+            ## A tool is gated twice
+
+            When a call arrives at `/api/mcp`, a tool is listed and callable only when **both** hold:
+
+            1. the caller's **role outcome** allows the endpoint — the same `auth.api` / `auth.api.roles` gate every API call passes; and
+            2. the **token's granted scope** covers the tool's tag.
+
+            The 401 challenge is decided once, at the route boundary, before the MCP transport runs. Past that boundary the transport answers over HTTP 200, so a role or scope shortfall never surfaces as a `403` or an `insufficient_scope` error to the assistant — the tool is simply not offered. This is intentional: the tool surface does not disclose the existence of tools the caller may not use.
+
+            ## The rule that catches everyone: keep MCP endpoints out of `auth.api.public`
+
+            > **Never list an MCP endpoint id in `auth.api.public`.**
+
+            One public tool suppresses the 401 challenge for the *whole* route. The build sets `mcp.json`'s `hasPublicTool` flag when any exposed endpoint is public, and the `/api/mcp` route then serves an anonymous caller a `200` with the public tools instead of a `401` with the `WWW-Authenticate` challenge. A freshly added assistant reports "connected, 1 tool" and **never runs the OAuth flow** — only a *stale* token would take the challenge branch. Every protected tool then sits behind a door the client was never told to knock on.
+
+            So a protected app keeps its `auth.api` gates and leaves every `mcp.endpoints` id out of the public list:
+
+            ```yaml
+            auth:
+              api:
+                protected: true
+                # Keep MCP endpoint ids OUT of this list. A single public tool
+                # flips mcp.json hasPublicTool, and /api/mcp then serves anonymous
+                # callers a 200 with that tool instead of the 401 challenge.
+                public:
+                  - webhooks/stripe   # a webhook receiver, not an MCP tool
+            ```
+
+            The build has a matching guard from the other direction: a protected or role-gated MCP endpoint **requires** `auth.oauthProvider`. Without the authorization server there is no way to authenticate the caller, so the build fails rather than shipping an unreachable tool — make the endpoint public (accepting the trade above) or configure `oauthProvider`.
+
+            ## The authorization flow, end to end
+
+            1. The assistant reads `/.well-known/oauth-protected-resource/api/mcp`, finds the authorization server, and (if it is not pre-registered and `dynamicClientRegistration` is on) registers itself.
+            2. It opens a browser to the authorization endpoint. The user signs in through your normal sign-in page.
+            3. **Under `tenant`,** the flow redirects to `postLoginPage`. The user picks the organization to work in; the page sets it active and continues the authorization. **Under `pinned`,** this step is skipped.
+            4. The flow redirects to `consentPage`. The user approves the client and the requested scopes — or, if they have already consented for this client in this organization, consent is skipped.
+            5. The app mints an access token whose **`organization_id` claim is the chosen organization** (the consent `referenceId`), and the assistant sends it as a `Bearer` token on every `/api/mcp` call.
+
+            Consent is recorded per **(client, user, organization)**. Re-authorizing into an organization the user has already consented for skips the consent screen; a first authorization into a *different* organization asks for consent again, for that organization.
+
+            ### How a token becomes a caller
+
+            On every `/api/mcp` request the token is verified in-process against the authorization server's own signing keys: the issuer and audience must match the resource, and the token must carry both a `sub` (the user) and an `organization_id` claim. The claim is not trusted on its own — the **consent row for `(client, user, organization)` must still exist**. That liveness read on every call is what makes switching and disconnecting take effect *immediately*: revoke the grant and the next call is refused at once, not at the token's expiry.
+
+            The caller is then resolved as a member of that organization, exactly as a session caller is — same membership wall, same role source, same `_user` shape — with one extra field: **`_user.auth_method` is `'mcp'`**, so a routine can tell an assistant apart from a browser without any app-side plumbing.
+
+            ```yaml
+            # In an endpoint routine, branch on how the caller arrived:
+            - id: set_channel
+              type: SetState
+              params:
+                channel:
+                  _if:
+                    test:
+                      _eq:
+                        - _user: auth_method
+                        - mcp
+                    then: mcp
+                    else: ui
+            ```
+
+            A token that cannot be verified (for example, an opaque token minted because the client omitted the RFC 8707 `resource` parameter), or one whose grant has been revoked, gets a `401` with a `WWW-Authenticate` challenge that tells the client what to do — reconnect and re-run the authorization, including the organization choice.
+
+            ## Building the consent and picker pages
+
+            Both pages are ordinary Lowdefy pages that read the authorization request from the URL query, show the user what is being asked, and finish the flow with client actions. Four actions do the work:
+
+            | Action | What it does |
+            | ------ | ------------ |
+            | `ListOrganizations` | Returns the caller's organization memberships — the rows the picker renders. |
+            | `SetActiveOrganization` | Sets the caller's active organization. The picker calls it for the chosen organization. |
+            | `OAuthContinue` | Continues the authorization after the organization is chosen (`POST /api/auth/oauth2/continue`). Returns `{ url }` to redirect to. |
+            | `OAuthConsent` | Approves (`accept: true`) or denies (`accept: false`) the client. Returns `{ url }` to redirect to. |
+
+            ### The organization picker (`postLoginPage`)
+
+            On mount the page calls `ListOrganizations` and stores the rows in state; a `ListSelector` renders them, and its click handler sets the chosen organization active and continues:
+
+            ```yaml
+            id: select_org_rows
+            type: ListSelector
+            properties:
+              selectable: false
+              hoverable: true
+              data:
+                _state: organizations
+            events:
+              onClick:
+                - id: set_active_organization
+                  type: SetActiveOrganization
+                  skip:
+                    _eq:
+                      - _event: item.id
+                      - _user: organization_id
+                  params:
+                    organizationId:
+                      _event: item.id
+                - id: continue_authorization
+                  type: OAuthContinue
+                  messages:
+                    error: false
+                - id: continue_redirect
+                  type: Link
+                  params:
+                    url:
+                      _actions: continue_authorization.response.url
+            ```
+
+            `SetActiveOrganization` is skipped when the chosen organization is already the active one, so re-picking the current organization is a no-op that still continues the flow.
+
+            ### The consent screen (`consentPage`)
+
+            Reads the request from the query, shows the client and scopes, and finishes on the user's decision:
+
+            ```yaml
+            id: consent_allow
+            type: Button
+            properties:
+              title: Allow access
+            events:
+              onClick:
+                - id: consent_allow_action
+                  type: OAuthConsent
+                  messages:
+                    error: false
+                  params:
+                    accept: true
+                - id: consent_allow_redirect
+                  type: Link
+                  params:
+                    url:
+                      _actions: consent_allow_action.response.url
+            ```
+
+            The deny button is identical with `params: { accept: false }`. Read `_url_query: client_id` and `_url_query: scope` to render what the client is asking for, and `_url_query: resource` to confirm the audience. Fetch the client's own metadata (name, logo) from `/api/auth/oauth2/public-client?client_id=...` to show a human-readable client name rather than an opaque id.
+
+            ## Switching organization from the assistant
+
+            An assistant connected to one organization switches by *disconnecting* — the client then re-runs the authorization and the user picks a different organization. Expose a tool that revokes the calling grant with the `RevokeMcpGrant` step:
+
+            ```yaml
+            id: switch-organization
+            type: Api
+            description: >
+              Disconnect this assistant from the organization it is connected to so
+              the user can connect it to another one. Use ONLY when the user asks to
+              work in a different organization. After it succeeds the connection is
+              gone: tell the user to reconnect in their assistant — the browser will
+              ask which organization to connect to.
+            payloadSchema:
+              type: object
+              additionalProperties: false
+              properties: {}
+            routine:
+              - id: revoke_grant
+                type: RevokeMcpGrant
+              - ':return':
+                  disconnected: true
+                  organization_id:
+                    _step: revoke_grant.organizationId
+                  message: >-
+                    Disconnected. Ask the user to reconnect in their assistant.
+            ```
+
+            [`RevokeMcpGrant`](/auth-steps) reads the calling token's `(client, user, organization)` from the request context, deletes that one consent row, and revokes its refresh tokens. It is **caller-scoped**: it touches only the grant the call arrived on, so another assistant the same person connected, or this assistant's grant in another organization, is untouched. It refuses to run for any caller that did not arrive over MCP — there is no grant behind a browser session for it to revoke.
+
+            Expose it as an `mcp:read` tool. The next tool call the assistant makes gets a `401`, the client re-runs OAuth, and the user lands back on the organization picker.
+
+            ## Disconnecting assistants from the app
+
+            The mirror control belongs in your app's UI: a person removing every assistant connected to their active organization. It deletes the caller's consent rows for that organization and revokes the matching refresh tokens — the same two writes `RevokeMcpGrant` makes, scoped to the active organization instead of one client:
+
+            ```yaml
+            id: disconnect-assistants
+            type: Api
+            description: Disconnect every assistant connected to the caller's active organization.
+            payloadSchema:
+              type: object
+              additionalProperties: false
+              properties: {}
+            routine:
+              - id: revoke_refresh_tokens
+                type: MongoDBUpdateMany
+                connectionId: oauth-refresh-tokens
+                properties:
+                  filter:
+                    user_id:
+                      _user: id
+                    reference_id:
+                      _user: organization_id
+                    revoked: null
+                  update:
+                    $set:
+                      revoked:
+                        _date: now
+              - id: delete_consents
+                type: MongoDBDeleteMany
+                connectionId: oauth-consents
+                properties:
+                  filter:
+                    user_id:
+                      _user: id
+                    reference_id:
+                      _user: organization_id
+              - ':return':
+                  disconnected:
+                    _step: delete_consents.deletedCount
+            ```
+
+            Because the `/api/mcp` route reads the live consent row on every call, every affected assistant is refused on its next call, not at token expiry.
+
+            ## Summary
+
+            - The app is an OAuth 2.1 authorization server; enable it with `auth.oauthProvider`.
+            - There is one MCP resource at `/api/mcp`. The organization is a token claim, not a URL segment.
+            - Tag each tool `mcp:read` or `mcp:write`; a tool is gated by both role and scope.
+            - **Never list an MCP endpoint id in `auth.api.public`** — one public tool suppresses the challenge for the whole route.
+            - Consent is per `(client, user, organization)` and read live on every call, so `RevokeMcpGrant` and disconnecting take effect immediately.
+            - `_user.auth_method` is `'mcp'` for assistant callers.

--- a/packages/docs/users/organizations.yaml
+++ b/packages/docs/users/organizations.yaml
@@ -1,0 +1,158 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_ref:
+  path: templates/general.yaml.njk
+  vars:
+    pageId: organizations
+    pageTitle: Organizations & Multi-Tenancy
+    section: User Authentication
+    filePath: users/organizations.yaml
+    content:
+      - id: content
+        type: MarkdownWithCode
+        properties:
+          content: |
+            Every Lowdefy app has organizations — always, even a single-team internal tool. A signed-in caller is a **member** of an organization, and it is the membership, not the user record, that carries the caller's app roles and per-organization attributes. This is the unit the whole auth system is built on: `_user.roles` is the active membership's roles, and the [tenant wall](#the-tenant-wall) scopes data to the active organization.
+
+            The single knob that decides how organizations behave is `auth.organizations.policy`.
+
+            ## Two policies: `pinned` and `tenant`
+
+            ```yaml
+            auth:
+              organizations:
+                policy: pinned   # or "tenant"
+            ```
+
+            **`pinned`** *(the default)* — one organization for the whole deployment, ensured at startup. This is the shape for an internal app or a single-customer install: there is one workspace, everyone is a member of it, and the active organization is never switched. The organization plugin's per-organization routes (create, switch, self-service org management) are disabled.
+
+            **`tenant`** — organizations are created per user, and a caller can belong to several and switch between them. This is the shape for a multi-tenant SaaS: each customer is an organization, members are invited into it, and `SetActiveOrganization` moves the caller between the workspaces they belong to.
+
+            An app that sets nothing gets `pinned` with one auto-seeded organization, invite-only. The policy is not something you can leave to a default and change later without thought — it changes what `_user.organization_id` means, whether the tenant wall is active, and whether the MCP flow needs an [organization picker](/mcp-oauth). Choose it up front.
+
+            ## The `organizations` keys
+
+            | Key | Type | Applies to | Default | Meaning |
+            | --- | ---- | ---------- | ------- | ------- |
+            | `policy` | `pinned` \| `tenant` | both | `pinned` | The organization model, above. |
+            | `org` | string | **pinned only** | `default` | The slug the deployment pins as the active organization. Under `pinned` the slug **is** the organization's id. |
+            | `signup` | `invite-only` \| `open` | both | `pinned` → `invite-only`, `tenant` → `open` | Whether uninvited sign-ups are admitted. `invite-only` refuses a sign-up with no invitation; `open` admits everyone. |
+            | `create` | `auto` \| `operator` | **tenant only** | `tenant` → `auto` | How a tenant organization comes into being: `auto` mints one for a user at first session; `operator` leaves creation to your own config (the `CreateOrganization` step). |
+            | `invitationExpiresIn` | integer (seconds, min 60) | both | `172800` (48h) | How long an invitation stays acceptable. Re-sending an invitation refreshes its expiry. |
+
+            The build cross-checks these, and the errors are worth knowing before you hit them:
+
+            - **`org` is required under `pinned`** and **rejected under `tenant`** — under `tenant` there is no single organization to pin; organizations are created per user.
+            - **`create` is rejected under `pinned`** — the active organization is ensured at startup, so there is nothing to create on demand.
+            - **Renaming `org` strands the existing membership.** The startup ensure is by slug, so changing `org` mints a *fresh* organization rather than renaming the old one, and every existing `member` row still points at the old id. Treat the pinned slug as permanent.
+
+            Defaults line up with intent: `pinned` defaults to a closed, invite-only internal app; `tenant` defaults to self-serve SaaS (`signup: open`, `create: auto`).
+
+            ## The `owner` / `admin` / `member` tier vs app roles
+
+            A membership carries **two** independent role authorities, and keeping them apart is the whole point:
+
+            - **`_user.org_roles`** — the organization tier: `owner`, `admin`, or `member`. This is BetterAuth's administrative fact about the membership, and it is what the [auth-step authority floor](/auth-steps) checks. **No page or API gate reads it.**
+            - **`_user.roles`** — the app's own role strings, from the membership's `appRoles`. These are what [`auth.pages.roles` and `auth.api.roles`](/roles) match, and the only thing they match.
+
+            So an app that wants a page for organization administrators does **not** gate it on the `admin` tier — it gates on one of its own app roles, and lets the write authority answer the administration question separately, at the step. See [Roles](/roles) for page and API gating, and [Auth Steps](/auth-steps) for the administration model.
+
+            ## Bootstrapping the first administrator
+
+            Nothing grants organization authority implicitly — not even to the first user. On a fresh `pinned` + `invite-only` deployment that is a closed loop: nobody can invite (inviting needs authority nobody holds) and nobody can sign up (the gate admits only members and pending invitees). Breaking the loop is a single invitation document inserted by hand into the `user-invitations` collection, seeded with the `owner` tier. The full recipe — the exact document, why the key must be `_id`, why the role must be `owner`, and how to deliver the accept link — is in the [Auth Upgrade guide](/auth-upgrade#bootstrapping-the-first-administrator).
+
+            ## The tenant wall
+
+            Under `policy: tenant`, data must not leak across organizations. The **tenant wall** enforces that mechanically: a scoping-capable connection is filtered to the caller's active organization on every read and stamped with it on every write, without the request author writing a single filter clause. The wall is declared **on the connection**; requests, steps and websockets only declare *exceptions*.
+
+            ### Declaring scope on a connection
+
+            Under `tenant`, a connection whose type implements the scoping contract (MongoDB does) is **scoped by default** — silence means scoped. You only ever declare the two exceptions:
+
+            ```yaml
+            connections:
+              # Scoped by default under tenant policy — nothing to declare.
+              - id: app_data
+                type: MongoDBCollection
+                properties:
+                  databaseUri:
+                    _secret: MONGODB_URI
+                  collection: records
+
+              # Data deliberately shared across organizations (reference data,
+              # a global catalogue) — opt out of scoping explicitly.
+              - id: countries
+                type: MongoDBCollection
+                tenant: shared
+                properties:
+                  databaseUri:
+                    _secret: MONGODB_URI
+                  collection: countries
+
+              # Scope on a field other than the default organization_id.
+              - id: legacy_records
+                type: MongoDBCollection
+                tenant:
+                  field: tenant_id
+                properties:
+                  databaseUri:
+                    _secret: MONGODB_URI
+                  collection: legacy
+            ```
+
+            `tenant` on a connection is either the string `shared` or `{ field: <name> }` (a non-empty name with no dots). The default scoping field is `organization_id`. There is deliberately **no `tenant: true`** — under `tenant` policy a capable connection is already scoped, so `true` would only restate the default; the build rejects it.
+
+            **Under `tenant` policy every connection type must declare its capability.** A connection whose type does not declare tenant support (`connectionMetas.tenant`) fails the build — no connection is ever *silently* unscoped. Connection plugins declare this in their `types.js`; you do not set it.
+
+            ### Exceptions at the point of use
+
+            The wall scopes mechanically, but a few operations need an explicit opt-out or opt-in, declared on the request, step or websocket — never on the connection:
+
+            | Surface | Allowed values | Meaning |
+            | ------- | -------------- | ------- |
+            | Request | `none` | Opt this request out of scoping entirely. |
+            | Request | `authored` | The request authors its own tenant clause (audited at runtime). |
+            | Websocket | `none` | Opt out. `authored` is not allowed — change streams are always scoped mechanically. |
+
+            An aggregation stage the wall cannot scope mechanically — `$search`, `$searchMeta`, `$vectorSearch`, `$geoNear`, `$graphLookup` — must declare `tenant: authored` and author the organization clause *inside the stage*. The runtime audits that clause against the caller's active organization; it does not trust the declaration alone.
+
+            ```yaml
+            # A $search aggregation on a scoped connection: author the org filter
+            # inside the stage and declare it.
+            id: search_records
+            type: MongoDBAggregation
+            connectionId: app_data
+            tenant: authored
+            properties:
+              pipeline:
+                - $search:
+                    compound:
+                      filter:
+                        - equals:
+                            path: organization_id
+                            value:
+                              _user: organization_id
+                      must:
+                        - text:
+                            query:
+                              _payload: q
+                            path: title
+            ```
+
+            ### Why the wall lives on the connection
+
+            Putting scope on the connection, and only exceptions at the point of use, means the default is safe: a developer who forgets to think about tenancy gets a scoped read and a stamped write, not a leak. The dangerous states — sharing across organizations, opting a request out, authoring a raw clause — are the ones that have to be typed out, reviewed in a diff, and (for `authored`) audited at runtime. This inverts the usual footgun where the safe path is the verbose one.
+
+            Under `policy: pinned` the wall is inert — there is one organization, so scoping to it is a no-op — but declaring `tenant` on connections does no harm, which lets one config serve both a pinned install and a tenant deployment.

--- a/packages/docs/users/roles.yaml
+++ b/packages/docs/users/roles.yaml
@@ -31,15 +31,21 @@ _ref:
               template: |
                 Roles can be used to limit user access to certain pages and API endpoints. Only users with a role linked to the page will be able to see that page, and the page will be filtered from menus if the user does not have the role.
 
-                Roles can be read from the `roles` field on the [user object](/user-object). It should be an array of strings which are the role names. If the provider returns a `roles` field on the user profile then this will be used, otherwise the `auth.userFields` configuration can be used to map another field to the `roles` field on the user object. Custom auth callback plugins can also be used to add a roles field to the user object.
+                Roles are read from the `roles` field on the [user object](/user-object) — an array of role-name strings. These are the caller's **app roles**, resolved from their membership in the active organization (`member.appRoles`), not from a provider claim. A member is granted app roles through an [invitation](/auth-steps) (`InviteMember`) or an auth step (`UpdateMemberRoles`), so the same person can hold different roles in two organizations they belong to.
 
-                ######  Setting user roles to the `my_roles` field returned from provider:
+                Declare the role names your app uses in `auth.roles` (id, optional label and description) so tooling can list them:
+
                 ```yaml
                 lowdefy: {{ version }}
                 auth:
-                  userFields:
-                    roles: profile.my_roles
+                  roles:
+                    - id: user-admin
+                      label: User Administrator
+                    - id: sales
+                    - id: reports
                 ```
+
+                Do **not** gate on `_user.org_roles` (the `owner`/`admin`/`member` organization tier) — no page or API gate reads it. It is an administrative fact used by the [auth-step authority floor](/auth-steps), separate from app roles. See [Organizations & Multi-Tenancy](/organizations#the-owner-admin-member-tier-vs-app-roles).
 
                 The pages that are protected by roles are configured in the `auth.pages.roles` section in the Lowdefy configuration. This should be an object, where the keys are the role names, and the values are an array of pageIds that are protected by that role.
 

--- a/packages/docs/users/user-object.yaml
+++ b/packages/docs/users/user-object.yaml
@@ -23,84 +23,63 @@ _ref:
       - id: user_object
         type: MarkdownWithCode
         properties:
-          content:
-            _nunjucks:
-              on:
-                version:
-                  _ref: version.yaml
-              template: |
-                The `user` object contains data about the currently logged in user, and can be accessed using the [`_user`](/_user) operator. The data on the user object depends on the fields returned by the provider. By default, Auth.js will add the `name`, `email` and `image` fields.
+          content: |
+            The `user` object holds data about the currently signed-in **caller**, read with the [`_user`](/_user) operator on both the server and the client. It is not the provider's profile — it is a caller Lowdefy resolves from the user's row *and their membership in the active organization*, so the same person carries a different `_user` in two organizations they belong to.
 
-                Lowdefy will also map the `roles` and the standard OpenID Connect claim fields from the provider to the user object. The OpenID Connect claims are:
-                - `sub`: The user id (Subject).
-                - `name`
-                - `given_name`
-                - `family_name`
-                - `middle_name`
-                - `nickname`
-                - `preferred_username`
-                - `profile`
-                - `picture`
-                - `website`
-                - `email`
-                - `email_verified`
-                - `gender`
-                - `birthdate`
-                - `zoneinfo`
-                - `locale`
-                - `phone_number`
-                - `phone_number_verified`
-                - `address`
-                - `updated_at`
+            Its shape is **fixed**. Unlike the old provider-claim mapping, there is no `userFields` config and no set of OpenID Connect claims copied onto the session — the provider subject and extra claims are not on the user object at all. If you need a provider claim at signup, persist it with an [auth hook](/auth-upgrade#7-rewrite-callbacks-and-events-as-hooks) and read it from where you stored it.
 
-                To map additional fields to the user object the `auth.userFields` configuration option can be used. This should be an object, where the key is the key in the user object to which the field should be mapped, and the value is the key of the value in the data from the provider. Auth.js provides three data objects called `account`, `profile` and `user`.
+            ## Fields
 
-                ## Examples
+            | Field | On which callers | Meaning |
+            | ----- | ---------------- | ------- |
+            | `id` | all | The internal user id. **This replaces the old `sub`** — it is a *different value* (the provider subject lives on the `user-accounts` collection as `accountId`). |
+            | `email` | all | The user's email. |
+            | `email_verified` | session | Whether the email is verified. |
+            | `name`, `image` | session | Display name and avatar — the **per-organization** copies from the active membership, falling back to the deployment-global user record. |
+            | `roles` | session, strategy | The app's own role strings, from the active membership's `appRoles`. **The only thing `auth.pages.roles` / `auth.api.roles` match.** |
+            | `org_roles` | session | The organization tier from `member.role`: `owner`, `admin` or `member`. An administrative fact — **no gate reads it**. |
+            | `attributes` | session | One merged bag: global `user.attributes` under the active `member.attributes`, per key, member wins. |
+            | `organization_id` | session, mcp | The organization the caller acts in — the value the [tenant wall](/organizations#the-tenant-wall) stamps and filters on. |
+            | `active_organization_id` | session | The active organization id (equal to `organization_id`). |
+            | `two_factor_enrolled` | session | Whether the caller holds a factor satisfying `auth.twoFactor.required`. |
+            | `auth_method` | strategy, mcp | How the caller authenticated — the strategy id, or `'mcp'` for an [assistant](/mcp-oauth). Absent on browser sessions. |
+            | `profile` | session | The user record's opaque display/app-data bag. Absent (never `{}`) when the user has written no profile. |
+            | `contact_id` | session | Link to the app's canonical record for this person, when one exists. |
 
-                ###### Use the user profile picture in a Avatar block:
-                ```yaml
-                id: avatar
-                type: Avatar
-                properties:
-                  src:
-                    _user: image
-                ```
+            > **`_user.role` (singular) carries nothing.** Lowdefy never writes it; it sits one character from `roles`, so gating on `_user.role` is gating on a constant. Read `roles`.
 
-                ###### Insert user name and id (sub) when inserting a document in MongoDB:
-                ```yaml
-                id: insert_data
-                type: MongoDBInsertOne
-                properties:
-                  doc:
-                    field:
-                      _state: field
-                    created_by:
-                      name:
-                        _user: name
-                      id:
-                        _user: sub
-                ```
+            A caller resolved from an [API strategy](/auth-configuration) (`apiKey`, `jwt`) sits outside the membership boundary: it carries `id`, `roles`, `attributes` and `auth_method`, but no organization, `name`, `image`, `profile` or `two_factor_enrolled`. A signed-in user who holds only a pending invitation (before they accept, under `tenant`) is an *awaiting-organization* caller — known to the always-public accept page, refused everywhere else.
 
-                ######  Setting all the data from the provider to the user object (Use this in development to see the data from the provider - it is not recommended to do this in production):
-                ```yaml
-                lowdefy: {{ version }}
-                auth:
-                  userFields:
-                    account: account
-                    profile: profile
-                    user: user
-                ```
+            ## Examples
 
-                ######  Mapping fields to user object:
-                ```yaml
-                lowdefy: {{ version }}
-                auth:
-                  userFields:
-                    id: profile.id
-                    roles: profile.my_roles
-                    # Some providers like Auth0 require custom claims to be added under a URL namespace
-                    openid_custom_claim: 'profile.https://example.com/custom'
-                ```
+            ###### Use the user's avatar in an Avatar block:
+            ```yaml
+            id: avatar
+            type: Avatar
+            properties:
+              src:
+                _user: image
+            ```
+
+            ###### Stamp the creator when inserting a document:
+            ```yaml
+            id: insert_data
+            type: MongoDBInsertOne
+            properties:
+              doc:
+                field:
+                  _state: field
+                created_by:
+                  name:
+                    _user: name
+                  id:
+                    _user: id
+            ```
+
+            ###### Read a value out of the merged attributes bag:
+            ```yaml
+            _user: attributes.plan
+            ```
 
       - _ref:
           path: templates/navigation_buttons.yaml


### PR DESCRIPTION
Documents the v7 (BetterAuth) auth surface, which the docs had fallen substantially behind — the [multi-tenant gap analysis](https://github.com/lowdefy) finding **G14** recorded "docs substantially behind code: the tenant wall, `oauthProvider`, captcha, org steps undocumented; `_user.sub` examples actively wrong. Read code, not docs." Everything here was written from the v7 code (`lowdefySchema.js`, the api caller/authority resolvers, the better-auth step plugin), not from the design docs, and the single-resource MCP work of **#2344** is the centrepiece.

## New pages

- **MCP Server & OAuth** (`users/mcp-oauth.yaml`) — the app as an OAuth 2.1 authorization server for MCP clients (#2344):
  - single `/api/mcp` resource; the organization is a token claim, not a URL segment (replacing the old per-org `/api/mcp/:org`)
  - routes: `/api/mcp`, `/.well-known/oauth-protected-resource/api/mcp`, `/.well-known/oauth-authorization-server/api/auth`, `/api/auth/*`
  - `auth.oauthProvider` — `consentPage`, `postLoginPage` (required under `organizations.policy: tenant`), `dynamicClientRegistration`
  - the post-login organisation choice, consent per `(client, user, organisation)`, the `organization_id` access-token claim and its live consent-row check
  - `mcp` block branding + `mcp.endpoints[].scope` (`mcp:read` / `mcp:write`, write implies read)
  - **the G23 rule**: never put an MCP endpoint id in `auth.api.public` (one public tool suppresses the challenge for the whole route)
  - `RevokeMcpGrant` (switch org) and app-side disconnect, plus minimal consent + organisation-picker page examples using `OAuthConsent` / `OAuthContinue` / `SetActiveOrganization` / `ListOrganizations`
  - `_user.auth_method: 'mcp'`
- **Organizations & Multi-Tenancy** (`users/organizations.yaml`) — `auth.organizations` `policy` (pinned vs tenant), `org`, `signup`, `create`, `invitationExpiresIn`; the connection **tenant wall** (`tenant: shared | { field }`, `connectionMetas`, request `none`/`authored`, websocket `none`, aggregation `authored` audit); the `owner`/`admin`/`member` tier vs app roles.
- **Auth Steps** (`users/auth-steps.yaml`) — the authority model (org/system/caller scopes, `permissions`, `targetUser`, `selfTargetExempt`, `system: true`, target-organization resolution) and a reference of the scope/permission/target for all 19 steps.

## Updated pages

- **User Object** (`users/user-object.yaml`) — rewritten for the fixed BetterAuth caller shape; documents `id`, `email`, `email_verified`, `name`, `image`, `roles`, `org_roles`, `attributes`, `organization_id`, `active_organization_id`, `two_factor_enrolled`, `auth_method`, `profile`, `contact_id`; removes the Auth.js/OIDC-claims/`userFields` model.
- **`_user` operator** (`operators/_user.yaml`) — **fixes the wrong `sub` examples to `id`** (G14) and updates the description.
- **Auth Configuration** (`users/auth-configuration.yaml`) — rewritten for BetterAuth (secret, database, mechanisms, auth email via SMTP connection, authPages, session `expiresIn`/`updateAge`, roles/organizations/strategies pointers, captcha, rate limiting, account linking); mock-user example fixed (`sub` → `id`, `Google`).
- **Roles** (`users/roles.yaml`) — app roles now resolve from membership `appRoles`, granted via invitations/steps; do not gate on `org_roles`.
- **Auth Upgrade** (`migration/auth-upgrade.yaml`) — adds an MCP/OAuth section and cross-links to the new pages.

Registered the new pages in `pages.yaml` + `menus.yaml`.

## Discrepancies vs the design docs

- The design labels the "one public tool" issue **G23** and the app enforces it as a build guard, but the guard fires from the *protected* side: a protected/role-gated MCP endpoint requires `auth.oauthProvider` or the build fails. Public MCP tools are still permitted (they set `mcp.json hasPublicTool`), so the app-author rule remains "keep MCP endpoint ids out of `auth.api.public`". Documented the code behaviour and the rule, not a hard build ban on public tools.

## Notes

- `pnpm docs:content` regeneration also picked up **pre-existing drift** in a few unrelated generated pages (`agentchat`, `checkboxselector`, `radioselector`, `two-factor`) whose source had changed on v7 without docs-content being regenerated. Included so `@lowdefy/docs-content` matches source.
- Not yet given individual reference pages: the newer auth **client actions** (`OAuthConsent`, `OAuthContinue`, `ListOrganizations`, `SetActiveOrganization`, `AcceptInvitation`, `LeaveOrganization`, `SignUp`, `Passkey*`, `PhoneNumber*`, `TwoFactor*`, websocket `Publish`/`Subscribe`/`Unsubscribe`) — they are covered contextually on the pages above; and the stale `reference/*` provider pages still carry Auth.js/next-auth naming. Flagged as follow-up.

## Verification

- `pnpm docs:content` builds clean (exit 0); every new/edited page compiles and `_ref`s resolve.
- `pnpm --filter=@lowdefy/docs test` — 78 passed.
- Prettier run on all changed files.
- Example config checked against the v7 plugin `types.js` (block/action/step/operator/connection names) and the schema.

Relates to #2344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)