### PR TITLE
fix(blocks-echarts): Apply theme updates after mount

### DIFF
--- a/packages/plugins/blocks/blocks-echarts/src/blocks/EChart/EChart.js
+++ b/packages/plugins/blocks/blocks-echarts/src/blocks/EChart/EChart.js
@@ -16,7 +16,6 @@
 
 import React from 'react';
 import { withBlockDefaults } from '@lowdefy/block-utils';
-import { registerTheme } from 'echarts';
 import ReactECharts from 'echarts-for-react';
 
 class EChart extends React.Component {
@@ -65,15 +64,38 @@ class EChart extends React.Component {
       if (props.events[eventName]) acc[eventName] = this.allEvents[eventName];
       return acc;
     }, {});
-    if (props.properties.theme) {
-      registerTheme(`custom_theme_${props.blockId}`, props.properties.theme);
-    }
+    // The theme handed to echarts-for-react is fixed for the life of the block.
+    // It deep-compares that prop and disposes + re-inits the chart whenever it
+    // changes; swapping the theme on the live instance instead (see syncTheme)
+    // repaints without the teardown, so the chart re-inks with no visible flash.
+    this.initialTheme = props.properties.theme;
+    this.appliedTheme = JSON.stringify(props.properties.theme);
+    this.chart = undefined;
+    this.onChartReady = (chart) => {
+      this.chart = chart;
+      // The instance is created asynchronously, so the theme may already have
+      // changed by the time it exists.
+      this.syncTheme();
+    };
   }
   triggerEvent(name, event) {
     this.props.methods.triggerEvent({
       name,
       event,
     });
+  }
+  componentDidUpdate() {
+    this.syncTheme();
+  }
+  // Apply a theme that changed after mount — an app switching to dark mode, say.
+  // A theme is plain JSON, so serialising it is a sound and cheap equality check.
+  syncTheme() {
+    const { theme } = this.props.properties;
+    if (!this.chart || !theme) return;
+    const applied = JSON.stringify(theme);
+    if (applied === this.appliedTheme) return;
+    this.appliedTheme = applied;
+    this.chart.setTheme(theme);
   }
   render() {
     return (
@@ -103,7 +125,8 @@ class EChart extends React.Component {
           }}
           opts={this.props.properties.init}
           style={{ width: '100%', height: '100%' }}
-          theme={this.props.properties.theme && `custom_theme_${this.props.blockId}`}
+          theme={this.initialTheme}
+          onChartReady={this.onChartReady}
         />
       </div>
     );

--- a/packages/plugins/blocks/blocks-echarts/src/blocks/EChart/tests/EChart.e2e.spec.js
+++ b/packages/plugins/blocks/blocks-echarts/src/blocks/EChart/tests/EChart.e2e.spec.js
@@ -102,4 +102,24 @@ test.describe('EChart Block', () => {
     const display = getBlock(page, 'echart_click_display');
     await expect(display).toHaveText('Chart clicked');
   });
+
+  // ============================================
+  // THEME TESTS
+  // ============================================
+
+  test('theme changes after mount reach the chart', async ({ page }) => {
+    const block = getBlock(page, 'echart_theme_update');
+    const svg = getSvg(page, 'echart_theme_update');
+    await expect(svg).toBeVisible();
+
+    // Axis labels are painted with the theme's categoryAxis.axisLabel.color.
+    await expect(block.locator('text[fill="#0000ff"]').first()).toBeVisible();
+
+    // Clicking a bar swaps the theme through state.
+    const bar = block.locator('path[fill="#5070dd"]').first();
+    await expect(bar).toBeVisible();
+    await bar.click({ force: true });
+
+    await expect(block.locator('text[fill="#ff0000"]').first()).toBeVisible();
+  });
 });

--- a/packages/plugins/blocks/blocks-echarts/src/blocks/EChart/tests/EChart.e2e.yaml
+++ b/packages/plugins/blocks/blocks-echarts/src/blocks/EChart/tests/EChart.e2e.yaml
@@ -190,3 +190,51 @@ blocks:
               - true
           then: Chart clicked
           else: ''
+
+  # ============================================
+  # THEME TESTS
+  # ============================================
+
+  # A theme that changes after the chart has mounted must reach ECharts. The SVG
+  # renderer writes resolved colours into the DOM, so the axis label fill can be
+  # read directly; clicking a bar swaps the theme through state.
+  - id: echart_theme_update
+    type: EChart
+    properties:
+      init:
+        renderer: svg
+      theme:
+        _if:
+          test:
+            _eq:
+              - _state: echart_theme_swapped
+              - true
+          then:
+            categoryAxis:
+              axisLabel:
+                color: '#ff0000'
+          else:
+            categoryAxis:
+              axisLabel:
+                color: '#0000ff'
+      option:
+        xAxis:
+          type: category
+          data:
+            - Mon
+            - Tue
+            - Wed
+        yAxis:
+          type: value
+        series:
+          - data:
+              - 120
+              - 200
+              - 150
+            type: bar
+    events:
+      click:
+        - id: swap_theme
+          type: SetState
+          params:
+            echart_theme_swapped: true


### PR DESCRIPTION
## Summary

`registerTheme` runs once in the `EChart` constructor, under a name derived from `blockId`, and that constant name is what gets handed to `echarts-for-react`. It re-inits only when the theme *name* changes, so a theme that changes after mount never reaches ECharts and the chart keeps its first-render colours until a page reload.

This shows up in any app that themes its charts per colour scheme: toggling dark mode re-resolves the block's `theme` property correctly, and the chart ignores it. Every other themed element on the page follows the toggle; the charts do not.

The fix swaps the theme on the live instance instead. ECharts 6's `setTheme` re-applies a theme to the existing model and repaints (`ecModel.setTheme` → `_resetOption('recreate')`, so series-level theme keys such as `pie` are re-merged too), and the chart re-inks with no dispose and no visible flash. The `theme` prop passed to `echarts-for-react` is deliberately held stable for the life of the block, because it deep-compares that prop and would otherwise dispose and re-init behind us — which is the teardown `setTheme` exists to avoid. `onChartReady` also syncs, since the instance is created asynchronously and the theme can already have changed by the time it exists.

### Why not simply pass the theme object through

`echarts.init` accepts an object theme (`_updateTheme` only consults `themeStorage` when the theme `isString`), so dropping `registerTheme` and passing `this.props.properties.theme` straight to `echarts-for-react` also fixes the bug, in three lines — its deep compare re-inits on change. That works, and it is a smaller diff, but it re-inits, which is a visible flash on every toggle. Both were tried against a real app and this one is clearly better to use; happy to switch to the smaller version if you'd prefer it.

## Test plan

Added an e2e case: a chart using the SVG renderer whose theme is state-driven, plus a bar click that swaps it. The SVG renderer writes resolved colours into the DOM, so the assertion reads the axis-label `fill` directly — blue before the click, red after. It fails against `v6` as it stands, and passes with this change.

Verified in a real application across both the initial render and repeated dark/light toggles, including pie charts, whose slice labels and slice borders are themed through the `pie` series key and re-ink correctly.

One caveat worth stating plainly: I was not able to run this package's e2e suite locally, so CI is the first real execution of that new test.

---

Same change as #2358, which targets `v6`. All three files are byte-identical on both branches, so this is the same commit applied to `develop` — close whichever you prefer if you forward-merge instead.
