### PR TITLE
feat(actions): Link action accepts replace and scroll

### DIFF
--- a/.changeset/link-action-scroll-replace.md
+++ b/.changeset/link-action-scroll-replace.md
@@ -1,0 +1,12 @@
+---
+'@lowdefy/client': patch
+'@lowdefy/actions-core': minor
+'@lowdefy/docs': patch
+---
+
+feat(actions): Link action accepts `replace` and `scroll`.
+
+A same-page `Link` that only reflects state into the `urlQuery` no longer has to jump the page to
+the top or push a history entry per click: `scroll: false` keeps the current scroll position and
+`replace: true` swaps the current history entry instead of pushing one. The router and the `<Link>`
+block component already supported both; the Link action's same-origin path now forwards them too.

--- a/packages/build/src/tests/success/01-minimal-config/snapshot.json
+++ b/packages/build/src/tests/success/01-minimal-config/snapshot.json
@@ -1019,6 +1019,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/02-minimal-with-name/snapshot.json
+++ b/packages/build/src/tests/success/02-minimal-with-name/snapshot.json
@@ -1020,6 +1020,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/03-minimal-with-version/snapshot.json
+++ b/packages/build/src/tests/success/03-minimal-with-version/snapshot.json
@@ -1019,6 +1019,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/04-minimal-with-license/snapshot.json
+++ b/packages/build/src/tests/success/04-minimal-with-license/snapshot.json
@@ -1019,6 +1019,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/05-empty-pages-array/snapshot.json
+++ b/packages/build/src/tests/success/05-empty-pages-array/snapshot.json
@@ -959,6 +959,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/06-single-page-minimal/snapshot.json
+++ b/packages/build/src/tests/success/06-single-page-minimal/snapshot.json
@@ -1019,6 +1019,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/07-single-page-with-title/snapshot.json
+++ b/packages/build/src/tests/success/07-single-page-with-title/snapshot.json
@@ -1028,6 +1028,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/08-page-with-single-block/snapshot.json
+++ b/packages/build/src/tests/success/08-page-with-single-block/snapshot.json
@@ -1071,6 +1071,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/09-page-with-multiple-blocks/snapshot.json
+++ b/packages/build/src/tests/success/09-page-with-multiple-blocks/snapshot.json
@@ -1119,6 +1119,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/10-page-with-nested-blocks/snapshot.json
+++ b/packages/build/src/tests/success/10-page-with-nested-blocks/snapshot.json
@@ -1169,6 +1169,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/100-module-agents/snapshot.json
+++ b/packages/build/src/tests/success/100-module-agents/snapshot.json
@@ -1671,6 +1671,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/101-mcp-endpoints-app/snapshot.json
+++ b/packages/build/src/tests/success/101-mcp-endpoints-app/snapshot.json
@@ -1093,6 +1093,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/102-collections-declaration/snapshot.json
+++ b/packages/build/src/tests/success/102-collections-declaration/snapshot.json
@@ -1297,6 +1297,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/102-page-state-schema/snapshot.json
+++ b/packages/build/src/tests/success/102-page-state-schema/snapshot.json
@@ -1398,6 +1398,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/102-response-schema-app/snapshot.json
+++ b/packages/build/src/tests/success/102-response-schema-app/snapshot.json
@@ -1517,6 +1517,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/103-migrations/snapshot.json
+++ b/packages/build/src/tests/success/103-migrations/snapshot.json
@@ -1317,6 +1317,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/103-runtime-components/snapshot.json
+++ b/packages/build/src/tests/success/103-runtime-components/snapshot.json
@@ -1532,6 +1532,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/104-archetype-listpage/snapshot.json
+++ b/packages/build/src/tests/success/104-archetype-listpage/snapshot.json
@@ -2790,6 +2790,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/11-page-with-areas/snapshot.json
+++ b/packages/build/src/tests/success/11-page-with-areas/snapshot.json
@@ -1127,6 +1127,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/12-page-with-content-area/snapshot.json
+++ b/packages/build/src/tests/success/12-page-with-content-area/snapshot.json
@@ -1073,6 +1073,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/13-page-with-multiple-areas/snapshot.json
+++ b/packages/build/src/tests/success/13-page-with-multiple-areas/snapshot.json
@@ -1165,6 +1165,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/14-page-with-events-onInit/snapshot.json
+++ b/packages/build/src/tests/success/14-page-with-events-onInit/snapshot.json
@@ -1086,6 +1086,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/15-page-with-events-onMount/snapshot.json
+++ b/packages/build/src/tests/success/15-page-with-events-onMount/snapshot.json
@@ -1130,6 +1130,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/16-page-with-layout-span/snapshot.json
+++ b/packages/build/src/tests/success/16-page-with-layout-span/snapshot.json
@@ -1083,6 +1083,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/17-page-with-layout-responsive/snapshot.json
+++ b/packages/build/src/tests/success/17-page-with-layout-responsive/snapshot.json
@@ -1099,6 +1099,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/18-page-with-style/snapshot.json
+++ b/packages/build/src/tests/success/18-page-with-style/snapshot.json
@@ -1114,6 +1114,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/19-page-with-visible/snapshot.json
+++ b/packages/build/src/tests/success/19-page-with-visible/snapshot.json
@@ -1093,6 +1093,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/20-page-with-properties/snapshot.json
+++ b/packages/build/src/tests/success/20-page-with-properties/snapshot.json
@@ -1077,6 +1077,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/21-multiple-pages/snapshot.json
+++ b/packages/build/src/tests/success/21-multiple-pages/snapshot.json
@@ -1300,6 +1300,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/22-page-404-auto-generated/snapshot.json
+++ b/packages/build/src/tests/success/22-page-404-auto-generated/snapshot.json
@@ -1019,6 +1019,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/24-page-with-skeleton/snapshot.json
+++ b/packages/build/src/tests/success/24-page-with-skeleton/snapshot.json
@@ -1089,6 +1089,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/25-page-with-loading/snapshot.json
+++ b/packages/build/src/tests/success/25-page-with-loading/snapshot.json
@@ -1085,6 +1085,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/30-multifile-pages-ref/snapshot.json
+++ b/packages/build/src/tests/success/30-multifile-pages-ref/snapshot.json
@@ -1453,6 +1453,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/31-multifile-blocks-ref/snapshot.json
+++ b/packages/build/src/tests/success/31-multifile-blocks-ref/snapshot.json
@@ -1552,6 +1552,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/32-multifile-connections-ref/snapshot.json
+++ b/packages/build/src/tests/success/32-multifile-connections-ref/snapshot.json
@@ -1208,6 +1208,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/33-multifile-nested-refs/snapshot.json
+++ b/packages/build/src/tests/success/33-multifile-nested-refs/snapshot.json
@@ -1871,6 +1871,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/34-crud-app-complete/snapshot.json
+++ b/packages/build/src/tests/success/34-crud-app-complete/snapshot.json
@@ -3181,6 +3181,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
+++ b/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
@@ -2389,6 +2389,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/36-auth-roles-app/snapshot.json
+++ b/packages/build/src/tests/success/36-auth-roles-app/snapshot.json
@@ -2268,6 +2268,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/37-api-endpoints-app/snapshot.json
+++ b/packages/build/src/tests/success/37-api-endpoints-app/snapshot.json
@@ -1255,6 +1255,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/38-menu-navigation-app/snapshot.json
+++ b/packages/build/src/tests/success/38-menu-navigation-app/snapshot.json
@@ -2473,6 +2473,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/39-global-state-app/snapshot.json
+++ b/packages/build/src/tests/success/39-global-state-app/snapshot.json
@@ -2049,6 +2049,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/40-form-validation-app/snapshot.json
+++ b/packages/build/src/tests/success/40-form-validation-app/snapshot.json
@@ -1939,6 +1939,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/41-list-crud-app/snapshot.json
+++ b/packages/build/src/tests/success/41-list-crud-app/snapshot.json
@@ -1577,6 +1577,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/42-dashboard-app/snapshot.json
+++ b/packages/build/src/tests/success/42-dashboard-app/snapshot.json
@@ -1597,6 +1597,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/43-wizard-flow-app/snapshot.json
+++ b/packages/build/src/tests/success/43-wizard-flow-app/snapshot.json
@@ -2178,6 +2178,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/44-modal-drawer-app/snapshot.json
+++ b/packages/build/src/tests/success/44-modal-drawer-app/snapshot.json
@@ -1814,6 +1814,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/45-tabs-layout-app/snapshot.json
+++ b/packages/build/src/tests/success/45-tabs-layout-app/snapshot.json
@@ -1801,6 +1801,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/46-responsive-layout-app/snapshot.json
+++ b/packages/build/src/tests/success/46-responsive-layout-app/snapshot.json
@@ -1837,6 +1837,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/47-operators-comprehensive/snapshot.json
+++ b/packages/build/src/tests/success/47-operators-comprehensive/snapshot.json
@@ -2638,6 +2638,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/48-events-actions-comprehensive/snapshot.json
+++ b/packages/build/src/tests/success/48-events-actions-comprehensive/snapshot.json
@@ -2812,6 +2812,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/49-request-payload-app/snapshot.json
+++ b/packages/build/src/tests/success/49-request-payload-app/snapshot.json
@@ -2772,6 +2772,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/50-logger-sentry-app/snapshot.json
+++ b/packages/build/src/tests/success/50-logger-sentry-app/snapshot.json
@@ -1219,6 +1219,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/51-config-options-app/snapshot.json
+++ b/packages/build/src/tests/success/51-config-options-app/snapshot.json
@@ -1196,6 +1196,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/52-skeleton-loading-app/snapshot.json
+++ b/packages/build/src/tests/success/52-skeleton-loading-app/snapshot.json
@@ -1418,6 +1418,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/53-deep-nesting-app/snapshot.json
+++ b/packages/build/src/tests/success/53-deep-nesting-app/snapshot.json
@@ -1345,6 +1345,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/54-many-pages-app/snapshot.json
+++ b/packages/build/src/tests/success/54-many-pages-app/snapshot.json
@@ -2036,6 +2036,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
+++ b/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
@@ -5864,6 +5864,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/56-build-operator-in-ref-vars/snapshot.json
+++ b/packages/build/src/tests/success/56-build-operator-in-ref-vars/snapshot.json
@@ -1149,6 +1149,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/57-static-op-with-dynamic-child-in-vars/snapshot.json
+++ b/packages/build/src/tests/success/57-static-op-with-dynamic-child-in-vars/snapshot.json
@@ -1210,6 +1210,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/58-build-array-map-with-var/snapshot.json
+++ b/packages/build/src/tests/success/58-build-array-map-with-var/snapshot.json
@@ -1075,6 +1075,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/60-module-single-basic/snapshot.json
+++ b/packages/build/src/tests/success/60-module-single-basic/snapshot.json
@@ -1179,6 +1179,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/61-module-multi-instance/snapshot.json
+++ b/packages/build/src/tests/success/61-module-multi-instance/snapshot.json
@@ -1948,6 +1948,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/62-module-with-connections/snapshot.json
+++ b/packages/build/src/tests/success/62-module-with-connections/snapshot.json
@@ -1243,6 +1243,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/63-module-connection-remapping/snapshot.json
+++ b/packages/build/src/tests/success/63-module-connection-remapping/snapshot.json
@@ -1454,6 +1454,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/64-module-exposed-component/snapshot.json
+++ b/packages/build/src/tests/success/64-module-exposed-component/snapshot.json
@@ -1110,6 +1110,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/65-module-exposed-menu/snapshot.json
+++ b/packages/build/src/tests/success/65-module-exposed-menu/snapshot.json
@@ -1286,6 +1286,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/66-module-with-api/snapshot.json
+++ b/packages/build/src/tests/success/66-module-with-api/snapshot.json
@@ -1430,6 +1430,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/67-module-var-defaults/snapshot.json
+++ b/packages/build/src/tests/success/67-module-var-defaults/snapshot.json
@@ -1155,6 +1155,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/68-module-nested-refs/snapshot.json
+++ b/packages/build/src/tests/success/68-module-nested-refs/snapshot.json
@@ -1357,6 +1357,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/69-module-with-app-pages/snapshot.json
+++ b/packages/build/src/tests/success/69-module-with-app-pages/snapshot.json
@@ -1627,6 +1627,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/70-cross-module-shared-layout/snapshot.json
+++ b/packages/build/src/tests/success/70-cross-module-shared-layout/snapshot.json
@@ -1194,6 +1194,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/71-cross-module-mutual-refs/snapshot.json
+++ b/packages/build/src/tests/success/71-cross-module-mutual-refs/snapshot.json
@@ -1356,6 +1356,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/72-cross-module-audit-events/snapshot.json
+++ b/packages/build/src/tests/success/72-cross-module-audit-events/snapshot.json
@@ -1287,6 +1287,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/73-cross-module-diamond-deps/snapshot.json
+++ b/packages/build/src/tests/success/73-cross-module-diamond-deps/snapshot.json
@@ -1360,6 +1360,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/74-cross-module-multi-instance/snapshot.json
+++ b/packages/build/src/tests/success/74-cross-module-multi-instance/snapshot.json
@@ -1544,6 +1544,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/75-cross-module-connection-remap/snapshot.json
+++ b/packages/build/src/tests/success/75-cross-module-connection-remap/snapshot.json
@@ -1306,6 +1306,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/76-cross-module-nested-refs/snapshot.json
+++ b/packages/build/src/tests/success/76-cross-module-nested-refs/snapshot.json
@@ -1360,6 +1360,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/77-cross-module-menu-refs/snapshot.json
+++ b/packages/build/src/tests/success/77-cross-module-menu-refs/snapshot.json
@@ -1349,6 +1349,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/78-cross-module-mutual-nested/snapshot.json
+++ b/packages/build/src/tests/success/78-cross-module-mutual-nested/snapshot.json
@@ -1349,6 +1349,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/79-cross-module-build-op-wrapping/snapshot.json
+++ b/packages/build/src/tests/success/79-cross-module-build-op-wrapping/snapshot.json
@@ -1157,6 +1157,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/80-cross-module-ref-in-vars/snapshot.json
+++ b/packages/build/src/tests/success/80-cross-module-ref-in-vars/snapshot.json
@@ -1231,6 +1231,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/81-cross-module-build-op-components/snapshot.json
+++ b/packages/build/src/tests/success/81-cross-module-build-op-components/snapshot.json
@@ -1194,6 +1194,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/82-cross-module-mutual-refs-reversed/snapshot.json
+++ b/packages/build/src/tests/success/82-cross-module-mutual-refs-reversed/snapshot.json
@@ -1356,6 +1356,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/83-cross-module-multi-consumer-vars/snapshot.json
+++ b/packages/build/src/tests/success/83-cross-module-multi-consumer-vars/snapshot.json
@@ -1242,6 +1242,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/84-cross-module-multi-consumer-menus/snapshot.json
+++ b/packages/build/src/tests/success/84-cross-module-multi-consumer-menus/snapshot.json
@@ -1464,6 +1464,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/85-module-component-data-export/snapshot.json
+++ b/packages/build/src/tests/success/85-module-component-data-export/snapshot.json
@@ -1284,6 +1284,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/86-module-component-cross-ref-vars/snapshot.json
+++ b/packages/build/src/tests/success/86-module-component-cross-ref-vars/snapshot.json
@@ -1448,6 +1448,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/87-module-default-plugin/snapshot.json
+++ b/packages/build/src/tests/success/87-module-default-plugin/snapshot.json
@@ -1080,6 +1080,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/88-module-nested-var-properties/snapshot.json
+++ b/packages/build/src/tests/success/88-module-nested-var-properties/snapshot.json
@@ -1470,6 +1470,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/89-module-null-namespace-defaults/snapshot.json
+++ b/packages/build/src/tests/success/89-module-null-namespace-defaults/snapshot.json
@@ -1830,6 +1830,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/90-module-lazy-default-resolution/snapshot.json
+++ b/packages/build/src/tests/success/90-module-lazy-default-resolution/snapshot.json
@@ -1444,6 +1444,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/91-i18n-config/snapshot.json
+++ b/packages/build/src/tests/success/91-i18n-config/snapshot.json
@@ -1117,6 +1117,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/92-api-with-schedules/snapshot.json
+++ b/packages/build/src/tests/success/92-api-with-schedules/snapshot.json
@@ -1125,6 +1125,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/93-api-generate-requests/snapshot.json
+++ b/packages/build/src/tests/success/93-api-generate-requests/snapshot.json
@@ -1356,6 +1356,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/94-api-call-agent/snapshot.json
+++ b/packages/build/src/tests/success/94-api-call-agent/snapshot.json
@@ -1450,6 +1450,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/95-auth-strategies-app/snapshot.json
+++ b/packages/build/src/tests/success/95-auth-strategies-app/snapshot.json
@@ -1662,6 +1662,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/96-auth-config-projection/snapshot.json
+++ b/packages/build/src/tests/success/96-auth-config-projection/snapshot.json
@@ -1274,6 +1274,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/96-module-notifications/snapshot.json
+++ b/packages/build/src/tests/success/96-module-notifications/snapshot.json
@@ -1564,6 +1564,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/97-module-authconfig-projection/snapshot.json
+++ b/packages/build/src/tests/success/97-module-authconfig-projection/snapshot.json
@@ -1555,6 +1555,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/98-auth-refs-module-component/snapshot.json
+++ b/packages/build/src/tests/success/98-auth-refs-module-component/snapshot.json
@@ -1244,6 +1244,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/98-module-authconfig-entry-vars/snapshot.json
+++ b/packages/build/src/tests/success/98-module-authconfig-entry-vars/snapshot.json
@@ -1326,6 +1326,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/99-authconfig-in-module-entry-var/snapshot.json
+++ b/packages/build/src/tests/success/99-authconfig-in-module-entry-var/snapshot.json
@@ -1291,6 +1291,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/99-js-modules/snapshot.json
+++ b/packages/build/src/tests/success/99-js-modules/snapshot.json
@@ -1305,6 +1305,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/expression-syntax/snapshot.json
+++ b/packages/build/src/tests/success/expression-syntax/snapshot.json
@@ -1356,6 +1356,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/client/src/setupLink.js
+++ b/packages/client/src/setupLink.js
@@ -52,17 +52,18 @@ function setupLink(lowdefy) {
     }
     return window.location.assign(target);
   };
-  const sameOriginLink = ({ newTab, pathname, query, setInput }) => {
+  // `replace` swaps the current history entry instead of pushing one and
+  // `scroll` (default true) controls the router's scroll-to-top - together they
+  // let a same-page Link reflect state into the url without moving the page.
+  const sameOriginLink = ({ newTab, pathname, query, replace, scroll, setInput }) => {
     if (newTab) {
       return openNewTab(
         `${window.location.origin}${createUrl({ basePath: lowdefy.basePath, pathname, query })}`
       );
     }
     setInput();
-    return router.push({
-      pathname,
-      query,
-    });
+    const navigate = replace ? router.replace : router.push;
+    return navigate({ pathname, query, scroll });
   };
   const noLink = () => {
     throw new ConfigError('Invalid Link: no target resolved.');

--- a/packages/client/src/setupLink.test.js
+++ b/packages/client/src/setupLink.test.js
@@ -21,7 +21,7 @@ import setupLink from './setupLink.js';
 // Minimal fake window: jsdom does not implement navigation, and the assertions
 // here are about which target string the link is handed.
 function createFakeLowdefy({ popupBlocked = false } = {}) {
-  const calls = { assign: [], open: [], push: [], focus: 0 };
+  const calls = { assign: [], open: [], push: [], replace: [], focus: 0 };
   const handle = {
     focus: () => {
       calls.focus += 1;
@@ -46,6 +46,7 @@ function createFakeLowdefy({ popupBlocked = false } = {}) {
       router: {
         back: jest.fn(),
         push: (args) => calls.push.push(args),
+        replace: (args) => calls.replace.push(args),
       },
       displayMessage: jest.fn(),
       translate: (key) => key,
@@ -136,4 +137,32 @@ test('a link that resolves to no target throws a ConfigError', () => {
   lowdefy.home = { pageId: undefined, configured: false };
 
   expect(() => setupLink(lowdefy)({})).toThrow('Invalid Link: no target resolved.');
+});
+
+test('scroll is forwarded to the router', () => {
+  const lowdefy = createFakeLowdefy();
+
+  setupLink(lowdefy)({ pageId: 'reports', scroll: false });
+
+  expect(lowdefy.calls.push).toEqual([{ pathname: '/reports', query: '', scroll: false }]);
+  expect(lowdefy.calls.replace).toEqual([]);
+});
+
+test('replace uses router.replace instead of router.push', () => {
+  const lowdefy = createFakeLowdefy();
+
+  setupLink(lowdefy)({ pageId: 'reports', urlQuery: { a: 1 }, replace: true, scroll: false });
+
+  expect(lowdefy.calls.push).toEqual([]);
+  expect(lowdefy.calls.replace).toEqual([{ pathname: '/reports', query: 'a=1', scroll: false }]);
+});
+
+test('newTab wins over replace and scroll', () => {
+  const lowdefy = createFakeLowdefy();
+
+  setupLink(lowdefy)({ pageId: 'reports', newTab: true, replace: true, scroll: false });
+
+  expect(lowdefy.calls.open).toEqual([['http://localhost/reports', '_blank']]);
+  expect(lowdefy.calls.push).toEqual([]);
+  expect(lowdefy.calls.replace).toEqual([]);
 });

--- a/packages/docs/actions/Link.yaml
+++ b/packages/docs/actions/Link.yaml
@@ -28,6 +28,8 @@ _ref:
         input?: object,
         newTab?:boolean,
         pageId?: string,
+        replace?: boolean,
+        scroll?: boolean,
         url?: string,
         urlQuery? object
       }): void
@@ -47,6 +49,8 @@ _ref:
       - `input: object`: Object to set as the input for the linked page.
       - `newTab: boolean`: Open the link in a new tab.
       - `pageId: string`: The pageId of a page in the app to link to.
+      - `replace: boolean`: Replace the current browser history entry instead of pushing a new one, so the browser back button skips this navigation. Defaults to `false`.
+      - `scroll: boolean`: Scroll to the top of the page after navigating. Set to `false` to keep the current scroll position, for example when a same-page link only updates the `urlQuery`. Defaults to `true`.
       - `url: string`: Link to an external url.
       - `urlQuery: object`: Object to set as the urlQuery for the linked page.
 
@@ -119,6 +123,19 @@ _ref:
           input:
             id:
               _args: row.id
+      ```
+
+      ###### Reflect state into the urlQuery without moving the page:
+      ```yaml
+      - id: sync_url
+        type: Link
+        params:
+          pageId: my_page_id
+          urlQuery:
+            selected:
+              _state: selected_id
+          replace: true
+          scroll: false
       ```
 
       ###### Go to the previous page:

--- a/packages/engine/test/createLink.test.js
+++ b/packages/engine/test/createLink.test.js
@@ -681,3 +681,21 @@ test('createLink, more than one grammar key throws the resolver ambiguity error'
     `"Invalid Link: To avoid ambiguity, only one of 'home', 'pageId' or 'url' can be defined."`
   );
 });
+
+test('createLink, replace and scroll are passed through to sameOriginLink', () => {
+  const lowdefy = { inputs: {} };
+  const link = createLink({
+    backLink: mockBackLink,
+    disabledLink: mockDisabledLink,
+    lowdefy,
+    newOriginLink: mockNewOriginLink,
+    noLink: mockNoLink,
+    sameOriginLink: mockSameOriginLink,
+  });
+  link({ pageId: 'page_1', replace: true, scroll: false });
+  expect(mockSameOriginLink.mock.calls[0][0]).toMatchObject({
+    pathname: '/page_1',
+    replace: true,
+    scroll: false,
+  });
+});

--- a/packages/plugins/actions/actions-core/src/actions/Link/schema.js
+++ b/packages/plugins/actions/actions-core/src/actions/Link/schema.js
@@ -30,6 +30,14 @@ export default {
             type: 'object',
             description: 'Input to pass to the linked page.',
           },
+          replace: {
+            type: 'boolean',
+            description: 'Replace the current history entry instead of pushing a new one.',
+          },
+          scroll: {
+            type: 'boolean',
+            description: 'Scroll to the top of the page after navigating. Defaults to true.',
+          },
         },
       },
     ],


### PR DESCRIPTION
## Summary

A same-page `Link` used purely to reflect selection state into the `urlQuery` (shareable URLs) currently jumps the page to the top on every click and pushes a history entry per click. The router (`createRouter.js`) and the `<Link>` block component path already honour `scroll` and `replace`; only the Link **action** path dropped them — `setupLink.js` `sameOriginLink` called `router.push({ pathname, query })`.

- `packages/client/src/setupLink.js`: forward `scroll` and pick `router.replace` when `replace: true` (`newTab` still wins).
- `actions-core` Link schema: declare `replace` and `scroll` booleans.
- Docs: signature, params, and a "reflect state into the urlQuery without moving the page" example.
- Tests: client `setupLink` (scroll forwarded, replace → `router.replace`, newTab wins) and engine `createLink` passthrough.
- Changeset: `@lowdefy/client` patch, `@lowdefy/actions-core` minor, `@lowdefy/docs` patch.

Motivating app bug: an app worked around this with a local action that re-applied `window.scrollY` in a second `requestAnimationFrame`.

## Verification

`pnpm test` in `@lowdefy/client` (252), `@lowdefy/engine` (470) and `@lowdefy/actions-core` (196) all pass; prettier clean.

https://claude.ai/code/session_014gvvgogPeh26JmnJtrjUnD

