### PR TITLE
fix(build): Treat a plugin subpath missing from exports as an expected miss

### DIFF
--- a/.changeset/fix-build-plugin-subpath-not-exported.md
+++ b/.changeset/fix-build-plugin-subpath-not-exported.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/build': patch
+---
+
+fix: A plugin package without a `schemas` (or other optional) subpath no longer fails the build.
+
+Node reports a subpath missing from a package's `exports` as `ERR_PACKAGE_PATH_NOT_EXPORTED`, which the plugin module importer treated as a broken module rather than the expected miss — so an app using a plugin that ships actions but no schemas (e.g. `@lowdefy/community-plugin-xlsx`) could not build.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -889,11 +889,11 @@ importers:
         version: 18.2.0
     devDependencies:
       '@lowdefy/block-dev-e2e':
-        specifier: 5.4.0
-        version: 5.4.0
+        specifier: 5.5.1
+        version: link:../../../utils/block-dev-e2e
       '@lowdefy/e2e-utils':
-        specifier: 5.4.0
-        version: 5.4.0(@playwright/test@1.59.1)
+        specifier: 5.5.1
+        version: link:../../../utils/e2e-utils
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -4633,21 +4633,6 @@ packages:
   '@levischuck/tiny-cbor@0.2.11':
     resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
 
-  '@lowdefy/block-dev-e2e@5.4.0':
-    resolution: {integrity: sha512-Wo8MuaFBZ/sx4rsATAmODlLjU2fuDBeeMwzVI2fz3YA64WXU74BasfKSSsJZ0d6d8bbcTcEaYOuozjnrQfwg2Q==}
-
-  '@lowdefy/e2e-utils@5.4.0':
-    resolution: {integrity: sha512-nU4Fq0N52kXJBnBhicTC9+Y3I3lTP8GXvqcr5cB+g5bDdjQgkRlKeMSVCUv9l4fuZo46HGLAIYI3GyynXn3kAw==}
-    hasBin: true
-    peerDependencies:
-      '@playwright/test': 1.50.1
-
-  '@lowdefy/errors@5.4.0':
-    resolution: {integrity: sha512-A0o4MXGBM3EFKTZaAxbQm7QCLfi+k9UojpXf/Z4tvA83IxUZUMAjHyIEHS026RgYDorkwZ6XjfVng28OIggsFQ==}
-
-  '@lowdefy/helpers@5.4.0':
-    resolution: {integrity: sha512-yTAoqmUGpQwPJ/3r3EXW46h7c3wnJsK/+HKX7BRlCP6oYK9Rvk1ozsFdZWic++Y1C8SxK6ROaQZYl8TfDkJrfA==}
-
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
@@ -5328,11 +5313,6 @@ packages:
   '@pkgr/utils@2.4.2':
     resolution: {integrity: sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
-
-  '@playwright/test@1.50.1':
-    resolution: {integrity: sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   '@playwright/test@1.59.1':
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
@@ -12403,18 +12383,8 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
-  playwright-core@1.50.1:
-    resolution: {integrity: sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.50.1:
-    resolution: {integrity: sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16486,33 +16456,6 @@ snapshots:
 
   '@levischuck/tiny-cbor@0.2.11': {}
 
-  '@lowdefy/block-dev-e2e@5.4.0':
-    dependencies:
-      '@lowdefy/e2e-utils': 5.4.0(@playwright/test@1.50.1)
-      '@playwright/test': 1.50.1
-
-  '@lowdefy/e2e-utils@5.4.0(@playwright/test@1.50.1)':
-    dependencies:
-      '@lowdefy/helpers': 5.4.0
-      '@playwright/test': 1.50.1
-      js-yaml: 4.1.0
-      prompts: 2.4.2
-
-  '@lowdefy/e2e-utils@5.4.0(@playwright/test@1.59.1)':
-    dependencies:
-      '@lowdefy/helpers': 5.4.0
-      '@playwright/test': 1.59.1
-      js-yaml: 4.1.0
-      prompts: 2.4.2
-
-  '@lowdefy/errors@5.4.0': {}
-
-  '@lowdefy/helpers@5.4.0':
-    dependencies:
-      '@lowdefy/errors': 5.4.0
-      intl-messageformat: 11.2.7
-      lodash.merge: 4.6.2
-
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -17278,10 +17221,6 @@ snapshots:
       open: 9.1.0
       picocolors: 1.1.1
       tslib: 2.8.1
-
-  '@playwright/test@1.50.1':
-    dependencies:
-      playwright: 1.50.1
 
   '@playwright/test@1.59.1':
     dependencies:
@@ -25548,15 +25487,7 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  playwright-core@1.50.1: {}
-
   playwright-core@1.59.1: {}
-
-  playwright@1.50.1:
-    dependencies:
-      playwright-core: 1.50.1
-    optionalDependencies:
-      fsevents: 2.3.2
 
   playwright@1.59.1:
     dependencies:


### PR DESCRIPTION
## Summary
Regression from #2349 on `v7`: `importPluginModule` now rethrows anything that is not `ERR_MODULE_NOT_FOUND`, but Node reports a subpath a package does not declare in `exports` as **`ERR_PACKAGE_PATH_NOT_EXPORTED`**. A plugin that ships actions but no schemas — `@lowdefy/community-plugin-xlsx` exports only `./actions` and `./types` — therefore fails the whole build:

```
[LowdefyInternalError] Package subpath './schemas' is not defined by "exports" in …/@lowdefy/community-plugin-xlsx/package.json
```

Found by encircle-mvp on `0.0.0-experimental-20260829185302`. The importer's stated contract is "returns undefined when unresolvable — callers degrade gracefully"; this adds the not-exported code to the set it degrades on, and a test with a fake plugin package that exports `./actions` but not `./schemas`.

## Test plan
- [x] `writePluginImports` suites pass (55 tests) incl. the new not-exported case.
- [x] encircle-mvp builds on `…185302` with this one-line change patched into the installed `@lowdefy/build`.