### PR TITLE
chore(server): Deploy docs Hono app to Vercel via Build Output API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ docs/superpowers/
 _server/
 
 packages/servers/*/build/**
+packages/servers/*/.vercel/
 packages/servers/*/lowdefy-build/**
 packages/servers/*/public/**
 packages/servers/*/package.original.json

--- a/packages/servers/server/vercel.README.md
+++ b/packages/servers/server/vercel.README.md
@@ -1,0 +1,54 @@
+# Vercel deployment — Lowdefy docs (from this monorepo)
+
+The docs app (`packages/docs`, `lowdefy: local`) is a Lowdefy v6 app: a [Hono](https://hono.dev)
+server serving a [Vite](https://vite.dev)-built React client. On Vercel it is deployed via the
+[Build Output API](https://vercel.com/docs/build-output-api) — static assets on the CDN plus one
+Node serverless function that runs the Hono app.
+
+Unlike a standalone Lowdefy app (which downloads a published server with `npx lowdefy@<version>`),
+the docs app builds against the **workspace**: `lowdefy: local` uses the server and plugins in this
+repo directly, via the CLI's `--server-directory` flag pointing at `@lowdefy/server` here. Because
+`@lowdefy/server` is a workspace member, `lowdefy vercel-output` traces the function against the repo
+root (where `pnpm-workspace.yaml` lives), so the linked `@lowdefy/*` files resolve and are copied
+into the function.
+
+The Build Output is written to `packages/servers/server/.vercel/output` — i.e. inside the Root
+Directory — where Vercel picks it up automatically.
+
+## Vercel project settings
+
+- **Framework Preset:** `Other`
+- **Root Directory:** `packages/servers/server`
+- **"Include files outside the root directory in the Build Step":** **ON** (the workspace, config and
+  linked packages all live above the server package)
+- **Install Command:** `bash vercel.install.docs.sh`
+- **Build Command:** `bash vercel.build.docs.sh`
+- **Output Directory:** leave blank — the build emits `.vercel/output`, auto-detected
+
+`vercel.json` here sets `framework: null`; install and build commands are set per-project in the
+Vercel dashboard (so other apps can deploy from the same server package with their own scripts).
+
+## Environment variables
+
+Set secrets in the Vercel project, prefixed with `LOWDEFY_SECRET_`. Use `AUTH_SECRET` (and, for
+OAuth, `AUTH_URL`) for auth. `CRON_SECRET` is only needed if the app uses scheduled endpoints.
+
+## How the build works
+
+`vercel.build.docs.sh`:
+
+1. `pnpm build` — builds every `@lowdefy/*` workspace package (`dist/`).
+2. `lowdefy build --config-directory packages/docs --server-directory packages/servers/server
+--no-client-build` — builds the docs config + Hono server artifacts into the server package.
+3. `build:client` — the Vite client build into `packages/servers/server/dist/client`.
+4. `lowdefy vercel-output ...` — assembles `.vercel/output` (static assets, the traced function, and
+   `config.json` routing everything not on disk to the function).
+
+## Notes
+
+- Building writes generated artifacts into `packages/servers/server` (`build/`, `dist/`, `.vercel/`)
+  and may add plugin deps to its `package.json`. These are gitignored / build-time only; do not
+  commit them.
+- The function runs on Vercel's Node.js runtime; streaming agent responses are subject to Vercel's
+  function duration limits. For heavy streaming, a long-lived Node host (`node src/index.js`) suits
+  better.

--- a/packages/servers/server/vercel.README.md
+++ b/packages/servers/server/vercel.README.md
@@ -30,8 +30,10 @@ Vercel dashboard (so other apps can deploy from the same server package with the
 
 ## Environment variables
 
-Set secrets in the Vercel project, prefixed with `LOWDEFY_SECRET_`. Use `AUTH_SECRET` (and, for
-OAuth, `AUTH_URL`) for auth. `CRON_SECRET` is only needed if the app uses scheduled endpoints.
+The docs app is a public site with no auth, so it needs no `AUTH_SECRET`/`AUTH_URL`. Any secrets a
+future app needs go in the Vercel project prefixed with `LOWDEFY_SECRET_`; `AUTH_SECRET` (and, for
+OAuth, `AUTH_URL`) are only needed by an app that configures auth, and `CRON_SECRET` only by one with
+scheduled endpoints.
 
 ## How the build works
 

--- a/packages/servers/server/vercel.build.docs.sh
+++ b/packages/servers/server/vercel.build.docs.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Vercel build step for the Lowdefy docs app, deployed from this monorepo.
+#
+# Builds the workspace, then the docs app's config + Hono server + Vite client against the real
+# @lowdefy/server package, and finally assembles the Vercel Build Output. Because the server is a
+# workspace member, `lowdefy vercel-output` traces the function against the repo root (where
+# pnpm-workspace.yaml lives), so the linked @lowdefy/* files in node_modules/.pnpm are all in scope.
+#
+# The Build Output lands in packages/servers/server/.vercel/output — i.e. inside the Root Directory —
+# where Vercel picks it up automatically (no Output Directory setting).
+set -euo pipefail
+
+# This script runs from the Root Directory (packages/servers/server); step up to the repo root.
+cd ../../..
+
+# The Lowdefy CLI is the workspace `lowdefy` package. Run it with `node` from the repo root (not
+# `pnpm --filter lowdefy`, which would change the working directory and break the relative
+# --config-directory/--server-directory paths). Its dist is built by step 1.
+CLI="node packages/cli/dist/index.js"
+
+# 1. Build every @lowdefy/* workspace package (dist/) so the CLI and server resolve local code.
+pnpm build
+
+# 2. Build the docs app config + server artifacts into the server package (client build runs next).
+$CLI build \
+  --config-directory packages/docs \
+  --server-directory packages/servers/server \
+  --no-client-build \
+  --log-level debug
+
+# 3. Build the Vite client into packages/servers/server/dist/client.
+pnpm --filter @lowdefy/server run build:client
+
+# 4. Assemble the Vercel Build Output (.vercel/output) inside the server package.
+$CLI vercel-output \
+  --config-directory packages/docs \
+  --server-directory packages/servers/server \
+  --log-level debug

--- a/packages/servers/server/vercel.install.docs.sh
+++ b/packages/servers/server/vercel.install.docs.sh
@@ -1,3 +1,20 @@
-pnpm install
-pnpm --workspace-root run build
-pnpm -r --workspace-root --filter="!@lowdefy/lowdefy" --filter=lowdefy start build --config-directory ../docs --server-directory ../servers/server --no-client-build
+#!/usr/bin/env bash
+#
+# Vercel install step for the Lowdefy docs app, deployed from this monorepo.
+#
+# Unlike a standalone Lowdefy app (which downloads a published server with `npx lowdefy@<version>`),
+# the docs app is built against the workspace: `lowdefy: local` in packages/docs/lowdefy.yaml uses
+# the server and plugins in this repo directly, via `--server-directory`. That is why the deploy runs
+# from the repo root and installs the whole workspace here.
+#
+# Vercel project settings:
+#   - Root Directory: packages/servers/server
+#   - "Include files outside the root directory in the Build Step": ON
+#   - Install Command: bash vercel.install.docs.sh
+#   - Build Command:   bash vercel.build.docs.sh
+set -euo pipefail
+
+# This script runs from the Root Directory (packages/servers/server); step up to the repo root.
+cd ../../..
+
+pnpm install --frozen-lockfile

--- a/packages/servers/server/vercel.install.web.sh
+++ b/packages/servers/server/vercel.install.web.sh
@@ -1,3 +1,0 @@
-pnpm install
-pnpm --workspace-root run build
-pnpm -r --workspace-root --filter="!@lowdefy/lowdefy" --filter=lowdefy start build --config-directory ../website --server-directory ../servers/server --no-client-build

--- a/packages/servers/server/vercel.json
+++ b/packages/servers/server/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null
+}


### PR DESCRIPTION
## Summary

The docs app (`packages/docs`) is a Lowdefy v6 Hono + Vite app, but the server package only had the pre-Build-Output-API deploy scripts plus a stale one for the website, which has since migrated off Lowdefy — so docs had no working path to Vercel. This adds one, deploying via Vercel's Build Output API: static assets on the CDN plus a single Node serverless function running the Hono app.

The key decision is that docs builds against the **in-repo** `@lowdefy/server` workspace package (`lowdefy: local` + `--server-directory`), not a published `npx lowdefy@<version>`. Because the server is a workspace member, `lowdefy vercel-output` traces the function against the repo root, so the linked `@lowdefy/*` files are all in scope and get copied into the function. Pointing at the isolated `_server/prod` copy would not work — its deps are symlinks out of itself that the tracer would miss.

This constrains the Vercel project's Root Directory to `packages/servers/server`: `vercel-output` writes `.vercel/output` inside the server directory, and Vercel only detects it in the Root Directory. That is also where the old scripts lived.

## Changes

- `vercel.build.docs.sh` — builds the workspace, then the docs config + Hono server + Vite client against `@lowdefy/server`, then assembles the Build Output. Invokes the CLI as `node packages/cli/dist/index.js` from the repo root (not `pnpm --filter lowdefy start`, which changes cwd and breaks the relative `--config-directory`/`--server-directory` paths).
- `vercel.install.docs.sh` — modernised to run `pnpm install` from the repo root.
- `vercel.json` — `framework: null`; install/build commands are set per-project in the Vercel dashboard so other apps can deploy from the same server package.
- `vercel.README.md` — the Vercel project settings and how the build works.
- Removed `vercel.install.web.sh` (website is no longer a Lowdefy app); gitignored `packages/servers/*/.vercel/`.

## Test plan

Ran the full pipeline locally against `packages/docs`: `pnpm build`, then `lowdefy build --server-directory packages/servers/server --no-client-build`, the Vite client build, and `lowdefy vercel-output`. The Build Output assembled a self-contained function (11,099 files traced) — handler, server `src`, build artifacts, the Vite manifest, and the linked `@lowdefy/*` packages all present, with the function's `node_modules` symlinks resolving inside it.

Vercel project settings (docs): Framework Preset `Other`; Root Directory `packages/servers/server`; "Include files outside the root directory in the Build Step" ON; Install Command `bash vercel.install.docs.sh`; Build Command `bash vercel.build.docs.sh`; Output Directory blank.
