### PR TITLE
fix(build): Treat every plugin subpath resolution failure as an absent optional module

### DIFF
--- a/.changeset/fix-build-plugin-import-resolution-errors.md
+++ b/.changeset/fix-build-plugin-import-resolution-errors.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/build': patch
+---
+
+fix: Any failure to resolve an optional plugin subpath is treated as an absent module, not a broken plugin.
+
+The plugin module importer now keys on the whole family of Node ESM resolution errors (not installed, subpath missing from `exports`, a legacy package whose subpath lands on a directory, a bad exports target) rather than on `ERR_MODULE_NOT_FOUND` alone, so an older published plugin without an `exports` map (e.g. `@lowdefy/plugin-aws/connections` resolving to `dist/connections/`) no longer fails the build with `ERR_UNSUPPORTED_DIR_IMPORT`. A module that resolves but throws while loading is still reported.

--- a/packages/build/src/build/writePluginImports/importPluginModule.js
+++ b/packages/build/src/build/writePluginImports/importPluginModule.js
@@ -17,21 +17,27 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
 
-// A module that cannot be found is the expected miss this function degrades
-// on. That includes a package that exists but does not export the requested
-// subpath (ERR_PACKAGE_PATH_NOT_EXPORTED): every subpath here is optional, and
-// a plugin that ships no `./schemas` is the normal case, not a broken plugin.
-// Any other failure means the module exists but does not load (a syntax error,
-// a throwing top-level import), which must surface here instead of resurfacing
-// later as "type X is not defined".
-const NOT_FOUND_CODES = new Set([
+// Every subpath this function imports (`./schemas`, `./connections`, ...) is
+// optional, so any failure to RESOLVE the specifier is the expected miss it
+// degrades on: a package that is not installed, one whose "exports" map has no
+// such subpath, a legacy package where the subpath lands on a directory, a bad
+// exports target. Node reports each under its own code, all raised before any
+// module code runs. A failure while LOADING a resolved module (a syntax error,
+// a throwing top-level import) is a real fault and must surface here instead
+// of resurfacing later as "type X is not defined".
+const RESOLUTION_ERROR_CODES = new Set([
   'ERR_MODULE_NOT_FOUND',
   'MODULE_NOT_FOUND',
   'ERR_PACKAGE_PATH_NOT_EXPORTED',
+  'ERR_PACKAGE_IMPORT_NOT_DEFINED',
+  'ERR_UNSUPPORTED_DIR_IMPORT',
+  'ERR_INVALID_PACKAGE_TARGET',
+  'ERR_INVALID_PACKAGE_CONFIG',
+  'ERR_INVALID_MODULE_SPECIFIER',
 ]);
 
-function isModuleNotFound(error) {
-  return NOT_FOUND_CODES.has(error?.code);
+function isResolutionError(error) {
+  return RESOLUTION_ERROR_CODES.has(error?.code);
 }
 
 // Import a plugin module (e.g. `${pkg}/schemas`, `${pkg}/connections`) for
@@ -44,7 +50,7 @@ async function importPluginModule({ context, specifier }) {
     return await import(/* webpackIgnore: true */ /* @vite-ignore */ specifier);
   } catch (error) {
     // Not resolvable from the build package — try the server's node_modules.
-    if (!isModuleNotFound(error)) throw error;
+    if (!isResolutionError(error)) throw error;
   }
   const serverDir = context.directories?.server;
   if (!serverDir) {
@@ -54,7 +60,7 @@ async function importPluginModule({ context, specifier }) {
     const require = createRequire(path.join(serverDir, 'package.json'));
     return await import(/* webpackIgnore: true */ /* @vite-ignore */ require.resolve(specifier));
   } catch (error) {
-    if (!isModuleNotFound(error)) throw error;
+    if (!isResolutionError(error)) throw error;
     return undefined;
   }
 }

--- a/packages/build/src/build/writePluginImports/importPluginModule.test.js
+++ b/packages/build/src/build/writePluginImports/importPluginModule.test.js
@@ -81,3 +81,15 @@ test('importPluginModule returns undefined when the package does not export the 
   });
   expect(result).toBe(undefined);
 });
+
+// A legacy package with no "exports" map resolves `pkg/connections` to the
+// dist directory itself, which ESM refuses (ERR_UNSUPPORTED_DIR_IMPORT). That
+// is a resolution miss like any other, not a broken plugin.
+test('importPluginModule returns undefined when the subpath resolves to a directory', async () => {
+  const connectionsDir = path.join(tempDirectory, 'legacy-plugin', 'connections');
+  fs.mkdirSync(connectionsDir, { recursive: true });
+  fs.writeFileSync(path.join(connectionsDir, 'S3.js'), 'export default {};\n');
+  const context = { directories: { server: tempDirectory } };
+  const result = await importPluginModule({ context, specifier: connectionsDir });
+  expect(result).toBe(undefined);
+});


### PR DESCRIPTION
## Problem

Third occurrence of the same regression from #2349's `importPluginModule` change, which made a plugin that fails to *load* surface instead of being swallowed. The miss detection enumerated codes (`ERR_MODULE_NOT_FOUND`, then `ERR_PACKAGE_PATH_NOT_EXPORTED` in #2351), so each new resolution shape broke a build:

```
[LowdefyInternalError] Directory import '.../@lowdefy/plugin-aws/dist/connections' is not supported resolving ES modules
Error [ERR_UNSUPPORTED_DIR_IMPORT]
```

An older published `@lowdefy/plugin-aws` has no `exports` map, so `@lowdefy/plugin-aws/connections` resolves to the `dist/connections/` directory, which ESM refuses.

## Fix

Key on the distinction that actually matters: a failure to **resolve** the specifier (any of Node's resolution error codes — not installed, subpath not exported, directory import, bad exports target, bad specifier) is the expected miss every optional subpath degrades on; a failure while **loading** a resolved module (syntax error, throwing top-level import) is the fault that must surface. Test added for the directory-import case.

## Test plan
- `pnpm --filter=@lowdefy/build test --testPathPattern=importPluginModule` — 5/5
- Manual: the encircle-mvp dev build that failed above gets past `Building config...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)