### PR TITLE
fix(servers): Send a route's own HTTP answer instead of a 500 for hono HTTPException

### DIFF
--- a/.changeset/fix-error-handler-http-exception.md
+++ b/.changeset/fix-error-handler-http-exception.md
@@ -1,0 +1,9 @@
+---
+'@lowdefy/server': patch
+'@lowdefy/server-dev': patch
+'@lowdefy/server-e2e': patch
+---
+
+fix: Send a route's own HTTP answer (hono `HTTPException`) instead of a 500.
+
+The MCP transport refuses an unsupported `MCP-Protocol-Version` header with a 404 carrying a JSON-RPC body that the client SDK falls back on to negotiate a version both sides know — Claude Code probes with a newer protocol revision than the server's SDK supports and then downgrades. The error handler turned that into a logged internal error and a 500 on every connection. It now sends the exception's own response with one warning line, no structured error log and no Sentry capture.

--- a/packages/servers/server-dev/src/middleware/errorHandler.js
+++ b/packages/servers/server-dev/src/middleware/errorHandler.js
@@ -15,6 +15,7 @@
 */
 
 import { redactErrorResponse } from '@lowdefy/api';
+import { HTTPException } from 'hono/http-exception';
 
 // Hono routes every handler error to the app-level error handler — upstream
 // middleware try/catch never sees them. API routes get the serialized error
@@ -54,6 +55,17 @@ function createErrorHandler({ basePath = '', logger }) {
         return c.json({ name: error.name, message: error.message }, 403);
       }
       return c.text('Two-factor enrolment required', 403);
+    }
+    // A route or transport that has already decided its own HTTP answer - hono's
+    // HTTPException carries the response to send. The MCP transport refuses an
+    // unsupported protocol-version header this way (a 404 with a JSON-RPC body
+    // that the client SDK falls back on to negotiate a version both sides
+    // know). Not a fault: send its response and log one warning line, no
+    // structured error log and no Sentry capture. Turning it into a 500 would
+    // hide the status the client acts on.
+    if (error instanceof HTTPException) {
+      logger.warn(`${error.status} answered by the route: ${c.req.method} ${c.req.path}`);
+      return error.getResponse();
     }
     const context = c.get('lowdefyContext');
     if (context) {

--- a/packages/servers/server-dev/src/middleware/errorHandler.test.mjs
+++ b/packages/servers/server-dev/src/middleware/errorHandler.test.mjs
@@ -15,6 +15,7 @@
 */
 
 import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
 import { jest } from '@jest/globals';
 
 import createErrorHandler from './errorHandler.js';
@@ -203,6 +204,24 @@ test('errorHandler returns text at 403 for a TwoFactorEnrolmentRequiredError on 
   expect(await res.text()).toEqual('Two-factor enrolment required');
   expect(logger.warn).toHaveBeenCalledTimes(1);
   expect(context.handleError).not.toHaveBeenCalled();
+});
+
+test('errorHandler sends an HTTPException response as-is with one warning and no error log', async () => {
+  const logger = createLogger();
+  const error = new HTTPException(404, {
+    res: Response.json(
+      { jsonrpc: '2.0', error: { code: -32000, message: 'Unsupported protocol version' } },
+      { status: 404 }
+    ),
+  });
+  const res = await createApp({ error, logger }).request('/api/mcp', { method: 'POST' });
+  expect(res.status).toEqual(404);
+  expect(await res.json()).toEqual({
+    jsonrpc: '2.0',
+    error: { code: -32000, message: 'Unsupported protocol version' },
+  });
+  expect(logger.warn).toHaveBeenCalledWith('404 answered by the route: POST /api/mcp');
+  expect(logger.error).not.toHaveBeenCalled();
 });
 
 test('errorHandler returns 500 with the serialized error envelope on an api path', async () => {

--- a/packages/servers/server-e2e/src/middleware/errorHandler.js
+++ b/packages/servers/server-e2e/src/middleware/errorHandler.js
@@ -15,6 +15,7 @@
 */
 
 import { redactErrorResponse } from '@lowdefy/api';
+import { HTTPException } from 'hono/http-exception';
 
 // Hono routes every handler error to the app-level error handler — upstream
 // middleware try/catch never sees them. API routes get the serialized error
@@ -54,6 +55,17 @@ function createErrorHandler({ basePath = '', logger }) {
         return c.json({ name: error.name, message: error.message }, 403);
       }
       return c.text('Two-factor enrolment required', 403);
+    }
+    // A route or transport that has already decided its own HTTP answer - hono's
+    // HTTPException carries the response to send. The MCP transport refuses an
+    // unsupported protocol-version header this way (a 404 with a JSON-RPC body
+    // that the client SDK falls back on to negotiate a version both sides
+    // know). Not a fault: send its response and log one warning line, no
+    // structured error log and no Sentry capture. Turning it into a 500 would
+    // hide the status the client acts on.
+    if (error instanceof HTTPException) {
+      logger.warn(`${error.status} answered by the route: ${c.req.method} ${c.req.path}`);
+      return error.getResponse();
     }
     const context = c.get('lowdefyContext');
     if (context) {

--- a/packages/servers/server-e2e/src/middleware/errorHandler.test.mjs
+++ b/packages/servers/server-e2e/src/middleware/errorHandler.test.mjs
@@ -15,6 +15,7 @@
 */
 
 import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
 import { jest } from '@jest/globals';
 
 import createErrorHandler from './errorHandler.js';
@@ -203,6 +204,24 @@ test('errorHandler returns text at 403 for a TwoFactorEnrolmentRequiredError on 
   expect(await res.text()).toEqual('Two-factor enrolment required');
   expect(logger.warn).toHaveBeenCalledTimes(1);
   expect(context.handleError).not.toHaveBeenCalled();
+});
+
+test('errorHandler sends an HTTPException response as-is with one warning and no error log', async () => {
+  const logger = createLogger();
+  const error = new HTTPException(404, {
+    res: Response.json(
+      { jsonrpc: '2.0', error: { code: -32000, message: 'Unsupported protocol version' } },
+      { status: 404 }
+    ),
+  });
+  const res = await createApp({ error, logger }).request('/api/mcp', { method: 'POST' });
+  expect(res.status).toEqual(404);
+  expect(await res.json()).toEqual({
+    jsonrpc: '2.0',
+    error: { code: -32000, message: 'Unsupported protocol version' },
+  });
+  expect(logger.warn).toHaveBeenCalledWith('404 answered by the route: POST /api/mcp');
+  expect(logger.error).not.toHaveBeenCalled();
 });
 
 test('errorHandler returns 500 with the serialized error envelope on an api path', async () => {

--- a/packages/servers/server/src/middleware/errorHandler.js
+++ b/packages/servers/server/src/middleware/errorHandler.js
@@ -16,6 +16,7 @@
 
 import * as Sentry from '@sentry/node';
 import { redactErrorResponse } from '@lowdefy/api';
+import { HTTPException } from 'hono/http-exception';
 
 // Hono routes every handler error to the app-level error handler — upstream
 // middleware try/catch never sees them (compose catches per dispatch level).
@@ -56,6 +57,17 @@ function createErrorHandler({ basePath = '', logger }) {
         return c.json({ name: error.name, message: error.message }, 403);
       }
       return c.text('Two-factor enrolment required', 403);
+    }
+    // A route or transport that has already decided its own HTTP answer - hono's
+    // HTTPException carries the response to send. The MCP transport refuses an
+    // unsupported protocol-version header this way (a 404 with a JSON-RPC body
+    // that the client SDK falls back on to negotiate a version both sides
+    // know). Not a fault: send its response and log one warning line, no
+    // structured error log and no Sentry capture. Turning it into a 500 would
+    // hide the status the client acts on.
+    if (error instanceof HTTPException) {
+      logger.warn(`${error.status} answered by the route: ${c.req.method} ${c.req.path}`);
+      return error.getResponse();
     }
     const context = c.get('lowdefyContext');
     if (context) {

--- a/packages/servers/server/src/middleware/errorHandler.test.mjs
+++ b/packages/servers/server/src/middleware/errorHandler.test.mjs
@@ -15,6 +15,7 @@
 */
 
 import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
 import { jest } from '@jest/globals';
 
 // The handler is byte-identical to `server-dev`'s and `server-e2e`'s apart from
@@ -205,6 +206,24 @@ test('errorHandler returns text at 403 for a TwoFactorEnrolmentRequiredError on 
   expect(await res.text()).toEqual('Two-factor enrolment required');
   expect(logger.warn).toHaveBeenCalledTimes(1);
   expect(context.handleError).not.toHaveBeenCalled();
+});
+
+test('errorHandler sends an HTTPException response as-is with one warning and no error log', async () => {
+  const logger = createLogger();
+  const error = new HTTPException(404, {
+    res: Response.json(
+      { jsonrpc: '2.0', error: { code: -32000, message: 'Unsupported protocol version' } },
+      { status: 404 }
+    ),
+  });
+  const res = await createApp({ error, logger }).request('/api/mcp', { method: 'POST' });
+  expect(res.status).toEqual(404);
+  expect(await res.json()).toEqual({
+    jsonrpc: '2.0',
+    error: { code: -32000, message: 'Unsupported protocol version' },
+  });
+  expect(logger.warn).toHaveBeenCalledWith('404 answered by the route: POST /api/mcp');
+  expect(logger.error).not.toHaveBeenCalled();
 });
 
 test('errorHandler returns 500 with the serialized error envelope on an api path', async () => {


### PR DESCRIPTION
## Summary
Every Claude Code connection to a Lowdefy MCP server logs this on the first POST:

```
✖ [Error]
    at #validateProtocolVersion (@hono/mcp/dist/index.js:387)
    at StreamableHTTPTransport.handlePostRequest
```

Diagnosed against a live server with the header logged: Claude Code 2.1.251 **probes with `MCP-Protocol-Version: 2026-07-28`** (a spec revision newer than anything `@modelcontextprotocol/sdk` 1.29/1.30 lists — their latest is `2025-11-25`), gets refused, and then re-initialises and continues with `2025-11-25`. That refusal is `@hono/mcp` throwing a hono `HTTPException(404)` whose response is the JSON-RPC "Unsupported protocol version" body the client SDK uses to fall back. Our error handler didn't know `HTTPException`: it logged the exception as an internal error and answered **500** with the redacted envelope — hiding the status the client acts on (the client still recovered because it treats the failure as a stale session).

Fix, in all three servers: `HTTPException` short-circuits to `error.getResponse()` with one warning line, no structured error log and no Sentry capture — the same treatment `AuthenticationError`/`AuthorizationError` already get.

Not fixable by bumping the SDK today: 1.30.0 (latest) has the same supported list; the noise-free negotiation is the correct behaviour until an SDK release knows the newer revision.

## Test plan
- [x] New `errorHandler` test in `server`, `server-dev`, `server-e2e`: an `HTTPException(404, { res })` is sent as-is (status + JSON body), `logger.warn` once, `logger.error` never. Suites 23/20/20 pass.
- [x] Root cause observed on encircle-mvp's dev server: `raw: 2026-07-28 … userAgent: claude-code/2.1.251 (cli)` immediately followed by the `#validateProtocolVersion` throw, then `null` (initialize) and `2025-11-25` on the following requests.