### PR TITLE
fix(connection-mongodb): tenant write guard scans document paths, not stored values

### DIFF
--- a/.changeset/connection-mongodb-tenant-write-scan-paths.md
+++ b/.changeset/connection-mongodb-tenant-write-scan-paths.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/connection-mongodb': patch
+---
+
+fix(connection-mongodb): the tenant wall's write guard rejects the tenant field only where it names a document path. It recursed into the values of `$set` / `$push` / insert documents, so any stored data that happened to carry a key named after the tenant field — a chat transcript holding a tool result with `organization_id`, a snapshot of another document — failed the whole write with "Tenant field can not be set in an update". Only a top-level key of an update operator's argument (or of an insert / replacement document) can move a row across the wall, and that is now the only thing the guard scans; filters keep their deep scan, where nesting is operator structure rather than data.

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/tenant/applyTenantToUpdate.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/tenant/applyTenantToUpdate.js
@@ -16,7 +16,7 @@
 
 import { ConfigError } from '@lowdefy/errors';
 
-import assertTenantFieldNotAuthored from './assertTenantFieldNotAuthored.js';
+import assertTenantPathNotAuthored from './assertTenantPathNotAuthored.js';
 
 // Guard and stamp an update document on a tenant connection.
 //
@@ -26,16 +26,24 @@ import assertTenantFieldNotAuthored from './assertTenantFieldNotAuthored.js';
 // reassign an owned row into another tenant. Reads of the field elsewhere are
 // fine; this scan covers only the update document.
 //
+// The scan is over document PATHS, not values. In { $set: { messages: [...] } }
+// the path is `messages`; whatever the array holds is data, and a nested
+// "organization_id" key in it (a stored tool result, a snapshot of another
+// document) is not a write to the tenant field. Only a top-level key of an
+// operator's argument - the field itself or a dotted path rooted in it - can
+// move the row across the wall.
+//
 // Object-form updates ({ $set: ..., $inc: ... }):
-// - authored tenant-field keys rejected anywhere in the operator tree,
-//   including $unset and $rename.
+// - the tenant field rejected as a path in every operator's argument,
+//   including $unset and $setOnInsert; $rename's value side is checked too.
 // - on upsert, the tenant field is added to $setOnInsert as belt-and-braces
 //   alongside the merged filter equality that MongoDB extracts into the
 //   upserted document.
 //
 // Pipeline-form updates ([{ $set: ... }, ...]):
-// - authored tenant-field keys rejected in every stage; $unset's string and
-//   array forms are checked too (an object key scan alone would miss them).
+// - the tenant field rejected as a path in every stage's argument ($set,
+//   $addFields, $project, $replaceRoot's newRoot, $replaceWith); $unset's
+//   string and array forms are checked too (a key scan alone would miss them).
 // - a final { $set: { <field>: <value> } } stage is appended. This restamps
 //   the field unconditionally, which covers the two shapes a key scan cannot:
 //   a $replaceRoot/$replaceWith that omits the field (the row would fall
@@ -68,18 +76,47 @@ function assertRenameDoesNotTargetTenantField({ update, field }) {
   });
 }
 
+// Every top-level key of an object-form update is an operator whose argument
+// maps document paths to values. A non-operator key (a replacement-shaped
+// document MongoDB will reject anyway) is itself a path.
+function assertUpdateDoesNotAuthorTenantField({ update, field }) {
+  if (update === undefined || update === null || typeof update !== 'object') return;
+  const position = 'an update';
+  assertTenantPathNotAuthored({ value: update, field, position });
+  Object.entries(update).forEach(([operator, argument]) => {
+    if (operator.startsWith('$')) {
+      assertTenantPathNotAuthored({ value: argument, field, position });
+    }
+  });
+}
+
+// The stages MongoDB allows in a pipeline update: the argument of $set,
+// $addFields and $project maps paths to values; $replaceRoot / $replaceWith
+// author a whole new root, whose top-level keys are the paths.
+function assertStageDoesNotAuthorTenantField({ stage, field }) {
+  if (stage === undefined || stage === null || typeof stage !== 'object') return;
+  const position = 'an update';
+  Object.entries(stage).forEach(([operator, argument]) => {
+    if (operator === '$replaceRoot') {
+      assertTenantPathNotAuthored({ value: argument?.newRoot, field, position });
+      return;
+    }
+    assertTenantPathNotAuthored({ value: argument, field, position });
+  });
+}
+
 function applyTenantToUpdate({ update, tenant, upsert = false }) {
   const { field, value } = tenant;
 
   if (Array.isArray(update)) {
     update.forEach((stage) => {
-      assertTenantFieldNotAuthored({ value: stage, field, position: 'an update' });
+      assertStageDoesNotAuthorTenantField({ stage, field });
       assertUnsetDoesNotDropTenantField({ stage, field });
     });
     return [...update, { $set: { [field]: value } }];
   }
 
-  assertTenantFieldNotAuthored({ value: update, field, position: 'an update' });
+  assertUpdateDoesNotAuthorTenantField({ update, field });
   assertRenameDoesNotTargetTenantField({ update, field });
   if (upsert) {
     return {

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/tenant/applyTenantToUpdate.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/tenant/applyTenantToUpdate.test.js
@@ -50,6 +50,36 @@ test('object form throws when $set authors the tenant field', () => {
   );
 });
 
+test('object form allows the tenant field name nested inside a $set value - it is data', () => {
+  const messages = [
+    { role: 'assistant', parts: [{ type: 'tool-result', output: { organization_id: 'org_b' } }] },
+  ];
+  const update = { $set: { messages, meta: { organization_id: 'org_b' } } };
+  expect(applyTenantToUpdate({ update, tenant })).toEqual(update);
+});
+
+test('object form allows the tenant field name nested inside $push and $addToSet values', () => {
+  const update = {
+    $push: { events: { organization_id: 'org_b' } },
+    $addToSet: { tags: { $each: [{ organization_id: 'org_b' }] } },
+  };
+  expect(applyTenantToUpdate({ update, tenant })).toEqual(update);
+});
+
+test('object form throws when a null-prototype $set authors the tenant field', () => {
+  const $set = Object.create(null);
+  $set.organization_id = 'org_b';
+  expect(() => applyTenantToUpdate({ update: { $set }, tenant })).toThrow(
+    'Tenant field "organization_id" can not be set in an update'
+  );
+});
+
+test('object form throws when a replacement-shaped update authors the tenant field', () => {
+  expect(() => applyTenantToUpdate({ update: { organization_id: 'org_b', v: 1 }, tenant })).toThrow(
+    'Tenant field "organization_id" can not be set in an update'
+  );
+});
+
 test('object form throws when $inc authors the tenant field', () => {
   expect(() => applyTenantToUpdate({ update: { $inc: { organization_id: 1 } }, tenant })).toThrow(
     'Tenant field "organization_id" can not be set in an update'
@@ -63,9 +93,9 @@ test('object form throws when $set authors a dotted tenant field path', () => {
 });
 
 test('object form throws when $unset drops the tenant field', () => {
-  expect(() => applyTenantToUpdate({ update: { $unset: { organization_id: '' } }, tenant })).toThrow(
-    'Tenant field "organization_id" can not be set in an update'
-  );
+  expect(() =>
+    applyTenantToUpdate({ update: { $unset: { organization_id: '' } }, tenant })
+  ).toThrow('Tenant field "organization_id" can not be set in an update');
 });
 
 test('object form throws when $setOnInsert authors the tenant field', () => {
@@ -135,6 +165,30 @@ test('pipeline form throws when a $replaceRoot stage authors the tenant field', 
       update: [{ $replaceRoot: { newRoot: { organization_id: 'org_b' } } }],
       tenant,
     })
+  ).toThrow('Tenant field "organization_id" can not be set in an update');
+});
+
+test('pipeline form allows the tenant field name nested inside a stage value', () => {
+  const update = [
+    { $set: { messages: [{ organization_id: 'org_b' }], meta: { organization_id: 'org_b' } } },
+    { $addFields: { snapshot: { organization_id: 'org_b' } } },
+    { $replaceRoot: { newRoot: { v: 1, meta: { organization_id: 'org_b' } } } },
+  ];
+  expect(applyTenantToUpdate({ update, tenant })).toEqual([
+    ...update,
+    { $set: { organization_id: 'org_a' } },
+  ]);
+});
+
+test('pipeline form throws when $addFields authors the tenant field', () => {
+  expect(() =>
+    applyTenantToUpdate({ update: [{ $addFields: { organization_id: 'org_b' } }], tenant })
+  ).toThrow('Tenant field "organization_id" can not be set in an update');
+});
+
+test('pipeline form throws when $replaceWith authors the tenant field', () => {
+  expect(() =>
+    applyTenantToUpdate({ update: [{ $replaceWith: { organization_id: 'org_b' } }], tenant })
   ).toThrow('Tenant field "organization_id" can not be set in an update');
 });
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/tenant/assertTenantPathNotAuthored.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/tenant/assertTenantPathNotAuthored.js
@@ -1,0 +1,47 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ConfigError } from '@lowdefy/errors';
+import { type } from '@lowdefy/helpers';
+
+// The write-position scan: reject the tenant field where it names a PATH of
+// the document being written, and nowhere else.
+//
+// In an update operator's argument ({ $set: { <path>: <value> } }) and in an
+// insert or replacement document, only the top-level keys are document
+// paths. Everything under them is data: a subdocument key spells
+// `<parent>.<key>`, never the root field, and an array of objects carries
+// whatever the app stores - a chat transcript, a tool result, an audit
+// snapshot. Recursing into values (assertTenantFieldNotAuthored) is right
+// for filters, where $and/$or/$elemMatch nest further clauses, but in a write
+// it turned any nested "organization_id" key inside stored data into a false
+// rejection of the whole write.
+//
+// type.isObject classifies by shape, not constructor, so a null-prototype
+// argument is scanned like any other - this is the security guard on the
+// update path.
+function assertTenantPathNotAuthored({ value, field, position }) {
+  if (!type.isObject(value)) return;
+  Object.keys(value).forEach((key) => {
+    if (key === field || key.startsWith(`${field}.`)) {
+      throw new ConfigError(
+        `Tenant field "${field}" can not be set in ${position} on a tenant connection - the tenant wall stamps and filters it mechanically.`
+      );
+    }
+  });
+}
+
+export default assertTenantPathNotAuthored;

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/tenant/assertTenantPathNotAuthored.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/tenant/assertTenantPathNotAuthored.test.js
@@ -1,0 +1,78 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import assertTenantPathNotAuthored from './assertTenantPathNotAuthored.js';
+
+const field = 'organization_id';
+const position = 'an update';
+
+test('throws when the tenant field is a top-level key', () => {
+  expect(() =>
+    assertTenantPathNotAuthored({ value: { organization_id: 'org_b' }, field, position })
+  ).toThrow(
+    'Tenant field "organization_id" can not be set in an update on a tenant connection - the tenant wall stamps and filters it mechanically.'
+  );
+});
+
+test('throws when a dotted path rooted in the tenant field is a top-level key', () => {
+  expect(() =>
+    assertTenantPathNotAuthored({ value: { 'organization_id.x': 1 }, field, position })
+  ).toThrow('Tenant field "organization_id" can not be set in an update');
+});
+
+test('throws for a null-prototype object keyed on the tenant field', () => {
+  const value = Object.create(null);
+  value.organization_id = 'org_b';
+  expect(() => assertTenantPathNotAuthored({ value, field, position })).toThrow(
+    'Tenant field "organization_id" can not be set in an update'
+  );
+});
+
+test('does not throw when the tenant field name is nested inside a value', () => {
+  expect(() =>
+    assertTenantPathNotAuthored({
+      value: {
+        meta: { organization_id: 'org_b' },
+        messages: [{ parts: [{ output: { organization_id: 'org_b' } }] }],
+      },
+      field,
+      position,
+    })
+  ).not.toThrow();
+});
+
+test('does not throw for a key that only shares the prefix', () => {
+  expect(() =>
+    assertTenantPathNotAuthored({ value: { organization_identifier: 'x' }, field, position })
+  ).not.toThrow();
+});
+
+test('does not throw for a subdocument path onto the field name', () => {
+  expect(() =>
+    assertTenantPathNotAuthored({ value: { 'meta.organization_id': 'x' }, field, position })
+  ).not.toThrow();
+});
+
+test('ignores non-object values', () => {
+  expect(() => assertTenantPathNotAuthored({ value: null, field, position })).not.toThrow();
+  expect(() => assertTenantPathNotAuthored({ value: undefined, field, position })).not.toThrow();
+  expect(() =>
+    assertTenantPathNotAuthored({ value: 'organization_id', field, position })
+  ).not.toThrow();
+  expect(() =>
+    assertTenantPathNotAuthored({ value: [{ organization_id: 1 }], field, position })
+  ).not.toThrow();
+});

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/tenant/stampTenantOnDoc.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/tenant/stampTenantOnDoc.js
@@ -16,11 +16,13 @@
 
 import { ConfigError } from '@lowdefy/errors';
 
-import assertTenantFieldNotAuthored from './assertTenantFieldNotAuthored.js';
+import assertTenantPathNotAuthored from './assertTenantPathNotAuthored.js';
 
 // The server owns the tenant field on every written document: authored values
 // are rejected (loud error over silent overwrite), then the caller's org is
-// stamped.
+// stamped. Only the document's own top-level keys are paths onto the field -
+// a nested key inside a subdocument or an embedded array is the app's data
+// (see assertTenantPathNotAuthored).
 function stampTenantOnDoc({ doc, tenant, position = 'an insert document' }) {
   const { field, value } = tenant;
   if (tenant.authored === true) {
@@ -30,7 +32,7 @@ function stampTenantOnDoc({ doc, tenant, position = 'an insert document' }) {
       '"tenant: authored" applies only to aggregation requests - the tenant wall scopes this request mechanically. Remove "tenant: authored".'
     );
   }
-  assertTenantFieldNotAuthored({ value: doc, field, position });
+  assertTenantPathNotAuthored({ value: doc, field, position });
   return { ...doc, [field]: value };
 }
 

--- a/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/tenant/stampTenantOnDoc.test.js
+++ b/packages/plugins/connections/connection-mongodb/src/connections/MongoDBCollection/tenant/stampTenantOnDoc.test.js
@@ -37,10 +37,17 @@ test('throws when the tenant field is authored on the document', () => {
   );
 });
 
-test('throws when the tenant field is authored nested in the document', () => {
-  expect(() => stampTenantOnDoc({ doc: { meta: { organization_id: 'org_b' } }, tenant })).toThrow(
-    'Tenant field "organization_id" can not be set in an insert document'
-  );
+test('allows the tenant field name nested inside the document - a subdocument key is data', () => {
+  expect(
+    stampTenantOnDoc({
+      doc: { meta: { organization_id: 'org_b' }, items: [{ organization_id: 'org_b' }] },
+      tenant,
+    })
+  ).toEqual({
+    meta: { organization_id: 'org_b' },
+    items: [{ organization_id: 'org_b' }],
+    organization_id: 'org_a',
+  });
 });
 
 test('throws when a dotted tenant field key is authored', () => {


### PR DESCRIPTION
## Problem

`assertTenantFieldNotAuthored` walks the whole update document, values included. In `{ $set: { messages: [...] } }` it descends into the messages array and throws on any nested key named after the tenant field. A production app hit this: its saved chat transcript carries tool results, one tool returned `{ organization: { organization_id } }`, and every `save-thread` upsert from that turn on failed with

```
Tenant field "organization_id" can not be set in an update on a tenant connection - the tenant wall stamps and filters it mechanically.
```

The same applied to insert and replacement documents: `{ meta: { organization_id } }` was rejected although it writes `meta.organization_id`, not the tenant field.

## Fix

- New `assertTenantPathNotAuthored`: rejects the tenant field (or a dotted path rooted in it) only as a **top-level key** of the object it is given.
- `applyTenantToUpdate` object form: scans the update's own keys (replacement-shaped) and each `$operator` argument's keys. `$rename`'s value side is still checked.
- `applyTenantToUpdate` pipeline form: scans the argument keys of each stage (`$set`, `$addFields`, `$project`, `$replaceWith`, and `$replaceRoot.newRoot`); `$unset` string / array forms as before; the final restamp `$set` stage stays.
- `stampTenantOnDoc`: top-level keys only.
- Filters and `$match` stages keep the deep scan (`assertTenantFieldNotAuthored`), where nesting is `$and` / `$or` / `$elemMatch` structure rather than data.

Security posture is unchanged: every path that could reassign a row's tenant is still rejected (null-prototype arguments included, tests cover it), and the belt-and-braces stamps on upsert / pipeline remain.

## Tests

`@lowdefy/connection-mongodb`: 35 suites, 535 tests pass. New `assertTenantPathNotAuthored.test.js`; `applyTenantToUpdate.test.js` gains nested-value, `$push` / `$addToSet`, null-prototype, replacement-shaped, `$addFields` and `$replaceWith` cases; `stampTenantOnDoc.test.js` flips the nested case to allowed.

Changeset included.

https://claude.ai/code/session_01BdvYG7gryiRopmYzvoF5Q3
