### PR TITLE
fix(server-dev): one event stream per dev tab — a third tab of the same app stalled every later fetch

### DIFF
--- a/.changeset/dev-client-single-event-stream.md
+++ b/.changeset/dev-client-single-event-stream.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/server-dev': patch
+---
+
+fix(server-dev): a dev tab now holds one event-stream connection instead of two. The dev server runs on HTTP/1.1, where browsers allow six connections per host, and each open event stream keeps one for the life of the tab. With the config-reload stream and the inspector stream both open per tab, three tabs of the same app saturated the pool and the next request on any of them queued forever — the page sat on its loading skeleton with a request pending and no server error. The inspector now listens on the reload stream and reports page navigation with a small POST instead of reconnecting. The manager's proxy also now closes the upstream request when a browser tab disconnects, so closed tabs leave the inspectable-tab registry instead of lingering and shadowing live ones.

--- a/code-docs/servers/server-dev.md
+++ b/code-docs/servers/server-dev.md
@@ -623,6 +623,18 @@ const Reload = ({ children, basePath, lowdefy }) => {
 
 Tailwind CSS updates arrive through Vite HMR (`globals.css` is in the dev module graph) — the old `tailwind-jit.css` link cache-bust is gone.
 
+### One Stream Per Tab
+
+Dev serves over HTTP/1.1, where browsers allow six connections per host, and an open event stream holds one for the life of the tab. The `/api/reload` EventSource in `Reload.jsx` is therefore the **only** stream a tab opens, and every other dev-only channel rides it:
+
+- `reload.js` registers each connection as an inspectable tab in `lib/docs/tabChannel.js` and sends the id it chose as the first event (`tab`). Agent inspect/eval requests (`/lowdefy-docs/inspect-state`, `eval-operator`) arrive on the same stream as `inspect-request` / `eval-request` events.
+- `Reload.jsx` publishes `{ source, tabId }` through `client/DevStreamContext.js`; `Inspector.jsx` (rendered inside `Reload`'s render prop) attaches its listeners to that source instead of opening its own EventSource.
+- Page navigation is reported with a POST to `/api/dev-inspect/page` (`{ tabId, pageId }` → `updateTabPage`) rather than reconnecting, so the registry stays current without churning connections or file watchers.
+
+Before this, the inspector opened a second stream per tab and reconnected it on every navigation; three tabs of one app saturated the browser's connection pool and the next fetch on any of them queued forever — the page sat on its skeleton with a request pending and no server error.
+
+The manager's proxy (`manager/processes/startProxy.mjs`) holds the public port and forwards to the Vite child. It destroys the upstream request when the client closes mid-response, so a closed tab reaches `stream.onAbort` in the child and its tab registration and file watcher are released. Without that the child never saw the disconnect: the SSE loop kept writing to a dead socket and closed tabs stayed in the registry, shadowing live ones in `findTab`.
+
 ### Reload Trigger
 
 **File:** `manager/processes/reloadClients.mjs`

--- a/packages/servers/server-dev/client/DevStreamContext.js
+++ b/packages/servers/server-dev/client/DevStreamContext.js
@@ -1,0 +1,30 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { createContext } from 'react';
+
+// The one /api/reload EventSource a dev tab holds, owned by Reload.jsx and
+// shared with Inspector.jsx: { source, tabId }. Dev runs on HTTP/1.1, where
+// browsers cap connections per host at six and an open event stream holds
+// one for the life of the tab. Two streams per tab meant three tabs of the
+// same app saturated the pool and the next fetch queued forever, so every
+// dev-only channel rides this single stream instead of opening its own.
+//   - source: the EventSource, null until Reload's effect has opened it.
+//   - tabId: the id the server assigned this connection in its tab registry
+//     (lib/docs/tabChannel.js), null until the stream's `tab` event arrives.
+const DevStreamContext = createContext({ source: null, tabId: null });
+
+export default DevStreamContext;

--- a/packages/servers/server-dev/client/Inspector.jsx
+++ b/packages/servers/server-dev/client/Inspector.jsx
@@ -14,38 +14,49 @@
   limitations under the License.
 */
 
-import { useEffect, useRef } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 
 import { type, serializer } from '@lowdefy/helpers';
 
-// Dev-only agent-state-xray channel — a sibling of Reload.jsx, but with its
-// own /api/reload SSE connection (rather than reusing Reload's) so that
-// connection can carry ?pageId=<pageId>. routes/reload.js only registers a
-// connection as an inspectable tab (lib/docs/tabChannel.js) when that query
-// param is present, which keeps Reload.jsx's plain reload/ping connection
-// out of the tab registry entirely.
+import DevStreamContext from './DevStreamContext.js';
+
+// Dev-only agent-state-xray channel. Listens for inspect-request/eval-request
+// events on the tab's single /api/reload EventSource (owned by Reload.jsx,
+// shared through DevStreamContext) rather than opening its own — a second
+// stream per tab exhausted the browser's HTTP/1.1 connection pool once a few
+// tabs of the same app were open, and every later fetch queued forever.
 //
-// pageId tracking: this effect depends on `pageId`, so React tears down and
-// reopens the EventSource (a fresh connection, fresh tab id server-side)
-// whenever the developer navigates to a different page — see the longer
-// design note in src/routes/reload.js.
+// pageId tracking: routes/reload.js registers every connection as an
+// inspectable tab (lib/docs/tabChannel.js) and announces the tab id on the
+// stream. This component then posts { tabId, pageId } to
+// /api/dev-inspect/page whenever the developer navigates, so the registry's
+// view of "what page is this tab on" stays current without reconnecting.
 //
 // Never let a bad payload or a plugin's operator error crash the app this is
 // piggybacking on — every handler is wrapped, and the component itself
 // always renders null.
-function postResult({ basePath, requestId, result }) {
+function postJson({ basePath, path, body }) {
   try {
-    fetch(`${basePath}/api/dev-inspect`, {
+    fetch(`${basePath}/api/dev-inspect${path}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ requestId, result }),
+      body: JSON.stringify(body),
     }).catch(() => {
       // Best-effort — a failed callback just leaves the agent's request to
-      // time out server-side.
+      // time out server-side, and a failed page update leaves the tab
+      // registered on its previous page.
     });
   } catch {
     // JSON.stringify or fetch throwing synchronously — still best-effort.
   }
+}
+
+function postResult({ basePath, requestId, result }) {
+  postJson({ basePath, path: '', body: { requestId, result } });
+}
+
+function postTabPage({ basePath, tabId, pageId }) {
+  postJson({ basePath, path: '/page', body: { tabId, pageId } });
 }
 
 function buildSnapshot({ lowdefy, pageId }) {
@@ -133,17 +144,16 @@ function evalExpression({ lowdefy, pageId, expression }) {
 }
 
 const Inspector = ({ basePath, lowdefy, pageId }) => {
+  const { source, tabId } = useContext(DevStreamContext);
   const pageIdRef = useRef(pageId);
   pageIdRef.current = pageId;
 
   useEffect(() => {
-    if (type.isNone(pageId)) {
+    if (type.isNone(source)) {
       return undefined;
     }
 
-    const sse = new EventSource(`${basePath}/api/reload?pageId=${encodeURIComponent(pageId)}`);
-
-    sse.addEventListener('inspect-request', (message) => {
+    const onInspectRequest = (message) => {
       let requestId;
       try {
         const data = JSON.parse(message.data);
@@ -154,9 +164,9 @@ const Inspector = ({ basePath, lowdefy, pageId }) => {
       } catch (error) {
         postResult({ basePath, requestId, result: { error: error.message } });
       }
-    });
+    };
 
-    sse.addEventListener('eval-request', (message) => {
+    const onEvalRequest = (message) => {
       let requestId;
       try {
         const data = JSON.parse(message.data);
@@ -171,12 +181,22 @@ const Inspector = ({ basePath, lowdefy, pageId }) => {
       } catch (error) {
         postResult({ basePath, requestId, result: { error: error.message } });
       }
-    });
-
-    return () => {
-      sse.close();
     };
-  }, [basePath, lowdefy, pageId]);
+
+    source.addEventListener('inspect-request', onInspectRequest);
+    source.addEventListener('eval-request', onEvalRequest);
+    return () => {
+      source.removeEventListener('inspect-request', onInspectRequest);
+      source.removeEventListener('eval-request', onEvalRequest);
+    };
+  }, [basePath, lowdefy, source]);
+
+  useEffect(() => {
+    if (type.isNone(tabId) || type.isNone(pageId)) {
+      return;
+    }
+    postTabPage({ basePath, tabId, pageId });
+  }, [basePath, tabId, pageId]);
 
   useEffect(() => {
     if (type.isNone(pageId)) {

--- a/packages/servers/server-dev/client/Reload.jsx
+++ b/packages/servers/server-dev/client/Reload.jsx
@@ -16,15 +16,21 @@
 
 import React, { useEffect, useState } from 'react';
 
+import DevStreamContext from './DevStreamContext.js';
 import useMutateCache from '../lib/client/utils/useMutateCache.js';
 import waitForRestartedServer from '../lib/client/utils/waitForRestartedServer.js';
 
 // SSE listener — config rebuilds notify via /api/reload. Tailwind CSS updates
 // arrive through Vite HMR now (globals.css is in the dev module graph), so
 // the old tailwind-jit.css link cache-bust is gone.
+//
+// This is the tab's only EventSource. It is shared through DevStreamContext
+// so Inspector.jsx can listen on the same connection instead of opening a
+// second one — see the connection-limit note in DevStreamContext.js.
 const Reload = ({ children, basePath, lowdefy }) => {
   const [reset, setReset] = useState(false);
   const [restarting, setRestarting] = useState(false);
+  const [devStream, setDevStream] = useState({ source: null, tabId: null });
   // reset is a one-shot boolean the engine lowers only after a page mounts
   // (getContext.js) — while a page is suspended it stays true and setReset(true)
   // bails out of re-rendering. The tick always changes, so every reload event
@@ -35,6 +41,15 @@ const Reload = ({ children, basePath, lowdefy }) => {
   const mutateCache = useMutateCache(basePath);
   useEffect(() => {
     const sse = new EventSource(`${basePath}/api/reload`);
+
+    // routes/reload.js registers every connection as an inspectable tab and
+    // announces the id it chose as the first event on the stream. The stream
+    // is published to consumers only then, in one state update, so the page
+    // subtree re-renders once at mount rather than once per field.
+    sse.addEventListener('tab', (message) => {
+      const { tabId } = JSON.parse(message.data);
+      setDevStream({ source: sse, tabId });
+    });
 
     sse.addEventListener('reload', () => {
       // add a update delay to prevent rerender before server is shut down for rebuild, ideally we don't want to do this.
@@ -60,7 +75,11 @@ const Reload = ({ children, basePath, lowdefy }) => {
       sse.close();
     };
   }, []);
-  return <>{children({ reset, setReset, restarting })}</>;
+  return (
+    <DevStreamContext.Provider value={devStream}>
+      {children({ reset, setReset, restarting })}
+    </DevStreamContext.Provider>
+  );
 };
 
 export default Reload;

--- a/packages/servers/server-dev/client/Routing.jsx
+++ b/packages/servers/server-dev/client/Routing.jsx
@@ -72,40 +72,43 @@ function Routing({ auth, lowdefy, router }) {
 
   return (
     <>
-      <Inspector basePath={router.basePath} lowdefy={lowdefy} pageId={pageId} />
       <FeedbackMount basePath={router.basePath} lowdefy={lowdefy} pageId={pageId} />
       <OpenInEditorListener basePath={router.basePath} pageId={pageId} />
       <Reload basePath={router.basePath} lowdefy={lowdefy}>
-        {(resetContext) =>
-          // Rendered here, not in Page — Page sits below the Suspense boundary
-          // and cannot render anything while its config fetch is suspended, so
-          // a restarting server would present as "Building page..." forever.
-          resetContext.restarting ? (
-            <RestartingPage />
-          ) : (
-            <Suspense key={`${pageId}_${getReloadVersion()}`} fallback={<BuildingPage />}>
-              <Page
-                auth={auth}
-                Components={{ Head, Link }}
-                config={{
-                  rootConfig,
-                }}
-                jsMap={staticJsMap}
-                lowdefy={lowdefy}
-                pageId={pageId}
-                resetContext={resetContext}
-                router={router}
-                types={{
-                  actions,
-                  blockMetas,
-                  blocks,
-                  icons,
-                  operators,
-                }}
-              />
-            </Suspense>
-          )
-        }
+        {(resetContext) => (
+          <>
+            {/* Inside Reload so it can share Reload's event stream (DevStreamContext). */}
+            <Inspector basePath={router.basePath} lowdefy={lowdefy} pageId={pageId} />
+            {/* Rendered here, not in Page — Page sits below the Suspense boundary
+                and cannot render anything while its config fetch is suspended, so
+                a restarting server would present as "Building page..." forever. */}
+            {resetContext.restarting ? (
+              <RestartingPage />
+            ) : (
+              <Suspense key={`${pageId}_${getReloadVersion()}`} fallback={<BuildingPage />}>
+                <Page
+                  auth={auth}
+                  Components={{ Head, Link }}
+                  config={{
+                    rootConfig,
+                  }}
+                  jsMap={staticJsMap}
+                  lowdefy={lowdefy}
+                  pageId={pageId}
+                  resetContext={resetContext}
+                  router={router}
+                  types={{
+                    actions,
+                    blockMetas,
+                    blocks,
+                    icons,
+                    operators,
+                  }}
+                />
+              </Suspense>
+            )}
+          </>
+        )}
       </Reload>
     </>
   );

--- a/packages/servers/server-dev/manager/processes/startProxy.mjs
+++ b/packages/servers/server-dev/manager/processes/startProxy.mjs
@@ -97,6 +97,13 @@ function forwardRequest(context, req, res) {
     });
     req.pipe(proxyReq);
     req.on('error', () => proxyReq.destroy());
+    // A client that goes away mid-response (a closed browser tab holding the
+    // reload SSE stream, an agent dropping its MCP stream) must reach the
+    // child as an aborted request — pipe() only unpipes, so without this the
+    // child keeps the stream open and, for SSE, its tab registered forever.
+    res.on('close', () => {
+      if (!res.writableFinished) proxyReq.destroy();
+    });
   });
 }
 
@@ -122,6 +129,8 @@ function forwardUpgrade(context, req, socket, head) {
     });
     upstream.on('error', () => socket.destroy());
     socket.on('error', () => upstream.destroy());
+    upstream.on('close', () => socket.destroy());
+    socket.on('close', () => upstream.destroy());
   });
 }
 

--- a/packages/servers/server-dev/manager/processes/startProxy.test.mjs
+++ b/packages/servers/server-dev/manager/processes/startProxy.test.mjs
@@ -1,0 +1,102 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import http from 'node:http';
+import net from 'node:net';
+
+import { jest } from '@jest/globals';
+
+const { default: startProxy } = await import('./startProxy.mjs');
+
+function listen(server) {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve(server.address().port));
+  });
+}
+
+function close(server) {
+  return new Promise((resolve) => {
+    server.closeAllConnections?.();
+    server.close(() => resolve());
+  });
+}
+
+function getFreePort() {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+let child;
+let context;
+
+afterEach(async () => {
+  if (context?.proxyServer) await close(context.proxyServer);
+  if (child) await close(child);
+  child = undefined;
+  context = undefined;
+});
+
+async function startChildAndProxy(handler) {
+  child = http.createServer(handler);
+  const internalPort = await listen(child);
+  context = {
+    internalPort,
+    options: { port: await getFreePort() },
+    logger: { debug: jest.fn() },
+  };
+  await startProxy(context);
+  return context.options.port;
+}
+
+test('startProxy forwards a request to the child and relays its response', async () => {
+  const port = await startChildAndProxy((req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ path: req.url }));
+  });
+  const response = await fetch(`http://localhost:${port}/api/ping?x=1`);
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({ path: '/api/ping?x=1' });
+});
+
+test('startProxy aborts the child request when the client drops a streaming response', async () => {
+  let upstreamClosed;
+  const upstreamClosedPromise = new Promise((resolve) => {
+    upstreamClosed = resolve;
+  });
+  const port = await startChildAndProxy((req, res) => {
+    res.writeHead(200, { 'content-type': 'text/event-stream' });
+    res.flushHeaders();
+    res.write('event: tab\ndata: {}\n\n');
+    // Never ends — like the reload SSE stream, it lives until the client goes.
+    req.on('close', () => upstreamClosed('closed'));
+  });
+
+  const clientRequest = http.get(`http://localhost:${port}/api/reload`);
+  const clientResponse = await new Promise((resolve) => clientRequest.on('response', resolve));
+  await new Promise((resolve) => clientResponse.once('data', resolve));
+  clientRequest.destroy();
+
+  const outcome = await Promise.race([
+    upstreamClosedPromise,
+    new Promise((resolve) => setTimeout(() => resolve('still open'), 2000)),
+  ]);
+  expect(outcome).toBe('closed');
+});

--- a/packages/servers/server-dev/src/routes/devInspect.js
+++ b/packages/servers/server-dev/src/routes/devInspect.js
@@ -19,7 +19,7 @@ import { serializer } from '@lowdefy/helpers';
 import { readCheckpoint } from '../../lib/docs/checkpointStore.js';
 import { loadMocks } from '../../lib/docs/devMockRegistry.js';
 import getPathSegments from '../lib/getPathSegments.js';
-import { listTabs, resolveTabRequest } from '../../lib/docs/tabChannel.js';
+import { listTabs, resolveTabRequest, updateTabPage } from '../../lib/docs/tabChannel.js';
 
 // Origin/host check mirrors clientError.js — this endpoint accepts a POST
 // from Inspector.jsx (a same-origin dev-only browser component), not from
@@ -62,10 +62,23 @@ function handleCheckpointBootstrap(c, { name }) {
   );
 }
 
+// Inspector.jsx posts { tabId, pageId } here whenever its tab navigates, so
+// the tab registry (lib/docs/tabChannel.js) knows which page each connected
+// tab is on without the tab reconnecting its event stream.
+async function handleTabPage(c) {
+  const { tabId, pageId } = await c.req.json();
+  if (!tabId) {
+    return c.json({ error: 'Missing "tabId".' }, 400);
+  }
+  updateTabPage({ id: tabId, pageId });
+  return c.json({ ok: true });
+}
+
 // GET lists connected tabs for diagnostics (or, under /checkpoint/<name>,
-// bootstraps a human tab from a state checkpoint); POST is the answer leg of
-// the SSE request/response round trip (Inspector.jsx posts back {requestId,
-// result} after handling an inspect-request/eval-request event).
+// bootstraps a human tab from a state checkpoint); POST /page updates the
+// page a connected tab is on; POST at the root is the answer leg of the SSE
+// request/response round trip (Inspector.jsx posts back {requestId, result}
+// after handling an inspect-request/eval-request event).
 async function devInspectHandler(c) {
   if (c.req.method === 'GET') {
     const segments = getPathSegments(c, '/api/dev-inspect/');
@@ -81,6 +94,10 @@ async function devInspectHandler(c) {
 
   if (!checkOrigin(c)) {
     return c.json({ error: 'Forbidden' }, 403);
+  }
+
+  if (getPathSegments(c, '/api/dev-inspect/')[0] === 'page') {
+    return handleTabPage(c);
   }
 
   const { requestId, result } = await c.req.json();

--- a/packages/servers/server-dev/src/routes/devInspect.test.mjs
+++ b/packages/servers/server-dev/src/routes/devInspect.test.mjs
@@ -1,0 +1,119 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { Hono } from 'hono';
+import { jest } from '@jest/globals';
+
+const { listTabs, registerTab, requestFromTab, unregisterTab } = await import(
+  '../../lib/docs/tabChannel.js'
+);
+const { default: devInspectHandler } = await import('./devInspect.js');
+
+function createApp() {
+  const app = new Hono();
+  app.all('/api/dev-inspect', devInspectHandler);
+  app.all('/api/dev-inspect/*', devInspectHandler);
+  return app;
+}
+
+const sameOriginHeaders = {
+  host: 'localhost:3001',
+  origin: 'http://localhost:3001',
+  'content-type': 'application/json',
+};
+
+// tabChannel keeps its registries at module scope, so clear connected tabs
+// between tests to keep them independent.
+afterEach(() => {
+  listTabs().forEach((tab) => unregisterTab({ id: tab.id }));
+});
+
+test('GET /api/dev-inspect lists connected tabs', async () => {
+  registerTab({ id: 'tab-1', pageId: 'home', send: jest.fn() });
+  const res = await createApp().request('/api/dev-inspect');
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.tabs).toHaveLength(1);
+  expect(body.tabs[0]).toMatchObject({ id: 'tab-1', pageId: 'home' });
+});
+
+test('POST /api/dev-inspect/page returns 403 when the Origin header is missing', async () => {
+  registerTab({ id: 'tab-1', pageId: 'home', send: jest.fn() });
+  const res = await createApp().request('/api/dev-inspect/page', {
+    method: 'POST',
+    headers: { host: 'localhost:3001', 'content-type': 'application/json' },
+    body: JSON.stringify({ tabId: 'tab-1', pageId: 'about' }),
+  });
+  expect(res.status).toBe(403);
+  expect(listTabs()[0].pageId).toBe('home');
+});
+
+test('POST /api/dev-inspect/page moves a connected tab to the posted page', async () => {
+  registerTab({ id: 'tab-1', pageId: 'home', send: jest.fn() });
+  const res = await createApp().request('/api/dev-inspect/page', {
+    method: 'POST',
+    headers: sameOriginHeaders,
+    body: JSON.stringify({ tabId: 'tab-1', pageId: 'about' }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true });
+  expect(listTabs()[0].pageId).toBe('about');
+});
+
+test('POST /api/dev-inspect/page returns 400 when tabId is missing', async () => {
+  const res = await createApp().request('/api/dev-inspect/page', {
+    method: 'POST',
+    headers: sameOriginHeaders,
+    body: JSON.stringify({ pageId: 'about' }),
+  });
+  expect(res.status).toBe(400);
+  expect(await res.json()).toEqual({ error: 'Missing "tabId".' });
+});
+
+test('POST /api/dev-inspect/page for a tab that already disconnected returns ok', async () => {
+  const res = await createApp().request('/api/dev-inspect/page', {
+    method: 'POST',
+    headers: sameOriginHeaders,
+    body: JSON.stringify({ tabId: 'gone', pageId: 'about' }),
+  });
+  expect(res.status).toBe(200);
+  expect(listTabs()).toHaveLength(0);
+});
+
+test('POST /api/dev-inspect resolves a pending tab request with the posted result', async () => {
+  const send = jest.fn();
+  registerTab({ id: 'tab-1', pageId: 'home', send });
+  const pending = requestFromTab({ pageId: 'home', event: 'inspect-request' });
+  const [, { requestId }] = send.mock.calls[0];
+
+  const res = await createApp().request('/api/dev-inspect', {
+    method: 'POST',
+    headers: sameOriginHeaders,
+    body: JSON.stringify({ requestId, result: { state: { a: 1 } } }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true });
+  await expect(pending).resolves.toEqual({ state: { a: 1 } });
+});
+
+test('POST /api/dev-inspect returns 400 when requestId is missing', async () => {
+  const res = await createApp().request('/api/dev-inspect', {
+    method: 'POST',
+    headers: sameOriginHeaders,
+    body: JSON.stringify({ result: {} }),
+  });
+  expect(res.status).toBe(400);
+});

--- a/packages/servers/server-dev/src/routes/reload.js
+++ b/packages/servers/server-dev/src/routes/reload.js
@@ -23,16 +23,18 @@ import { registerTab, unregisterTab } from '../../lib/docs/tabChannel.js';
 
 // SSE endpoint — notifies the client when build/reload is written so it can
 // mutate the SWR cache and refetch config. Also doubles as the transport for
-// the agent-state-xray tab channel (lib/docs/tabChannel.js): a connection
-// that includes ?pageId=<id> is registered as an inspectable dev tab so an
-// agent can push it inspect-request/eval-request SSE events.
+// the agent-state-xray tab channel (lib/docs/tabChannel.js): every
+// connection is a browser tab (client/Reload.jsx opens exactly one per tab),
+// so each is registered as an inspectable dev tab and told its id in a `tab`
+// event, after which an agent can push it inspect-request/eval-request
+// events on the same stream.
 //
-// pageId tracking design: Inspector.jsx (not Reload.jsx) owns this query
-// param, and re-opens its EventSource — new connection, new tab id — every
-// time the developer navigates to a different page. That keeps tabChannel's
-// view of "what page is this tab on" always correct without a separate
-// ping route: Reload.jsx's own connection never sends pageId, so it is never
-// registered as a tab and can't be mistaken for one by requestFromTab.
+// One stream per tab is deliberate: dev serves over HTTP/1.1, where browsers
+// allow six connections per host, and an open event stream holds one for the
+// life of the tab. The tab's page is not carried on this connection — it
+// would force a reconnect on every navigation — but posted by
+// client/Inspector.jsx to /api/dev-inspect/page (routes/devInspect.js) as
+// { tabId, pageId } whenever it changes.
 async function reloadHandler(c) {
   return streamSSE(c, async (stream) => {
     const watcher = chokidar.watch(['./build/reload'], {
@@ -40,24 +42,20 @@ async function reloadHandler(c) {
       ignoreInitial: true,
     });
 
-    const pageId = c.req.query('pageId');
-    const tabId = pageId === undefined ? undefined : randomUUID();
-    if (tabId) {
-      registerTab({
-        id: tabId,
-        pageId,
-        send: (event, data) => stream.writeSSE({ event, data: JSON.stringify(data) }),
-      });
-    }
+    const tabId = randomUUID();
+    registerTab({
+      id: tabId,
+      send: (event, data) => stream.writeSSE({ event, data: JSON.stringify(data) }),
+    });
 
     let open = true;
     stream.onAbort(() => {
       open = false;
       watcher.close();
-      if (tabId) {
-        unregisterTab({ id: tabId });
-      }
+      unregisterTab({ id: tabId });
     });
+
+    await stream.writeSSE({ event: 'tab', data: JSON.stringify({ tabId }) });
 
     const reload = () => {
       stream.writeSSE({ event: 'reload', data: JSON.stringify({}) });


### PR DESCRIPTION
## Problem

A dev page "loads forever": root config, session and page config return in ~100ms, then the first request the page fires sits pending indefinitely. No server error, and the dev server only logs the request as aborted when the tab navigates away.

The dev server runs on HTTP/1.1, where Chrome allows six connections per host and port. The dev client opened **two** event-stream connections per tab — one for config reloads (`Reload.jsx`) and one for the inspector (`Inspector.jsx`), which also reconnected on every navigation. Three tabs of the same app saturated the pool, and any further fetch queued forever.

| Other tabs of the app open | Before                                   | After              |
| -------------------------- | ---------------------------------------- | ------------------ |
| 0 or 1                     | loads                                    | loads              |
| 2                          | config loads, first request pends forever | loads              |
| 3                          | page never finishes loading              | loads              |

Verified with Playwright: five tabs of one app all load with their mount request returning 200; navigation updates the tab registry; tab inspection through `/lowdefy-docs/inspect-state/:pageId?source=tab` works; a closed tab leaves the registry within 200ms.

## Fix

- **One stream per tab.** `Reload.jsx` owns the tab's only `EventSource` and shares it through a new `DevStreamContext`. `Inspector.jsx` attaches its `inspect-request` / `eval-request` listeners to that source instead of opening its own. `Routing.jsx` renders `Inspector` inside `Reload`'s render prop so it sits in the provider.
- **No reconnect on navigation.** `routes/reload.js` registers every connection as an inspectable tab and announces the id it chose in a `tab` event. `Inspector.jsx` posts `{ tabId, pageId }` to a new `POST /api/dev-inspect/page` (`updateTabPage`, which already existed in `tabChannel.js`) whenever the page changes.
- **Proxy propagates disconnects.** While verifying, closed tabs never left the registry through the public port, although they did against the Vite child port directly. `manager/processes/startProxy.mjs` piped the upstream response but never destroyed the upstream request when the client went away, so the child never saw the abort, the SSE loop wrote to a dead socket forever, and stale tabs shadowed live ones in `findTab`. The proxy now destroys the upstream request on client close mid-response (and splices socket closes on upgrades).

Performance: strictly less work than before — one stream instead of two per tab, and one small fire-and-forget POST per navigation instead of tearing down and reopening a stream (which also started a fresh chokidar watcher server-side each time). The only added cost is one extra React re-render of the page subtree at mount when the `tab` event arrives.

## Tests

- `src/routes/devInspect.test.mjs` (new): tab listing, the page-update route incl. origin check and validation, and the request/response answer leg.
- `manager/processes/startProxy.test.mjs` (new): forwards a request; aborts the child request when the client drops a streaming response (fails without the proxy fix).
- Backport of #2372 (v7); the cherry-pick applied cleanly. The server-dev suites touched by this change pass locally; four unrelated suites (auth, errorHandler, getDevSession, createDocsMcpServer) fail locally only because my checkout carries the v7 install and lacks v6-only modules, so CI is the reference for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NC4NLjPGokMFmckvCvKKai
