### PR TITLE
fix(build): Resolve refs at the root of ref vars.

### DIFF
--- a/.changeset/fix-build-vars-root-ref.md
+++ b/.changeset/fix-build-vars-root-ref.md
@@ -1,0 +1,7 @@
+---
+'@lowdefy/build': patch
+---
+
+fix: Resolve refs at the root of reference vars.
+
+A `_ref` used directly as the value of `vars` (e.g. `vars: { _ref: config.yaml }`) was not evaluated, so `_var` lookups in the referenced file returned null. Refs at the root of `vars` are now resolved again, restoring pre-v5 behavior.

--- a/packages/build/src/build/buildRefs/buildRefs.test.js
+++ b/packages/build/src/build/buildRefs/buildRefs.test.js
@@ -694,6 +694,61 @@ content:
     });
   });
 
+  test('buildRefs resolves a ref at the root of vars', async () => {
+    const files = [
+      {
+        path: 'lowdefy.yaml',
+        content: `
+shorthand:
+  _ref:
+    path: template.yaml
+    vars:
+      _ref: config.yaml
+withKey:
+  _ref:
+    path: template.yaml
+    vars:
+      _ref:
+        path: nested_config.yaml
+        key: vars`,
+      },
+      {
+        path: 'template.yaml',
+        content: `
+title:
+  _var: title
+count:
+  _var: count`,
+      },
+      {
+        path: 'config.yaml',
+        content: `
+title: Config title
+count: 1`,
+      },
+      {
+        path: 'nested_config.yaml',
+        content: `
+vars:
+  title: Nested title
+  count: 2`,
+      },
+    ];
+    mockReadConfigFile.mockImplementation(readConfigFileMockImplementation(files));
+    const res = await buildRefs({ context });
+    expect(context.errors).toEqual([]);
+    expect(res).toEqual({
+      shorthand: {
+        title: 'Config title',
+        count: 1,
+      },
+      withKey: {
+        title: 'Nested title',
+        count: 2,
+      },
+    });
+  });
+
   test('buildRefs use a ref in var, with a var from parent as a var', async () => {
     const files = [
       {

--- a/packages/build/src/build/buildRefs/walker.js
+++ b/packages/build/src/build/buildRefs/walker.js
@@ -686,20 +686,27 @@ async function prepareRef(node, ctx) {
   if (type.isObject(refDef.path)) {
     refDef.path = await resolve(cloneWithMarkers(refDef.path), ctx);
   }
-  await Promise.all(
-    varKeys.map(async (varKey) => {
-      if (type.isObject(refDef.vars[varKey]) || type.isArray(refDef.vars[varKey])) {
-        // Under prepare (deferModuleRefs), nested module refs inside this ref's
-        // vars become entryRef records too. Extend the path with a reserved
-        // segment so their coordinates are unique (distinct from this ref's own
-        // record) and recognizably nested (slot: null — their placeholder lives
-        // in the prepared body, not in consumerVars).
-        const varCtx =
-          ctx.deferModuleRefs && refDef.module ? ctx.child('$refvars').child(varKey) : ctx;
-        refDef.vars[varKey] = await resolve(refDef.vars[varKey], varCtx);
-      }
-    }),
-  );
+  if (type.isObject(refDef.vars) && !type.isUndefined(refDef.vars._ref)) {
+    // A _ref at the root of vars resolves to the whole vars object
+    // (vars: { _ref: config.yaml }).
+    const varCtx = ctx.deferModuleRefs && refDef.module ? ctx.child('$refvars') : ctx;
+    refDef.vars = (await resolve(refDef.vars, varCtx)) ?? {};
+  } else {
+    await Promise.all(
+      varKeys.map(async (varKey) => {
+        if (type.isObject(refDef.vars[varKey]) || type.isArray(refDef.vars[varKey])) {
+          // Under prepare (deferModuleRefs), nested module refs inside this ref's
+          // vars become entryRef records too. Extend the path with a reserved
+          // segment so their coordinates are unique (distinct from this ref's own
+          // record) and recognizably nested (slot: null — their placeholder lives
+          // in the prepared body, not in consumerVars).
+          const varCtx =
+            ctx.deferModuleRefs && refDef.module ? ctx.child('$refvars').child(varKey) : ctx;
+          refDef.vars[varKey] = await resolve(refDef.vars[varKey], varCtx);
+        }
+      }),
+    );
+  }
   if (type.isObject(refDef.key)) {
     refDef.key = await resolve(cloneWithMarkers(refDef.key), ctx);
   }


### PR DESCRIPTION
## Summary

A `_ref` placed directly as the value of `vars:` (e.g. `vars: { _ref: config.yaml }`) was silently ignored by the buildRefs walker, so every `_var` in the referenced file resolved to `null`. This is a regression from the walker rewrite: the pre-walker `recursiveBuild` resolved refs deepest-first specifically so that "references in the variables of a reference" — including a ref that is the entire `vars` object — were resolved before the parent ref consumed them.

The walker's `prepareRef` only resolved refs nested inside individual var values; a `_ref` node at the root of `vars` was treated as a var literally named `_ref` and passed down unresolved.

**Fix:** in `prepareRef` step 3, when `refDef.vars` is itself a ref node, resolve the whole object through the walker before continuing — mirroring the existing per-key logic, including the `$refvars` context segment for deferred module refs. Since this happens before `getRefContent`, resolved vars also reach nunjucks templates (`.yaml.njk`), and refs nested inside the resolved config file are still walked normally.

## Test plan

- Added `buildRefs resolves a ref at the root of vars` covering both the shorthand string form (`vars: { _ref: config.yaml }`) and the object form with a `key` extract. Fails before the fix (all vars `null`), passes after.
- Full `@lowdefy/build` suite passes: 144 suites, 1846 tests.

## PR Checklist
- [ ] `/r:docs-update` - Documentation updated for behavioral changes
- [ ] `/r:pr-review` - Self-review completed before requesting team review

🤖 Generated with [Claude Code](https://claude.com/claude-code)