### PR TITLE
fix: Stop the MCP post-login organization choice looping back to the picker

### DIFF
--- a/.changeset/fix-oauth-post-login-loop.md
+++ b/.changeset/fix-oauth-post-login-loop.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/api': patch
+---
+
+fix: The MCP post-login organization choice no longer loops back to the picker.
+
+The oauth-provider asks `postLogin.shouldRedirect` again on the authorize call that `/oauth2/continue` re-enters with, and only its consent redirect carries the "post-login done" marker — so choosing an organization sent the user straight back to the picker. A request hook on `/oauth2/continue` now stamps the request's cached session when the choice is confirmed, and `shouldRedirect` reads that stamp: the picker shows once per authorization, then the flow proceeds to consent.

--- a/packages/api/src/routes/auth/buildOauthPostLogin.js
+++ b/packages/api/src/routes/auth/buildOauthPostLogin.js
@@ -29,12 +29,24 @@ import { type } from '@lowdefy/helpers';
 //
 // Under the tenant policy the member chooses on the configured page (the page
 // runs SetActiveOrganization for the chosen organization, then OAuthContinue),
-// and shouldRedirect is unconditional so the choice is made on every
-// authorization - a one-organization member sees a single preselected row.
-// Under the pinned policy there is one organization and nothing to choose:
-// the redirect is skipped and the reference is the pinned organization, whose
-// id is its slug. The page is still required by the plugin option shape, so
-// the consent page stands in - it is never redirected to.
+// and the choice is made on every authorization - a one-organization member
+// sees a single preselected row. The plugin asks shouldRedirect on every
+// authorize call, including the one /oauth2/continue re-enters with after the
+// choice, and only its CONSENT redirect carries the "post-login done" marker
+// (ba_pl) - so an unconditional true would loop back to the picker forever.
+// The request hook on /oauth2/continue (createOauthPostLoginHook) stamps the
+// session object cached on that request instead, and shouldRedirect reads the
+// stamp: true until the choice has been posted, false on the authorize call
+// that carries it. Under the pinned policy there is one organization and
+// nothing to choose: the redirect is skipped and the reference is the pinned
+// organization, whose id is its slug. The page is still required by the
+// plugin option shape, so the consent page stands in - it is never redirected
+// to.
+//
+// The marker lives on the in-request session object only - never persisted -
+// so it cannot outlive the request that made the choice.
+const OAUTH_POST_LOGIN_CONFIRMED = 'oauthPostLoginConfirmed';
+
 function buildOauthPostLogin({ authConfig, baseUrlOrigin, basePath }) {
   if (authConfig.organizations?.policy === 'pinned') {
     return {
@@ -45,7 +57,7 @@ function buildOauthPostLogin({ authConfig, baseUrlOrigin, basePath }) {
   }
   return {
     page: `${baseUrlOrigin}${basePath}${authConfig.oauthProvider.postLoginPage}`,
-    shouldRedirect: () => true,
+    shouldRedirect: ({ session }) => session?.[OAUTH_POST_LOGIN_CONFIRMED] !== true,
     consentReferenceId: ({ session }) => {
       const organizationId = session?.activeOrganizationId;
       // The plugin's contract: fail here when the reference is missing rather
@@ -63,4 +75,5 @@ function buildOauthPostLogin({ authConfig, baseUrlOrigin, basePath }) {
   };
 }
 
+export { OAUTH_POST_LOGIN_CONFIRMED };
 export default buildOauthPostLogin;

--- a/packages/api/src/routes/auth/buildOauthPostLogin.test.js
+++ b/packages/api/src/routes/auth/buildOauthPostLogin.test.js
@@ -16,7 +16,7 @@
 
 import { APIError } from 'better-auth/api';
 
-import buildOauthPostLogin from './buildOauthPostLogin.js';
+import buildOauthPostLogin, { OAUTH_POST_LOGIN_CONFIRMED } from './buildOauthPostLogin.js';
 
 const baseUrlOrigin = 'https://app.example.com';
 
@@ -31,6 +31,23 @@ test('buildOauthPostLogin redirects to the post-login page on every authorizatio
   });
   expect(postLogin.page).toBe('https://app.example.com/base/oauth-select-organization');
   expect(postLogin.shouldRedirect({ session: { activeOrganizationId: 'org_1' } })).toBe(true);
+  expect(postLogin.shouldRedirect({})).toBe(true);
+});
+
+test('buildOauthPostLogin skips the redirect on the authorize call that carries the confirmed choice', () => {
+  const postLogin = buildOauthPostLogin({
+    authConfig: {
+      organizations: { policy: 'tenant' },
+      oauthProvider: { consentPage: '/oauth-consent', postLoginPage: '/oauth-select-organization' },
+    },
+    baseUrlOrigin,
+    basePath: '',
+  });
+  expect(
+    postLogin.shouldRedirect({
+      session: { activeOrganizationId: 'org_1', [OAUTH_POST_LOGIN_CONFIRMED]: true },
+    })
+  ).toBe(false);
 });
 
 test('buildOauthPostLogin references the session active organization under the tenant policy', () => {

--- a/packages/api/src/routes/auth/requestHooks/buildRequestHooks.js
+++ b/packages/api/src/routes/auth/requestHooks/buildRequestHooks.js
@@ -18,6 +18,7 @@ import { createAuthMiddleware } from 'better-auth/api';
 import { type } from '@lowdefy/helpers';
 
 import createMagicLinkSendGate from '../organizations/createMagicLinkSendGate.js';
+import createOauthPostLoginHook from './createOauthPostLoginHook.js';
 import createTwoFactorChallengeHook from './createTwoFactorChallengeHook.js';
 import dispatchRequestHooks from './dispatchRequestHooks.js';
 import matchOAuthCallback from './matchOAuthCallback.js';
@@ -55,6 +56,18 @@ function buildRequestHooks({ authConfig, basePath = '', baseUrlOrigin, getAuth }
         getAuth,
         organizations: authConfig.organizations,
       }),
+    });
+  }
+
+  // The post-login organization choice (buildOauthPostLogin): stamps the
+  // request's cached session when /oauth2/continue confirms the choice, so the
+  // authorize call it re-enters with does not send the member back to the
+  // picker. Registered with the authorization server itself.
+  if (!type.isNone(authConfig.oauthProvider)) {
+    before.push({
+      id: 'oauthPostLogin',
+      matches: (path) => path === '/oauth2/continue',
+      handler: createOauthPostLoginHook(),
     });
   }
 

--- a/packages/api/src/routes/auth/requestHooks/buildRequestHooks.test.js
+++ b/packages/api/src/routes/auth/requestHooks/buildRequestHooks.test.js
@@ -19,7 +19,12 @@ import { jest } from '@jest/globals';
 // Each slot is wrapped in createAuthMiddleware; mock it to identity so the unit
 // test can invoke a slot with a plain endpoint context.
 jest.unstable_mockModule('better-auth/api', () => ({
+  // The post-login hook's module graph reaches buildOauthPostLogin, which
+  // imports APIError; the hook itself reads the session through
+  // getSessionFromCtx. Neither is exercised here.
+  APIError: class APIError extends Error {},
   createAuthMiddleware: (handler) => handler,
+  getSessionFromCtx: jest.fn(),
 }));
 
 // beginTwoFactorChallenge is exercised against a fake endpoint context in its

--- a/packages/api/src/routes/auth/requestHooks/createOauthPostLoginHook.js
+++ b/packages/api/src/routes/auth/requestHooks/createOauthPostLoginHook.js
@@ -1,0 +1,48 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { getSessionFromCtx } from 'better-auth/api';
+
+import { OAUTH_POST_LOGIN_CONFIRMED } from '../buildOauthPostLogin.js';
+
+// The engine-tier request hooks.before on /oauth2/continue. The oauth-provider
+// resumes the authorization inside this very request and asks
+// postLogin.shouldRedirect again, but it stamps "post-login done" (ba_pl) into
+// the signed query only on its consent redirect - never on the post-login one
+// - so without help the picker page would be shown again and the flow would
+// loop. The choice was just posted (body.postLogin === true), so this marks
+// the session object the request caches (getSessionFromCtx memoizes it on
+// ctx.context.session; the endpoint's sessionMiddleware and authorize read
+// that same object). Nothing is written to the database: the marker exists for
+// this request only, which is exactly as long as it is true.
+//
+// A bare handler: the request-hook assembler matches /oauth2/continue and owns
+// the createAuthMiddleware wrapper. Always falls through - the endpoint itself
+// validates the signed query and the session.
+function createOauthPostLoginHook() {
+  return async function oauthPostLoginHook(ctx) {
+    if (ctx.body?.postLogin !== true) {
+      return undefined;
+    }
+    const session = await getSessionFromCtx(ctx);
+    if (session?.session) {
+      session.session[OAUTH_POST_LOGIN_CONFIRMED] = true;
+    }
+    return undefined;
+  };
+}
+
+export default createOauthPostLoginHook;

--- a/packages/api/src/routes/auth/requestHooks/createOauthPostLoginHook.test.js
+++ b/packages/api/src/routes/auth/requestHooks/createOauthPostLoginHook.test.js
@@ -1,0 +1,57 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+
+const mockGetSessionFromCtx = jest.fn();
+jest.unstable_mockModule('better-auth/api', () => ({
+  // buildOauthPostLogin (the marker constant's home) imports APIError.
+  APIError: class APIError extends Error {},
+  getSessionFromCtx: mockGetSessionFromCtx,
+}));
+
+const { default: createOauthPostLoginHook } = await import('./createOauthPostLoginHook.js');
+
+beforeEach(() => {
+  mockGetSessionFromCtx.mockReset();
+});
+
+test('marks the cached session as post-login confirmed and falls through', async () => {
+  const session = {
+    session: { id: 'sess_1', activeOrganizationId: 'org_1' },
+    user: { id: 'user_1' },
+  };
+  mockGetSessionFromCtx.mockResolvedValue(session);
+  const ctx = { body: { postLogin: true }, context: {} };
+
+  const result = await createOauthPostLoginHook()(ctx);
+
+  expect(result).toBeUndefined();
+  expect(mockGetSessionFromCtx).toHaveBeenCalledWith(ctx);
+  expect(session.session.oauthPostLoginConfirmed).toBe(true);
+});
+
+test('leaves a continue that is not a post-login confirmation alone', async () => {
+  const result = await createOauthPostLoginHook()({ body: { selected: true }, context: {} });
+  expect(result).toBeUndefined();
+  expect(mockGetSessionFromCtx).not.toHaveBeenCalled();
+});
+
+test('falls through without a session so the endpoint answers unauthorized itself', async () => {
+  mockGetSessionFromCtx.mockResolvedValue(null);
+  const result = await createOauthPostLoginHook()({ body: { postLogin: true }, context: {} });
+  expect(result).toBeUndefined();
+});


### PR DESCRIPTION
## Summary
Follow-up to #2344, found on the first real round trip: choosing an organization on the post-login page navigated straight back to the picker.

Cause: `@better-auth/oauth-provider` calls `postLogin.shouldRedirect` on **every** `authorize`, including the one `/oauth2/continue { postLogin: true }` re-enters with, and it stamps its "post-login done" marker (`ba_pl`) into the signed query only on the **consent** redirect — never on the post-login redirect. With `shouldRedirect: () => true` the plugin therefore redirects to the picker again, forever. The plugin's contract is that `shouldRedirect` must turn false once a selection has been recorded.

Fix (no schema, nothing persisted):
- New `hooks.before` registration on `/oauth2/continue` (`createOauthPostLoginHook`): when the body confirms the choice, it stamps `oauthPostLoginConfirmed` on the session object the request caches (`getSessionFromCtx` memoises on `ctx.context.session`, and the endpoint's `sessionMiddleware` + `authorize` read that same object).
- `buildOauthPostLogin.shouldRedirect` returns `session.oauthPostLoginConfirmed !== true` under the tenant policy — true until the choice is posted, false on the authorize call that carries it. The consent redirect then carries `ba_pl` as before, so later authorize calls skip the seat.

## Test plan
- [x] `buildOauthPostLogin` tests: redirect without the marker, skip with it; `createOauthPostLoginHook` tests (marks + falls through; ignores non-post-login continues; no session); `buildRequestHooks`/`getBetterAuthConfig` suites pass (165 tests).
- [ ] Encircle round trip on the next pin: picker → consent → tools (the same change is patched into the local `.lowdefy/dev` api dist meanwhile).