### PR TITLE
fix: make release pipeline idempotent and recoverable on re-run

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -31,48 +32,85 @@ jobs:
       - name: Upgrade npm for OIDC trusted publishing
         run: npm install -g npm@latest
 
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
+      # Versioning only: when changesets exist, this opens/updates the "Publish new
+      # release" PR. Publishing is handled explicitly below so we control its exit
+      # semantics and can recover from a partial publish by re-running.
+      - name: Create Release Pull Request
         uses: changesets/action@v1
         with:
           version: pnpm release:version
-          publish: pnpm release:publish
           createGithubReleases: false
           commit: 'chore: Publish new release'
           title: 'Publish new release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # No pending changesets means the version PR has been merged: this is a publish
+      # commit. Everything below runs only in that case, and each step is idempotent so
+      # a re-run recovers cleanly from a config or network error part-way through.
+      - name: Detect publish mode
+        id: mode
+        run: |
+          count=$(find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' | wc -l | tr -d ' ')
+          if [ "$count" -eq 0 ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Attempt the publish, but do not trust its exit code: `changeset publish` fails on
+      # versions that already exist, which is a success condition on a re-run. The verify
+      # step below is the real gate.
+      - name: Publish to npm
+        if: steps.mode.outputs.publish == 'true'
+        run: pnpm release:publish || true
+        env:
           NPM_CONFIG_PROVENANCE: 'true'
 
+      # Source of truth: every publishable package must be live on npm at its release
+      # version. Missing anything fails the job (a real failure — re-run after fixing).
+      - name: Verify all packages published
+        if: steps.mode.outputs.publish == 'true'
+        run: node scripts/verify-published.mjs
+
+      - name: Resolve release version
+        if: steps.mode.outputs.publish == 'true'
+        id: version
+        run: echo "version=v$(node -p "require('./packages/cli/package.json').version")" >> "$GITHUB_OUTPUT"
+
       - name: Generate release notes
-        if: steps.changesets.outputs.published == 'true'
-        id: release-notes
+        if: steps.mode.outputs.publish == 'true'
         run: |
           npm install -g @anthropic-ai/claude-code
           node scripts/release-notes.mjs --output-file=/tmp/release-notes.md
-
-          # Extract version from script output
-          VERSION=$(node -e "
-            const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('packages/cli/package.json', 'utf-8'));
-            console.log('v' + pkg.version);
-          ")
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
+      # Idempotent: query origin so a re-run on a fresh checkout still sees an existing tag.
       - name: Tag release commit
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.mode.outputs.publish == 'true'
         run: |
-          git tag ${{ steps.release-notes.outputs.version }} ${{ github.sha }}
-          git push origin ${{ steps.release-notes.outputs.version }}
+          VERSION="${{ steps.version.outputs.version }}"
+          if git ls-remote --tags origin "refs/tags/$VERSION" | grep -q .; then
+            echo "Tag $VERSION already exists, skipping."
+          else
+            git tag "$VERSION" ${{ github.sha }}
+            git push origin "$VERSION"
+          fi
 
+      # Idempotent: only create the release if one does not already exist for this version.
       - name: Create Github Release
-        uses: softprops/action-gh-release@v2
-        if: steps.changesets.outputs.published == 'true'
-        with:
-          tag_name: ${{ steps.release-notes.outputs.version }}
-          name: ${{ steps.release-notes.outputs.version }}
-          draft: true
-          body_path: /tmp/release-notes.md
-          target_commitish: ${{ github.sha }}
+        if: steps.mode.outputs.publish == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists, skipping."
+          else
+            gh release create "$VERSION" \
+              --draft \
+              --title "$VERSION" \
+              --target ${{ github.sha }} \
+              --notes-file /tmp/release-notes.md
+          fi

--- a/scripts/verify-published.mjs
+++ b/scripts/verify-published.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/**
+ * Idempotent release gate.
+ *
+ * Asserts that every publishable workspace package is live on npm at the
+ * version in its local package.json. This is the source of truth for whether a
+ * release succeeded — not the exit code of `changeset publish`, which treats an
+ * already-published version as an error and so cannot tell "already done" apart
+ * from "genuinely failed".
+ *
+ * - All packages present at their local version -> exit 0 (release complete,
+ *   even on a rerun where publish re-attempted and rejected existing versions).
+ * - Any package missing its version -> exit 1 (a real failure: a missing trusted
+ *   publisher, a network error, etc. — rerun after fixing to recover).
+ *
+ * The publishable set mirrors what `changeset publish` targets: every non-private
+ * workspace package, minus the `ignore` list in .changeset/config.json.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const RETRIES = 5;
+const RETRY_DELAY_MS = 5000;
+const CONCURRENCY = 10;
+const REGISTRY = (process.env.npm_config_registry ?? 'https://registry.npmjs.org').replace(/\/$/, '');
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function getPublishablePackages() {
+  const { ignore = [] } = readJson('.changeset/config.json');
+  const ignored = new Set(ignore);
+
+  const workspaces = JSON.parse(
+    execFileSync('pnpm', ['ls', '-r', '--depth', '-1', '--json'], { encoding: 'utf8' })
+  );
+
+  return workspaces
+    .map((workspace) => readJson(join(workspace.path, 'package.json')))
+    .filter((pkg) => pkg.name && pkg.version && pkg.private !== true && !ignored.has(pkg.name))
+    .map((pkg) => ({ name: pkg.name, version: pkg.version }));
+}
+
+async function isPublished({ name, version }) {
+  // The version manifest endpoint is a single lightweight request: 200 = live, 404 = not there.
+  try {
+    const response = await fetch(`${REGISTRY}/${name}/${version}`, { cache: 'no-store' });
+    return response.status === 200;
+  } catch {
+    // Network/registry error — treat as not-yet-confirmed and let the retry loop reassess.
+    return false;
+  }
+}
+
+async function findMissing(packages) {
+  const remaining = [...packages];
+  const missing = [];
+  async function worker() {
+    let pkg;
+    while ((pkg = remaining.pop())) {
+      if (!(await isPublished(pkg))) missing.push(pkg);
+    }
+  }
+  await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+  return missing;
+}
+
+const packages = getPublishablePackages();
+let missing = packages;
+
+for (let attempt = 1; attempt <= RETRIES && missing.length > 0; attempt += 1) {
+  missing = await findMissing(missing);
+  if (missing.length > 0 && attempt < RETRIES) {
+    // Freshly published versions can lag in the registry — wait and re-check.
+    console.log(
+      `Waiting for ${missing.length} package(s) to appear on npm (attempt ${attempt}/${RETRIES})...`
+    );
+    await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+  }
+}
+
+if (missing.length > 0) {
+  console.error('The following packages are not published at their release version:');
+  missing.forEach((pkg) => console.error(`  ${pkg.name}@${pkg.version}`));
+  console.error('\nRelease is incomplete. Fix the cause and re-run the release to recover.');
+  process.exit(1);
+}
+
+console.log(`All ${packages.length} publishable packages are live on npm at their release version.`);


### PR DESCRIPTION
## Problem

The v6 release exposed that the Release workflow cannot recover from a partial publish by re-running.

- A partial publish (e.g. new packages missing their npm trusted-publisher config → 404) fails the publish step.
- On a re-run, `changeset publish` exits non-zero on versions that already exist (`You cannot publish over the previously published versions`) — indistinguishable from a genuine failure.
- The tag + GitHub-release steps were gated on the changesets step succeeding, so a re-run that published nothing new **skipped them entirely**. Net result for v6: every package live on npm, but no `v6.0.0` tag and no GitHub release.

## Fix

- **npm is the source of truth, not the publish exit code.** Publish runs as its own step with its exit code ignored (`|| true`); `scripts/verify-published.mjs` then asserts every publishable workspace package is live on npm at its release version. Missing anything fails the job (a real failure — re-run after fixing to recover); already-published passes.
- **Tag + release gate on end-state**, not "published this run": they run on a publish commit (no pending changesets) and each is idempotent (skip if the tag/release already exists), so a re-run converges.
- **`workflow_dispatch`** added so a stuck release can be re-run manually without a dummy commit.

Merging this to `main` should itself demonstrate the fix: it's a publish commit with nothing new to publish, so publish no-ops, verify passes against the already-live v6 packages, and the `v6.0.0` tag + draft release finally get created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)