### PR TITLE
fix(server-dev): keep the public port bound across dev-server restarts

### DIFF
--- a/.changeset/fix-server-dev-stable-port.md
+++ b/.changeset/fix-server-dev-stable-port.md
@@ -1,0 +1,15 @@
+---
+'@lowdefy/server-dev': patch
+---
+
+fix(server-dev): Keep the public port bound across dev-server restarts.
+
+The manager now owns the public port with a lightweight proxy and runs the
+Vite child on an internal loopback port. Previously every child restart (js
+module change, .env change, plugin install) dropped the TCP listener for the
+whole Vite boot, so long-lived clients — MCP coding agents on
+/lowdefy-docs/mcp, the reload SSE stream, HMR websockets — hit ECONNREFUSED;
+MCP clients in particular latch the failure and demand a manual reconnect
+(sometimes surfacing a spurious authentication prompt). Requests and websocket
+upgrades that arrive while the child is down now wait for it to come back (up
+to 30s) instead of failing, so a restart reads as one slow request.

--- a/packages/servers/server-dev/manager/processes/startProxy.mjs
+++ b/packages/servers/server-dev/manager/processes/startProxy.mjs
@@ -1,0 +1,151 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import http from 'node:http';
+import net from 'node:net';
+
+/*
+The manager owns the public port; the Vite child listens on an internal
+loopback port and every restart replaces only the child. Before this proxy the
+child bound the public port directly, so each restart (js module change, .env
+change, plugin install) dropped the TCP listener for the whole Vite boot —
+long-lived clients (MCP agents on /lowdefy-docs/mcp, the reload SSE stream,
+HMR websockets) saw ECONNREFUSED and gave up; coding agents in particular
+latch the failure and need a manual reconnect. Holding the listener here turns
+a restart into a briefly-slow request instead of a dead port.
+
+While the child is down, requests and upgrades wait for it to come back
+(probing every RETRY_MS up to HOLD_MS) rather than failing fast. HOLD_MS
+covers a Vite respawn with headroom; a child that stays down longer than that
+answers 503 so callers are not held forever. In-flight streams cannot survive
+a child exit — those sockets close and the client reconnects into the hold.
+*/
+
+const RETRY_MS = 250;
+const HOLD_MS = 30000;
+
+function probeChild(port) {
+  return new Promise((resolve) => {
+    const socket = net.connect({ host: '127.0.0.1', port });
+    socket.once('connect', () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once('error', () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
+
+async function waitForChild({ port }) {
+  const deadline = Date.now() + HOLD_MS;
+  for (;;) {
+    if (await probeChild(port)) return true;
+    if (Date.now() > deadline) return false;
+    await new Promise((resolve) => setTimeout(resolve, RETRY_MS));
+  }
+}
+
+function forwardRequest(context, req, res) {
+  // Wait for a live child BEFORE piping the request body — the body stream can
+  // only be consumed once, so retrying after a failed proxy request would need
+  // full-body buffering. A probe-then-forward race (child dies between the
+  // probe and the connect) surfaces as one 502, which the client's next
+  // attempt resolves through the hold.
+  waitForChild({ port: context.internalPort }).then((up) => {
+    if (req.destroyed) return;
+    if (!up) {
+      res.writeHead(503, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ message: 'Lowdefy dev server is restarting.' }));
+      return;
+    }
+    const proxyReq = http.request({
+      host: '127.0.0.1',
+      port: context.internalPort,
+      method: req.method,
+      path: req.url,
+      headers: req.headers,
+    });
+    proxyReq.on('response', (proxyRes) => {
+      res.writeHead(proxyRes.statusCode, proxyRes.headers);
+      // flushHeaders so SSE endpoints (reload stream, MCP notifications)
+      // reach the client before the first event.
+      res.flushHeaders?.();
+      proxyRes.pipe(res);
+    });
+    proxyReq.on('error', () => {
+      if (res.headersSent) {
+        res.destroy();
+        return;
+      }
+      res.writeHead(502, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ message: 'Lowdefy dev server connection dropped.' }));
+    });
+    req.pipe(proxyReq);
+    req.on('error', () => proxyReq.destroy());
+  });
+}
+
+function forwardUpgrade(context, req, socket, head) {
+  waitForChild({ port: context.internalPort }).then((up) => {
+    if (socket.destroyed) return;
+    if (!up) {
+      socket.end('HTTP/1.1 503 Service Unavailable\r\nconnection: close\r\n\r\n');
+      return;
+    }
+    const upstream = net.connect({ host: '127.0.0.1', port: context.internalPort }, () => {
+      // Replay the upgrade request verbatim (rawHeaders preserves order and
+      // case) and splice the sockets — protocol-agnostic, so Vite HMR and app
+      // websockets both pass through untouched.
+      const lines = [`${req.method} ${req.url} HTTP/1.1`];
+      for (let i = 0; i < req.rawHeaders.length; i += 2) {
+        lines.push(`${req.rawHeaders[i]}: ${req.rawHeaders[i + 1]}`);
+      }
+      upstream.write(lines.join('\r\n') + '\r\n\r\n');
+      if (head?.length) upstream.write(head);
+      upstream.pipe(socket);
+      socket.pipe(upstream);
+    });
+    upstream.on('error', () => socket.destroy());
+    socket.on('error', () => upstream.destroy());
+  });
+}
+
+function startProxy(context) {
+  if (context.proxyServer) return Promise.resolve();
+  const proxy = http.createServer((req, res) => forwardRequest(context, req, res));
+  proxy.on('upgrade', (req, socket, head) => forwardUpgrade(context, req, socket, head));
+  // Long-lived streams (SSE, MCP) must not be reaped by the default 5-minute
+  // request timeout; keep the proxy transparent.
+  proxy.requestTimeout = 0;
+  proxy.headersTimeout = 60000;
+  context.proxyServer = proxy;
+  return new Promise((resolve, reject) => {
+    proxy.once('error', reject);
+    // 'localhost' for parity with the Vite default host the child used to bind
+    // — the dev server stays loopback-only, not exposed on the LAN.
+    proxy.listen(context.options.port, 'localhost', () => {
+      proxy.removeListener('error', reject);
+      context.logger.debug(
+        `Proxy listening on port ${context.options.port}, forwarding to ${context.internalPort}.`
+      );
+      resolve();
+    });
+  });
+}
+
+export default startProxy;

--- a/packages/servers/server-dev/manager/processes/startServer.mjs
+++ b/packages/servers/server-dev/manager/processes/startServer.mjs
@@ -18,11 +18,11 @@ import { spawn } from 'child_process';
 
 
 function createStdErrLineHandler({ context }) {
-  const port = context.options.port;
+  const port = context.internalPort;
   return function stdErrLineHandler(line) {
     if (line.includes('EADDRINUSE')) {
       context.logger.error(
-        `Port ${port} is already in use. Stop the other process or use a different port with --port.`
+        `Internal port ${port} is already in use. Stop the other process or use a different port with --port.`
       );
       return;
     }
@@ -33,14 +33,28 @@ function createStdErrLineHandler({ context }) {
 function startServer(context) {
   context.shutdownServer();
 
-  const devServer = spawn('node', [context.bin.vite, '--port', String(context.options.port), '--strictPort'], {
-    stdio: ['ignore', 'inherit', 'pipe'],
-    env: {
-      ...process.env,
-      LOWDEFY_DIRECTORY_CONFIG: context.directories.config,
-      PORT: context.options.port,
-    },
-  });
+  // The child binds context.internalPort on loopback; the manager's proxy owns
+  // the public context.options.port (see startProxy.mjs) so a restart never
+  // drops the listener that browsers, SSE reload streams and MCP agents hold.
+  const devServer = spawn(
+    'node',
+    [
+      context.bin.vite,
+      '--host',
+      '127.0.0.1',
+      '--port',
+      String(context.internalPort),
+      '--strictPort',
+    ],
+    {
+      stdio: ['ignore', 'inherit', 'pipe'],
+      env: {
+        ...process.env,
+        LOWDEFY_DIRECTORY_CONFIG: context.directories.config,
+        PORT: context.internalPort,
+      },
+    }
+  );
 
   const stdErrLineHandler = createStdErrLineHandler({ context });
   devServer.stderr.on('data', (data) => {

--- a/packages/servers/server-dev/manager/run.mjs
+++ b/packages/servers/server-dev/manager/run.mjs
@@ -20,6 +20,7 @@ import { findAvailablePort } from '@lowdefy/node-utils';
 import opener from 'opener';
 import getContext from './getContext.mjs';
 import acquireManagerLock from './utils/acquireManagerLock.mjs';
+import startProxy from './processes/startProxy.mjs';
 import startServer from './processes/startServer.mjs';
 import formatNoticeBox from './utils/formatNoticeBox.mjs';
 
@@ -121,6 +122,14 @@ try {
     );
     context.options.port = availablePort;
   }
+
+  // The manager holds the public port for the whole session and proxies to the
+  // Vite child on an internal loopback port — restarting the child (js module
+  // or .env change) then never drops the listener, so long-lived clients (MCP
+  // agents, the reload SSE stream, HMR websockets) reconnect instead of dying
+  // on ECONNREFUSED.
+  context.internalPort = await findAvailablePort({ port: context.options.port + 1 });
+  await startProxy(context);
 
   startServer(context);
   await wait(800);


### PR DESCRIPTION
## Problem

The dev manager kills and respawns the Vite child on every js-module or .env change, and the child binds the public port directly (`--strictPort`). The port is therefore dark for the whole Vite boot on every restart. Long-lived clients hit `ECONNREFUSED`:

- **MCP coding agents** connected to `/lowdefy-docs/mcp` latch the failure and need a manual reconnect — Claude Code sometimes surfaces a spurious *authenticate* prompt for a server that has no auth at all. In an app with many `_js` modules this happens on nearly every edit.
- The reload SSE stream and HMR websockets die the same way (they recover via ping/reconnect, but only after failing).

## Fix

The manager now owns the public port for the whole session with a dependency-free proxy (`manager/processes/startProxy.mjs`) and runs the Vite child on an internal loopback port (`findAvailablePort(port + 1)`):

- Requests and websocket upgrades that arrive while the child is down are **held** (probe every 250ms, up to 30s) and then forwarded — a restart reads as one slow request instead of a dead port. A child down longer than the hold answers 503.
- Body streams are only piped after a successful child probe, so no request-body buffering is needed.
- Upgrades are replayed verbatim (`rawHeaders`) and the sockets spliced — protocol-agnostic, covers Vite HMR and `lowdefyWebSocket`.
- The proxy listens on `localhost` for parity with the Vite default host the child used to bind (loopback-only, no LAN exposure); `requestTimeout` is disabled so SSE/MCP streams aren't reaped.

## Verified

Harness (child up → 200; SSE passthrough; child killed → request issued while dead **completes** ~1.2s later when the child returns; upgrade → 101 spliced). `node --check` on all touched files.

https://claude.ai/code/session_01HVzfZGZ4HmDr73wxCiXyLV