### PR TITLE
fix(build): swc test-file exclusion matched commands/test/test.js — lowdefy test never shipped

### DIFF
--- a/.changeset/cli-test-command-ships.md
+++ b/.changeset/cli-test-command-ships.md
@@ -1,0 +1,5 @@
+---
+'lowdefy': patch
+---
+
+fix(cli): the `lowdefy test` command ships in the published package. The root swc config excluded test files with an unescaped `.*.test.js$`, which also matched `commands/test/test.js`, so the compiled CLI was missing the module `program.js` imports and every `lowdefy` command failed with `ERR_MODULE_NOT_FOUND` on 0.0.0-experimental-20260905094305. The pattern now escapes its dots.

--- a/.swcrc
+++ b/.swcrc
@@ -1,5 +1,5 @@
 {
-  "exclude": [".*.test.js$", ".*/tests/.*", ".*/__mocks__/.*"],
+  "exclude": [".*\\.test\\.js$", ".*/tests/.*", ".*/__mocks__/.*"],
   "jsc": {
     "parser": {
       "syntax": "ecmascript",


### PR DESCRIPTION
`lowdefy@0.0.0-experimental-20260905094305` is unusable: every command fails with

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '…/lowdefy/dist/commands/test/test.js' imported from …/lowdefy/dist/program.js
```

The tarball has `dist/commands/test/{discoverJourneys,formatJourneyResult,journeySchema,runJourney,startDevServer,validateJourney}.js` but not `test.js`. Cause: the root `.swcrc` excludes `".*.test.js$"` — with the dots unescaped, `commands/test/test.js` matches (`…/test` + any char + `test.js`), so swc skipped the command module that `program.js` imports.

Fix: `".*\\.test\\.js$"`. After `pnpm build` in `packages/cli`, `dist/commands/test/test.js` exists and `node dist/index.js test --help` prints the command's usage. Changeset for `lowdefy` (patch). Needs a new experimental publish before downstream apps can take 20260905094305's features.

https://claude.ai/code/session_01DyLjzZAAFJuX9FioZTM6Fg