### PR TITLE
chore(v7): Backport stable dev-server port (#2357) and Link replace/scroll (#2360)

### DIFF
--- a/.changeset/fix-server-dev-stable-port.md
+++ b/.changeset/fix-server-dev-stable-port.md
@@ -1,0 +1,15 @@
+---
+'@lowdefy/server-dev': patch
+---
+
+fix(server-dev): Keep the public port bound across dev-server restarts.
+
+The manager now owns the public port with a lightweight proxy and runs the
+Vite child on an internal loopback port. Previously every child restart (js
+module change, .env change, plugin install) dropped the TCP listener for the
+whole Vite boot, so long-lived clients — MCP coding agents on
+/lowdefy-docs/mcp, the reload SSE stream, HMR websockets — hit ECONNREFUSED;
+MCP clients in particular latch the failure and demand a manual reconnect
+(sometimes surfacing a spurious authentication prompt). Requests and websocket
+upgrades that arrive while the child is down now wait for it to come back (up
+to 30s) instead of failing, so a restart reads as one slow request.

--- a/.changeset/link-action-scroll-replace.md
+++ b/.changeset/link-action-scroll-replace.md
@@ -1,0 +1,12 @@
+---
+'@lowdefy/client': patch
+'@lowdefy/actions-core': minor
+'@lowdefy/docs': patch
+---
+
+feat(actions): Link action accepts `replace` and `scroll`.
+
+A same-page `Link` that only reflects state into the `urlQuery` no longer has to jump the page to
+the top or push a history entry per click: `scroll: false` keeps the current scroll position and
+`replace: true` swaps the current history entry instead of pushing one. The router and the `<Link>`
+block component already supported both; the Link action's same-origin path now forwards them too.

--- a/packages/build/src/tests/success/01-minimal-config/snapshot.json
+++ b/packages/build/src/tests/success/01-minimal-config/snapshot.json
@@ -1007,6 +1007,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/02-minimal-with-name/snapshot.json
+++ b/packages/build/src/tests/success/02-minimal-with-name/snapshot.json
@@ -1008,6 +1008,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/03-minimal-with-version/snapshot.json
+++ b/packages/build/src/tests/success/03-minimal-with-version/snapshot.json
@@ -1007,6 +1007,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/04-minimal-with-license/snapshot.json
+++ b/packages/build/src/tests/success/04-minimal-with-license/snapshot.json
@@ -1007,6 +1007,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/05-empty-pages-array/snapshot.json
+++ b/packages/build/src/tests/success/05-empty-pages-array/snapshot.json
@@ -947,6 +947,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/06-single-page-minimal/snapshot.json
+++ b/packages/build/src/tests/success/06-single-page-minimal/snapshot.json
@@ -1007,6 +1007,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/07-single-page-with-title/snapshot.json
+++ b/packages/build/src/tests/success/07-single-page-with-title/snapshot.json
@@ -1016,6 +1016,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/08-page-with-single-block/snapshot.json
+++ b/packages/build/src/tests/success/08-page-with-single-block/snapshot.json
@@ -1059,6 +1059,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/09-page-with-multiple-blocks/snapshot.json
+++ b/packages/build/src/tests/success/09-page-with-multiple-blocks/snapshot.json
@@ -1107,6 +1107,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/10-page-with-nested-blocks/snapshot.json
+++ b/packages/build/src/tests/success/10-page-with-nested-blocks/snapshot.json
@@ -1157,6 +1157,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/100-module-agents/snapshot.json
+++ b/packages/build/src/tests/success/100-module-agents/snapshot.json
@@ -1659,6 +1659,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/101-mcp-endpoints-app/snapshot.json
+++ b/packages/build/src/tests/success/101-mcp-endpoints-app/snapshot.json
@@ -1081,6 +1081,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/11-page-with-areas/snapshot.json
+++ b/packages/build/src/tests/success/11-page-with-areas/snapshot.json
@@ -1115,6 +1115,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/12-page-with-content-area/snapshot.json
+++ b/packages/build/src/tests/success/12-page-with-content-area/snapshot.json
@@ -1061,6 +1061,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/13-page-with-multiple-areas/snapshot.json
+++ b/packages/build/src/tests/success/13-page-with-multiple-areas/snapshot.json
@@ -1153,6 +1153,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/14-page-with-events-onInit/snapshot.json
+++ b/packages/build/src/tests/success/14-page-with-events-onInit/snapshot.json
@@ -1074,6 +1074,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/15-page-with-events-onMount/snapshot.json
+++ b/packages/build/src/tests/success/15-page-with-events-onMount/snapshot.json
@@ -1118,6 +1118,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/16-page-with-layout-span/snapshot.json
+++ b/packages/build/src/tests/success/16-page-with-layout-span/snapshot.json
@@ -1071,6 +1071,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/17-page-with-layout-responsive/snapshot.json
+++ b/packages/build/src/tests/success/17-page-with-layout-responsive/snapshot.json
@@ -1087,6 +1087,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/18-page-with-style/snapshot.json
+++ b/packages/build/src/tests/success/18-page-with-style/snapshot.json
@@ -1102,6 +1102,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/19-page-with-visible/snapshot.json
+++ b/packages/build/src/tests/success/19-page-with-visible/snapshot.json
@@ -1081,6 +1081,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/20-page-with-properties/snapshot.json
+++ b/packages/build/src/tests/success/20-page-with-properties/snapshot.json
@@ -1065,6 +1065,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/21-multiple-pages/snapshot.json
+++ b/packages/build/src/tests/success/21-multiple-pages/snapshot.json
@@ -1288,6 +1288,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/22-page-404-auto-generated/snapshot.json
+++ b/packages/build/src/tests/success/22-page-404-auto-generated/snapshot.json
@@ -1007,6 +1007,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/24-page-with-skeleton/snapshot.json
+++ b/packages/build/src/tests/success/24-page-with-skeleton/snapshot.json
@@ -1077,6 +1077,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/25-page-with-loading/snapshot.json
+++ b/packages/build/src/tests/success/25-page-with-loading/snapshot.json
@@ -1073,6 +1073,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/30-multifile-pages-ref/snapshot.json
+++ b/packages/build/src/tests/success/30-multifile-pages-ref/snapshot.json
@@ -1441,6 +1441,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/31-multifile-blocks-ref/snapshot.json
+++ b/packages/build/src/tests/success/31-multifile-blocks-ref/snapshot.json
@@ -1540,6 +1540,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/32-multifile-connections-ref/snapshot.json
+++ b/packages/build/src/tests/success/32-multifile-connections-ref/snapshot.json
@@ -1196,6 +1196,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/33-multifile-nested-refs/snapshot.json
+++ b/packages/build/src/tests/success/33-multifile-nested-refs/snapshot.json
@@ -1859,6 +1859,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/34-crud-app-complete/snapshot.json
+++ b/packages/build/src/tests/success/34-crud-app-complete/snapshot.json
@@ -3169,6 +3169,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
+++ b/packages/build/src/tests/success/35-auth-protected-app/snapshot.json
@@ -2351,6 +2351,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/36-auth-roles-app/snapshot.json
+++ b/packages/build/src/tests/success/36-auth-roles-app/snapshot.json
@@ -2256,6 +2256,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/37-api-endpoints-app/snapshot.json
+++ b/packages/build/src/tests/success/37-api-endpoints-app/snapshot.json
@@ -1243,6 +1243,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/38-menu-navigation-app/snapshot.json
+++ b/packages/build/src/tests/success/38-menu-navigation-app/snapshot.json
@@ -2461,6 +2461,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/39-global-state-app/snapshot.json
+++ b/packages/build/src/tests/success/39-global-state-app/snapshot.json
@@ -1997,6 +1997,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/40-form-validation-app/snapshot.json
+++ b/packages/build/src/tests/success/40-form-validation-app/snapshot.json
@@ -1881,6 +1881,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/41-list-crud-app/snapshot.json
+++ b/packages/build/src/tests/success/41-list-crud-app/snapshot.json
@@ -1565,6 +1565,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/42-dashboard-app/snapshot.json
+++ b/packages/build/src/tests/success/42-dashboard-app/snapshot.json
@@ -1585,6 +1585,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/43-wizard-flow-app/snapshot.json
+++ b/packages/build/src/tests/success/43-wizard-flow-app/snapshot.json
@@ -2096,6 +2096,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/44-modal-drawer-app/snapshot.json
+++ b/packages/build/src/tests/success/44-modal-drawer-app/snapshot.json
@@ -1802,6 +1802,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/45-tabs-layout-app/snapshot.json
+++ b/packages/build/src/tests/success/45-tabs-layout-app/snapshot.json
@@ -1789,6 +1789,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/46-responsive-layout-app/snapshot.json
+++ b/packages/build/src/tests/success/46-responsive-layout-app/snapshot.json
@@ -1825,6 +1825,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/47-operators-comprehensive/snapshot.json
+++ b/packages/build/src/tests/success/47-operators-comprehensive/snapshot.json
@@ -2626,6 +2626,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/48-events-actions-comprehensive/snapshot.json
+++ b/packages/build/src/tests/success/48-events-actions-comprehensive/snapshot.json
@@ -2800,6 +2800,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/49-request-payload-app/snapshot.json
+++ b/packages/build/src/tests/success/49-request-payload-app/snapshot.json
@@ -2715,6 +2715,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/50-logger-sentry-app/snapshot.json
+++ b/packages/build/src/tests/success/50-logger-sentry-app/snapshot.json
@@ -1207,6 +1207,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/51-config-options-app/snapshot.json
+++ b/packages/build/src/tests/success/51-config-options-app/snapshot.json
@@ -1184,6 +1184,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/52-skeleton-loading-app/snapshot.json
+++ b/packages/build/src/tests/success/52-skeleton-loading-app/snapshot.json
@@ -1406,6 +1406,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/53-deep-nesting-app/snapshot.json
+++ b/packages/build/src/tests/success/53-deep-nesting-app/snapshot.json
@@ -1333,6 +1333,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/54-many-pages-app/snapshot.json
+++ b/packages/build/src/tests/success/54-many-pages-app/snapshot.json
@@ -2024,6 +2024,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
+++ b/packages/build/src/tests/success/55-complete-enterprise-app/snapshot.json
@@ -5826,6 +5826,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/56-build-operator-in-ref-vars/snapshot.json
+++ b/packages/build/src/tests/success/56-build-operator-in-ref-vars/snapshot.json
@@ -1137,6 +1137,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/57-static-op-with-dynamic-child-in-vars/snapshot.json
+++ b/packages/build/src/tests/success/57-static-op-with-dynamic-child-in-vars/snapshot.json
@@ -1198,6 +1198,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/58-build-array-map-with-var/snapshot.json
+++ b/packages/build/src/tests/success/58-build-array-map-with-var/snapshot.json
@@ -1063,6 +1063,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/60-module-single-basic/snapshot.json
+++ b/packages/build/src/tests/success/60-module-single-basic/snapshot.json
@@ -1167,6 +1167,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/61-module-multi-instance/snapshot.json
+++ b/packages/build/src/tests/success/61-module-multi-instance/snapshot.json
@@ -1918,6 +1918,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/62-module-with-connections/snapshot.json
+++ b/packages/build/src/tests/success/62-module-with-connections/snapshot.json
@@ -1231,6 +1231,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/63-module-connection-remapping/snapshot.json
+++ b/packages/build/src/tests/success/63-module-connection-remapping/snapshot.json
@@ -1442,6 +1442,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/64-module-exposed-component/snapshot.json
+++ b/packages/build/src/tests/success/64-module-exposed-component/snapshot.json
@@ -1098,6 +1098,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/65-module-exposed-menu/snapshot.json
+++ b/packages/build/src/tests/success/65-module-exposed-menu/snapshot.json
@@ -1274,6 +1274,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/66-module-with-api/snapshot.json
+++ b/packages/build/src/tests/success/66-module-with-api/snapshot.json
@@ -1418,6 +1418,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/67-module-var-defaults/snapshot.json
+++ b/packages/build/src/tests/success/67-module-var-defaults/snapshot.json
@@ -1107,6 +1107,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/68-module-nested-refs/snapshot.json
+++ b/packages/build/src/tests/success/68-module-nested-refs/snapshot.json
@@ -1345,6 +1345,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/69-module-with-app-pages/snapshot.json
+++ b/packages/build/src/tests/success/69-module-with-app-pages/snapshot.json
@@ -1615,6 +1615,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/70-cross-module-shared-layout/snapshot.json
+++ b/packages/build/src/tests/success/70-cross-module-shared-layout/snapshot.json
@@ -1182,6 +1182,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/71-cross-module-mutual-refs/snapshot.json
+++ b/packages/build/src/tests/success/71-cross-module-mutual-refs/snapshot.json
@@ -1326,6 +1326,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/72-cross-module-audit-events/snapshot.json
+++ b/packages/build/src/tests/success/72-cross-module-audit-events/snapshot.json
@@ -1246,6 +1246,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/73-cross-module-diamond-deps/snapshot.json
+++ b/packages/build/src/tests/success/73-cross-module-diamond-deps/snapshot.json
@@ -1348,6 +1348,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/74-cross-module-multi-instance/snapshot.json
+++ b/packages/build/src/tests/success/74-cross-module-multi-instance/snapshot.json
@@ -1532,6 +1532,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/75-cross-module-connection-remap/snapshot.json
+++ b/packages/build/src/tests/success/75-cross-module-connection-remap/snapshot.json
@@ -1265,6 +1265,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/76-cross-module-nested-refs/snapshot.json
+++ b/packages/build/src/tests/success/76-cross-module-nested-refs/snapshot.json
@@ -1348,6 +1348,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/77-cross-module-menu-refs/snapshot.json
+++ b/packages/build/src/tests/success/77-cross-module-menu-refs/snapshot.json
@@ -1337,6 +1337,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/78-cross-module-mutual-nested/snapshot.json
+++ b/packages/build/src/tests/success/78-cross-module-mutual-nested/snapshot.json
@@ -1319,6 +1319,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/79-cross-module-build-op-wrapping/snapshot.json
+++ b/packages/build/src/tests/success/79-cross-module-build-op-wrapping/snapshot.json
@@ -1145,6 +1145,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/80-cross-module-ref-in-vars/snapshot.json
+++ b/packages/build/src/tests/success/80-cross-module-ref-in-vars/snapshot.json
@@ -1219,6 +1219,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/81-cross-module-build-op-components/snapshot.json
+++ b/packages/build/src/tests/success/81-cross-module-build-op-components/snapshot.json
@@ -1182,6 +1182,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/82-cross-module-mutual-refs-reversed/snapshot.json
+++ b/packages/build/src/tests/success/82-cross-module-mutual-refs-reversed/snapshot.json
@@ -1326,6 +1326,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/83-cross-module-multi-consumer-vars/snapshot.json
+++ b/packages/build/src/tests/success/83-cross-module-multi-consumer-vars/snapshot.json
@@ -1230,6 +1230,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/84-cross-module-multi-consumer-menus/snapshot.json
+++ b/packages/build/src/tests/success/84-cross-module-multi-consumer-menus/snapshot.json
@@ -1452,6 +1452,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/85-module-component-data-export/snapshot.json
+++ b/packages/build/src/tests/success/85-module-component-data-export/snapshot.json
@@ -1279,6 +1279,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/86-module-component-cross-ref-vars/snapshot.json
+++ b/packages/build/src/tests/success/86-module-component-cross-ref-vars/snapshot.json
@@ -1441,6 +1441,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/87-module-default-plugin/snapshot.json
+++ b/packages/build/src/tests/success/87-module-default-plugin/snapshot.json
@@ -1068,6 +1068,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/88-module-nested-var-properties/snapshot.json
+++ b/packages/build/src/tests/success/88-module-nested-var-properties/snapshot.json
@@ -1226,6 +1226,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/89-module-null-namespace-defaults/snapshot.json
+++ b/packages/build/src/tests/success/89-module-null-namespace-defaults/snapshot.json
@@ -1530,6 +1530,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/90-module-lazy-default-resolution/snapshot.json
+++ b/packages/build/src/tests/success/90-module-lazy-default-resolution/snapshot.json
@@ -1414,6 +1414,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/91-i18n-config/snapshot.json
+++ b/packages/build/src/tests/success/91-i18n-config/snapshot.json
@@ -1105,6 +1105,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/92-api-with-schedules/snapshot.json
+++ b/packages/build/src/tests/success/92-api-with-schedules/snapshot.json
@@ -1113,6 +1113,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/93-api-generate-requests/snapshot.json
+++ b/packages/build/src/tests/success/93-api-generate-requests/snapshot.json
@@ -1344,6 +1344,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/94-api-call-agent/snapshot.json
+++ b/packages/build/src/tests/success/94-api-call-agent/snapshot.json
@@ -1438,6 +1438,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/95-auth-strategies-app/snapshot.json
+++ b/packages/build/src/tests/success/95-auth-strategies-app/snapshot.json
@@ -1650,6 +1650,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/96-auth-config-projection/snapshot.json
+++ b/packages/build/src/tests/success/96-auth-config-projection/snapshot.json
@@ -1263,6 +1263,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/96-module-notifications/snapshot.json
+++ b/packages/build/src/tests/success/96-module-notifications/snapshot.json
@@ -1552,6 +1552,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/97-module-authconfig-projection/snapshot.json
+++ b/packages/build/src/tests/success/97-module-authconfig-projection/snapshot.json
@@ -1575,6 +1575,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/98-auth-refs-module-component/snapshot.json
+++ b/packages/build/src/tests/success/98-auth-refs-module-component/snapshot.json
@@ -1234,6 +1234,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/98-module-authconfig-entry-vars/snapshot.json
+++ b/packages/build/src/tests/success/98-module-authconfig-entry-vars/snapshot.json
@@ -1314,6 +1314,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/build/src/tests/success/99-authconfig-in-module-entry-var/snapshot.json
+++ b/packages/build/src/tests/success/99-authconfig-in-module-entry-var/snapshot.json
@@ -1281,6 +1281,14 @@
               "input": {
                 "type": "object",
                 "description": "Input to pass to the linked page."
+              },
+              "replace": {
+                "type": "boolean",
+                "description": "Replace the current history entry instead of pushing a new one."
+              },
+              "scroll": {
+                "type": "boolean",
+                "description": "Scroll to the top of the page after navigating. Defaults to true."
               }
             }
           }

--- a/packages/client/src/setupLink.js
+++ b/packages/client/src/setupLink.js
@@ -52,17 +52,18 @@ function setupLink(lowdefy) {
     }
     return window.location.assign(target);
   };
-  const sameOriginLink = ({ newTab, pathname, query, setInput }) => {
+  // `replace` swaps the current history entry instead of pushing one and
+  // `scroll` (default true) controls the router's scroll-to-top - together they
+  // let a same-page Link reflect state into the url without moving the page.
+  const sameOriginLink = ({ newTab, pathname, query, replace, scroll, setInput }) => {
     if (newTab) {
       return openNewTab(
         `${window.location.origin}${createUrl({ basePath: lowdefy.basePath, pathname, query })}`
       );
     }
     setInput();
-    return router.push({
-      pathname,
-      query,
-    });
+    const navigate = replace ? router.replace : router.push;
+    return navigate({ pathname, query, scroll });
   };
   const noLink = () => {
     throw new ConfigError('Invalid Link: no target resolved.');

--- a/packages/client/src/setupLink.test.js
+++ b/packages/client/src/setupLink.test.js
@@ -21,7 +21,7 @@ import setupLink from './setupLink.js';
 // Minimal fake window: jsdom does not implement navigation, and the assertions
 // here are about which target string the link is handed.
 function createFakeLowdefy({ popupBlocked = false } = {}) {
-  const calls = { assign: [], open: [], push: [], focus: 0 };
+  const calls = { assign: [], open: [], push: [], replace: [], focus: 0 };
   const handle = {
     focus: () => {
       calls.focus += 1;
@@ -46,6 +46,7 @@ function createFakeLowdefy({ popupBlocked = false } = {}) {
       router: {
         back: jest.fn(),
         push: (args) => calls.push.push(args),
+        replace: (args) => calls.replace.push(args),
       },
       displayMessage: jest.fn(),
       translate: (key) => key,
@@ -136,4 +137,32 @@ test('a link that resolves to no target throws a ConfigError', () => {
   lowdefy.home = { pageId: undefined, configured: false };
 
   expect(() => setupLink(lowdefy)({})).toThrow('Invalid Link: no target resolved.');
+});
+
+test('scroll is forwarded to the router', () => {
+  const lowdefy = createFakeLowdefy();
+
+  setupLink(lowdefy)({ pageId: 'reports', scroll: false });
+
+  expect(lowdefy.calls.push).toEqual([{ pathname: '/reports', query: '', scroll: false }]);
+  expect(lowdefy.calls.replace).toEqual([]);
+});
+
+test('replace uses router.replace instead of router.push', () => {
+  const lowdefy = createFakeLowdefy();
+
+  setupLink(lowdefy)({ pageId: 'reports', urlQuery: { a: 1 }, replace: true, scroll: false });
+
+  expect(lowdefy.calls.push).toEqual([]);
+  expect(lowdefy.calls.replace).toEqual([{ pathname: '/reports', query: 'a=1', scroll: false }]);
+});
+
+test('newTab wins over replace and scroll', () => {
+  const lowdefy = createFakeLowdefy();
+
+  setupLink(lowdefy)({ pageId: 'reports', newTab: true, replace: true, scroll: false });
+
+  expect(lowdefy.calls.open).toEqual([['http://localhost/reports', '_blank']]);
+  expect(lowdefy.calls.push).toEqual([]);
+  expect(lowdefy.calls.replace).toEqual([]);
 });

--- a/packages/docs/actions/Link.yaml
+++ b/packages/docs/actions/Link.yaml
@@ -28,6 +28,8 @@ _ref:
         input?: object,
         newTab?:boolean,
         pageId?: string,
+        replace?: boolean,
+        scroll?: boolean,
         url?: string,
         urlQuery? object
       }): void
@@ -47,6 +49,8 @@ _ref:
       - `input: object`: Object to set as the input for the linked page.
       - `newTab: boolean`: Open the link in a new tab.
       - `pageId: string`: The pageId of a page in the app to link to.
+      - `replace: boolean`: Replace the current browser history entry instead of pushing a new one, so the browser back button skips this navigation. Defaults to `false`.
+      - `scroll: boolean`: Scroll to the top of the page after navigating. Set to `false` to keep the current scroll position, for example when a same-page link only updates the `urlQuery`. Defaults to `true`.
       - `url: string`: Link to an external url.
       - `urlQuery: object`: Object to set as the urlQuery for the linked page.
 
@@ -119,6 +123,19 @@ _ref:
           input:
             id:
               _args: row.id
+      ```
+
+      ###### Reflect state into the urlQuery without moving the page:
+      ```yaml
+      - id: sync_url
+        type: Link
+        params:
+          pageId: my_page_id
+          urlQuery:
+            selected:
+              _state: selected_id
+          replace: true
+          scroll: false
       ```
 
       ###### Go to the previous page:

--- a/packages/engine/test/createLink.test.js
+++ b/packages/engine/test/createLink.test.js
@@ -681,3 +681,21 @@ test('createLink, more than one grammar key throws the resolver ambiguity error'
     `"Invalid Link: To avoid ambiguity, only one of 'home', 'pageId' or 'url' can be defined."`
   );
 });
+
+test('createLink, replace and scroll are passed through to sameOriginLink', () => {
+  const lowdefy = { inputs: {} };
+  const link = createLink({
+    backLink: mockBackLink,
+    disabledLink: mockDisabledLink,
+    lowdefy,
+    newOriginLink: mockNewOriginLink,
+    noLink: mockNoLink,
+    sameOriginLink: mockSameOriginLink,
+  });
+  link({ pageId: 'page_1', replace: true, scroll: false });
+  expect(mockSameOriginLink.mock.calls[0][0]).toMatchObject({
+    pathname: '/page_1',
+    replace: true,
+    scroll: false,
+  });
+});

--- a/packages/plugins/actions/actions-core/src/actions/Link/schema.js
+++ b/packages/plugins/actions/actions-core/src/actions/Link/schema.js
@@ -30,6 +30,14 @@ export default {
             type: 'object',
             description: 'Input to pass to the linked page.',
           },
+          replace: {
+            type: 'boolean',
+            description: 'Replace the current history entry instead of pushing a new one.',
+          },
+          scroll: {
+            type: 'boolean',
+            description: 'Scroll to the top of the page after navigating. Defaults to true.',
+          },
         },
       },
     ],

--- a/packages/servers/server-dev/manager/processes/startProxy.mjs
+++ b/packages/servers/server-dev/manager/processes/startProxy.mjs
@@ -1,0 +1,151 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import http from 'node:http';
+import net from 'node:net';
+
+/*
+The manager owns the public port; the Vite child listens on an internal
+loopback port and every restart replaces only the child. Before this proxy the
+child bound the public port directly, so each restart (js module change, .env
+change, plugin install) dropped the TCP listener for the whole Vite boot —
+long-lived clients (MCP agents on /lowdefy-docs/mcp, the reload SSE stream,
+HMR websockets) saw ECONNREFUSED and gave up; coding agents in particular
+latch the failure and need a manual reconnect. Holding the listener here turns
+a restart into a briefly-slow request instead of a dead port.
+
+While the child is down, requests and upgrades wait for it to come back
+(probing every RETRY_MS up to HOLD_MS) rather than failing fast. HOLD_MS
+covers a Vite respawn with headroom; a child that stays down longer than that
+answers 503 so callers are not held forever. In-flight streams cannot survive
+a child exit — those sockets close and the client reconnects into the hold.
+*/
+
+const RETRY_MS = 250;
+const HOLD_MS = 30000;
+
+function probeChild(port) {
+  return new Promise((resolve) => {
+    const socket = net.connect({ host: '127.0.0.1', port });
+    socket.once('connect', () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once('error', () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
+
+async function waitForChild({ port }) {
+  const deadline = Date.now() + HOLD_MS;
+  for (;;) {
+    if (await probeChild(port)) return true;
+    if (Date.now() > deadline) return false;
+    await new Promise((resolve) => setTimeout(resolve, RETRY_MS));
+  }
+}
+
+function forwardRequest(context, req, res) {
+  // Wait for a live child BEFORE piping the request body — the body stream can
+  // only be consumed once, so retrying after a failed proxy request would need
+  // full-body buffering. A probe-then-forward race (child dies between the
+  // probe and the connect) surfaces as one 502, which the client's next
+  // attempt resolves through the hold.
+  waitForChild({ port: context.internalPort }).then((up) => {
+    if (req.destroyed) return;
+    if (!up) {
+      res.writeHead(503, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ message: 'Lowdefy dev server is restarting.' }));
+      return;
+    }
+    const proxyReq = http.request({
+      host: '127.0.0.1',
+      port: context.internalPort,
+      method: req.method,
+      path: req.url,
+      headers: req.headers,
+    });
+    proxyReq.on('response', (proxyRes) => {
+      res.writeHead(proxyRes.statusCode, proxyRes.headers);
+      // flushHeaders so SSE endpoints (reload stream, MCP notifications)
+      // reach the client before the first event.
+      res.flushHeaders?.();
+      proxyRes.pipe(res);
+    });
+    proxyReq.on('error', () => {
+      if (res.headersSent) {
+        res.destroy();
+        return;
+      }
+      res.writeHead(502, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ message: 'Lowdefy dev server connection dropped.' }));
+    });
+    req.pipe(proxyReq);
+    req.on('error', () => proxyReq.destroy());
+  });
+}
+
+function forwardUpgrade(context, req, socket, head) {
+  waitForChild({ port: context.internalPort }).then((up) => {
+    if (socket.destroyed) return;
+    if (!up) {
+      socket.end('HTTP/1.1 503 Service Unavailable\r\nconnection: close\r\n\r\n');
+      return;
+    }
+    const upstream = net.connect({ host: '127.0.0.1', port: context.internalPort }, () => {
+      // Replay the upgrade request verbatim (rawHeaders preserves order and
+      // case) and splice the sockets — protocol-agnostic, so Vite HMR and app
+      // websockets both pass through untouched.
+      const lines = [`${req.method} ${req.url} HTTP/1.1`];
+      for (let i = 0; i < req.rawHeaders.length; i += 2) {
+        lines.push(`${req.rawHeaders[i]}: ${req.rawHeaders[i + 1]}`);
+      }
+      upstream.write(lines.join('\r\n') + '\r\n\r\n');
+      if (head?.length) upstream.write(head);
+      upstream.pipe(socket);
+      socket.pipe(upstream);
+    });
+    upstream.on('error', () => socket.destroy());
+    socket.on('error', () => upstream.destroy());
+  });
+}
+
+function startProxy(context) {
+  if (context.proxyServer) return Promise.resolve();
+  const proxy = http.createServer((req, res) => forwardRequest(context, req, res));
+  proxy.on('upgrade', (req, socket, head) => forwardUpgrade(context, req, socket, head));
+  // Long-lived streams (SSE, MCP) must not be reaped by the default 5-minute
+  // request timeout; keep the proxy transparent.
+  proxy.requestTimeout = 0;
+  proxy.headersTimeout = 60000;
+  context.proxyServer = proxy;
+  return new Promise((resolve, reject) => {
+    proxy.once('error', reject);
+    // 'localhost' for parity with the Vite default host the child used to bind
+    // — the dev server stays loopback-only, not exposed on the LAN.
+    proxy.listen(context.options.port, 'localhost', () => {
+      proxy.removeListener('error', reject);
+      context.logger.debug(
+        `Proxy listening on port ${context.options.port}, forwarding to ${context.internalPort}.`
+      );
+      resolve();
+    });
+  });
+}
+
+export default startProxy;

--- a/packages/servers/server-dev/manager/processes/startServer.mjs
+++ b/packages/servers/server-dev/manager/processes/startServer.mjs
@@ -18,11 +18,11 @@ import { spawn } from 'child_process';
 
 
 function createStdErrLineHandler({ context }) {
-  const port = context.options.port;
+  const port = context.internalPort;
   return function stdErrLineHandler(line) {
     if (line.includes('EADDRINUSE')) {
       context.logger.error(
-        `Port ${port} is already in use. Stop the other process or use a different port with --port.`
+        `Internal port ${port} is already in use. Stop the other process or use a different port with --port.`
       );
       return;
     }
@@ -33,14 +33,28 @@ function createStdErrLineHandler({ context }) {
 function startServer(context) {
   context.shutdownServer();
 
-  const devServer = spawn('node', [context.bin.vite, '--port', String(context.options.port), '--strictPort'], {
-    stdio: ['ignore', 'inherit', 'pipe'],
-    env: {
-      ...process.env,
-      LOWDEFY_DIRECTORY_CONFIG: context.directories.config,
-      PORT: context.options.port,
-    },
-  });
+  // The child binds context.internalPort on loopback; the manager's proxy owns
+  // the public context.options.port (see startProxy.mjs) so a restart never
+  // drops the listener that browsers, SSE reload streams and MCP agents hold.
+  const devServer = spawn(
+    'node',
+    [
+      context.bin.vite,
+      '--host',
+      '127.0.0.1',
+      '--port',
+      String(context.internalPort),
+      '--strictPort',
+    ],
+    {
+      stdio: ['ignore', 'inherit', 'pipe'],
+      env: {
+        ...process.env,
+        LOWDEFY_DIRECTORY_CONFIG: context.directories.config,
+        PORT: context.internalPort,
+      },
+    }
+  );
 
   const stdErrLineHandler = createStdErrLineHandler({ context });
   devServer.stderr.on('data', (data) => {

--- a/packages/servers/server-dev/manager/run.mjs
+++ b/packages/servers/server-dev/manager/run.mjs
@@ -19,6 +19,7 @@ import { wait } from '@lowdefy/helpers';
 import { findAvailablePort } from '@lowdefy/node-utils';
 import opener from 'opener';
 import getContext from './getContext.mjs';
+import startProxy from './processes/startProxy.mjs';
 import startServer from './processes/startServer.mjs';
 import formatNoticeBox from './utils/formatNoticeBox.mjs';
 
@@ -107,6 +108,14 @@ try {
     );
     context.options.port = availablePort;
   }
+
+  // The manager holds the public port for the whole session and proxies to the
+  // Vite child on an internal loopback port — restarting the child (js module
+  // or .env change) then never drops the listener, so long-lived clients (MCP
+  // agents, the reload SSE stream, HMR websockets) reconnect instead of dying
+  // on ECONNREFUSED.
+  context.internalPort = await findAvailablePort({ port: context.options.port + 1 });
+  await startProxy(context);
 
   startServer(context);
   await wait(800);


### PR DESCRIPTION
Backport of #2357 and #2360 from `v8`.

## fix(server-dev): keep the public port bound across dev-server restarts (#2357)

The dev manager kills and respawns the Vite child on every js-module or .env change, and the child bound the public port directly with `--strictPort`, so the port was dark for every restart. Long-lived clients (MCP agents on `/lowdefy-docs/mcp`, the reload SSE stream, HMR websockets) hit `ECONNREFUSED`. The manager now owns the public port with a dependency-free proxy (`manager/processes/startProxy.mjs`) and runs Vite on an internal loopback port; requests and upgrades that arrive while the child is down are held (up to 30s) and forwarded when it returns.

Cherry-pick conflict: only the `acquireManagerLock` import in `run.mjs`, which does not exist on this branch. Resolved by keeping just the `startProxy` import; the remaining hunks are identical to the v8 commit.

## feat(actions): Link action accepts replace and scroll (#2360)

The router already honoured `replace` and `scroll`; the Link action path dropped them in `setupLink.js`. Now `replace: true` uses `router.replace` and `scroll` is forwarded, with `newTab` still winning. Schema, docs, tests and changeset carried over. Build artifact snapshots regenerated on this branch (additive only: the two new schema properties).

## Verification

`pnpm build`, then `pnpm --filter=@lowdefy/{client,engine,actions-core,server-dev,build} test` all pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013puo2354LBtmVmMMKLUCaJ
