### PR TITLE
fix(build): a module manifest may declare the magicLink auth page role

### DIFF
--- a/packages/build/src/build/buildAuth/authPageRoles.js
+++ b/packages/build/src/build/buildAuth/authPageRoles.js
@@ -17,8 +17,8 @@
 // The auth page roles an app (auth.authPages) or a module manifest
 // (auth.pages) may fill. Mirrors the authPages keys in lowdefySchema.js - a
 // role added there is added here too. Most also get a path default in
-// setAuthDefaults.js; acceptInvitation, twoFactor and twoFactorEnrol are the
-// exceptions (intentionally unset). twoFactorEnrol has no default because the
+// setAuthDefaults.js; acceptInvitation, twoFactor, twoFactorEnrol and magicLink
+// are the exceptions (intentionally unset). twoFactorEnrol has no default because the
 // page is contributed by a module or hand-written - a default path pointing at
 // a nonexistent page would satisfy the required check while redirecting to /404.
 const authPageRoles = [
@@ -31,6 +31,7 @@ const authPageRoles = [
   'twoFactor',
   'twoFactorEnrol',
   'acceptInvitation',
+  'magicLink',
 ];
 
 export default authPageRoles;

--- a/packages/build/src/build/validateModuleAuthManifest.test.js
+++ b/packages/build/src/build/validateModuleAuthManifest.test.js
@@ -107,7 +107,7 @@ test('validateModuleAuthManifest throws on an unknown authPages role', () => {
   expect(() =>
     validateModuleAuthManifest({ auth: { pages: { logIn: 'login' } }, entryId: 'crm' })
   ).toThrow(
-    'Module "crm" manifest "auth.pages" has unknown role "logIn". Valid roles are: signIn, signUp, error, forgotPassword, resetPassword, verifyEmail, twoFactor, twoFactorEnrol, acceptInvitation.'
+    'Module "crm" manifest "auth.pages" has unknown role "logIn". Valid roles are: signIn, signUp, error, forgotPassword, resetPassword, verifyEmail, twoFactor, twoFactorEnrol, acceptInvitation, magicLink.'
   );
 });
 
@@ -115,6 +115,17 @@ test('validateModuleAuthManifest passes a module manifest declaring auth.pages.t
   expect(() =>
     validateModuleAuthManifest({
       auth: { pages: { twoFactor: 'two-factor-challenge' } },
+      entryId: 'crm',
+    })
+  ).not.toThrow();
+});
+
+// A module ships the magic-link landing page and declares the role for it, the
+// same way it declares twoFactor; the app need not know the page exists.
+test('validateModuleAuthManifest passes a module manifest declaring auth.pages.magicLink', () => {
+  expect(() =>
+    validateModuleAuthManifest({
+      auth: { pages: { magicLink: 'magic-link' } },
       entryId: 'crm',
     })
   ).not.toThrow();


### PR DESCRIPTION
Follow-up to #2375. The module-manifest validator (`validateModuleAuthManifest`) checks `auth.pages` roles against `authPageRoles.js`, which did not list the new `magicLink` role, so a module shipping the landing page could not contribute the role and failed the build with "unknown role magicLink". Adds the role to the registry (no path default, like twoFactor) with a validator test. Found while adopting the landing page in lowdefy/modules-mongodb#216 on `0.0.0-experimental-20260908103554`.