### PR TITLE
feat(client): page onVisible / onHidden events

### DIFF
--- a/.changeset/page-visibility-events.md
+++ b/.changeset/page-visibility-events.md
@@ -1,0 +1,23 @@
+---
+'@lowdefy/client': minor
+'@lowdefy/engine': minor
+'@lowdefy/docs': minor
+'@lowdefy/docs-content': minor
+---
+
+feat(client,engine): page lifecycle events for the browser tab, network and window
+
+Pages can now react to the browser instead of polling to notice that something
+changed while the user was away. Five new events can be defined on the first
+blocks of a page: `onVisible` and `onHidden` when the tab is shown or hidden, or
+the window regains or loses focus (coalesced over 300ms so a focus and
+visibility pair only runs the chain once, with `_event` carrying `visible` and
+`reason`); `onOnline` and `onOffline` when the browser reports the network
+connection was regained or lost (`_event` carrying `online`); and `onResize`
+when the window is resized, debounced by 200ms (`_event` carrying `width` and
+`height`).
+
+The listeners are attached once while the page is mounted and removed when the
+user navigates away, so they never trigger for a page that is no longer open,
+and none of them trigger on the initial page load. The action chains run
+non-blocking, like `onMountAsync`, so they never hold the page in loading.

--- a/packages/client/src/Context.js
+++ b/packages/client/src/Context.js
@@ -17,12 +17,22 @@
 import React, { useEffect } from 'react';
 import getContext from '@lowdefy/engine';
 
+import createPageLifecycleManager from './createPageLifecycleManager.js';
 import createShortcutManager from './createShortcutManager.js';
 import MountEvents from './MountEvents.js';
 
 const ShortcutEffect = ({ context }) => {
   useEffect(() => {
     const manager = createShortcutManager();
+    manager.init(context);
+    return () => manager.destroy();
+  }, [context]);
+  return null;
+};
+
+const PageLifecycleEffect = ({ context }) => {
+  useEffect(() => {
+    const manager = createPageLifecycleManager();
     manager.init(context);
     return () => manager.destroy();
   }, [context]);
@@ -62,6 +72,7 @@ const Context = ({ children, config, jsMap, lowdefy, resetContext }) => {
         return (
           <>
             <ShortcutEffect context={context} />
+            <PageLifecycleEffect context={context} />
             <WebSocketsEffect context={context} />
             {children(context)}
           </>

--- a/packages/client/src/createPageLifecycleManager.js
+++ b/packages/client/src/createPageLifecycleManager.js
@@ -1,0 +1,156 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// Page lifecycle events. Browser signals a page can react to, so apps do not
+// have to poll to notice that a tab went away and came back, that the network
+// dropped, or that the window was resized.
+//
+// - onVisible  document became visible again, or the window regained focus.
+// - onHidden   document became hidden, or the window lost focus.
+// - onOnline   the browser reports the network is back.
+// - onOffline  the browser reports the network is gone.
+// - onResize   the window was resized.
+//
+// None of these fire on the initial page load - the active state is seeded from
+// the document when the page mounts, and only transitions away from that seed
+// trigger an event.
+
+const VISIBILITY_DEBOUNCE_MS = 300;
+const RESIZE_DEBOUNCE_MS = 200;
+
+function createPageLifecycleManager() {
+  let destroyed = false;
+  let removeListeners = [];
+  let timeouts = [];
+
+  function init(context) {
+    destroyed = false;
+    const globals = context?._internal?.lowdefy?._internal?.globals ?? {};
+    const win = globals.window;
+    const doc = globals.document;
+    // Server side render guard - there are no browser listeners to attach to.
+    if (typeof document === 'undefined' || !win || !doc) return;
+    if (typeof win.addEventListener !== 'function' || typeof doc.addEventListener !== 'function') {
+      return;
+    }
+
+    const events = context._internal.rootBlock?.events ?? {};
+    const configured = (name) => !!events[name];
+
+    const trigger = (name, event) => {
+      if (destroyed) return;
+      // Page lifecycle chains run like onMountAsync - non blocking, and a
+      // failure in the chain must not break the page.
+      try {
+        Promise.resolve(context._internal.triggerPageEvent({ name, event })).catch((error) => {
+          context._internal.lowdefy._internal.handleError?.(error);
+        });
+      } catch (error) {
+        context._internal.lowdefy._internal.handleError?.(error);
+      }
+    };
+
+    const setTimer = (fn, ms) => {
+      const timeout = setTimeout(() => {
+        timeouts = timeouts.filter((t) => t !== timeout);
+        fn();
+      }, ms);
+      timeouts.push(timeout);
+      return timeout;
+    };
+
+    const listen = (target, name, handler) => {
+      target.addEventListener(name, handler);
+      removeListeners.push(() => target.removeEventListener(name, handler));
+    };
+
+    // --- onVisible / onHidden ------------------------------------------------
+    if (configured('onVisible') || configured('onHidden')) {
+      // Seeded from the document so the initial load never fires an event.
+      let active = doc.visibilityState !== 'hidden';
+      let pending = null;
+
+      const flush = () => {
+        const next = pending;
+        pending = null;
+        if (destroyed || !next) return;
+        // A focus that only restores a state we are already in is not an event.
+        if (next.active === active) return;
+        active = next.active;
+        trigger(next.active ? 'onVisible' : 'onHidden', {
+          visible: next.active,
+          reason: next.reason,
+        });
+      };
+
+      // A tab coming back to the front fires visibilitychange and focus. Both
+      // are collected into one window so the event chain only runs once.
+      const signal = (nextActive, reason) => {
+        if (destroyed) return;
+        if (pending) {
+          pending.active = nextActive;
+          // A visibilitychange is the more precise reason, so it wins the pair.
+          if (reason === 'visibility') pending.reason = 'visibility';
+          return;
+        }
+        pending = { active: nextActive, reason };
+        setTimer(flush, VISIBILITY_DEBOUNCE_MS);
+      };
+
+      listen(doc, 'visibilitychange', () => {
+        signal(doc.visibilityState !== 'hidden', 'visibility');
+      });
+      listen(win, 'focus', () => signal(true, 'focus'));
+      listen(win, 'blur', () => signal(false, 'focus'));
+    }
+
+    // --- onOnline / onOffline ------------------------------------------------
+    if (configured('onOnline')) {
+      listen(win, 'online', () => trigger('onOnline', { online: true }));
+    }
+    if (configured('onOffline')) {
+      listen(win, 'offline', () => trigger('onOffline', { online: false }));
+    }
+
+    // --- onResize ------------------------------------------------------------
+    if (configured('onResize')) {
+      let resizeTimeout = null;
+      listen(win, 'resize', () => {
+        if (resizeTimeout) {
+          clearTimeout(resizeTimeout);
+          timeouts = timeouts.filter((t) => t !== resizeTimeout);
+        }
+        resizeTimeout = setTimer(() => {
+          resizeTimeout = null;
+          trigger('onResize', { width: win.innerWidth, height: win.innerHeight });
+        }, RESIZE_DEBOUNCE_MS);
+      });
+    }
+  }
+
+  function destroy() {
+    destroyed = true;
+    removeListeners.forEach((remove) => remove());
+    removeListeners = [];
+    timeouts.forEach((timeout) => clearTimeout(timeout));
+    timeouts = [];
+  }
+
+  return { init, destroy };
+}
+
+export { RESIZE_DEBOUNCE_MS, VISIBILITY_DEBOUNCE_MS };
+export default createPageLifecycleManager;

--- a/packages/client/src/createPageLifecycleManager.test.js
+++ b/packages/client/src/createPageLifecycleManager.test.js
@@ -1,0 +1,277 @@
+/*
+  Copyright 2020-2026 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+
+import createPageLifecycleManager from './createPageLifecycleManager.js';
+
+const allEvents = {
+  onVisible: [],
+  onHidden: [],
+  onOnline: [],
+  onOffline: [],
+  onResize: [],
+};
+
+const setVisibilityState = (state) => {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => state,
+  });
+};
+
+const getContext = ({ events = allEvents, triggerPageEvent } = {}) => ({
+  _internal: {
+    rootBlock: { events },
+    triggerPageEvent: triggerPageEvent ?? jest.fn(() => Promise.resolve()),
+    lowdefy: {
+      _internal: {
+        globals: { document, window },
+        handleError: jest.fn(),
+      },
+    },
+  },
+});
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  setVisibilityState('visible');
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+test('does not fire on init', () => {
+  const context = getContext();
+  const manager = createPageLifecycleManager();
+  manager.init(context);
+  jest.advanceTimersByTime(1000);
+  expect(context._internal.triggerPageEvent).not.toHaveBeenCalled();
+  manager.destroy();
+});
+
+test('onVisible fires on visibilitychange to visible', () => {
+  const context = getContext();
+  const manager = createPageLifecycleManager();
+  setVisibilityState('hidden');
+  manager.init(context);
+  setVisibilityState('visible');
+  document.dispatchEvent(new Event('visibilitychange'));
+  jest.advanceTimersByTime(300);
+  expect(context._internal.triggerPageEvent).toHaveBeenCalledTimes(1);
+  expect(context._internal.triggerPageEvent).toHaveBeenCalledWith({
+    name: 'onVisible',
+    event: { visible: true, reason: 'visibility' },
+  });
+  manager.destroy();
+});
+
+test('onVisible fires on window focus', () => {
+  const context = getContext();
+  const manager = createPageLifecycleManager();
+  setVisibilityState('hidden');
+  manager.init(context);
+  window.dispatchEvent(new Event('focus'));
+  jest.advanceTimersByTime(300);
+  expect(context._internal.triggerPageEvent).toHaveBeenCalledTimes(1);
+  expect(context._internal.triggerPageEvent).toHaveBeenCalledWith({
+    name: 'onVisible',
+    event: { visible: true, reason: 'focus' },
+  });
+  manager.destroy();
+});
+
+test('a focus and visibilitychange pair is coalesced into one onVisible', () => {
+  const context = getContext();
+  const manager = createPageLifecycleManager();
+  setVisibilityState('hidden');
+  manager.init(context);
+  setVisibilityState('visible');
+  document.dispatchEvent(new Event('visibilitychange'));
+  window.dispatchEvent(new Event('focus'));
+  jest.advanceTimersByTime(300);
+  expect(context._internal.triggerPageEvent).toHaveBeenCalledTimes(1);
+  expect(context._internal.triggerPageEvent).toHaveBeenCalledWith({
+    name: 'onVisible',
+    event: { visible: true, reason: 'visibility' },
+  });
+  manager.destroy();
+});
+
+test('visibility wins the reason when focus arrives first', () => {
+  const context = getContext();
+  const manager = createPageLifecycleManager();
+  setVisibilityState('hidden');
+  manager.init(context);
+  window.dispatchEvent(new Event('focus'));
+  setVisibilityState('visible');
+  document.dispatchEvent(new Event('visibilitychange'));
+  jest.advanceTimersByTime(300);
+  expect(context._internal.triggerPageEvent).toHaveBeenCalledWith({
+    name: 'onVisible',
+    event: { visible: true, reason: 'visibility' },
+  });
+  manager.destroy();
+});
+
+test('a focus while the page is already visible does not fire onVisible', () => {
+  const context = getContext();
+  const manager = createPageLifecycleManager();
+  manager.init(context);
+  window.dispatchEvent(new Event('focus'));
+  jest.advanceTimersByTime(300);
+  expect(context._internal.triggerPageEvent).not.toHaveBeenCalled();
+  manager.destroy();
+});
+
+test('onHidden fires on visibilitychange to hidden', () => {
+  const context = getContext();
+  const manager = createPageLifecycleManager();
+  manager.init(context);
+  setVisibilityState('hidden');
+  document.dispatchEvent(new Event('visibilitychange'));
+  jest.advanceTimersByTime(300);
+  expect(context._internal.triggerPageEvent).toHaveBeenCalledTimes(1);
+  expect(context._internal.triggerPageEvent).toHaveBeenCalledWith({
+    name: 'onHidden',
+    event: { visible: false, reason: 'visibility' },
+  });
+  manager.destroy();
+});
+
+test('onHidden fires on window blur', () => {
+  const context = getContext();
+  const manager = createPageLifecycleManager();
+  manager.init(context);
+  window.dispatchEvent(new Event('blur'));
+  jest.advanceTimersByTime(300);
+  expect(context._internal.triggerPageEvent).toHaveBeenCalledWith({
+    name: 'onHidden',
+    event: { visible: false, reason: 'focus' },
+  });
+  manager.destroy();
+});
+
+test('onOnline and onOffline fire with the online payload', () => {
+  const context = getContext();
+  const manager = createPageLifecycleManager();
+  manager.init(context);
+  window.dispatchEvent(new Event('offline'));
+  expect(context._internal.triggerPageEvent).toHaveBeenCalledWith({
+    name: 'onOffline',
+    event: { online: false },
+  });
+  window.dispatchEvent(new Event('online'));
+  expect(context._internal.triggerPageEvent).toHaveBeenCalledWith({
+    name: 'onOnline',
+    event: { online: true },
+  });
+  expect(context._internal.triggerPageEvent).toHaveBeenCalledTimes(2);
+  manager.destroy();
+});
+
+test('onResize is debounced and carries the window size', () => {
+  const context = getContext();
+  const manager = createPageLifecycleManager();
+  manager.init(context);
+  window.innerWidth = 800;
+  window.innerHeight = 600;
+  window.dispatchEvent(new Event('resize'));
+  window.dispatchEvent(new Event('resize'));
+  jest.advanceTimersByTime(100);
+  expect(context._internal.triggerPageEvent).not.toHaveBeenCalled();
+  window.innerWidth = 1024;
+  window.innerHeight = 768;
+  window.dispatchEvent(new Event('resize'));
+  jest.advanceTimersByTime(200);
+  expect(context._internal.triggerPageEvent).toHaveBeenCalledTimes(1);
+  expect(context._internal.triggerPageEvent).toHaveBeenCalledWith({
+    name: 'onResize',
+    event: { width: 1024, height: 768 },
+  });
+  manager.destroy();
+});
+
+test('listeners are removed on destroy', () => {
+  const context = getContext();
+  const manager = createPageLifecycleManager();
+  manager.init(context);
+  manager.destroy();
+  setVisibilityState('hidden');
+  document.dispatchEvent(new Event('visibilitychange'));
+  window.dispatchEvent(new Event('blur'));
+  window.dispatchEvent(new Event('offline'));
+  window.dispatchEvent(new Event('resize'));
+  jest.advanceTimersByTime(1000);
+  expect(context._internal.triggerPageEvent).not.toHaveBeenCalled();
+});
+
+test('a pending event does not fire after destroy', () => {
+  const context = getContext();
+  const manager = createPageLifecycleManager();
+  manager.init(context);
+  setVisibilityState('hidden');
+  document.dispatchEvent(new Event('visibilitychange'));
+  manager.destroy();
+  jest.advanceTimersByTime(1000);
+  expect(context._internal.triggerPageEvent).not.toHaveBeenCalled();
+});
+
+test('listeners are only attached for configured events', () => {
+  const context = getContext({ events: { onResize: [] } });
+  const manager = createPageLifecycleManager();
+  manager.init(context);
+  setVisibilityState('hidden');
+  document.dispatchEvent(new Event('visibilitychange'));
+  window.dispatchEvent(new Event('offline'));
+  jest.advanceTimersByTime(1000);
+  expect(context._internal.triggerPageEvent).not.toHaveBeenCalled();
+  window.dispatchEvent(new Event('resize'));
+  jest.advanceTimersByTime(200);
+  expect(context._internal.triggerPageEvent).toHaveBeenCalledTimes(1);
+  manager.destroy();
+});
+
+test('no listeners are attached when the page has no lifecycle events', () => {
+  const context = getContext({ events: { onMount: [] } });
+  const addEventListener = jest.spyOn(window, 'addEventListener');
+  const manager = createPageLifecycleManager();
+  manager.init(context);
+  expect(addEventListener).not.toHaveBeenCalled();
+  addEventListener.mockRestore();
+  manager.destroy();
+});
+
+test('an error in a lifecycle chain is handled', async () => {
+  const error = new Error('Test error.');
+  const context = getContext({ triggerPageEvent: jest.fn(() => Promise.reject(error)) });
+  const manager = createPageLifecycleManager();
+  manager.init(context);
+  window.dispatchEvent(new Event('offline'));
+  await Promise.resolve();
+  expect(context._internal.lowdefy._internal.handleError).toHaveBeenCalledWith(error);
+  manager.destroy();
+});
+
+test('init is a noop when there are no browser globals', () => {
+  const context = getContext();
+  context._internal.lowdefy._internal.globals = {};
+  const manager = createPageLifecycleManager();
+  manager.init(context);
+  manager.destroy();
+  expect(context._internal.triggerPageEvent).not.toHaveBeenCalled();
+});

--- a/packages/docs-content/content/concepts/events-and-actions.md
+++ b/packages/docs-content/content/concepts/events-and-actions.md
@@ -225,9 +225,11 @@ events:
           searchOpen: true
 ```
 
-## Page initialization events
+## Page lifecycle events
 
-The first blocks on a page, usually a [`container`](/container) type block, can define `onInit` and `onInitAsync` events. All blocks have `onMount` and `onMountAsync` events, that can be used to initialize the page or blocks.
+The first blocks on a page, usually a [`container`](/container) type block, can define page lifecycle events. The page initialization events `onInit` and `onInitAsync` are triggered when the page is first loaded, and the browser lifecycle events `onVisible`, `onHidden`, `onOnline`, `onOffline` and `onResize` are triggered while the page stays open. All blocks have `onMount` and `onMountAsync` events, that can be used to initialize the page or blocks.
+
+### Page initialization events
 
 The `onInit` event is triggered the first time a page is loaded. This event blocks page render, in other words, the page __will__ remain in a loading state, rendering only the progress bar, until all the actions have completed execution. It can be used to set up [`state`](/page-and-app-state). Actions that take a long time to execute, like `Request`, should be used sparingly here for a better user experience.
 
@@ -236,6 +238,62 @@ The `onInitAsync` event is triggered the first time a page loaded, but does not 
 The `onMount` event is triggered every time a block is rendered on a page. This event can be used on any block, and causes the block and it's children to render in their loading state. It typically executes actions that should be run each time a block is loaded, like checking if an id is present in the [url query parameters](/_url_query), or fetching data for [`Selector`](/Selector) options using a [`Request`](/Request) action.
 
 The `onMountAsync` event is triggered every time a block is mounted, but does not render the block in loading.
+
+### Browser lifecycle events
+
+The first blocks on a page can also define events that react to the browser: `onVisible`, `onHidden`, `onOnline`, `onOffline` and `onResize`. These are useful to refresh data that went stale while the user was away, instead of polling the server on a timer.
+
+These events are only attached while the page is mounted, and are removed again when the user navigates away, so they never trigger for a page the user has left. They never trigger on the initial page load either — only a change after the page has loaded triggers them. Their action chains run like `onMountAsync`: they do not keep the page or block in a loading state.
+
+The `onVisible` event is triggered when the browser tab becomes visible again, or when the window regains focus. Rapid pairs of these signals — a tab switch usually produces both — are coalesced over 300ms, so the event is only triggered once. The [`_event`](/_event) object contains `visible: true` and `reason`, which is `visibility` when the browser reported the tab becoming visible, or `focus` when the window regained focus.
+
+```yaml
+events:
+  onVisible:
+    - id: refresh_tasks
+      type: Request
+      params: get_tasks
+```
+
+The `onHidden` event is triggered when the browser tab is hidden, or when the window loses focus, coalesced in the same way. The `_event` object contains `visible: false` and the same `reason` field.
+
+```yaml
+events:
+  onHidden:
+    - id: stop_refreshing
+      type: SetState
+      params:
+        live: false
+```
+
+The `onOnline` and `onOffline` events are triggered when the browser reports that the network connection was regained or lost. The `_event` object contains `online: true` or `online: false`.
+
+```yaml
+events:
+  onOnline:
+    - id: back_online
+      type: Message
+      params:
+        content: You are back online.
+  onOffline:
+    - id: went_offline
+      type: Message
+      params:
+        status: warning
+        content: You are offline, changes will not be saved.
+```
+
+The `onResize` event is triggered when the window is resized, debounced by 200ms so that the actions only run once the user stops resizing. The `_event` object contains the `width` and `height` of the window.
+
+```yaml
+events:
+  onResize:
+    - id: set_width
+      type: SetState
+      params:
+        window_width:
+          _event: width
+```
 
 ## Action types
 
@@ -269,3 +327,7 @@ See additional action type available under the Actions tab in the menu.
 - The `onInitAsync` event is triggered the first time a page is mounted and does not keep the page in loading.
 - The `onMount` events is triggered the every time a block is mounted and keeps the block in loading until all actions have finished.
 - The `onMountAsync` event is triggered the every time a block is mounted, after `onMount` has completed, and does not keep the block in loading.
+- The `onVisible` and `onHidden` events are triggered when the browser tab is shown or hidden, or when the window gains or loses focus, coalesced over 300ms.
+- The `onOnline` and `onOffline` events are triggered when the browser reports that the network connection was regained or lost.
+- The `onResize` event is triggered when the window is resized, debounced by 200ms.
+- Browser lifecycle events are never triggered on the initial page load, and are removed when the user navigates away from the page.

--- a/packages/docs/concepts/events-and-actions.yaml
+++ b/packages/docs/concepts/events-and-actions.yaml
@@ -249,9 +249,11 @@ _ref:
                       searchOpen: true
             ```
 
-            ## Page initialization events
+            ## Page lifecycle events
 
-            The first blocks on a page, usually a [`container`](/container) type block, can define `onInit` and `onInitAsync` events. All blocks have `onMount` and `onMountAsync` events, that can be used to initialize the page or blocks.
+            The first blocks on a page, usually a [`container`](/container) type block, can define page lifecycle events. The page initialization events `onInit` and `onInitAsync` are triggered when the page is first loaded, and the browser lifecycle events `onVisible`, `onHidden`, `onOnline`, `onOffline` and `onResize` are triggered while the page stays open. All blocks have `onMount` and `onMountAsync` events, that can be used to initialize the page or blocks.
+
+            ### Page initialization events
 
             The `onInit` event is triggered the first time a page is loaded. This event blocks page render, in other words, the page __will__ remain in a loading state, rendering only the progress bar, until all the actions have completed execution. It can be used to set up [`state`](/page-and-app-state). Actions that take a long time to execute, like `Request`, should be used sparingly here for a better user experience.
 
@@ -260,6 +262,62 @@ _ref:
             The `onMount` event is triggered every time a block is rendered on a page. This event can be used on any block, and causes the block and it's children to render in their loading state. It typically executes actions that should be run each time a block is loaded, like checking if an id is present in the [url query parameters](/_url_query), or fetching data for [`Selector`](/Selector) options using a [`Request`](/Request) action.
 
             The `onMountAsync` event is triggered every time a block is mounted, but does not render the block in loading.
+
+            ### Browser lifecycle events
+
+            The first blocks on a page can also define events that react to the browser: `onVisible`, `onHidden`, `onOnline`, `onOffline` and `onResize`. These are useful to refresh data that went stale while the user was away, instead of polling the server on a timer.
+
+            These events are only attached while the page is mounted, and are removed again when the user navigates away, so they never trigger for a page the user has left. They never trigger on the initial page load either — only a change after the page has loaded triggers them. Their action chains run like `onMountAsync`: they do not keep the page or block in a loading state.
+
+            The `onVisible` event is triggered when the browser tab becomes visible again, or when the window regains focus. Rapid pairs of these signals — a tab switch usually produces both — are coalesced over 300ms, so the event is only triggered once. The [`_event`](/_event) object contains `visible: true` and `reason`, which is `visibility` when the browser reported the tab becoming visible, or `focus` when the window regained focus.
+
+            ```yaml
+            events:
+              onVisible:
+                - id: refresh_tasks
+                  type: Request
+                  params: get_tasks
+            ```
+
+            The `onHidden` event is triggered when the browser tab is hidden, or when the window loses focus, coalesced in the same way. The `_event` object contains `visible: false` and the same `reason` field.
+
+            ```yaml
+            events:
+              onHidden:
+                - id: stop_refreshing
+                  type: SetState
+                  params:
+                    live: false
+            ```
+
+            The `onOnline` and `onOffline` events are triggered when the browser reports that the network connection was regained or lost. The `_event` object contains `online: true` or `online: false`.
+
+            ```yaml
+            events:
+              onOnline:
+                - id: back_online
+                  type: Message
+                  params:
+                    content: You are back online.
+              onOffline:
+                - id: went_offline
+                  type: Message
+                  params:
+                    status: warning
+                    content: You are offline, changes will not be saved.
+            ```
+
+            The `onResize` event is triggered when the window is resized, debounced by 200ms so that the actions only run once the user stops resizing. The `_event` object contains the `width` and `height` of the window.
+
+            ```yaml
+            events:
+              onResize:
+                - id: set_width
+                  type: SetState
+                  params:
+                    window_width:
+                      _event: width
+            ```
 
             ## Action types
 
@@ -293,6 +351,10 @@ _ref:
             - The `onInitAsync` event is triggered the first time a page is mounted and does not keep the page in loading.
             - The `onMount` events is triggered the every time a block is mounted and keeps the block in loading until all actions have finished.
             - The `onMountAsync` event is triggered the every time a block is mounted, after `onMount` has completed, and does not keep the block in loading.
+            - The `onVisible` and `onHidden` events are triggered when the browser tab is shown or hidden, or when the window gains or loses focus, coalesced over 300ms.
+            - The `onOnline` and `onOffline` events are triggered when the browser reports that the network connection was regained or lost.
+            - The `onResize` event is triggered when the window is resized, debounced by 200ms.
+            - Browser lifecycle events are never triggered on the initial page load, and are removed when the user navigates away from the page.
 
       - _ref:
           path: templates/navigation_buttons.yaml

--- a/packages/engine/src/getContext.js
+++ b/packages/engine/src/getContext.js
@@ -160,6 +160,14 @@ function getContext({
       _internal.onInitAsyncDone = true;
     }
   };
+  // Page lifecycle events (onVisible, onHidden, onOnline, onOffline, onResize) are
+  // triggered on the page's root block by browser listeners attached in the client.
+  _internal.triggerPageEvent = ({ name, event, progress = () => undefined }) =>
+    _internal.RootSlots.slots.root.blocks[0].triggerEvent({
+      name,
+      event,
+      progress,
+    });
   ctx._internal.update();
   lowdefy.contexts[id] = ctx;
   return ctx;

--- a/packages/engine/test/getContext.test.js
+++ b/packages/engine/test/getContext.test.js
@@ -92,6 +92,7 @@ test('create context', () => {
   expect(context._internal.State).toBeDefined();
   expect(context._internal.runOnInit).toBeDefined();
   expect(context._internal.runOnInitAsync).toBeDefined();
+  expect(context._internal.triggerPageEvent).toBeDefined();
   expect(context._internal.lowdefy).toEqual(lowdefy);
   expect(context.eventLog).toEqual([]);
   expect(context.id).toEqual('page:pageId');
@@ -102,6 +103,28 @@ test('create context', () => {
   expect(context._internal.rootBlock).toBeDefined();
   expect(context.state).toEqual({});
   expect(context._internal.update).toBeDefined();
+});
+
+test('triggerPageEvent triggers the event on the page root block', () => {
+  const resetContext = { reset: true, setReset: () => {} };
+  const lowdefy = getLowdefy();
+  const page = {
+    id: 'pageId',
+    type: 'Box',
+  };
+  const config = buildTestPage({ pageConfig: page });
+  const context = getContext({ config, lowdefy, resetContext });
+  const rootBlock = context._internal.RootSlots.slots.root.blocks[0];
+  const triggerEvent = jest.fn();
+  rootBlock.triggerEvent = triggerEvent;
+  context._internal.triggerPageEvent({
+    name: 'onVisible',
+    event: { visible: true, reason: 'visibility' },
+  });
+  expect(triggerEvent.mock.calls.length).toBe(1);
+  expect(triggerEvent.mock.calls[0][0].name).toEqual('onVisible');
+  expect(triggerEvent.mock.calls[0][0].event).toEqual({ visible: true, reason: 'visibility' });
+  expect(typeof triggerEvent.mock.calls[0][0].progress).toBe('function');
 });
 
 test('create context, initialize input', () => {
@@ -158,8 +181,16 @@ test('dynamic page config builds a fresh context for a new config object', () =>
   // dynamic page must render the newly resolved content.
   const config2 = buildTestPage({ pageConfig: { id: 'pageId', type: 'Box' } });
   config2.dynamic = true;
-  const c1 = getContext({ config: config1, lowdefy, resetContext: { reset: true, setReset: () => {} } });
-  const c2 = getContext({ config: config2, lowdefy, resetContext: { reset: false, setReset: () => {} } });
+  const c1 = getContext({
+    config: config1,
+    lowdefy,
+    resetContext: { reset: true, setReset: () => {} },
+  });
+  const c2 = getContext({
+    config: config2,
+    lowdefy,
+    resetContext: { reset: false, setReset: () => {} },
+  });
   expect(c1).not.toBe(c2);
   expect(c1._internal.RootSlots.id).not.toEqual(c2._internal.RootSlots.id);
 });
@@ -186,14 +217,22 @@ test('dynamic rebuild does not call mounted updaters during construction', () =>
   config1.dynamic = true;
   const config2 = buildTestPage({ pageConfig: { id: 'pageId', type: 'Box' } });
   config2.dynamic = true;
-  const c1 = getContext({ config: config1, lowdefy, resetContext: { reset: true, setReset: () => {} } });
+  const c1 = getContext({
+    config: config1,
+    lowdefy,
+    resetContext: { reset: true, setReset: () => {} },
+  });
   // Simulate a mounted Block component registered on the live context.
   const updaterSpy = jest.fn();
   c1._internal.updaters[c1._internal.rootBlock.id] = updaterSpy;
   // getContext runs in the render body — updating mounted Block components
   // during the rebuild would setState mid-render. Updaters are scoped per
   // context, so construction of the new context cannot reach the old ones.
-  const c2 = getContext({ config: config2, lowdefy, resetContext: { reset: false, setReset: () => {} } });
+  const c2 = getContext({
+    config: config2,
+    lowdefy,
+    resetContext: { reset: false, setReset: () => {} },
+  });
   expect(updaterSpy).not.toHaveBeenCalled();
   expect(c2._internal.updaters).toEqual({});
 });
@@ -202,7 +241,15 @@ test('static page config memoizes context across different config objects', () =
   const lowdefy = getLowdefy();
   const config1 = buildTestPage({ pageConfig: { id: 'pageId', type: 'Box' } });
   const config2 = buildTestPage({ pageConfig: { id: 'pageId', type: 'Box' } });
-  const c1 = getContext({ config: config1, lowdefy, resetContext: { reset: true, setReset: () => {} } });
-  const c2 = getContext({ config: config2, lowdefy, resetContext: { reset: false, setReset: () => {} } });
+  const c1 = getContext({
+    config: config1,
+    lowdefy,
+    resetContext: { reset: true, setReset: () => {} },
+  });
+  const c2 = getContext({
+    config: config2,
+    lowdefy,
+    resetContext: { reset: false, setReset: () => {} },
+  });
   expect(c1).toBe(c2);
 });


### PR DESCRIPTION
## What

Five new page lifecycle events that let a page react to the browser:

| Event | Fires on | `_event` |
| --- | --- | --- |
| `onVisible` | `visibilitychange` → visible, or `window.focus` | `{ visible: true, reason: 'visibility' \| 'focus' }` |
| `onHidden` | `visibilitychange` → hidden, or `window.blur` | `{ visible: false, reason: 'visibility' \| 'focus' }` |
| `onOnline` | `window.online` | `{ online: true }` |
| `onOffline` | `window.offline` | `{ online: false }` |
| `onResize` | `window.resize` | `{ width, height }` |

```yaml
events:
  onVisible:
    - id: refresh_tasks
      type: Request
      params: get_tasks
```

## Why

An app that wanted a tab to show fresh data after the user came back to it had
only one option: poll. A `PollingTimer` or an interval keeps hitting the server
while nobody is looking at the page, and still shows stale content for up to one
interval when the user does return. These events let the page refresh exactly
when the user comes back, and stop work when they leave.

## How it is wired

- `packages/client/src/createPageLifecycleManager.js` — a manager in the style of
  `createShortcutManager`: `init(context)` attaches the browser listeners,
  `destroy()` removes them and clears any pending timers.
- `packages/client/src/Context.js` — a `PageLifecycleEffect` component next to
  the existing `ShortcutEffect` / `WebSocketsEffect`, so listeners are attached
  once per mounted page context and removed on unmount or page change. An event
  can never fire for a page that is no longer mounted: the effect cleanup both
  removes the listeners and latches the manager destroyed, which pending
  debounce timers check before triggering.
- `packages/engine/src/getContext.js` — `_internal.triggerPageEvent({ name, event })`
  triggers the named event on the page's root block, the same block `onInit` /
  `onInitAsync` run on.
- Chains run non-blocking, like `onMountAsync` — they never hold the page in
  loading, and a rejected chain goes to `handleError` rather than breaking the page.
- SSR safe: `init` is a noop unless `document` and the browser globals are present.
- Listeners are only attached for the events the page actually declares.

## Debounce and coalescing

- `onVisible` / `onHidden` share a 300ms window. A tab switch usually produces
  both a `visibilitychange` and a `focus`, so the signals are collected and one
  event is triggered at the end of the window. `reason` is `visibility` when a
  `visibilitychange` contributed to the pair, otherwise `focus`.
- The active state is seeded from `document.visibilityState` when the page
  mounts, so nothing fires on the initial page load, and a `focus` that only
  restores a state the page is already in is not an event.
- `onResize` is trailing-debounced by 200ms.

## Build schema

Event names are not enumerated in the build schema (`events` uses
`patternProperties: '^.*$'`), so `lowdefy build` accepts the new names with no
schema change.

## Tests

- `packages/client/src/createPageLifecycleManager.test.js` — 16 tests: fires on
  visibilitychange, fires on focus, coalesces a focus + visibility pair, reason
  precedence, no fire on initial mount, no fire on a focus while already
  visible, `onHidden` on hidden and on blur, online/offline payloads, resize
  debounce and payload, listeners removed on destroy, a pending event dropped
  after destroy, listeners only attached for declared events, chain errors
  handled, noop without browser globals.
- `packages/engine/test/getContext.test.js` — `triggerPageEvent` triggers on the
  page root block.

`@lowdefy/client` 275 tests pass (12 suites), `@lowdefy/engine` 449 tests pass
(49 suites). Prettier and ESLint clean on the changed files.

## Docs

`concepts/events-and-actions` — "Page initialization events" becomes
"Page lifecycle events", with the existing init/mount events under a
"Page initialization events" sub-heading and a new "Browser lifecycle events"
section documenting all five with an example each. `@lowdefy/docs-content` was
regenerated for that page (unrelated regeneration drift on other pages left out
of this PR).

https://claude.ai/code/session_01AgDzfuRFT2s1p5WbdS7Z4P
