### PR TITLE
feat(auth): magic-link landing page keeps the token unconsumed until a real click

### DIFF
--- a/.changeset/magic-link-landing-page.md
+++ b/.changeset/magic-link-landing-page.md
@@ -1,0 +1,30 @@
+---
+'@lowdefy/actions-core': patch
+'@lowdefy/email-templates': patch
+'@lowdefy/engine': patch
+'@lowdefy/client': patch
+'@lowdefy/build': patch
+'@lowdefy/api': patch
+---
+
+feat(api,client,build,actions-core): magic-link landing page keeps the token unconsumed until a real click
+
+A magic-link sign-in token can only be used once, and the auth server spends it on
+the first request to the link — including a request nobody made. Corporate email
+security (Microsoft Defender Safe Links, Proofpoint URL Defense, Mimecast) opens
+every link in a message as it is delivered, so by the time the person clicks, the
+link is already used up and they land on the error page.
+
+Set the new `auth.authPages.magicLink` to a page in your app and the sign-in email
+links there instead, carrying the token and the sign-in destinations along. The
+page just sits there when a scanner fetches it; a button on it runs the new
+`MagicLinkVerify` action, which finishes the sign-in. The token is only spent when
+a person clicks, so scanned mailboxes can sign in again.
+
+`MagicLinkVerify` needs no configuration — it reads the token and the destinations
+from the page's own address. Bind it to a button click, never to page load: a
+scanner that runs the page's JavaScript would use up the token all the same.
+
+Leave `auth.authPages.magicLink` unset and magic-link sign-in behaves exactly as
+before. The sign-in email also now shows the link as readable text under the
+button, for mail clients that strip or rewrite buttons.

--- a/packages/api/src/routes/auth/getBetterAuthConfig.js
+++ b/packages/api/src/routes/auth/getBetterAuthConfig.js
@@ -122,6 +122,33 @@ const ADMIN_PATHS_DISABLED = [
 // scopes_supported) - both read this list so they can never drift apart.
 const MCP_OAUTH_SCOPES = ['mcp:read', 'mcp:write', 'offline_access'];
 
+// The verify link BetterAuth mints is single-use and is consumed atomically by
+// the first GET (magicLinkVerify -> consumeVerificationValue; allowedAttempts is
+// ignored upstream). Corporate mail security - Defender Safe Links, Proofpoint
+// URL Defense, Mimecast - pre-fetches every link in a delivered message, so that
+// first GET is a scanner and the person clicking lands on INVALID_TOKEN. When the
+// app declares a landing page, the email points there instead: the page is inert
+// to a fetch and only the MagicLinkVerify action on a real click walks to verify.
+//
+// Every query BetterAuth put on the verify URL - token, callbackURL, and the
+// newUserCallbackURL / errorCallbackURL it adds when the caller supplied them -
+// is copied onto the landing URL, because the action reads its defaults back out
+// of the page query. The origin comes from the verify URL rather than
+// baseUrlOrigin: on the zero-config path (no BETTER_AUTH_URL) baseUrlOrigin is
+// undefined while BetterAuth has already derived the request's origin here.
+function buildMagicLinkUrl({ authConfig, config, url }) {
+  const landingPage = authConfig.authPages?.magicLink;
+  if (!type.isString(landingPage)) {
+    return url;
+  }
+  const verifyUrl = new URL(url);
+  const landingUrl = new URL(`${config.basePath ?? ''}${landingPage}`, verifyUrl.origin);
+  verifyUrl.searchParams.forEach((value, key) => {
+    landingUrl.searchParams.set(key, value);
+  });
+  return landingUrl.href;
+}
+
 function getBetterAuthConfig({
   appMeta,
   authJson,
@@ -355,7 +382,7 @@ function getBetterAuthConfig({
           const context = createSystemContext({ auth: getAuth() });
           const { subject, html, text } = await renderAuthEmail({
             flow: 'magicLink',
-            vars: { url },
+            vars: { url: buildMagicLinkUrl({ authConfig, config, url }) },
             authEmailConfig: authConfig.email,
             baseURL: baseUrlOrigin,
             context,

--- a/packages/api/src/routes/auth/getBetterAuthConfig.test.js
+++ b/packages/api/src/routes/auth/getBetterAuthConfig.test.js
@@ -647,6 +647,97 @@ describe('auth email flows route through renderAuthEmail and sendEmail', () => {
     );
   });
 
+  test('sendMagicLink links at the verify endpoint when authPages.magicLink is unset', async () => {
+    const options = getBetterAuthConfig({
+      appMeta,
+      authJson: createAuthJson({
+        email: emailConfig,
+        authPages: { signIn: '/login', error: '/auth/error' },
+        magicLink: { enabled: true, expiresIn: 300, disableSignUp: false },
+      }),
+      config: { basePath: '/base' },
+      createSystemContext,
+      getAuth,
+      logger: createLogger(),
+      plugins: createPlugins(),
+      secrets: baseSecrets,
+    });
+    const magicPlugin = options.plugins.find((p) => p.id === 'magic-link');
+    await magicPlugin.options.sendMagicLink({
+      email: 'user@example.com',
+      url: 'https://app.example.com/base/api/auth/magic-link/verify?token=mmm&callbackURL=%2Fbase%2Freports',
+    });
+    expect(mockRenderAuthEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        vars: {
+          url: 'https://app.example.com/base/api/auth/magic-link/verify?token=mmm&callbackURL=%2Fbase%2Freports',
+        },
+      })
+    );
+  });
+
+  // The landing page keeps the single-use token unspent until a real click -
+  // mail-security scanners GET the emailed link at delivery time, and the verify
+  // endpoint consumes the token on that first GET.
+  test('sendMagicLink links at the landing page, carrying the whole verify query', async () => {
+    const options = getBetterAuthConfig({
+      appMeta,
+      authJson: createAuthJson({
+        email: emailConfig,
+        authPages: { signIn: '/login', error: '/auth/error', magicLink: '/magic-link' },
+        magicLink: { enabled: true, expiresIn: 300, disableSignUp: false },
+      }),
+      config: { basePath: '/base' },
+      createSystemContext,
+      getAuth,
+      logger: createLogger(),
+      plugins: createPlugins(),
+      secrets: baseSecrets,
+    });
+    const magicPlugin = options.plugins.find((p) => p.id === 'magic-link');
+    await magicPlugin.options.sendMagicLink({
+      email: 'user@example.com',
+      url: 'https://app.example.com/base/api/auth/magic-link/verify?token=mmm&callbackURL=%2Fbase%2Freports&errorCallbackURL=%2Fbase%2Fauth%2Ferror',
+    });
+    expect(mockRenderAuthEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flow: 'magicLink',
+        vars: {
+          url: 'https://app.example.com/base/magic-link?token=mmm&callbackURL=%2Fbase%2Freports&errorCallbackURL=%2Fbase%2Fauth%2Ferror',
+        },
+      })
+    );
+  });
+
+  // BETTER_AUTH_URL is unset here, so baseUrlOrigin is undefined while BetterAuth
+  // has already derived the request's origin onto the verify URL - the landing
+  // URL has to take the origin from there or it is not an absolute URL at all.
+  test('sendMagicLink takes the landing origin from the verify url, not the pinned base url', async () => {
+    const options = getBetterAuthConfig({
+      appMeta,
+      authJson: createAuthJson({
+        email: emailConfig,
+        authPages: { signIn: '/login', error: '/auth/error', magicLink: '/magic-link' },
+        magicLink: { enabled: true, expiresIn: 300, disableSignUp: false },
+      }),
+      createSystemContext,
+      getAuth,
+      logger: createLogger(),
+      plugins: createPlugins(),
+      secrets: baseSecrets,
+    });
+    const magicPlugin = options.plugins.find((p) => p.id === 'magic-link');
+    await magicPlugin.options.sendMagicLink({
+      email: 'user@example.com',
+      url: 'https://derived.example.com/api/auth/magic-link/verify?token=mmm',
+    });
+    expect(mockRenderAuthEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        vars: { url: 'https://derived.example.com/magic-link?token=mmm' },
+      })
+    );
+  });
+
   test('the invitation sender composes the accept URL when origin and acceptInvitation are set', async () => {
     process.env.BETTER_AUTH_URL = 'https://app.example.com';
     const options = getBetterAuthConfig({

--- a/packages/build/src/build/buildAuth/setAuthDefaults.js
+++ b/packages/build/src/build/buildAuth/setAuthDefaults.js
@@ -76,6 +76,10 @@ function setAuthDefaults({ components }) {
   // No default for authPages.twoFactor either - the build requires it
   // explicitly when "twoFactor.enabled" is true (validateAuthConfig), and a
   // default here would make that check unsatisfiable-by-failure.
+  // No default for authPages.magicLink - it is opt-in. Its presence is what
+  // switches the emailed link from the verify endpoint to the landing page, so
+  // defaulting it would silently point every existing magic-link app at a page
+  // it has not built.
 
   if (!type.isNone(auth.emailAndPassword)) {
     setDefault(auth.emailAndPassword, 'requireEmailVerification', false);

--- a/packages/build/src/build/buildAuth/validateAuthConfig.js
+++ b/packages/build/src/build/buildAuth/validateAuthConfig.js
@@ -205,6 +205,18 @@ function validateAuthConfig({ components }) {
     );
   }
 
+  // The magic-link landing page only has a token to spend when the engine mints
+  // the emailed link at it, and the engine does that only for an enabled
+  // magic-link login. Setting the page without the login method is therefore a
+  // page nothing ever navigates to. The reverse is not required: an app with
+  // magic-link enabled and no landing page keeps the direct verify link.
+  if (!type.isNone(auth.authPages?.magicLink) && !magicLinkEnabled) {
+    throw new ConfigError(
+      'Auth "authPages.magicLink" applies only when "magicLink.enabled" is true - the sign-in email is the only thing that navigates to the landing page.',
+      { configKey: auth.authPages['~k'] ?? configKey }
+    );
+  }
+
   const requireEmailVerification = auth.emailAndPassword?.requireEmailVerification === true;
   if ((magicLinkEnabled || requireEmailVerification) && type.isNone(auth.email)) {
     throw new ConfigError(

--- a/packages/build/src/build/buildAuth/validateAuthConfig.test.js
+++ b/packages/build/src/build/buildAuth/validateAuthConfig.test.js
@@ -896,6 +896,47 @@ test('validateAuthConfig throws when phoneNumber contains an unknown property', 
   expect(() => validateAuthConfig({ components, context })).toThrow(/contains an unknown property/);
 });
 
+test('validateAuthConfig throws when authPages.magicLink is set without magicLink enabled', () => {
+  const components = {
+    auth: {
+      secret: validSecret,
+      database: validDatabase,
+      emailAndPassword: { enabled: true },
+      authPages: { magicLink: '/magic-link' },
+    },
+  };
+  expect(() => validateAuthConfig({ components, context })).toThrow(
+    'Auth "authPages.magicLink" applies only when "magicLink.enabled" is true - the sign-in email is the only thing that navigates to the landing page.'
+  );
+});
+
+test('validateAuthConfig passes when authPages.magicLink is set with magicLink enabled', () => {
+  const components = {
+    auth: {
+      secret: validSecret,
+      database: validDatabase,
+      magicLink: { enabled: true },
+      email: { connectionId: 'email' },
+      authPages: { magicLink: '/magic-link' },
+    },
+  };
+  expect(() => validateAuthConfig({ components, context })).not.toThrow();
+});
+
+// The landing page stays opt-in: every app already shipping magic-link sign-in
+// keeps building, and keeps linking straight at the verify endpoint.
+test('validateAuthConfig does not require authPages.magicLink when magicLink is enabled', () => {
+  const components = {
+    auth: {
+      secret: validSecret,
+      database: validDatabase,
+      magicLink: { enabled: true },
+      email: { connectionId: 'email' },
+    },
+  };
+  expect(() => validateAuthConfig({ components, context })).not.toThrow();
+});
+
 test('validateAuthConfig throws when twoFactor is enabled without authPages.twoFactor', () => {
   const components = {
     auth: {

--- a/packages/build/src/lowdefySchema.js
+++ b/packages/build/src/lowdefySchema.js
@@ -1407,6 +1407,14 @@ export default {
                 type: 'Auth "authPages.acceptInvitation" should be a string.',
               },
             },
+            magicLink: {
+              type: 'string',
+              description:
+                'Public landing page the sign-in email links to instead of the verify endpoint, carrying the ?token= and callback queries forward. A MagicLinkVerify action on the page spends the token on a real click, so link-scanning mail security cannot consume it at delivery time.',
+              errorMessage: {
+                type: 'Auth "authPages.magicLink" should be a string.',
+              },
+            },
           },
           errorMessage: {
             type: 'Auth "authPages" should be an object.',

--- a/packages/client/src/auth/createAuthMethods.js
+++ b/packages/client/src/auth/createAuthMethods.js
@@ -706,6 +706,70 @@ function createAuthMethods(lowdefy, auth) {
     return data;
   }
 
+  // The landing-page half of the magic-link flow. BetterAuth's verify endpoint
+  // consumes the token atomically on its first GET, and corporate mail security
+  // (Defender Safe Links, Proofpoint URL Defense, Mimecast) GETs every link in a
+  // delivered message - so when the email points at verify directly, the scanner
+  // spends the token and the person lands on INVALID_TOKEN. With
+  // authPages.magicLink set, the engine points the email at a Lowdefy page
+  // instead, which is inert to a fetch, and this method walks to verify on a real
+  // click.
+  //
+  // No BetterAuth client call: verify answers with a Set-Cookie and its own
+  // redirect, which only a whole-document navigation can follow. That is also why
+  // the chain stops here, like every other navigating method - a step after it
+  // would race the page being replaced.
+  //
+  // The engine copied the verify URL's whole query onto the landing URL, so the
+  // token and the three destinations are already on this page. The params exist
+  // to override them; each falls back to the query value, and errorCallbackURL
+  // falls back once more to the app's authPages.error, mirroring the default
+  // Login applies when it asks for the link.
+  function magicLinkVerify({ callbackUrl, errorCallbackUrl, newUserCallbackUrl, token } = {}) {
+    const window = lowdefy._internal?.globals?.window;
+    const pageQuery = new URLSearchParams(window?.location?.search ?? '');
+    const verifyToken = type.isString(token) ? token : pageQuery.get('token');
+    if (!type.isString(verifyToken) || verifyToken === '') {
+      throw new Error(
+        'MagicLinkVerify requires a "token" param, or a "token" URL query parameter on the landing page the sign-in email links to.'
+      );
+    }
+    // Every destination here is spent by BetterAuth as a later redirect hop, so
+    // "stay put" cannot be honored - the browser has already left.
+    assertCallbackUrlNavigable({ callbackUrl, method: 'MagicLinkVerify' });
+
+    const verifyQuery = new URLSearchParams({ token: verifyToken });
+    const params = {
+      callbackURL: callbackUrl,
+      newUserCallbackURL: newUserCallbackUrl,
+      errorCallbackURL: errorCallbackUrl,
+    };
+    Object.entries(params).forEach(([key, param]) => {
+      const explicit = serializeTarget(resolveTarget({ lowdefy, target: param, name: key }));
+      const resolved = type.isNone(explicit) ? pageQuery.get(key) : explicit;
+      if (!type.isNone(resolved)) {
+        verifyQuery.set(key, resolved);
+      }
+    });
+    if (!verifyQuery.has('errorCallbackURL')) {
+      const errorPage = auth.authConfig?.authPages?.error;
+      const errorTarget = type.isString(errorPage)
+        ? serializeTarget(
+            resolveTarget({ lowdefy, target: { url: errorPage }, name: 'errorCallbackUrl' })
+          )
+        : undefined;
+      if (!type.isNone(errorTarget)) {
+        verifyQuery.set('errorCallbackURL', errorTarget);
+      }
+    }
+
+    // The same address the email used to carry: basePath, then BetterAuth's
+    // mount, which AuthConfigured gives the client as `${basePath}/api/auth`.
+    const url = `${lowdefy.basePath ?? ''}/api/auth/magic-link/verify?${verifyQuery.toString()}`;
+    lowdefy._internal.globals.window.location.assign(url);
+    return stopChain({ url });
+  }
+
   async function twoFactorDisable({ password, ...rest } = {}) {
     if (!type.isString(password)) {
       throw new Error('TwoFactorDisable requires a "password" param.');
@@ -775,6 +839,7 @@ function createAuthMethods(lowdefy, auth) {
     listOrganizations,
     login,
     logout,
+    magicLinkVerify,
     oauth2Consent,
     oauth2Continue,
     passkeyDelete,

--- a/packages/client/src/auth/createAuthMethods.test.js
+++ b/packages/client/src/auth/createAuthMethods.test.js
@@ -424,6 +424,80 @@ test('a protocol-relative ?callbackUrl= query never leaves the challenge page (o
   expect(assign.mock.calls).toEqual([['/home-page']]);
 });
 
+// The magic-link landing page: the engine put the verify query on this page's
+// URL, so the defaults come from there and the action only has to walk to the
+// verify endpoint on a real click.
+test('magicLinkVerify navigates to the verify endpoint with the token from the URL query', () => {
+  const { auth, lowdefy, assign } = setup();
+  lowdefy._internal.globals.window.location.search = '?token=abc123';
+  const { magicLinkVerify } = createAuthMethods(lowdefy, auth);
+  magicLinkVerify();
+  expect(assign.mock.calls).toEqual([['/api/auth/magic-link/verify?token=abc123']]);
+});
+
+test('magicLinkVerify carries the callback destinations from the URL query, basePath-prefixed', () => {
+  const { auth, lowdefy, assign } = setup();
+  lowdefy.basePath = '/base';
+  lowdefy._internal.globals.window.location.search =
+    '?token=abc123&callbackURL=%2Fbase%2Freports&newUserCallbackURL=%2Fbase%2Fwelcome&errorCallbackURL=%2Fbase%2Fauth%2Ferror';
+  const { magicLinkVerify } = createAuthMethods(lowdefy, auth);
+  magicLinkVerify();
+  expect(assign.mock.calls).toEqual([
+    [
+      '/base/api/auth/magic-link/verify?token=abc123&callbackURL=%2Fbase%2Freports&newUserCallbackURL=%2Fbase%2Fwelcome&errorCallbackURL=%2Fbase%2Fauth%2Ferror',
+    ],
+  ]);
+});
+
+test('magicLinkVerify prefers explicit params over the URL query values', () => {
+  const { auth, lowdefy, assign } = setup();
+  lowdefy._internal.globals.window.location.search = '?token=fromquery&callbackURL=%2Ffromquery';
+  const { magicLinkVerify } = createAuthMethods(lowdefy, auth);
+  magicLinkVerify({
+    token: 'fromparam',
+    callbackUrl: { url: '/reports' },
+    newUserCallbackUrl: { url: '/welcome' },
+    errorCallbackUrl: { url: '/oops' },
+  });
+  expect(assign.mock.calls).toEqual([
+    [
+      '/api/auth/magic-link/verify?token=fromparam&callbackURL=%2Freports&newUserCallbackURL=%2Fwelcome&errorCallbackURL=%2Foops',
+    ],
+  ]);
+});
+
+// The default Login applies when it asks for the link, applied again here so a
+// failed verify lands on the app's error page with ?error= intact.
+test('magicLinkVerify defaults errorCallbackURL to authPages.error when the query has none', () => {
+  const { auth, lowdefy, assign } = setup();
+  auth.authConfig = { providers: [], authPages: { error: '/auth/error' } };
+  lowdefy._internal.globals.window.location.search = '?token=abc123';
+  const { magicLinkVerify } = createAuthMethods(lowdefy, auth);
+  magicLinkVerify();
+  expect(assign.mock.calls).toEqual([
+    ['/api/auth/magic-link/verify?token=abc123&errorCallbackURL=%2Fauth%2Ferror'],
+  ]);
+});
+
+test('magicLinkVerify throws when neither a token param nor a ?token= query is present', () => {
+  const { auth, lowdefy, assign } = setup();
+  const { magicLinkVerify } = createAuthMethods(lowdefy, auth);
+  expect(() => magicLinkVerify()).toThrow(
+    'MagicLinkVerify requires a "token" param, or a "token" URL query parameter on the landing page the sign-in email links to.'
+  );
+  expect(assign).not.toHaveBeenCalled();
+});
+
+test('magicLinkVerify rejects callbackUrl false, which the verify redirect cannot honor', () => {
+  const { auth, lowdefy, assign } = setup();
+  lowdefy._internal.globals.window.location.search = '?token=abc123';
+  const { magicLinkVerify } = createAuthMethods(lowdefy, auth);
+  expect(() => magicLinkVerify({ callbackUrl: false })).toThrow(
+    'Invalid callbackUrl: "false" is not valid for MagicLinkVerify, which redirects through an external hop. Give a destination.'
+  );
+  expect(assign).not.toHaveBeenCalled();
+});
+
 test('twoFactorDisable calls auth.twoFactorDisable with the password', async () => {
   const { auth, lowdefy } = setup();
   const { twoFactorDisable } = createAuthMethods(lowdefy, auth);

--- a/packages/docs-content/content/actions/magiclinkverify.md
+++ b/packages/docs-content/content/actions/magiclinkverify.md
@@ -1,0 +1,113 @@
+# MagicLinkVerify
+
+```
+(params?: {
+  callbackUrl?: {
+    home?: boolean
+    pageId?: string
+    url?: string
+    urlQuery?: object
+  }
+  errorCallbackUrl?: {
+    home?: boolean
+    pageId?: string
+    url?: string
+    urlQuery?: object
+  }
+  newUserCallbackUrl?: {
+    home?: boolean
+    pageId?: string
+    url?: string
+    urlQuery?: object
+  }
+  token?: string
+}): void
+```
+
+The `MagicLinkVerify` action completes a magic-link sign-in from the landing page the sign-in email points at. It navigates the browser to the auth server's verify endpoint, which sets the session cookie and redirects the user on to their destination.
+
+## Why a landing page
+
+A magic-link token is single-use, and the verify endpoint consumes it on the **first** `GET` of the URL. Corporate mail security — Microsoft Defender Safe Links, Proofpoint URL Defense, Mimecast — fetches every link in a message as it is delivered. When the email links straight at the verify endpoint the scanner spends the token minutes before the person clicks, and the person lands on the auth error page with `INVALID_TOKEN`.
+
+Setting [`auth.authPages.magicLink`](/auth-configuration#the-magic-link-landing-page) to a page in your app moves the email's link to that page, carrying the token and callback destinations on the URL query. Fetching a Lowdefy page has no side effect, so the token stays unspent until a person clicks a button that runs `MagicLinkVerify`.
+
+This action **must** be bound to a click. Do not run it in `onMount` and do not auto-redirect from the landing page: scanning sandboxes that execute JavaScript would consume the token anyway, and you would be no better off than linking at the verify endpoint directly.
+
+## Defaults come from the URL query
+
+Every parameter is optional. The auth server minted the landing URL with the verify query on it, so the action reads its defaults from the page's own URL:
+
+| Parameter | Default |
+| --------- | ------- |
+| `token` | the `?token=` query parameter |
+| `callbackUrl` | the `?callbackURL=` query parameter, else the auth server's default |
+| `newUserCallbackUrl` | the `?newUserCallbackURL=` query parameter, else `callbackUrl` |
+| `errorCallbackUrl` | the `?errorCallbackURL=` query parameter, else `auth.authPages.error` |
+
+Pass a parameter only to override what the email carried. The action throws if there is no token in either place, because there is nothing to verify.
+
+`callbackUrl: false` is not valid here. Verification redirects through a hop the app does not control, so there is no staying put.
+
+The event chain ends after this action, like every other action that navigates the browser away — a step after it would race the page being replaced.
+
+#### Parameters
+
+###### object
+- `token: string`: The single-use magic-link token. Defaults to the `?token=` URL query parameter of the landing page.
+- `callbackUrl: object`: Where a successful sign-in lands. Defaults to the `?callbackURL=` URL query parameter.
+  - `home: boolean`: Land on the app's home page.
+  - `pageId: string`: The pageId to land on.
+  - `url: string`: The URL to land on. An absolute URL is not `basePath`-prefixed, so it can be an external landing page.
+  - `urlQuery: object`: The urlQuery to set on the destination.
+- `newUserCallbackUrl: object`: Where a sign-in that creates a new account lands, for a first-run or onboarding page. Defaults to the `?newUserCallbackURL=` URL query parameter. Same fields as `callbackUrl`.
+- `errorCallbackUrl: object`: Where a failed verification lands, with the reason in `?error=`. Defaults to the `?errorCallbackURL=` URL query parameter, then to `auth.authPages.error`. Same fields as `callbackUrl`.
+
+#### Examples
+
+###### The landing page, with everything taken from the URL query:
+```yaml
+id: magic-link
+type: PageHeaderMenu
+blocks:
+  - id: content
+    type: Box
+    blocks:
+      - id: title
+        type: Title
+        properties:
+          content: Sign in
+          level: 3
+      - id: description
+        type: Paragraph
+        properties:
+          content: Click the button below to finish signing in.
+      - id: verify_button
+        type: Button
+        properties:
+          title: Sign in
+        events:
+          onClick:
+            - id: verify
+              type: MagicLinkVerify
+```
+
+###### Send a new user to an onboarding page instead:
+```yaml
+- id: verify
+  type: MagicLinkVerify
+  params:
+    newUserCallbackUrl:
+      pageId: welcome
+```
+
+###### Override where a successful sign-in lands:
+```yaml
+- id: verify
+  type: MagicLinkVerify
+  params:
+    callbackUrl:
+      pageId: dashboard
+      urlQuery:
+        source: magic-link
+```

--- a/packages/docs-content/content/user-authentication/login-and-logout.md
+++ b/packages/docs-content/content/user-authentication/login-and-logout.md
@@ -95,6 +95,55 @@ events:
             screen_hint: signup
 ```
 
+## Magic link sign-in
+
+`Login` with `magicLink: true` emails the user a sign-in link. By default that link points straight at Better Auth's verify endpoint, which consumes the single-use token on the first `GET` of the URL.
+
+That is a problem in corporate inboxes. Mail security products — Microsoft Defender Safe Links, Proofpoint URL Defense, Mimecast — fetch every link in a message as it is delivered, so the scanner spends the token minutes before the person clicks, and the person lands on the error page with `INVALID_TOKEN`.
+
+Set [`auth.authPages.magicLink`](/auth-configuration#auth-pages) to a page in your app to close that gap. The email then links to your page, carrying the token and the callback destinations on its URL query, and a [`MagicLinkVerify`](/MagicLinkVerify) action on a **button click** walks to the verify endpoint. Fetching the landing page does nothing, so a scanner cannot consume the token.
+
+```yaml
+lowdefy: {{ version }}
+auth:
+  magicLink:
+    enabled: true
+  authPages:
+    magicLink: /magic-link
+```
+
+```yaml
+id: magic-link
+type: PageHeaderMenu
+blocks:
+  - id: content
+    type: Box
+    blocks:
+      - id: title
+        type: Title
+        properties:
+          content: Sign in
+          level: 3
+      - id: description
+        type: Paragraph
+        properties:
+          content: Click the button below to finish signing in.
+      - id: verify_button
+        type: Button
+        properties:
+          title: Sign in
+        events:
+          onClick:
+            - id: verify
+              type: MagicLinkVerify
+```
+
+The landing page must be reachable while signed out, so add it to `auth.pages.public`.
+
+Do **not** run `MagicLinkVerify` in the page's `onMount`, and do not auto-redirect to the verify endpoint. Some scanning sandboxes render the page and execute its JavaScript, so an automatic verify hands the token back to the scanner and you are no better off than linking at the endpoint directly. The whole protection is that a human has to click.
+
+The action needs no parameters: the token and the `callbackURL`, `newUserCallbackURL` and `errorCallbackURL` values are read from the landing page's own URL query, which the email put there. Pass parameters only to override them.
+
 ## SMS sign-in
 
 `PhoneNumberVerify` completes a sign-in with an SMS code, and lands the user through the same three sources as `Login`: the `callbackUrl` param, then the `?callbackUrl=` query, then the app's home page. `callbackUrl: false` verifies without navigating.

--- a/packages/docs-content/index.json
+++ b/packages/docs-content/index.json
@@ -1562,6 +1562,14 @@
       "typeName": "Logout"
     },
     {
+      "slug": "actions/magiclinkverify",
+      "title": "MagicLinkVerify",
+      "section": "Actions",
+      "path": "content/actions/magiclinkverify.md",
+      "kind": "action",
+      "typeName": "MagicLinkVerify"
+    },
+    {
       "slug": "actions/pdfmake",
       "title": "PdfMake",
       "section": "Actions",

--- a/packages/docs/actions/MagicLinkVerify.yaml
+++ b/packages/docs/actions/MagicLinkVerify.yaml
@@ -1,0 +1,130 @@
+# Copyright 2020-2026 Lowdefy, Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_ref:
+  path: templates/actions.yaml.njk
+  vars:
+    pageId: MagicLinkVerify
+    pageTitle: MagicLinkVerify
+    filePath: actions/MagicLinkVerify.yaml
+    types: |
+      ```
+      (params?: {
+        callbackUrl?: {
+          home?: boolean
+          pageId?: string
+          url?: string
+          urlQuery?: object
+        }
+        errorCallbackUrl?: {
+          home?: boolean
+          pageId?: string
+          url?: string
+          urlQuery?: object
+        }
+        newUserCallbackUrl?: {
+          home?: boolean
+          pageId?: string
+          url?: string
+          urlQuery?: object
+        }
+        token?: string
+      }): void
+      ```
+    description: |
+      The `MagicLinkVerify` action completes a magic-link sign-in from the landing page the sign-in email points at. It navigates the browser to the auth server's verify endpoint, which sets the session cookie and redirects the user on to their destination.
+
+      ## Why a landing page
+
+      A magic-link token is single-use, and the verify endpoint consumes it on the **first** `GET` of the URL. Corporate mail security — Microsoft Defender Safe Links, Proofpoint URL Defense, Mimecast — fetches every link in a message as it is delivered. When the email links straight at the verify endpoint the scanner spends the token minutes before the person clicks, and the person lands on the auth error page with `INVALID_TOKEN`.
+
+      Setting [`auth.authPages.magicLink`](/auth-configuration#the-magic-link-landing-page) to a page in your app moves the email's link to that page, carrying the token and callback destinations on the URL query. Fetching a Lowdefy page has no side effect, so the token stays unspent until a person clicks a button that runs `MagicLinkVerify`.
+
+      This action **must** be bound to a click. Do not run it in `onMount` and do not auto-redirect from the landing page: scanning sandboxes that execute JavaScript would consume the token anyway, and you would be no better off than linking at the verify endpoint directly.
+
+      ## Defaults come from the URL query
+
+      Every parameter is optional. The auth server minted the landing URL with the verify query on it, so the action reads its defaults from the page's own URL:
+
+      | Parameter | Default |
+      | --------- | ------- |
+      | `token` | the `?token=` query parameter |
+      | `callbackUrl` | the `?callbackURL=` query parameter, else the auth server's default |
+      | `newUserCallbackUrl` | the `?newUserCallbackURL=` query parameter, else `callbackUrl` |
+      | `errorCallbackUrl` | the `?errorCallbackURL=` query parameter, else `auth.authPages.error` |
+
+      Pass a parameter only to override what the email carried. The action throws if there is no token in either place, because there is nothing to verify.
+
+      `callbackUrl: false` is not valid here. Verification redirects through a hop the app does not control, so there is no staying put.
+
+      The event chain ends after this action, like every other action that navigates the browser away — a step after it would race the page being replaced.
+
+    params: |
+      ###### object
+      - `token: string`: The single-use magic-link token. Defaults to the `?token=` URL query parameter of the landing page.
+      - `callbackUrl: object`: Where a successful sign-in lands. Defaults to the `?callbackURL=` URL query parameter.
+        - `home: boolean`: Land on the app's home page.
+        - `pageId: string`: The pageId to land on.
+        - `url: string`: The URL to land on. An absolute URL is not `basePath`-prefixed, so it can be an external landing page.
+        - `urlQuery: object`: The urlQuery to set on the destination.
+      - `newUserCallbackUrl: object`: Where a sign-in that creates a new account lands, for a first-run or onboarding page. Defaults to the `?newUserCallbackURL=` URL query parameter. Same fields as `callbackUrl`.
+      - `errorCallbackUrl: object`: Where a failed verification lands, with the reason in `?error=`. Defaults to the `?errorCallbackURL=` URL query parameter, then to `auth.authPages.error`. Same fields as `callbackUrl`.
+
+    examples: |
+      ###### The landing page, with everything taken from the URL query:
+      ```yaml
+      id: magic-link
+      type: PageHeaderMenu
+      blocks:
+        - id: content
+          type: Box
+          blocks:
+            - id: title
+              type: Title
+              properties:
+                content: Sign in
+                level: 3
+            - id: description
+              type: Paragraph
+              properties:
+                content: Click the button below to finish signing in.
+            - id: verify_button
+              type: Button
+              properties:
+                title: Sign in
+              events:
+                onClick:
+                  - id: verify
+                    type: MagicLinkVerify
+      ```
+
+      ###### Send a new user to an onboarding page instead:
+      ```yaml
+      - id: verify
+        type: MagicLinkVerify
+        params:
+          newUserCallbackUrl:
+            pageId: welcome
+      ```
+
+      ###### Override where a successful sign-in lands:
+      ```yaml
+      - id: verify
+        type: MagicLinkVerify
+        params:
+          callbackUrl:
+            pageId: dashboard
+            urlQuery:
+              source: magic-link
+      ```

--- a/packages/docs/menus.yaml
+++ b/packages/docs/menus.yaml
@@ -977,6 +977,9 @@
         - id: Logout
           type: MenuLink
           pageId: Logout
+        - id: MagicLinkVerify
+          type: MenuLink
+          pageId: MagicLinkVerify
         - id: PdfMake
           type: MenuLink
           pageId: PdfMake

--- a/packages/docs/pages.yaml
+++ b/packages/docs/pages.yaml
@@ -243,6 +243,7 @@
 - _ref: actions/Link.yaml
 - _ref: actions/Login.yaml
 - _ref: actions/Logout.yaml
+- _ref: actions/MagicLinkVerify.yaml
 - _ref: actions/PdfMake.yaml
 - _ref: actions/Request.yaml
 - _ref: actions/Reset.yaml

--- a/packages/docs/users/auth-configuration.yaml
+++ b/packages/docs/users/auth-configuration.yaml
@@ -112,6 +112,7 @@ _ref:
                 | `twoFactor` | — | **required** when `twoFactor.enabled` |
                 | `twoFactorEnrol` | — | **required** when `twoFactor.required` |
                 | `acceptInvitation` | — | consumes an `?invitationId=` link |
+                | `magicLink` | — | landing page for the sign-in email; only valid with `magicLink.enabled` |
 
                 ```yaml
                 lowdefy: {{ version }}
@@ -121,6 +122,54 @@ _ref:
                     signUp: /signup
                     error: /auth-error
                 ```
+
+                ### The magic link landing page
+
+                `authPages.magicLink` is opt-in, and it exists for one reason: Better Auth's magic-link verify endpoint consumes the single-use token on the **first** `GET` of the URL. Corporate mail security — Microsoft Defender Safe Links, Proofpoint URL Defense, Mimecast — fetches every link in a message at delivery time, so that first `GET` is a scanner and the person clicking arrives to `INVALID_TOKEN`.
+
+                Set the key and the sign-in email links to a page of your own instead, with the token and the callback destinations carried on its URL query. Fetching a Lowdefy page is harmless, so the token stays unspent until a real click runs [`MagicLinkVerify`](/MagicLinkVerify):
+
+                ```yaml
+                lowdefy: {{ version }}
+                auth:
+                  magicLink:
+                    enabled: true
+                  authPages:
+                    magicLink: /magic-link
+                  pages:
+                    public:
+                      - magic-link
+                ```
+
+                ```yaml
+                id: magic-link
+                type: PageHeaderMenu
+                blocks:
+                  - id: content
+                    type: Box
+                    blocks:
+                      - id: title
+                        type: Title
+                        properties:
+                          content: Sign in
+                          level: 3
+                      - id: description
+                        type: Paragraph
+                        properties:
+                          content: Click the button below to finish signing in.
+                      - id: verify_button
+                        type: Button
+                        properties:
+                          title: Sign in
+                        events:
+                          onClick:
+                            - id: verify
+                              type: MagicLinkVerify
+                ```
+
+                The page must **not** call `MagicLinkVerify` in `onMount`, and must not auto-redirect to the verify endpoint. Scanning sandboxes that render the page and execute its JavaScript would consume the token anyway, which puts you back where you started. The protection is the click, not the page.
+
+                Leave the key unset and magic-link sign-in keeps working exactly as before, linking straight at the verify endpoint.
 
                 See [Two-Factor Authentication](/two-factor) for the two-factor pages, and the [MCP Server & OAuth](/mcp-oauth) page for `oauthProvider.consentPage` and `postLoginPage`.
 

--- a/packages/docs/users/login-and-logout.yaml
+++ b/packages/docs/users/login-and-logout.yaml
@@ -119,6 +119,55 @@ _ref:
                         screen_hint: signup
             ```
 
+            ## Magic link sign-in
+
+            `Login` with `magicLink: true` emails the user a sign-in link. By default that link points straight at Better Auth's verify endpoint, which consumes the single-use token on the first `GET` of the URL.
+
+            That is a problem in corporate inboxes. Mail security products — Microsoft Defender Safe Links, Proofpoint URL Defense, Mimecast — fetch every link in a message as it is delivered, so the scanner spends the token minutes before the person clicks, and the person lands on the error page with `INVALID_TOKEN`.
+
+            Set [`auth.authPages.magicLink`](/auth-configuration#auth-pages) to a page in your app to close that gap. The email then links to your page, carrying the token and the callback destinations on its URL query, and a [`MagicLinkVerify`](/MagicLinkVerify) action on a **button click** walks to the verify endpoint. Fetching the landing page does nothing, so a scanner cannot consume the token.
+
+            ```yaml
+            lowdefy: {{ version }}
+            auth:
+              magicLink:
+                enabled: true
+              authPages:
+                magicLink: /magic-link
+            ```
+
+            ```yaml
+            id: magic-link
+            type: PageHeaderMenu
+            blocks:
+              - id: content
+                type: Box
+                blocks:
+                  - id: title
+                    type: Title
+                    properties:
+                      content: Sign in
+                      level: 3
+                  - id: description
+                    type: Paragraph
+                    properties:
+                      content: Click the button below to finish signing in.
+                  - id: verify_button
+                    type: Button
+                    properties:
+                      title: Sign in
+                    events:
+                      onClick:
+                        - id: verify
+                          type: MagicLinkVerify
+            ```
+
+            The landing page must be reachable while signed out, so add it to `auth.pages.public`.
+
+            Do **not** run `MagicLinkVerify` in the page's `onMount`, and do not auto-redirect to the verify endpoint. Some scanning sandboxes render the page and execute its JavaScript, so an automatic verify hands the token back to the scanner and you are no better off than linking at the endpoint directly. The whole protection is that a human has to click.
+
+            The action needs no parameters: the token and the `callbackURL`, `newUserCallbackURL` and `errorCallbackURL` values are read from the landing page's own URL query, which the email put there. Pass parameters only to override them.
+
             ## SMS sign-in
 
             `PhoneNumberVerify` completes a sign-in with an SMS code, and lands the user through the same three sources as `Login`: the `callbackUrl` param, then the `?callbackUrl=` query, then the app's home page. `callbackUrl: false` verifies without navigating.

--- a/packages/engine/src/actions/createMagicLinkVerify.js
+++ b/packages/engine/src/actions/createMagicLinkVerify.js
@@ -1,0 +1,23 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+function createMagicLinkVerify({ context }) {
+  return function magicLinkVerify(params) {
+    return context._internal.lowdefy._internal.auth.magicLinkVerify(params);
+  };
+}
+
+export default createMagicLinkVerify;

--- a/packages/engine/src/actions/getActionMethods.js
+++ b/packages/engine/src/actions/getActionMethods.js
@@ -34,6 +34,7 @@ import createLink from './createLink.js';
 import createListOrganizations from './createListOrganizations.js';
 import createLogin from './createLogin.js';
 import createLogout from './createLogout.js';
+import createMagicLinkVerify from './createMagicLinkVerify.js';
 import createDisplayMessage from './createDisplayMessage.js';
 import createOauth2Consent from './createOauth2Consent.js';
 import createOauth2Continue from './createOauth2Continue.js';
@@ -88,6 +89,7 @@ function getActionMethods(props) {
     listOrganizations: createListOrganizations(props),
     login: createLogin(props),
     logout: createLogout(props),
+    magicLinkVerify: createMagicLinkVerify(props),
     oauth2Consent: createOauth2Consent(props),
     oauth2Continue: createOauth2Continue(props),
     passkeyDelete: createPasskeyDelete(props),

--- a/packages/plugins/actions/actions-core/src/actions.js
+++ b/packages/plugins/actions/actions-core/src/actions.js
@@ -27,6 +27,7 @@ export { default as Link } from './actions/Link/Link.js';
 export { default as ListOrganizations } from './actions/ListOrganizations/ListOrganizations.js';
 export { default as Login } from './actions/Login/Login.js';
 export { default as Logout } from './actions/Logout/Logout.js';
+export { default as MagicLinkVerify } from './actions/MagicLinkVerify/MagicLinkVerify.js';
 export { default as OAuthConsent } from './actions/OAuthConsent/OAuthConsent.js';
 export { default as OAuthContinue } from './actions/OAuthContinue/OAuthContinue.js';
 export { default as PasskeyDelete } from './actions/PasskeyDelete/PasskeyDelete.js';

--- a/packages/plugins/actions/actions-core/src/actions/MagicLinkVerify/MagicLinkVerify.js
+++ b/packages/plugins/actions/actions-core/src/actions/MagicLinkVerify/MagicLinkVerify.js
@@ -1,0 +1,27 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Spends the magic-link token from the landing page the sign-in email points
+// at (auth.authPages.magicLink). The browser navigates to BetterAuth's verify
+// endpoint, which sets the session cookie and redirects on, so the event chain
+// ends here. Bind it to a real click: the landing page exists precisely because
+// mail-security link scanners fetch the page, and a token spent on mount would
+// be consumed by the scanner all the same.
+function MagicLinkVerify({ methods: { magicLinkVerify }, params }) {
+  return magicLinkVerify(params);
+}
+
+export default MagicLinkVerify;

--- a/packages/plugins/actions/actions-core/src/actions/MagicLinkVerify/MagicLinkVerify.test.js
+++ b/packages/plugins/actions/actions-core/src/actions/MagicLinkVerify/MagicLinkVerify.test.js
@@ -1,0 +1,36 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+
+import MagicLinkVerify from './MagicLinkVerify.js';
+
+const mockMagicLinkVerify = jest.fn();
+const methods = { magicLinkVerify: mockMagicLinkVerify };
+
+beforeEach(() => {
+  mockMagicLinkVerify.mockReset();
+});
+
+test('MagicLinkVerify action invocation passes the params through', () => {
+  MagicLinkVerify({ methods, params: { callbackUrl: { pageId: 'dashboard' } } });
+  expect(mockMagicLinkVerify.mock.calls).toEqual([[{ callbackUrl: { pageId: 'dashboard' } }]]);
+});
+
+test('MagicLinkVerify action invocation without params defaults from the page URL query', () => {
+  MagicLinkVerify({ methods, params: undefined });
+  expect(mockMagicLinkVerify.mock.calls).toEqual([[undefined]]);
+});

--- a/packages/plugins/actions/actions-core/src/actions/MagicLinkVerify/schema.js
+++ b/packages/plugins/actions/actions-core/src/actions/MagicLinkVerify/schema.js
@@ -1,0 +1,69 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const callbackTargetProperties = {
+  home: {
+    type: 'boolean',
+    description: "Land on the app's home page.",
+  },
+  pageId: {
+    type: 'string',
+    description: 'The pageId to land on.',
+  },
+  url: {
+    type: 'string',
+    description:
+      'The URL to land on. An absolute URL is not basePath-prefixed, so it can be an external landing page.',
+  },
+  urlQuery: {
+    type: 'object',
+    description: 'The urlQuery to set on the destination.',
+  },
+};
+
+export default {
+  type: 'object',
+  params: {
+    type: 'object',
+    description:
+      'Parameters for spending the magic-link token. All are optional: the sign-in email links to the landing page named by "auth.authPages.magicLink" with the token and the callback destinations already on its URL query, and this action reads its defaults from there. Set a parameter only to override what the email carried.',
+    properties: {
+      token: {
+        type: 'string',
+        description:
+          'The single-use magic-link token. Defaults to the "token" URL query parameter of the landing page. The action fails when neither is a string, because there is nothing to verify.',
+      },
+      callbackUrl: {
+        type: 'object',
+        description:
+          'Where a successful sign-in lands. Defaults to the "callbackURL" URL query parameter the sign-in email carried onto the landing page, and to BetterAuth\'s own default when that is absent too. "false" is not valid here - verification redirects through a hop the app does not control, so there is no staying put.',
+        properties: callbackTargetProperties,
+      },
+      newUserCallbackUrl: {
+        type: 'object',
+        description:
+          'Where a sign-in that creates a new account lands, for a first-run or onboarding page. Defaults to the "newUserCallbackURL" URL query parameter, and to callbackUrl when neither is set.',
+        properties: callbackTargetProperties,
+      },
+      errorCallbackUrl: {
+        type: 'object',
+        description:
+          'Where a failed verification lands, with the reason in "?error=". Defaults to the "errorCallbackURL" URL query parameter, then to the app\'s "auth.authPages.error" page.',
+        properties: callbackTargetProperties,
+      },
+    },
+  },
+};

--- a/packages/plugins/actions/actions-core/src/schemas.js
+++ b/packages/plugins/actions/actions-core/src/schemas.js
@@ -27,6 +27,7 @@ export { default as Link } from './actions/Link/schema.js';
 export { default as ListOrganizations } from './actions/ListOrganizations/schema.js';
 export { default as Login } from './actions/Login/schema.js';
 export { default as Logout } from './actions/Logout/schema.js';
+export { default as MagicLinkVerify } from './actions/MagicLinkVerify/schema.js';
 export { default as OAuthConsent } from './actions/OAuthConsent/schema.js';
 export { default as OAuthContinue } from './actions/OAuthContinue/schema.js';
 export { default as PasskeyDelete } from './actions/PasskeyDelete/schema.js';

--- a/packages/plugins/actions/actions-core/src/types.js
+++ b/packages/plugins/actions/actions-core/src/types.js
@@ -29,6 +29,7 @@ export default {
     'ListOrganizations',
     'Login',
     'Logout',
+    'MagicLinkVerify',
     'OAuthConsent',
     'OAuthContinue',
     'PasskeyDelete',

--- a/packages/utils/email-templates/src/auth/MagicLinkEmail/MagicLinkEmail.js
+++ b/packages/utils/email-templates/src/auth/MagicLinkEmail/MagicLinkEmail.js
@@ -15,7 +15,7 @@
 */
 
 import React from 'react';
-import { Heading, Text } from '@react-email/components';
+import { Heading, Link, Text } from '@react-email/components';
 
 import CtaButton from '../../components/CtaButton.js';
 import EmailLayout from '../../components/EmailLayout.js';
@@ -34,6 +34,17 @@ const textStyle = {
   margin: '0 0 16px 0',
 };
 
+// The same destination as the button, in plain sight. Locked-down mail clients
+// strip or rewrite button markup, and some people copy links by hand rather
+// than clicking - the URL has to be readable, and long enough to wrap.
+const fallbackTextStyle = {
+  color: '#666666',
+  fontSize: '12px',
+  lineHeight: '18px',
+  margin: '0',
+  wordBreak: 'break-all',
+};
+
 function MagicLinkEmail({ properties = {}, data = {}, theme = {}, links = {} }) {
   return (
     <EmailLayout theme={theme}>
@@ -41,9 +52,15 @@ function MagicLinkEmail({ properties = {}, data = {}, theme = {}, links = {} }) 
         Sign in to your account
       </Heading>
       <Text style={textStyle}>
-        Click the button below to sign in. This link will expire shortly, so please use it soon.
+        Click the button below to sign in. The link will expire shortly, so please use it soon, and
+        do not forward this email - anyone with the link can sign in as you.
       </Text>
       <CtaButton label="Sign in" href={properties.url} theme={theme} />
+      <Text style={fallbackTextStyle}>
+        If the button does not work, copy this link into your browser:
+        <br />
+        <Link href={properties.url}>{properties.url}</Link>
+      </Text>
     </EmailLayout>
   );
 }

--- a/packages/utils/email-templates/src/auth/MagicLinkEmail/MagicLinkEmail.test.js
+++ b/packages/utils/email-templates/src/auth/MagicLinkEmail/MagicLinkEmail.test.js
@@ -30,6 +30,19 @@ test('MagicLinkEmail renders to html and text and includes the url', async () =>
   expect(html).toContain('https://example.com/verify?token=abc');
 });
 
+// The button is the happy path, but a locked-down mail client may strip or
+// rewrite it - the readable URL underneath is what a person falls back to, and
+// the plain-text part is all some clients render at all.
+test('MagicLinkEmail renders the url as readable fallback text under the button', async () => {
+  const { html, text } = await renderEmail({
+    Template: MagicLinkEmail,
+    properties: { url: 'https://example.com/magic-link?token=abc' },
+    theme: {},
+  });
+  expect(html).toContain('If the button does not work, copy this link into your browser:');
+  expect(text).toContain('https://example.com/magic-link?token=abc');
+});
+
 test('MagicLinkEmail subject is the expected string', () => {
   expect(MagicLinkEmail.subject).toEqual('Your sign-in link');
 });


### PR DESCRIPTION
## Problem

Magic-link sign-in emails link straight at Better Auth's `GET /api/auth/magic-link/verify`, which consumes the single-use token atomically on the first GET (`allowedAttempts` is explicitly ignored upstream). Corporate mail security (Microsoft Defender Safe Links, Proofpoint URL Defense, Mimecast) pre-fetches links at delivery time, so the scanner spends the token and the person clicking lands on `INVALID_TOKEN`. The server already short-circuits HEAD prefetches; the GET prefetch was the remaining gap.

## Fix

- **`auth.authPages.magicLink`** (opt-in page path). When set, the engine points the sign-in email at that Lowdefy page instead of the verify endpoint, copying the whole verify query (token, `callbackURL`, `newUserCallbackURL`, `errorCallbackURL`) onto it. Origin is taken from the verify URL so the zero-config path (no `BETTER_AUTH_URL`) keeps working. Unset, behaviour is byte-for-byte unchanged.
- **`MagicLinkVerify` action** (actions-core + engine + client): on a real click it navigates the browser to the verify endpoint. Token and destinations default from the landing page's URL query; params override. `callbackUrl: false` is rejected (redirect hop). Chain stops after navigation like every other navigating auth method.
- **Build validation**: the page is not required when magic link is enabled, so existing apps keep building. It is also allowed when magic link is off: modules contribute `authPages` roles statically (they cannot read the auth projection inside the auth block), so a stricter rule would break every consumer of a module that ships the landing page.
- **MagicLinkEmail**: the URL is also shown as readable text under the button for mail clients that strip or rewrite buttons.
- **Docs**: new `MagicLinkVerify` action page, a "Magic link sign-in" section in Login and Logout, and "The magic link landing page" in Auth configuration, all stating the page must bind the action to a click and never auto-redirect (JS-executing sandboxes would consume the token anyway). Agent docs regenerated for the touched pages only; `pnpm docs:content` on v7 also shows unrelated pre-existing drift that was left out of this PR on purpose.

## Tests

`@lowdefy/api`, `client`, `actions-core`, `engine`, `email-templates`, `build` suites pass, and the Vercel docs deploy check has been failing on every recent v7 commit independently of this PR (build snapshot fixtures unchanged; the cross-module fixtures time out at 5 s when two jest runs share the machine, and pass in isolation).

## Follow-up

A sibling PR adds `auth.emailOTP` and carries a one-time code in the same email for people whose mail security also blocks the landing page.
