### PR TITLE
fix(ai): a failed agent turn no longer poisons the conversation

### DIFF
--- a/.changeset/agent-chat-error-empty-assistant.md
+++ b/.changeset/agent-chat-error-empty-assistant.md
@@ -1,0 +1,6 @@
+---
+'@lowdefy/ai-utils': patch
+'@lowdefy/blocks-antd-x': patch
+---
+
+fix(ai): a failed agent turn no longer poisons the conversation. The chat client pushes the assistant message on the stream's `start` chunk, so a request that failed after that left an assistant message with no parts in the history; every later send then failed UIMessage validation, and the error toast dumped the whole conversation as JSON. AgentChat now drops empty assistant shells on error, the agent handler ignores empty messages and redacts validation errors, and a validation failure is logged like any other stream fault.

--- a/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
+++ b/packages/plugins/blocks/blocks-antd-x/src/blocks/AgentChat/AgentChat.js
@@ -187,6 +187,15 @@ function AgentChat({
       }
     },
     onError: (error) => {
+      // A request that fails after the stream's `start` chunk leaves the
+      // assistant shell the SDK pushed on that chunk — id set, parts: [] — in
+      // the message list. Left there, every later send fails UIMessage
+      // validation ("Message must contain at least one part") and the
+      // conversation is dead until a reload. Drop empty shells so the user can
+      // simply try again; there is nothing in them to show or to send.
+      setMessages((prev) =>
+        prev.filter((m) => m.role !== 'assistant' || (m.parts?.length ?? 0) > 0)
+      );
       methods.triggerEvent({
         name: 'onError',
         event: { message: error.message },

--- a/packages/utils/ai-utils/src/handleAgentChat.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.js
@@ -22,6 +22,7 @@ import {
   generateId,
   generateText,
   pruneMessages,
+  TypeValidationError,
   validateUIMessages,
 } from 'ai';
 
@@ -49,6 +50,29 @@ function convertDataUrlsToBase64(messages) {
   });
 }
 
+// Drop messages that carry no parts. The AI SDK client pushes the assistant
+// message on the stream's `start` chunk, before any content arrives, so a
+// request that fails after that point leaves an assistant shell with
+// `parts: []` in the client's history. Sent back, that shell fails UIMessage
+// validation ("Message must contain at least one part") — and keeps failing on
+// every later turn, so one transient error would otherwise kill the
+// conversation until a reload. There is nothing in an empty message for the
+// model anyway.
+function dropEmptyMessages(messages) {
+  return messages.filter((msg) => Array.isArray(msg.parts) && msg.parts.length > 0);
+}
+
+// What the client is told when a turn fails. TypeValidationError.message
+// embeds JSON.stringify(value) — for a UIMessage validation failure that is
+// the entire conversation, which the chat block then shows in a toast. The
+// full error is logged server-side before this is written to the stream.
+function clientErrorText(error) {
+  if (TypeValidationError.isInstance(error)) {
+    return 'The conversation could not be sent: a message failed validation.';
+  }
+  return error?.message ?? String(error);
+}
+
 // Concatenate the text parts of the first user message — used as the source
 // for generateTitle.
 function getFirstUserText(messages) {
@@ -68,7 +92,7 @@ async function handleAgentChat({ connection, properties, context }) {
   }
 
   const { agent, messages: rawMessages } = properties;
-  const messages = convertDataUrlsToBase64(rawMessages);
+  const messages = dropEmptyMessages(convertDataUrlsToBase64(rawMessages));
 
   const { agentInstance, mcpClients, model, timeoutConfig, locale } = await createToolLoopAgent({
     connection,
@@ -85,6 +109,7 @@ async function handleAgentChat({ connection, properties, context }) {
   const titleEnabled = agent.properties.generateTitle === true;
 
   const stream = createUIMessageStream({
+    onError: clientErrorText,
     execute: async ({ writer }) => {
       const usageAccumulator = createUsageAccumulator();
       const steps = [];
@@ -135,62 +160,66 @@ async function handleAgentChat({ connection, properties, context }) {
         }
       }
 
-      if (pruneConfig) {
-        // Decompose createAgentUIStream so we can insert pruneMessages
-        // between the UIMessage→ModelMessage conversion and agent execution.
-        const validatedMessages = await validateUIMessages({
-          messages,
-          tools: agentInstance.tools,
-        });
-        const modelMessages = await convertToModelMessages(validatedMessages, {
-          tools: agentInstance.tools,
-        });
-        const prunedMessages = pruneMessages({
-          messages: modelMessages,
-          ...pruneConfig,
-        });
-        const result = await agentInstance.stream({
-          prompt: prunedMessages,
-          ...timeoutConfig,
-          onStepFinish: collectStep,
-        });
-        agentStream = result.toUIMessageStream({
-          originalMessages: validatedMessages,
-          // Without a generator the assistant message reaches onFinish with
-          // id: '' — see the createAgentUIStream call below.
-          generateMessageId: generateId,
-          onFinish: captureMessages,
-        });
-      } else {
-        // createAgentUIStream validates UIMessages, converts to ModelMessages,
-        // runs the agent, and returns a UIMessageStream — handling the full
-        // UI→model→UI conversion that ToolLoopAgent.stream() does not.
-        agentStream = await createAgentUIStream({
-          agent: agentInstance,
-          uiMessages: messages,
-          ...timeoutConfig,
-          // The AI SDK only ids the assistant message it builds when the caller
-          // supplies a generator: toUIMessageStream derives responseMessageId
-          // only if generateMessageId != null, and handleUIMessageStreamFinish
-          // then seeds the streaming state with `messageId ?? ''`, with no
-          // messageId on the start chunk to override it. Without this every
-          // assistant message an onFinish hook persists carries id: '', so a
-          // saved transcript has them all sharing one id — and a UI that keys
-          // its bubbles by message id (AgentChat does) renders the last reply in
-          // every assistant bubble when the conversation is reloaded. The client
-          // generates its own id while streaming, so the damage only shows up
-          // after a reload.
-          generateMessageId: generateId,
-          onStepFinish: collectStep,
-          onFinish: captureMessages,
-        });
-      }
-
-      // Read the agent stream to completion before running onFinish hooks.
-      // writer.merge() is fire-and-forget (returns void in the AI SDK), so we
-      // manually read the stream to ensure hooks fire after the agent finishes.
-      const reader = agentStream.getReader();
+      // One try around validation, the agent run and the read: a UIMessage that
+      // fails validation throws from createAgentUIStream / validateUIMessages
+      // before any stream exists, and that fault has to be logged and redacted
+      // the same way as a fault mid-stream.
       try {
+        if (pruneConfig) {
+          // Decompose createAgentUIStream so we can insert pruneMessages
+          // between the UIMessage→ModelMessage conversion and agent execution.
+          const validatedMessages = await validateUIMessages({
+            messages,
+            tools: agentInstance.tools,
+          });
+          const modelMessages = await convertToModelMessages(validatedMessages, {
+            tools: agentInstance.tools,
+          });
+          const prunedMessages = pruneMessages({
+            messages: modelMessages,
+            ...pruneConfig,
+          });
+          const result = await agentInstance.stream({
+            prompt: prunedMessages,
+            ...timeoutConfig,
+            onStepFinish: collectStep,
+          });
+          agentStream = result.toUIMessageStream({
+            originalMessages: validatedMessages,
+            // Without a generator the assistant message reaches onFinish with
+            // id: '' — see the createAgentUIStream call below.
+            generateMessageId: generateId,
+            onFinish: captureMessages,
+          });
+        } else {
+          // createAgentUIStream validates UIMessages, converts to ModelMessages,
+          // runs the agent, and returns a UIMessageStream — handling the full
+          // UI→model→UI conversion that ToolLoopAgent.stream() does not.
+          agentStream = await createAgentUIStream({
+            agent: agentInstance,
+            uiMessages: messages,
+            ...timeoutConfig,
+            // The AI SDK only ids the assistant message it builds when the caller
+            // supplies a generator: toUIMessageStream derives responseMessageId
+            // only if generateMessageId != null, and handleUIMessageStreamFinish
+            // then seeds the streaming state with `messageId ?? ''`, with no
+            // messageId on the start chunk to override it. Without this every
+            // assistant message an onFinish hook persists carries id: '', so a
+            // saved transcript has them all sharing one id — and a UI that keys
+            // its bubbles by message id (AgentChat does) renders the last reply in
+            // every assistant bubble when the conversation is reloaded. The client
+            // generates its own id while streaming, so the damage only shows up
+            // after a reload.
+            generateMessageId: generateId,
+            onStepFinish: collectStep,
+            onFinish: captureMessages,
+          });
+        }
+
+        // Read the agent stream to completion before running onFinish hooks.
+        // writer.merge() is fire-and-forget (returns void in the AI SDK), so we
+        // manually read the stream to ensure hooks fire after the agent finishes.
+        const reader = agentStream.getReader();
         while (true) {
           const { done, value } = await reader.read();
           if (done) break;

--- a/packages/utils/ai-utils/src/handleAgentChat.test.js
+++ b/packages/utils/ai-utils/src/handleAgentChat.test.js
@@ -88,8 +88,15 @@ const mockConvertToModelMessages = jest.fn().mockResolvedValue([]);
 const mockPruneMessages = jest.fn().mockReturnValue([]);
 const mockValidateUIMessages = jest.fn().mockResolvedValue([]);
 
+class MockTypeValidationError extends Error {
+  static isInstance(error) {
+    return error instanceof MockTypeValidationError;
+  }
+}
+
 jest.unstable_mockModule('ai', () => ({
   ToolLoopAgent: MockToolLoopAgent,
+  TypeValidationError: MockTypeValidationError,
   convertToModelMessages: mockConvertToModelMessages,
   createAgentUIStream: mockCreateAgentUIStream,
   createUIMessageStream: mockCreateUIMessageStream,
@@ -196,6 +203,7 @@ test('creates ToolLoopAgent with correct parameters', async () => {
   );
   expect(mockCreateUIMessageStream).toHaveBeenCalledWith({
     execute: expect.any(Function),
+    onError: expect.any(Function),
   });
   expect(mockCreateUIMessageStreamResponse).toHaveBeenCalledWith({
     stream: { type: 'readable-stream' },
@@ -2411,4 +2419,82 @@ test('generateTitle failure is non-fatal and does not break the stream', async (
   );
 
   mockGenerateText.mockResolvedValue({ text: 'Generated Title' });
+});
+
+test('messages without parts are dropped before the agent runs', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
+  mockCreateAgentUIStream.mockImplementation(defaultCreateAgentUIStream);
+
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+
+  const user = { id: 'msg-1', role: 'user', parts: [{ type: 'text', text: 'hi' }] };
+  // The shell the client keeps when a turn fails after the stream's start chunk.
+  const emptyShell = { id: 'msg-2', role: 'assistant', parts: [] };
+  const retry = { id: 'msg-3', role: 'user', parts: [{ type: 'text', text: 'again' }] };
+
+  await handleAgentChat({
+    connection: { provider: jest.fn().mockReturnValue({}) },
+    properties: {
+      agent: { tools: [], properties: { model: 'gpt-4o' } },
+      messages: [user, emptyShell, retry],
+    },
+    context: { logger: testLogger, callEndpoint: jest.fn(), getEndpointConfig: jest.fn() },
+  });
+
+  await mockCreateUIMessageStream._lastExecute({ writer: { write: jest.fn() } });
+
+  expect(mockCreateAgentUIStream).toHaveBeenCalledWith(
+    expect.objectContaining({ uiMessages: [user, retry] })
+  );
+});
+
+test('a validation failure is logged and written to the stream as an error, not thrown', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
+  const validationError = new MockTypeValidationError('Type validation failed: Value: [...]');
+  mockCreateAgentUIStream.mockRejectedValueOnce(validationError);
+
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+  const logger = { debug: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn() };
+
+  await handleAgentChat({
+    connection: { provider: jest.fn().mockReturnValue({}) },
+    properties: {
+      agent: { tools: [], properties: { model: 'gpt-4o' } },
+      messages: [{ id: 'msg-1', role: 'user', parts: [{ type: 'text', text: 'hi' }] }],
+    },
+    context: { logger, callEndpoint: jest.fn(), getEndpointConfig: jest.fn() },
+  });
+
+  const writer = { write: jest.fn(), onError: (error) => `redacted: ${error.message}` };
+  await expect(mockCreateUIMessageStream._lastExecute({ writer })).resolves.toBeUndefined();
+
+  expect(logger.error).toHaveBeenCalledWith({ err: validationError }, 'Agent stream failed.');
+  expect(writer.write).toHaveBeenCalledWith({
+    type: 'error',
+    errorText: 'redacted: Type validation failed: Value: [...]',
+  });
+});
+
+test('stream onError hides the value dump of a TypeValidationError from the client', async () => {
+  mockTool.mockImplementation((def) => def);
+  mockJsonSchema.mockReturnValue(MOCK_SCHEMA);
+
+  const { default: handleAgentChat } = await import('./handleAgentChat.js');
+
+  await handleAgentChat({
+    connection: { provider: jest.fn().mockReturnValue({}) },
+    properties: {
+      agent: { tools: [], properties: { model: 'gpt-4o' } },
+      messages: [{ id: 'msg-1', role: 'user', parts: [{ type: 'text', text: 'hi' }] }],
+    },
+    context: { logger: testLogger, callEndpoint: jest.fn(), getEndpointConfig: jest.fn() },
+  });
+
+  const { onError } = mockCreateUIMessageStream.mock.calls.at(-1)[0];
+  expect(onError(new MockTypeValidationError('Type validation failed: Value: [{"id":"x"}]'))).toBe(
+    'The conversation could not be sent: a message failed validation.'
+  );
+  expect(onError(new Error('Rate limit exceeded'))).toBe('Rate limit exceeded');
 });


### PR DESCRIPTION
## Problem

Reported from a production app: after one failed agent turn, every later message in the chat produced an error toast containing the entire conversation serialised as JSON.

The AI SDK client pushes the assistant message on the stream's `start` chunk, before any content arrives. A request that fails after that point leaves an assistant message with `parts: []` in the client's history. On the next send that shell fails UIMessage validation (`Message must contain at least one part`). The `TypeValidationError` message embeds `JSON.stringify(value)`, i.e. the whole conversation, and that text reached the client verbatim because validation ran outside the handler's try/catch and `createUIMessageStream` used the default `onError`. Every subsequent turn failed the same way until a page reload.

## Fix

- **AgentChat** (`blocks-antd-x`): on `onError`, drop assistant messages with no parts so the user can simply retry.
- **handleAgentChat** (`ai-utils`):
  - ignore empty messages before validation (nothing in them for the model);
  - run validation inside the same try as the stream read so the fault is logged server-side (`Agent stream failed.`);
  - pass an `onError` to `createUIMessageStream` that maps `TypeValidationError` to a short client message instead of the value dump. Other errors keep their message.

## Tests

`@lowdefy/ai-utils`: 176 passed (3 new: empty messages dropped, validation failure logged + written as a stream error, `onError` redaction).

https://claude.ai/code/session_01QiqYjqaQEmWiYu9kDxBbVZ
