### PR TITLE
fix(blocks-antd-x): Track workspace version for block-dev-e2e and e2e-utils

### DIFF
--- a/.changeset/fix-blocks-antd-x-e2e-dep-versions.md
+++ b/.changeset/fix-blocks-antd-x-e2e-dep-versions.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/blocks-antd-x': patch
+---
+
+fix: Track the current workspace version for the `@lowdefy/block-dev-e2e` and `@lowdefy/e2e-utils` dev dependencies (were pinned at `5.4.0`).

--- a/packages/plugins/blocks/blocks-antd-x/package.json
+++ b/packages/plugins/blocks/blocks-antd-x/package.json
@@ -55,8 +55,8 @@
     "ai": "6.0.176"
   },
   "devDependencies": {
-    "@lowdefy/block-dev-e2e": "5.4.0",
-    "@lowdefy/e2e-utils": "5.4.0",
+    "@lowdefy/block-dev-e2e": "5.5.1",
+    "@lowdefy/e2e-utils": "5.5.1",
     "@playwright/test": "1.59.1",
     "@swc/cli": "0.8.1",
     "@swc/core": "1.15.32",


### PR DESCRIPTION
`@lowdefy/blocks-antd-x` pinned its `@lowdefy/block-dev-e2e` and `@lowdefy/e2e-utils` dev dependencies at `5.4.0` while the workspace is at `5.5.1`, failing the internal version-consistency check:

```
Package "@lowdefy/blocks-antd-x" must depend on the current version of "@lowdefy/block-dev-e2e": "5.5.1" vs "5.4.0"
Package "@lowdefy/blocks-antd-x" must depend on the current version of "@lowdefy/e2e-utils": "5.5.1" vs "5.4.0"
```

Bumps both to `5.5.1`, matching how every other `blocks-*` package pins them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)