### PR TITLE
fix: Expose oauth2Continue on the client auth methods

### DIFF
--- a/.changeset/fix-oauth2-continue-client-method.md
+++ b/.changeset/fix-oauth2-continue-client-method.md
@@ -1,0 +1,8 @@
+---
+'@lowdefy/server': patch
+'@lowdefy/server-dev': patch
+---
+
+fix: Expose `oauth2Continue` on the client auth methods so the `OAuthContinue` action works.
+
+The post-login organization picker's `OAuthContinue` action failed with "auth.oauth2Continue is not a function": the client's fixed method table only carried `oauth2Consent`. Both servers now hand `oauth2Continue` (POST `/oauth2/continue`) through with the same signed-query contract.

--- a/packages/servers/server-dev/lib/client/auth/AuthConfigured.jsx
+++ b/packages/servers/server-dev/lib/client/auth/AuthConfigured.jsx
@@ -188,6 +188,11 @@ function AuthConfigured({ authConfig, children, serverUser }) {
     // the page still holds the query the oauth-provider redirect arrived
     // with.
     oauth2Consent: (params) => authClient.oauth2.consent(params),
+    // POST /oauth2/continue - resumes the authorization after the post-login
+    // organization choice (the page runs SetActiveOrganization first). Same
+    // oauth_query contract as oauth2Consent: the signed query rides from
+    // window.location.search, so the call must run before any navigation.
+    oauth2Continue: (params) => authClient.oauth2.continue(params),
     phoneNumberRequestPasswordReset: (params) =>
       authClient.phoneNumber.requestPasswordReset(params),
     phoneNumberResetPassword: (params) => authClient.phoneNumber.resetPassword(params),

--- a/packages/servers/server/lib/client/auth/AuthConfigured.jsx
+++ b/packages/servers/server/lib/client/auth/AuthConfigured.jsx
@@ -188,6 +188,11 @@ function AuthConfigured({ authConfig, children, serverUser }) {
     // the page still holds the query the oauth-provider redirect arrived
     // with.
     oauth2Consent: (params) => authClient.oauth2.consent(params),
+    // POST /oauth2/continue - resumes the authorization after the post-login
+    // organization choice (the page runs SetActiveOrganization first). Same
+    // oauth_query contract as oauth2Consent: the signed query rides from
+    // window.location.search, so the call must run before any navigation.
+    oauth2Continue: (params) => authClient.oauth2.continue(params),
     phoneNumberRequestPasswordReset: (params) =>
       authClient.phoneNumber.requestPasswordReset(params),
     phoneNumberResetPassword: (params) => authClient.phoneNumber.resetPassword(params),


### PR DESCRIPTION
## Summary
Follow-up to #2344. The `OAuthContinue` action (post-login organization picker) fails at runtime with `auth.oauth2Continue is not a function`: `AuthConfigured.jsx` hands Lowdefy a **fixed** table of BetterAuth client methods, and only `oauth2Consent` was on it — the engine/action/`createAuthMethods` halves were wired, this table was not.

Both servers now expose `oauth2Continue: (params) => authClient.oauth2.continue(params)` with the same signed-query contract as `oauth2Consent`.

## Test plan
- [x] Found on the first real round trip in encircle-mvp (login → picker rendered → click → ActionError).
- [ ] Encircle verifies the picker → consent → tools round trip on the next experimental pin (the same fix is patched into its local `.lowdefy/dev` server meanwhile).